### PR TITLE
Limit tts dependency to Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ stable-baselines3==2.7.0
 streamlit==1.48.1
 torch==2.8.0
 transformers==4.55.2
-tts==0.22.0
+tts==0.22.0; python_version<'3.12'
 ultralytics==8.3.179
 uvicorn==0.35.0
 voicefixer==0.1.3


### PR DESCRIPTION
## Summary
- restricts `tts` to Python versions below 3.12 in requirements

## Testing
- `pytest` *(fails: AttributeError and missing modules during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4262166d4832ebad98bee05dbafc6