### PR TITLE
Expose vector and invocation subsystems in RAG orchestrator

### DIFF
--- a/rag/orchestrator.py
+++ b/rag/orchestrator.py
@@ -60,6 +60,10 @@ import vector_memory
 import archetype_shift_engine
 from config import settings
 
+# Re-export commonly used subsystems for external consumers.
+vector_memory = vector_memory
+invocation_engine = invocation_engine
+
 logger = logging.getLogger(__name__)
 
 
@@ -357,4 +361,9 @@ def schedule_action(func: Callable[[], Any], delay: float) -> threading.Timer:
     return timer
 
 
-__all__ = ["MoGEOrchestrator", "schedule_action"]
+__all__ = [
+    "MoGEOrchestrator",
+    "schedule_action",
+    "vector_memory",
+    "invocation_engine",
+]


### PR DESCRIPTION
## Summary
- Re-export `vector_memory` and `invocation_engine` through `rag.orchestrator` for easier access
- List these subsystems in `__all__` so wildcard imports expose them

## Testing
- `pytest tests/test_vast_pipeline.py tests/test_orchestrator_routing.py -q` *(fails: NameError: LOADER_DIR undefined in cv2 and missing pydantic-settings)*


------
https://chatgpt.com/codex/tasks/task_e_68a434974528832e944c303b909c4723