### PR TITLE
Improve Vast.ai helper scripts

### DIFF
--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -72,7 +72,7 @@ cp secrets.env.example secrets.env
 # edit secrets.env
 ```
 
-Launch the stack with the helper script. Pass `--setup` on the first run to prepare directories:
+Launch the stack with the helper script. Pass `--setup` on the first run to perform the full initialization, installing packages and preparing directories:
 
 ```bash
 bash scripts/vast_start.sh --setup

--- a/scripts/setup_vast_ai.sh
+++ b/scripts/setup_vast_ai.sh
@@ -3,13 +3,16 @@
 set -e
 
 # install dependencies
-pip install -r requirements.txt
+if ! pip install -r requirements.txt; then
+    echo "Failed to install Python packages" >&2
+    exit 1
+fi
 
 # create directories for models and outputs
 mkdir -p INANNA_AI/models
 mkdir -p output
 
-# placeholder model download (optional)
+# optional model download
 if [ "$1" = "--download" ]; then
     python download_models.py deepseek || true
 fi

--- a/scripts/vast_start.sh
+++ b/scripts/vast_start.sh
@@ -2,6 +2,11 @@
 # Start Spiral OS on a Vast.ai instance
 set -e
 
+if ! command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose is required" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/.."
 
@@ -19,12 +24,25 @@ fi
 
 cd "$REPO_ROOT"
 
-docker-compose up -d INANNA_AI
+if ! docker-compose up -d INANNA_AI; then
+    echo "docker-compose failed" >&2
+    exit 1
+fi
 
 printf "Waiting for port 8000...\n"
-while ! nc -z localhost 8000; do
+PORT_READY=0
+for i in {1..60}; do
+    if nc -z localhost 8000; then
+        PORT_READY=1
+        break
+    fi
     sleep 1
 done
+
+if [ "$PORT_READY" -ne 1 ]; then
+    echo "Port 8000 did not become available" >&2
+    exit 1
+fi
 
 python -m webbrowser "${REPO_ROOT}/web_console/index.html" >/dev/null 2>&1 &
 


### PR DESCRIPTION
## Summary
- verify pip install in `setup_vast_ai.sh`
- add docker-compose and port check handling in `vast_start.sh`
- document full initialization using `vast_start.sh --setup`

## Testing
- `pytest -q` *(fails: FileNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a64a034bc832ebe63c6a45711d779