### PR TITLE
docs: add quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
+- For a quick start geared toward non-technical users, see
+  [docs/quick_start_non_technical.md](docs/quick_start_non_technical.md).
 - For an orientation covering the chakra layers, key modules and milestone history, see
   [docs/project_overview.md](docs/project_overview.md).
 - For a map of each script's role and the libraries it calls upon, see

--- a/docs/quick_start_non_technical.md
+++ b/docs/quick_start_non_technical.md
@@ -1,0 +1,9 @@
+# Quick Start Guide (Non-Technical)
+
+Follow these steps to get the system running with minimal setup.
+
+1. Run `bash scripts/easy_setup.sh` to download models and install the core dependencies.
+2. Launch the local environment with `bash scripts/start_local.sh`.
+3. *(Optional)* For a cloud deployment on Vast.ai, run `bash scripts/vast_start.sh --setup`.
+
+These commands should be executed from the project root directory.


### PR DESCRIPTION
## Summary
- Add non-technical quick start guide with simple setup steps.
- Link the new guide from the top of the README.

## Testing
- `python -m pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/ABZU/spiral_os')*

------
https://chatgpt.com/codex/tasks/task_e_68a25b589f28832eba72bfe4f5029a3c