### PR TITLE
Add easy setup script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ pip install .[dev]
 ```
 
 ## Local Usage
+Run the helper script to check prerequisites, configure `secrets.env`, and
+optionally download the default DeepSeek‑V3 model:
+
+```bash
+./scripts/easy_setup.sh
+```
+
+The manual steps are outlined below.
 
 1. Copy `secrets.env.example` to `secrets.env` and provide values for
    environment variables such as `HF_TOKEN`, `GITHUB_TOKEN`,
@@ -76,10 +84,10 @@ pip install .[dev]
 2. Download the required model weights before first launch:
 
    ```bash
-   python download_models.py deepseek
+   python download_models.py deepseek_v3
    ```
 
-   This saves `deepseek-ai/DeepSeek-R1` under `INANNA_AI/models/DeepSeek-R1/`.
+   This saves the DeepSeek‑V3 weights under `INANNA_AI/models/DeepSeek-V3/`.
 3. Start the INANNA chat agent via the helper script:
 
    ```bash

--- a/scripts/easy_setup.sh
+++ b/scripts/easy_setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+"$SCRIPT_DIR/check_prereqs.sh"
+
+if [ ! -f secrets.env ]; then
+    cp secrets.env.example secrets.env
+    echo "Configuring secrets.env"
+    read -p "Enter HF_TOKEN: " HF_TOKEN
+    read -p "Enter GLM_API_URL: " GLM_API_URL
+    read -p "Enter GLM_API_KEY: " GLM_API_KEY
+    sed -i "s|^HF_TOKEN=.*|HF_TOKEN=$HF_TOKEN|" secrets.env
+    sed -i "s|^GLM_API_URL=.*|GLM_API_URL=$GLM_API_URL|" secrets.env
+    sed -i "s|^GLM_API_KEY=.*|GLM_API_KEY=$GLM_API_KEY|" secrets.env
+else
+    echo "secrets.env already exists. Skipping secrets setup."
+fi
+
+read -p "Download DeepSeek-V3 model now? (Y/n): " download_choice
+download_choice=${download_choice:-Y}
+if [[ "$download_choice" =~ ^[Yy]$ ]]; then
+    python download_models.py deepseek_v3
+else
+    echo "Skipping model download."
+fi
+
+echo "Easy setup complete."


### PR DESCRIPTION
## Summary
- add `scripts/easy_setup.sh` to check prerequisites, set up `secrets.env`, and optionally download the DeepSeek-V3 model
- document helper script usage in README

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: '/workspace/ABZU/spiral_os')*

------
https://chatgpt.com/codex/tasks/task_e_68a24e801a70832eb444477d41f31697