### PR TITLE
Add emotion-aware options for music generation and mixing

### DIFF
--- a/audio/mix_tracks.py
+++ b/audio/mix_tracks.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-"""Utility script for mixing audio files."""
+"""Utility script for mixing audio files.
+
+``mix_audio`` analyzes each track to estimate tempo and key and chooses
+transition parameters that can optionally be guided by an ``emotion``.
+"""
 
 import argparse
 from pathlib import Path
 
 import numpy as np
+import yaml
 
 try:  # pragma: no cover - optional dependency
     import soundfile as sf
@@ -13,6 +18,9 @@ except Exception:  # pragma: no cover - optional dependency
     sf = None  # type: ignore
 
 from MUSIC_FOUNDATION.qnl_utils import quantum_embed
+from . import audio_ingestion
+
+EMOTION_MAP = Path(__file__).resolve().parent.parent / "emotion_music_map.yaml"
 
 
 def _load(path: Path) -> tuple[np.ndarray, int]:
@@ -22,20 +30,51 @@ def _load(path: Path) -> tuple[np.ndarray, int]:
     return np.asarray(data, dtype=float), sr
 
 
-def mix_audio(paths: list[Path]) -> tuple[np.ndarray, int]:
+def _load_emotion_map() -> dict:
+    try:
+        with EMOTION_MAP.open("r") as f:
+            return yaml.safe_load(f) or {}
+    except FileNotFoundError:  # pragma: no cover - configuration optional
+        return {}
+
+
+def mix_audio(
+    paths: list[Path], emotion: str | None = None
+) -> tuple[np.ndarray, int, dict[str, float | str | None]]:
+    """Return mixed audio and transition info.
+
+    Tempo and key are estimated for each track. When ``emotion`` is provided,
+    tempo/key from :mod:`emotion_music_map` override the analyzed values.
+    The returned ``info`` dictionary contains the chosen ``tempo`` and ``key``.
+    """
+
     data, sr = _load(paths[0])
     mix = np.zeros_like(data, dtype=float)
+    tempos: list[float] = []
+    keys: list[str | None] = []
     for p in paths:
         d, s = _load(p)
         if s != sr:
             raise ValueError("sample rates differ")
+        tempos.append(audio_ingestion.extract_tempo(d, s))
+        keys.append(audio_ingestion.extract_key(d))
         if d.shape[0] > mix.shape[0]:
             mix = np.pad(mix, (0, d.shape[0] - mix.shape[0]))
         if d.shape[0] < mix.shape[0]:
             d = np.pad(d, (0, mix.shape[0] - d.shape[0]))
         mix += d
     mix /= len(paths)
-    return mix, sr
+
+    tempo = float(np.mean(tempos)) if tempos else 0.0
+    key = keys[0] if keys else None
+
+    if emotion:
+        mapping = _load_emotion_map()
+        emot_info = mapping.get(emotion, {})
+        tempo = float(emot_info.get("tempo", tempo))
+        key = emot_info.get("scale", key)
+
+    return mix, sr, {"tempo": tempo, "key": key}
 
 
 def main(args: list[str] | None = None) -> None:
@@ -45,12 +84,13 @@ def main(args: list[str] | None = None) -> None:
     parser.add_argument("--preview")
     parser.add_argument("--preview-duration", type=float, default=1.0)
     parser.add_argument("--qnl-text")
+    parser.add_argument("--emotion")
     opts = parser.parse_args(args)
 
     if opts.qnl_text:
         quantum_embed(opts.qnl_text)
 
-    mix, sr = mix_audio([Path(f) for f in opts.files])
+    mix, sr, info = mix_audio([Path(f) for f in opts.files], opts.emotion)
     if sf is None:
         raise RuntimeError("soundfile library not installed")
     sf.write(opts.output, mix, sr, subtype="PCM_16")

