### PR TITLE
Add optional ML-based emotion classifier

### DIFF
--- a/INANNA_AI/emotion_analysis.py
+++ b/INANNA_AI/emotion_analysis.py
@@ -56,15 +56,94 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     opensmile = None  # type: ignore
 
+# Optional ML-based classifier support
+try:  # pragma: no cover - optional dependency
+    import torch
+    from transformers import (
+        AutoModelForAudioClassification,
+        AutoProcessor,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+    AutoModelForAudioClassification = AutoProcessor = None  # type: ignore
 
 
-def analyze_audio_emotion(audio_path: str) -> Dict[str, Any]:
+def predict_emotion_ml(
+    audio_path: str, model_name: str = "m-a-p/MERT-v1-330M-CLAP"
+) -> Dict[str, float]:
+    """Return emotion probabilities from a pretrained model.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio file to analyze.
+    model_name:
+        Hugging Face model identifier. Defaults to a MERT/CLAP variant.
+
+    Returns
+    -------
+    Dict[str, float]
+        Mapping from emotion label to probability.
+
+    Raises
+    ------
+    RuntimeError
+        If required libraries are missing or the model cannot be loaded.
+    """
+
+    if (
+        torch is None
+        or AutoModelForAudioClassification is None
+        or AutoProcessor is None
+        or librosa is None
+    ):
+        raise RuntimeError("transformers, torch and librosa are required")
+
+    wave, sr = librosa.load(audio_path, sr=16000, mono=True)
+    processor = AutoProcessor.from_pretrained(model_name)
+    model = AutoModelForAudioClassification.from_pretrained(model_name)
+    inputs = processor(wave, sampling_rate=sr, return_tensors="pt")
+    with torch.no_grad():
+        logits = model(**inputs).logits[0]
+    probs = torch.nn.functional.softmax(logits, dim=-1).cpu().numpy()
+    labels = model.config.id2label
+    return {labels[i]: float(probs[i]) for i in range(len(labels))}
+
+
+def _rule_based_classify(
+    pitch: float, tempo: float, arousal: float, valence: float
+) -> str:
+    """Return a discrete emotion using the heuristic rules."""
+
+    emotion = "neutral"
+    if arousal > 0.75:
+        emotion = "stress"
+    elif valence < 0.3 and arousal > 0.5:
+        emotion = "fear"
+    elif valence > 0.7 and arousal > 0.5:
+        emotion = "joy"
+    elif valence < 0.4 and arousal < 0.4:
+        emotion = "sad"
+    elif pitch > 180 and tempo > 120:
+        emotion = "excited"
+    elif pitch < 120 and tempo < 90:
+        emotion = "calm"
+    return emotion
+
+
+
+def analyze_audio_emotion(
+    audio_path: str, use_ml: bool = False, model_name: str | None = None
+) -> Dict[str, Any]:
     """Return an emotion estimate for ``audio_path``.
 
     The analysis extracts pitch and tempo using ``librosa`` and uses
     ``openSMILE``'s eGeMAPSv02 configuration to obtain coarse arousal and
-    valence scores. A basic rule-based classifier then derives a discrete
-    emotion label from these values.
+    valence scores. A basic rule-based classifier derives a discrete emotion
+    label from these values. If ``use_ml`` is ``True`` and a compatible
+    pretrained model is available, the classifier result is replaced by the
+    model prediction. When the model cannot be loaded the heuristic classifier
+    is used as a fallback.
     """
     if librosa is None or opensmile is None:
         raise RuntimeError("librosa and opensmile libraries are required")
@@ -94,19 +173,16 @@ def analyze_audio_emotion(audio_path: str) -> Dict[str, Any]:
 
     energy = float(np.mean(np.abs(wave)))
 
-    emotion = "neutral"
-    if arousal > 0.75:
-        emotion = "stress"
-    elif valence < 0.3 and arousal > 0.5:
-        emotion = "fear"
-    elif valence > 0.7 and arousal > 0.5:
-        emotion = "joy"
-    elif valence < 0.4 and arousal < 0.4:
-        emotion = "sad"
-    elif pitch > 180 and tempo > 120:
-        emotion = "excited"
-    elif pitch < 120 and tempo < 90:
-        emotion = "calm"
+    emotion = _rule_based_classify(pitch, tempo, arousal, valence)
+
+    probs: Dict[str, float] | None = None
+    if use_ml:
+        try:
+            probs = predict_emotion_ml(audio_path, model_name or "m-a-p/MERT-v1-330M-CLAP")
+            if probs:
+                emotion = max(probs, key=probs.get)
+        except Exception:
+            probs = None
 
     _CURRENT_STATE["emotion"] = emotion
     _CURRENT_STATE["archetype"] = EMOTION_ARCHETYPES.get(emotion, "Everyman")
@@ -114,13 +190,18 @@ def analyze_audio_emotion(audio_path: str) -> Dict[str, Any]:
     _CURRENT_STATE["arousal"] = arousal
     _CURRENT_STATE["valence"] = valence
 
-    return {
+    result: Dict[str, Any] = {
         "emotion": emotion,
         "pitch": round(pitch, 2),
         "tempo": round(tempo, 2),
         "arousal": round(arousal, 3),
         "valence": round(valence, 3),
     }
+    if probs is not None:
+        result["probabilities"] = {
+            k: round(float(v), 3) for k, v in sorted(probs.items(), key=lambda x: -x[1])
+        }
+    return result
 
 def get_current_archetype() -> str:
     """Return the Jungian archetype for the last analyzed emotion."""
@@ -153,6 +234,7 @@ def get_emotion_and_tone(emotion: str | None = None) -> Tuple[str, str]:
 
 __all__ = [
     "analyze_audio_emotion",
+    "predict_emotion_ml",
     "get_current_archetype",
     "get_emotional_weight",
     "emotion_to_archetype",

--- a/ml/evaluate_emotion_models.py
+++ b/ml/evaluate_emotion_models.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Evaluate pretrained emotion models on a labelled dataset."""
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from INANNA_AI.emotion_analysis import predict_emotion_ml
+
+
+def _iter_dataset(root: Path) -> Iterable[Tuple[str, str]]:
+    """Yield ``(path, label)`` pairs from ``root``.
+
+    The directory must contain subdirectories named after emotion labels. Each
+    subdirectory is searched for ``.wav`` files which are associated with the
+    label given by the directory name.
+    """
+
+    for label_dir in root.iterdir():
+        if not label_dir.is_dir():
+            continue
+        label = label_dir.name
+        for wav in label_dir.glob("*.wav"):
+            yield str(wav), label
+
+
+def evaluate_model(model_name: str, data: Iterable[Tuple[str, str]]) -> float:
+    """Return the accuracy for ``model_name`` on ``data``."""
+
+    total = 0
+    correct = 0
+    for path, label in data:
+        total += 1
+        try:
+            probs = predict_emotion_ml(path, model_name)
+            pred = max(probs, key=probs.get)
+        except Exception:
+            pred = None
+        if pred == label:
+            correct += 1
+    return correct / total if total else 0.0
+
+
+def main() -> None:  # pragma: no cover - CLI utility
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Evaluate emotion models")
+    parser.add_argument("dataset", type=Path, help="Path to labelled dataset")
+    parser.add_argument(
+        "--model",
+        dest="models",
+        action="append",
+        default=["m-a-p/MERT-v1-330M-CLAP", "laion/clap-htsat-unfused"],
+        help="Hugging Face model identifiers",
+    )
+    args = parser.parse_args()
+
+    dataset = list(_iter_dataset(args.dataset))
+    for m in args.models:
+        acc = evaluate_model(m, dataset)
+        print(f"{m}: accuracy={acc:.3f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
+

--- a/tests/test_audio_tools.py
+++ b/tests/test_audio_tools.py
@@ -5,7 +5,7 @@ import base64
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from INANNA_AI import stt_whisper, emotion_analysis, voice_evolution, utils
+from INANNA_AI import stt_whisper, emotion_analysis, utils
 from INANNA_AI.listening_engine import _extract_features
 from tests.data.test1_wav_base64 import TEST1_WAV_BASE64
 
@@ -43,6 +43,18 @@ def test_analyze_audio_emotion(tmp_path):
     weight = emotion_analysis.get_emotional_weight()
     assert isinstance(arch, str)
     assert isinstance(weight, float)
+
+
+def test_analyze_audio_emotion_with_ml(tmp_path, monkeypatch):
+    audio_path = _write_audio(tmp_path)
+
+    def fake_predict(path: str, model_name: str | None = None):
+        return {"joy": 0.9, "sad": 0.1}
+
+    monkeypatch.setattr(emotion_analysis, "predict_emotion_ml", fake_predict)
+    info = emotion_analysis.analyze_audio_emotion(str(audio_path), use_ml=True)
+    assert info["emotion"] == "joy"
+    assert set(info["probabilities"]) == {"joy", "sad"}
 
 
 def test_extract_features(tmp_path):
@@ -93,6 +105,8 @@ def test_voice_evolution_updates_from_emotion(tmp_path):
     path = _save_sine(tmp_path, 440.0, 0.8)
     info = emotion_analysis.analyze_audio_emotion(str(path))
     info["sentiment"] = utils.sentiment_score("good")
+    from INANNA_AI import voice_evolution
+
     voice_evolution.update_voice_from_history([info])
     params = voice_evolution.get_voice_params(info["emotion"])
     expected_speed = round(1.0 + (info["arousal"] - 0.5) * 0.4, 3)


### PR DESCRIPTION
## Summary
- add `predict_emotion_ml` using pretrained transformers models for probability-based emotion detection
- allow `analyze_audio_emotion` to optionally use ML predictions and return probabilities
- script to evaluate pretrained emotion models
- tests covering ML classifier pathway

## Testing
- `pytest tests/test_audio_tools.py::test_analyze_audio_emotion tests/test_audio_tools.py::test_analyze_audio_emotion_with_ml -q`
- `PYTHONPATH=. python ml/evaluate_emotion_models.py tmp_dataset --model laion/clap-htsat-unfused --model m-a-p/MERT-v1-95M`


------
https://chatgpt.com/codex/tasks/task_e_68a43e05e680832e93d6753fd2db44bc