### PR TITLE
feat: guard config dependency and isolate test modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,3 +21,16 @@ def mock_emotion_state(tmp_path, monkeypatch):
     emotional_state.set_last_emotion("longing")
     emotional_state.set_resonance_level(0.75)
     return state_file
+
+
+# ---------------------------------------------------------------------------
+# Test isolation helpers
+
+
+def pytest_collectstart(collector):
+    """Ensure stubbed ``rag`` modules from other tests do not leak."""
+    sys.modules.pop("rag", None)
+    sys.modules.pop("rag.orchestrator", None)
+    sys.modules.pop("SPIRAL_OS", None)
+    sys.modules.pop("SPIRAL_OS.qnl_engine", None)
+    sys.modules.pop("SPIRAL_OS.symbolic_parser", None)


### PR DESCRIPTION
## Summary
- make `config` resilient to missing `pydantic-settings` by providing a simple fallback that reads environment variables
- reset stubbed modules during test collection to prevent cross-file leakage

## Testing
- `pytest` *(fails: 47 failed, 123 passed, 44 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a31be854832eb4d416c223775647