--- a/music_generation.py
+++ b/music_generation.py
@@ -22,11 +22,25 @@ MODEL_IDS = {
 OUTPUT_DIR = Path(__file__).resolve().parent / "output"
 
 
-def generate_from_text(prompt: str, model: str = "musicgen") -> Path:
-    """Generate audio from ``prompt`` and return the file path."""
+def generate_from_text(
+    prompt: str,
+    model: str = "musicgen",
+    emotion: str | None = None,
+    tempo: int | None = None,
+) -> Path:
+    """Generate audio from ``prompt`` and return the file path.
+
+    ``emotion`` and ``tempo`` are appended to the text prompt when provided so
+    downstream models can adapt the generation.
+    """
     model_id = MODEL_IDS.get(model)
     if not model_id:
         raise ValueError(f"Unsupported model '{model}'")
+
+    if emotion:
+        prompt = f"{prompt} in a {emotion} mood"
+    if tempo:
+        prompt = f"{prompt} at {tempo} BPM"
 
     if hf_pipeline is None:
         raise ImportError("transformers is required for music generation")
@@ -52,8 +66,10 @@ def main(argv: list[str] | None = None) -> None:
         default="musicgen",
         help="Model to use (default: musicgen)",
     )
+    parser.add_argument("--emotion", help="Optional emotion to guide style")
+    parser.add_argument("--tempo", type=int, help="Optional tempo in BPM")
     args = parser.parse_args(argv)
-    path = generate_from_text(args.prompt, args.model)
+    path = generate_from_text(args.prompt, args.model, args.emotion, args.tempo)
     print(path)
 
 

--- a/tests/test_mix_tracks_emotion.py
+++ b/tests/test_mix_tracks_emotion.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import numpy as np
+
+from audio import mix_tracks
+
+
+def test_mix_audio_emotion_guides_tempo(monkeypatch):
+    monkeypatch.setattr(mix_tracks, "_load", lambda p: (np.zeros(10), 44100))
+    monkeypatch.setattr(mix_tracks.audio_ingestion, "extract_tempo", lambda d, s: 100.0)
+    monkeypatch.setattr(mix_tracks.audio_ingestion, "extract_key", lambda d: "C:maj")
+
+    mix, sr, info = mix_tracks.mix_audio([Path("a.wav"), Path("b.wav")], emotion="joy")
+    assert info["tempo"] == 140
+    assert info["key"] == "C_major"
+
+
+def test_mix_audio_averages_analysis(monkeypatch):
+    monkeypatch.setattr(mix_tracks, "_load", lambda p: (np.zeros(10), 44100))
+    tempos = iter([100.0, 120.0])
+    monkeypatch.setattr(
+        mix_tracks.audio_ingestion, "extract_tempo", lambda d, s: next(tempos)
+    )
+    monkeypatch.setattr(mix_tracks.audio_ingestion, "extract_key", lambda d: "C:maj")
+
+    mix, sr, info = mix_tracks.mix_audio([Path("a.wav"), Path("b.wav")])
+    assert info["tempo"] == 110.0
+    assert info["key"] == "C:maj"

--- a/tests/test_music_generation_emotion.py
+++ b/tests/test_music_generation_emotion.py
@@ -1,0 +1,20 @@
+import music_generation
+
+
+def test_generate_from_text_includes_emotion_and_tempo(monkeypatch, tmp_path):
+    captured = {}
+
+    class DummyPipe:
+        def __call__(self, prompt: str):
+            captured["prompt"] = prompt
+            return [{"audio": b"data"}]
+
+    monkeypatch.setattr(music_generation, "hf_pipeline", lambda *_, **__: DummyPipe())
+    monkeypatch.setattr(music_generation, "OUTPUT_DIR", tmp_path)
+
+    path = music_generation.generate_from_text(
+        "melody", emotion="joy", tempo=120
+    )
+    assert "joy" in captured["prompt"]
+    assert "120" in captured["prompt"]
+    assert path.exists()


### PR DESCRIPTION
## Summary
- allow `generate_from_text` to append optional emotion and tempo info to prompts
- analyze track tempo/key in `mix_audio` and let emotion mappings override them
- test that emotion inputs modify generation prompts and mixing tempo/key

## Testing
- `pytest tests/test_music_generation_emotion.py tests/test_mix_tracks_emotion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a455c44d54832ea25cb5027312e2cc