### PR TITLE
Add ethics policy and update glm setup

### DIFF
--- a/docs/ETHICS_POLICY.md
+++ b/docs/ETHICS_POLICY.md
@@ -1,0 +1,12 @@
+# Ethics Policy
+
+This document outlines the minimum rules for handling data while working with Spiral OS.
+
+## Data Handling
+
+- Use only data that you have explicit permission to process.
+- Keep personal or sensitive information out of the repository and audit logs.
+- Store logs under `/audit_logs` and rotate them every 30 days.
+- Remove data promptly when a contributor requests deletion.
+- Strip private details from embeddings and generated outputs before sharing.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Milestone VIII expands on the sovereign voice work with memory-aided routing and
 - [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md)
 - [DASHBOARD.md](DASHBOARD.md)
 - [ETHICS_VALIDATION.md](ETHICS_VALIDATION.md)
+- [ETHICS_POLICY.md](ETHICS_POLICY.md)
 - [INANNA_CORE.md](INANNA_CORE.md)
 - [JSON_STRUCTURES.md](JSON_STRUCTURES.md)
 - [LLM_FRAMEWORKS.md](LLM_FRAMEWORKS.md)

--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -50,7 +50,8 @@ Run the setup script to install Python packages and create core directories unde
 bash scripts/setup_glm.sh
 ```
 
-It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs` with placeholder ethics notes.
+It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs` and copies the
+ethics policy found in [ETHICS_POLICY.md](ETHICS_POLICY.md).
 
 ## Clone a private repository
 

--- a/scripts/setup_glm.sh
+++ b/scripts/setup_glm.sh
@@ -10,19 +10,15 @@ mkdir -p /INANNA_AI
 mkdir -p /QNL_LANGUAGE
 mkdir -p /audit_logs
 
-# placeholder ethical guideline files
-cat <<'EON' > /INANNA_AI/ETHICS_PLACEHOLDER.txt
-This directory stores INANNA_AI assets.
-Ensure all data complies with ethical guidelines.
-EON
-
-cat <<'EON' > /QNL_LANGUAGE/ETHICS_PLACEHOLDER.txt
-This directory holds QNL language resources.
-Use responsibly and respect copyright.
-EON
+# copy the ethics policy to key directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cp "$ROOT_DIR/docs/ETHICS_POLICY.md" /INANNA_AI/ETHICS_POLICY.md
+cp "$ROOT_DIR/docs/ETHICS_POLICY.md" /QNL_LANGUAGE/ETHICS_POLICY.md
 
 cat <<'EON' > /audit_logs/README.txt
 Audit logs for monitoring system behavior.
+See /INANNA_AI/ETHICS_POLICY.md for the data policy.
 EON
 
 printf "Setup complete.\n"


### PR DESCRIPTION
## Summary
- add `docs/ETHICS_POLICY.md`
- reference the new policy from `docs/README.md` and `docs/VAST_DEPLOYMENT.md`
- copy the policy in `scripts/setup_glm.sh`

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687a5c407670832ea15b6b9f7840068f