### PR TITLE
Add start_local script for local web console

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ optionally download the default DeepSeek‑V3 model:
 ./scripts/easy_setup.sh
 ```
 
+Start the local environment and open the web console:
+
+```bash
+./scripts/start_local.sh
+```
+
 The manual steps are outlined below.
 
 1. Copy `secrets.env.example` to `secrets.env` and provide values for

--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+# Launch containers, building images if needed
+docker-compose up --build -d
+
+# Wait for the service to be ready on port 8000
+echo "Waiting for localhost:8000 to become available..."
+until nc -z localhost 8000; do
+  sleep 1
+done
+
+# Open the web console in the default browser
+python -m webbrowser "web_console/index.html"


### PR DESCRIPTION
## Summary
- add `scripts/start_local.sh` to build and launch docker-compose stack, wait for port 8000, and open web console
- document `start_local.sh` in `README.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'opensmile', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a250a36804832ea86838c60df84f39