### PR TITLE
Centralize environment configuration using Pydantic settings

### DIFF
--- a/INANNA_AI/speaking_engine.py
+++ b/INANNA_AI/speaking_engine.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Iterable, Tuple
@@ -15,6 +14,7 @@ from .voice_evolution import get_voice_params, update_voice_from_history
 from . import tts_coqui, tts_tortoise, tts_bark, tts_xtts
 from .emotion_analysis import emotion_to_archetype
 from tools import voice_conversion
+from config import settings
 
 try:
     from gtts import gTTS
@@ -122,7 +122,7 @@ def synthesize_speech(
     timbre: str = "neutral",
 ) -> str:
     """Dispatch to the configured TTS backend."""
-    backend = os.getenv("CROWN_TTS_BACKEND", "gtts").lower()
+    backend = settings.crown_tts_backend.lower()
     if backend == "coqui":
         return tts_coqui.synthesize_speech(text, emotion)
     if backend == "tortoise":
@@ -156,13 +156,13 @@ class SpeakingEngine:
     ) -> str:
         """Return a path to synthesized speech for ``text``."""
         path = Path(synthesize_speech(text, emotion, history, timbre))
-        preset = os.getenv("RVC_PRESET")
+        preset = settings.rvc_preset
         if preset:
             try:  # pragma: no cover - external binary
                 path = voice_conversion.apply_rvc(path, preset)
             except Exception:
                 logger.exception("RVC conversion failed")
-        if os.getenv("VOICEFIX"):
+        if settings.voicefix:
             try:  # pragma: no cover - external binary
                 path = voice_conversion.voicefix(path)
             except Exception:

--- a/INANNA_AI/voice_evolution.py
+++ b/INANNA_AI/voice_evolution.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 from pathlib import Path
-import os
 import yaml
 
 from . import emotional_synaptic_engine
@@ -11,6 +10,7 @@ import emotional_state
 
 from . import db_storage
 import vector_memory
+from config import settings
 
 import numpy as np
 
@@ -29,7 +29,7 @@ SCALE_PITCH = {"C_major": 0.0, "A_minor": -3.0, "D_minor": 2.0}
 
 def load_voice_config(path: Path = CONFIG_PATH) -> Dict[str, Dict[str, Any]]:
     """Return archetype settings loaded from ``path`` if it exists."""
-    env_path = os.getenv("VOICE_AVATAR_CONFIG_PATH")
+    env_path = settings.voice_avatar_config_path
     if env_path:
         path = Path(env_path)
     if path.exists():
@@ -164,7 +164,7 @@ class VoiceEvolution:
                     "emotion": emotion,
                     "speed": style.get("speed", 1.0),
                     "pitch": style.get("pitch", 0.0),
-                    "model": os.getenv("CROWN_TTS_BACKEND", "gtts"),
+                    "model": settings.crown_tts_backend,
                 },
             )
         except Exception:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,56 @@
