### PR TITLE
Update GLM endpoint configuration

### DIFF
--- a/INANNA_AI/existential_reflector.py
+++ b/INANNA_AI/existential_reflector.py
@@ -17,7 +17,7 @@ INANNA_DIR = ROOT / "INANNA_AI"
 QNL_DIR = ROOT / "QNL_LANGUAGE"
 AUDIT_DIR = ROOT / "audit_logs"
 INSIGHTS_FILE = AUDIT_DIR / "existential_insights.txt"
-ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm")
+ENDPOINT = os.getenv("GLM_API_URL", "https://glm.example.com/glm")
 API_KEY = os.getenv("GLM_API_KEY")
 HEADERS = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else None
 

--- a/INANNA_AI/glm_integration.py
+++ b/INANNA_AI/glm_integration.py
@@ -12,7 +12,7 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "https://api.example.com/glm41v_9b"
+DEFAULT_ENDPOINT = "https://glm.example.com/glm41v_9b"
 SAFE_ERROR_MESSAGE = "GLM unavailable"
 
 

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -31,7 +31,8 @@ The requirements include common libraries like `numpy` and `scipy` as well as
 ### Environment variables
 
 Create a `secrets.env` file in the repository root and define the following
-variables used by the tools and Docker setup:
+variables used by the tools and Docker setup.  The helper scripts source this
+file so you don't need to export the variables manually:
 
 - `HF_TOKEN` – Hugging Face token for downloading models
 - `GITHUB_TOKEN` – optional GitHub token for scraping repositories
@@ -64,6 +65,9 @@ variables used by the tools and Docker setup:
   `docker-compose.yml`)
 - `TELEGRAM_BOT_TOKEN` – token for the Telegram bot
 - `DISCORD_BOT_TOKEN` – token for the Discord bot
+
+Provide `GLM_API_URL` and `GLM_API_KEY` in `secrets.env` to point to your
+production GLM service.  The helper scripts read these variables on startup.
 
 Configuration options for `config/INANNA_CORE.yaml` and the corresponding
 environment variables are explained in
@@ -144,7 +148,8 @@ background tasks.
    for example `./run_inanna.sh --model-dir INANNA_AI/models/gemma2`.
 4. Optionally configure `GLMIntegration` with your GLM endpoint and API key.  If
    no values are provided the class reads `GLM_API_URL` and `GLM_API_KEY` from
-   the environment and defaults to `https://api.example.com/glm41v_9b`.
+   the environment (for example via `secrets.env`) and defaults to
+   `https://glm.example.com/glm41v_9b`.
 
 ## Download Models
 

--- a/config/INANNA_CORE.yaml
+++ b/config/INANNA_CORE.yaml
@@ -8,7 +8,7 @@
 #   MISTRAL_URL   -> servant_models.mistral
 #   KIMI_K2_URL   -> servant_models.kimi_k2
 
-glm_api_url: https://api.example.com/glm41v_9b
+glm_api_url: https://glm.example.com/glm41v_9b
 glm_api_key: your-api-key
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -19,7 +19,7 @@ The **Albedo** layer introduces a stateful persona that drives responses through
 from INANNA_AI.glm_integration import GLMIntegration
 
 glm = GLMIntegration(
-    endpoint="https://api.example.com/glm41v_9b",
+    endpoint="https://glm.example.com/glm41v_9b",
     api_key="<your key>",
 )
 ```
@@ -34,7 +34,7 @@ To engage the Albedo personality, create the layer and pass it to the orchestrat
 
 ```bash
 export GLM_API_KEY=<your key>
-export GLM_API_URL=https://api.example.com/glm41v_9b
+export GLM_API_URL=https://glm.example.com/glm41v_9b
 python -m INANNA_AI.main --duration 3 --personality albedo
 ```
 

--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -28,7 +28,7 @@
 ## Example
 
 ```yaml
-glm_api_url: https://api.example.com/glm41v_9b
+glm_api_url: https://glm.example.com/glm41v_9b
 glm_api_key: your-api-key
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,7 +1,9 @@
 HF_TOKEN=
 GITHUB_TOKEN=
 OPENAI_API_KEY=
-GLM_API_URL=
+# Endpoint for the production GLM service
+GLM_API_URL=https://glm.example.com/glm41v_9b
+# API key for the GLM service
 GLM_API_KEY=
 GLM_SHELL_URL=
 GLM_SHELL_KEY=


### PR DESCRIPTION
## Summary
- set production GLM URL in `GLMIntegration`
- document providing `GLM_API_URL` and `GLM_API_KEY`
- update environment example and configs to use the production endpoint
- clean up all references to `api.example.com`

## Testing
- `pytest -k glm_integration -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a655edbac832e82251581b0bf22f9