### PR TITLE
Add retrain threshold to config stub and update tests

### DIFF
--- a/tests/helpers/config_stub.py
+++ b/tests/helpers/config_stub.py
@@ -8,6 +8,7 @@ def build_settings():
         vector_db_path=Path("/tmp"),
         crown_tts_backend="gtts",
         voice_avatar_config_path=None,
+        retrain_threshold=10,
         llm_rotation_period=300,
         llm_max_failures=3,
         feedback_novelty_threshold=0.5,

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -1,11 +1,18 @@
 import json
 import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 import logging
 
+from tests.helpers.config_stub import build_settings
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
 
 import auto_retrain
 
@@ -39,10 +46,11 @@ def test_main_invokes_api(tmp_path, monkeypatch):
     fb = tmp_path / "feed.json"
     fb.write_text(json.dumps(feedback), encoding="utf-8")
     monkeypatch.setattr(auto_retrain, "INSIGHT_FILE", ins)
-    monkeypatch.setattr(auto_retrain, "FEEDBACK_FILE", fb)
+    monkeypatch.setattr(auto_retrain.feedback_logging, "LOG_FILE", fb)
     monkeypatch.setattr(auto_retrain, "NOVELTY_THRESHOLD", 0.0)
     monkeypatch.setattr(auto_retrain, "COHERENCE_THRESHOLD", 0.0)
     monkeypatch.setattr(auto_retrain, "system_idle", lambda: True)
+    monkeypatch.setattr(auto_retrain, "_load_vector_logs", lambda: [{}])
 
     calls = {}
 

--- a/tests/test_autoretrain_full.py
+++ b/tests/test_autoretrain_full.py
@@ -1,10 +1,17 @@
 import json
 import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
+from tests.helpers.config_stub import build_settings
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
 
 import auto_retrain
 
@@ -22,10 +29,11 @@ def test_main_triggers_finetune(tmp_path, monkeypatch):
     fb.write_text(json.dumps(feedback), encoding="utf-8")
 
     monkeypatch.setattr(auto_retrain, "INSIGHT_FILE", ins)
-    monkeypatch.setattr(auto_retrain, "FEEDBACK_FILE", fb)
+    monkeypatch.setattr(auto_retrain.feedback_logging, "LOG_FILE", fb)
     monkeypatch.setattr(auto_retrain, "NOVELTY_THRESHOLD", 0.3)
     monkeypatch.setattr(auto_retrain, "COHERENCE_THRESHOLD", 0.7)
     monkeypatch.setattr(auto_retrain, "system_idle", lambda: True)
+    monkeypatch.setattr(auto_retrain, "_load_vector_logs", lambda: [{}])
 
     captured = {}
 

--- a/tests/test_spiral_cortex_memory.py
+++ b/tests/test_spiral_cortex_memory.py
@@ -27,6 +27,12 @@ sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from tests.helpers.config_stub import build_settings
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
+
 from rag import retriever as rag_retriever
 import spiral_cortex_memory as scm
 import ritual_trainer

--- a/tests/test_training_feedback.py
+++ b/tests/test_training_feedback.py
@@ -3,8 +3,14 @@ import sys
 import types
 from pathlib import Path
 
+from tests.helpers.config_stub import build_settings
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
 
 import training_guide
 

--- a/tests/test_training_guide_logger.py
+++ b/tests/test_training_guide_logger.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 import json
 import sys
+import types
+
+from tests.helpers.config_stub import build_settings
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
 
 import training_guide
 

--- a/tests/test_training_guide_trigger.py
+++ b/tests/test_training_guide_trigger.py
@@ -1,8 +1,15 @@
 from pathlib import Path
 import sys
+import types
+
+from tests.helpers.config_stub import build_settings
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+config = types.ModuleType("config")
+config.settings = build_settings()
+sys.modules.setdefault("config", config)
 
 import training_guide
 


### PR DESCRIPTION
## Summary
- supply `retrain_threshold` default in testing settings stub
- patch tests to inject the new stubbed settings when importing modules
- fix auto-retrain tests by stubbing feedback log path and vector log loader

## Testing
- `pytest tests/test_training_guide_logger.py tests/test_training_feedback.py tests/test_training_guide_trigger.py tests/test_auto_retrain.py tests/test_autoretrain_full.py tests/test_spiral_cortex_memory.py -q`
- `pytest -q` *(fails: module 'rag.orchestrator' lacks required attributes, missing QNL engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d34f34c832eb3197e1f910bd0f2