### PR TITLE
Add architecture overview guide and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
   [guides/visual_customization.md](guides/visual_customization.md).
 - For the metaphysical blueprint of the chakra-based code layout, see
   [docs/spiritual_architecture.md](docs/spiritual_architecture.md).
+- For a pragmatic overview of core components like the LLM router, audio pipeline, and model registry, see
+  [docs/architecture_overview.md](docs/architecture_overview.md).
 - For how archetypal states shape personality behavior, read
   [docs/archetype_logic.md](docs/archetype_logic.md).
 - For insight into the self-reflection cycle that tunes responses, check

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,13 @@
+# Architecture Overview
+
+This guide surveys the major pieces of Spiral OS in everyday engineering terms.
+
+## LLM Router
+The LLM router decides which language model and voice pathway should handle a message. `crown_router.py` calls the `MoGEOrchestrator` and considers recent emotional context from `vector_memory`. It returns a model choice along with recommendations for text‑to‑speech and avatar style so the reply matches the current mood.
+
+## Audio Pipeline
+Audio flows through two main modules. `audio_ingestion.py` loads samples and can extract features such as MFCCs, musical key, tempo and CLAP embeddings. `audio_engine.py` applies DSP effects, plays ritual loops and can synthesise tones when assets are missing. Together they cover capture, analysis and playback.
+
+## Model Registry
+`servant_model_manager.py` keeps a registry of helper models. Handlers may be native Python functions or subprocesses, and the Kimi‑K2 servant registers here by default. The orchestrator can invoke a model by name through a uniform `invoke` API, simplifying the addition of new specialised models.
+


### PR DESCRIPTION
## Summary
- Document core modules in new `docs/architecture_overview.md`
- Link the architecture overview from `README.md`

## Testing
- `pytest` (fails: FileNotFoundError for spiral_os and 21 other errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68a261eb4f60832e8de137a852ff2b5c