### PR TITLE
Guard optional numpy and scipy in QNL engine

### DIFF
--- a/INANNA_AI_AGENT/inanna_ai.py
+++ b/INANNA_AI_AGENT/inanna_ai.py
@@ -128,6 +128,8 @@ def run_qnl(hex_input: str, wav: str = "qnl_hex_song.wav", json_file: str = "qnl
     from SPIRAL_OS import qnl_engine
 
     phrases, waveform = qnl_engine.hex_to_song(hex_input)
+    if qnl_engine.write is None:
+        raise ImportError("scipy is required to write WAV files; please install scipy.")
     qnl_engine.write(wav, 44100, waveform)
     metadata = qnl_engine.generate_qnl_metadata(phrases)
     Path(json_file).write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")


### PR DESCRIPTION
## Summary
- Allow importing `SPIRAL_OS.qnl_engine` without NumPy/SciPy by catching import errors and using a math fallback
- Raise clear ImportError when waveform generation or song conversion are invoked without NumPy
- Check for SciPy before writing WAV files in `run_qnl`

## Testing
- `pytest 'tests/test_qnl_engine.py::test_*'` *(no tests found: `/workspace/ABZU/tests/test_qnl_engine.py::test_*`)*
- `pytest tests/test_qnl_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68a496c22b54832ea2fba2a8a1c9f916