+"""Application configuration loaded from environment variables."""
+from __future__ import annotations
+
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Settings pulled from environment variables.
+
+    The field names correspond to environment variables using Pydantic's
+    standard mapping rules (``field_name" -> "FIELD_NAME").
+    """
+
+    glm_command_token: str | None = Field(None, env="GLM_COMMAND_TOKEN")
+    crown_tts_backend: str = Field("gtts", env="CROWN_TTS_BACKEND")
+    voice_avatar_config_path: str | None = Field(
+        None, env="VOICE_AVATAR_CONFIG_PATH"
+    )
+    rvc_preset: str | None = Field(None, env="RVC_PRESET")
+    voicefix: bool = Field(False, env="VOICEFIX")
+
+    class Config:
+        case_sensitive = True
+
+
+settings = Settings()
+
+
+def require(*names: str) -> None:
+    """Ensure that the given configuration values are present.
+
+    Parameters
+    ----------
+    names:
+        Attribute names on :data:`settings` that must be truthy.
+
+    Raises
+    ------
+    RuntimeError
+        If any requested variables are unset.
+    """
+
+    missing = [name for name in names if getattr(settings, name) in (None, "")]
+    if missing:
+        plural = "s" if len(missing) > 1 else ""
+        env_names = ", ".join(n.upper() for n in missing)
+        raise RuntimeError(f"Missing required environment variable{plural}: {env_names}")
+
+
+def reload() -> None:
+    """Reload configuration from the current environment.
+
+    Useful for tests that modify ``os.environ``.
+    """
+    global settings
+    settings = Settings()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from pathlib import Path
 import tempfile
 from typing import Any, Dict, Deque, List, Callable
-import os
 from collections import deque
 import soundfile as sf
 from time import perf_counter
@@ -54,6 +53,7 @@ from tools import reflection_loop
 from INANNA_AI import listening_engine
 import vector_memory
 import archetype_shift_engine
+from config import settings
 
 # Emotion to model lookup derived from docs/crown_manifest.md
 _EMOTION_MODEL_MATRIX = {
@@ -279,7 +279,7 @@ class MoGEOrchestrator:
 
         if voice_modality:
             opts = crown_decider.decide_expression_options(emotion)
-            os.environ["CROWN_TTS_BACKEND"] = opts.get("tts_backend", "gtts")
+            settings.crown_tts_backend = opts.get("tts_backend", "gtts")
             result.update(
                 {
                     "tts_backend": opts.get("tts_backend"),

--- a/tests/test_avatar_stream_pipeline.py
+++ b/tests/test_avatar_stream_pipeline.py
@@ -111,6 +111,9 @@ import server
 import vector_memory
 import crown_decider
 import voice_aura
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_avatar_stream_pipeline(tmp_path, monkeypatch):

--- a/tests/test_orchestrator_routing.py
+++ b/tests/test_orchestrator_routing.py
@@ -50,6 +50,7 @@ sys.modules.setdefault("gymnasium", gym_mod)
 
 from orchestrator import MoGEOrchestrator
 import orchestrator
+from config import settings
 
 
 def test_route_all_modalities(monkeypatch, tmp_path):
@@ -142,7 +143,7 @@ def test_expression_decision(monkeypatch, tmp_path):
     voice_path = tmp_path / "voice.wav"
     monkeypatch.setattr("INANNA_AI.tts_coqui.synthesize_speech", lambda *a, **k: str(voice_path))
     monkeypatch.setattr("orchestrator.voice_aura.apply_voice_aura", lambda p, **k: p)
-    monkeypatch.setenv("CROWN_TTS_BACKEND", "gtts")
+    settings.crown_tts_backend = "gtts"
 
     monkeypatch.setattr(
         "orchestrator.crown_decider.decide_expression_options",
@@ -159,7 +160,7 @@ def test_expression_decision(monkeypatch, tmp_path):
     assert result["avatar_style"] == "Soprano"
     assert result["aura_amount"] == 0.3
     assert logged["tts_backend"] == "coqui"
-    assert os.getenv("CROWN_TTS_BACKEND") == "coqui"
+    assert settings.crown_tts_backend == "coqui"
 
 
 def test_memory_biases_model_choice(monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 import asyncio
-
 import httpx
 import numpy as np
 from fastapi.testclient import TestClient
@@ -37,6 +36,9 @@ inanna_mod.GLMIntegration = lambda *a, **k: None
 sys.modules.setdefault("INANNA_AI.glm_integration", inanna_mod)
 
 import server
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_health_and_ready_return_200():
@@ -68,7 +70,6 @@ def test_glm_command_endpoint(monkeypatch):
         return resp.status_code, resp.json()
 
     monkeypatch.setattr(server, "send_command", lambda cmd: f"ran {cmd}")
-    monkeypatch.setattr(server, "GLM_COMMAND_TOKEN", "token")
     status, data = asyncio.run(run_request())
     assert status == 200
     assert data == {"result": "ran ls"}
@@ -86,7 +87,6 @@ def test_glm_command_requires_authorization(monkeypatch):
         return resp.status_code
 
     monkeypatch.setattr(server, "send_command", lambda cmd: "ran")
-    monkeypatch.setattr(server, "GLM_COMMAND_TOKEN", "token")
     status_missing = asyncio.run(run_request({}))
     status_wrong = asyncio.run(run_request({"Authorization": "bad"}))
     assert status_missing == 401

--- a/tests/test_server_endpoints.py
+++ b/tests/test_server_endpoints.py
@@ -43,6 +43,9 @@ sys.modules.setdefault("connectors", connectors_mod)
 sys.modules.setdefault("connectors.webrtc_connector", webrtc_stub)
 
 import server
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_health_and_ready():
@@ -57,7 +60,6 @@ def test_health_and_ready():
 
 def test_glm_command_authorized(monkeypatch):
     monkeypatch.setattr(server, "send_command", lambda c: f"ran {c}")
-    monkeypatch.setattr(server, "GLM_COMMAND_TOKEN", "token")
     with TestClient(server.app) as client:
         resp = client.post(
             "/glm-command",
@@ -70,7 +72,6 @@ def test_glm_command_authorized(monkeypatch):
 
 def test_glm_command_requires_authorization(monkeypatch):
     monkeypatch.setattr(server, "send_command", lambda c: "out")
-    monkeypatch.setattr(server, "GLM_COMMAND_TOKEN", "token")
     with TestClient(server.app) as client:
         missing = client.post("/glm-command", json={"command": "ls"})
         wrong = client.post(

--- a/tests/test_tts_backends.py
+++ b/tests/test_tts_backends.py
@@ -19,10 +19,11 @@ sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
 sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
 
 from INANNA_AI import speaking_engine, tts_coqui, tts_tortoise, tts_bark, tts_xtts
+from config import settings
 
 
 def _test_backend(monkeypatch, name, module, attr):
-    monkeypatch.setenv("CROWN_TTS_BACKEND", name)
+    settings.crown_tts_backend = name
     called = {}
     def fake(text: str, emotion: str) -> str:
         called["args"] = (text, emotion)
@@ -39,7 +40,7 @@ def _test_backend(monkeypatch, name, module, attr):
     assert path == f"{name}.wav"
     assert called.get("args") == ("hello", "joy")
     assert "gtts" not in called
-    monkeypatch.delenv("CROWN_TTS_BACKEND", raising=False)
+    settings.crown_tts_backend = "gtts"
 
 
 def test_backend_selection(monkeypatch):

--- a/tests/test_vast_pipeline.py
+++ b/tests/test_vast_pipeline.py
@@ -37,6 +37,9 @@ import video_stream
 from connectors import webrtc_connector
 from orchestrator import MoGEOrchestrator
 from core import language_engine, context_tracker
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_hex_to_song_short_payload():

--- a/tests/test_video_stream.py
+++ b/tests/test_video_stream.py
@@ -13,6 +13,9 @@ sys.modules.setdefault("SPIRAL_OS", ModuleType("SPIRAL_OS"))
 sys.modules.setdefault("SPIRAL_OS.qnl_utils", ModuleType("qnl_utils"))
 
 import server
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_webrtc_offer(monkeypatch):

--- a/tests/test_video_stream_audio.py
+++ b/tests/test_video_stream_audio.py
@@ -16,6 +16,9 @@ sys.modules.setdefault("SPIRAL_OS.qnl_utils", ModuleType("qnl_utils"))
 
 import server
 import video_stream
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def test_avatar_audio_track(tmp_path):

--- a/tests/test_voice_avatar_pipeline.py
+++ b/tests/test_voice_avatar_pipeline.py
@@ -47,6 +47,7 @@ from INANNA_AI import speaking_engine
 from tools import voice_conversion
 from core import avatar_expression_engine, expressive_output
 import vector_memory
+from config import settings
 
 
 def test_voice_avatar_pipeline(tmp_path, monkeypatch):
@@ -82,8 +83,8 @@ def test_voice_avatar_pipeline(tmp_path, monkeypatch):
         return tmp_path / "final.wav"
     monkeypatch.setattr(voice_conversion, "apply_rvc", fake_rvc)
     monkeypatch.setattr(voice_conversion, "voicefix", fake_vf)
-    monkeypatch.setenv("RVC_PRESET", "demo")
-    monkeypatch.setenv("VOICEFIX", "1")
+    settings.rvc_preset = "demo"
+    settings.voicefix = True
 
     engine = speaking_engine.SpeakingEngine()
     out_path = Path(engine.synthesize("hello", "joy"))
@@ -110,3 +111,6 @@ def test_voice_avatar_pipeline(tmp_path, monkeypatch):
 
     logs = vector_memory.LOG_FILE.read_text(encoding="utf-8").splitlines()
     assert logs and '"operation": "add"' in logs[-1]
+
+    settings.rvc_preset = None
+    settings.voicefix = False

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(ROOT))
 
 from tools import voice_conversion
 from INANNA_AI import speaking_engine
+from config import settings
 
 
 def test_apply_rvc_invokes_binary(monkeypatch, tmp_path):
@@ -67,8 +68,8 @@ def test_voicefix_invokes_binary(monkeypatch, tmp_path):
 
 def test_synthesize_applies_converters(monkeypatch, tmp_path):
     engine = speaking_engine.SpeakingEngine()
-    monkeypatch.setenv("RVC_PRESET", "demo")
-    monkeypatch.setenv("VOICEFIX", "1")
+    settings.rvc_preset = "demo"
+    settings.voicefix = True
 
     wav = tmp_path / "orig.wav"
     monkeypatch.setattr(speaking_engine, "synthesize_speech", lambda *a, **k: str(wav))
@@ -87,3 +88,5 @@ def test_synthesize_applies_converters(monkeypatch, tmp_path):
     assert calls["rvc"] == (wav, "demo")
     assert calls["vf"] == tmp_path / "rvc.wav"
     assert out == str(tmp_path / "final.wav")
+    settings.rvc_preset = None
+    settings.voicefix = False

--- a/tests/test_webrtc_connector.py
+++ b/tests/test_webrtc_connector.py
@@ -16,6 +16,9 @@ sys.modules.setdefault("SPIRAL_OS.qnl_utils", ModuleType("qnl_utils"))
 import server
 from connectors import webrtc_connector
 from tests.data.short_wav_base64 import SHORT_WAV_BASE64
+from config import settings
+
+settings.glm_command_token = "token"
 
 
 def _write_audio(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary
- Add `config.py` to load environment variables with Pydantic and provide helper utilities
- Use centralized settings in `server.py` for token validation and in orchestration pipeline
- Read TTS and audio configuration from shared settings instead of ad-hoc `os.getenv`

## Testing
- `pytest` *(fails: ModuleNotFoundError and missing test resources)*

------
https://chatgpt.com/codex/tasks/task_e_68a26427aaa0832eb48a9a9b83b9374d