### PR TITLE
Add audio environment setup script and diagnostic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ manually use:
 pip install opencv-python librosa soundfile openai-whisper opensmile
 ```
 
+Run `./scripts/setup_audio_env.sh` to install a pinned set of audio
+dependencies. Verify the environment with:
+
+```bash
+python -m audio.check_env
+```
+
 For a reproducible environment based on the pinned versions, install from the
 lock file:
 

--- a/audio/check_env.py
+++ b/audio/check_env.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Diagnostic CLI to verify audio dependencies are installed."""
+
+import importlib
+import sys
+from typing import Dict, Tuple
+
+REQUIRED_PACKAGES: Dict[str, str] = {
+    "librosa": "librosa",
+    "soundfile": "soundfile",
+    "opensmile": "opensmile",
+    "clap": "clap",
+    "rave": "rave",
+}
+
+
+def check_packages() -> Dict[str, Tuple[bool, str]]:
+    """Attempt to import each required package and return status information."""
+    results: Dict[str, Tuple[bool, str]] = {}
+    for name, module_name in REQUIRED_PACKAGES.items():
+        try:
+            module = importlib.import_module(module_name)
+            version = getattr(module, "__version__", "unknown")
+            results[name] = (True, str(version))
+        except Exception as exc:  # pragma: no cover - diagnostic output
+            results[name] = (False, str(exc))
+    return results
+
+
+def main() -> None:
+    """Print the installation status of required audio packages."""
+    results = check_packages()
+    all_present = True
+    for name, (ok, info) in results.items():
+        if ok:
+            print(f"{name}: {info}")
+        else:
+            all_present = False
+            print(f"{name}: MISSING ({info})")
+    sys.exit(0 if all_present else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_audio_env.sh
+++ b/scripts/setup_audio_env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Install pinned audio dependencies
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+pip install \
+  librosa==0.11.0 \
+  soundfile==0.13.1 \
+  opensmile==2.6.0 \
+  clap==0.7 \
+  rave==1.0.0


### PR DESCRIPTION
## Summary
- add `setup_audio_env.sh` script to install pinned audio packages
- document audio setup and environment check in README
- implement `audio.check_env` module for dependency diagnostics

## Testing
- `python -m audio.check_env` *(fails: No module named 'clap'; No module named 'rave')*
- `pytest tests/test_audio_engine.py::test_play_sound_uses_pydub -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4590f04c8832e987c0beefed1430a