### PR TITLE
feat: add autonomous dev assistant service

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -41,6 +41,8 @@ file so you don't need to export the variables manually:
 - `GLM_API_KEY` – API key for the GLM service
 - `GLM_SHELL_URL` – URL for the shell service
 - `GLM_SHELL_KEY` – API key for the shell service
+- `PLANNER_MODEL`, `CODER_MODEL`, `REVIEWER_MODEL` – optional per-agent
+  endpoints for the development assistant
 - `DEEPSEEK_URL` – optional endpoint for the DeepSeek servant model
 - `MISTRAL_URL` – optional endpoint for the Mistral servant model
 - `KIMI_K2_URL` – optional endpoint for the Kimi-K2 servant model
@@ -104,19 +106,23 @@ python start_dev_agents.py --objective "Refactor audio engine"
 Launch the long-running watcher:
 
 ```bash
-python start_dev_agents.py --watch --planner-model glm-4.1
+python start_dev_agents.py --watch \
+    --planner-model https://glm.example.com/planner \
+    --coder-model https://glm.example.com/coder \
+    --reviewer-model https://glm.example.com/reviewer
 ```
 
 The watcher monitors `logs/dev_agent.log` for failing tests and schedules
 `run_dev_cycle` with the objective "repair failing tests" when failures appear.
-Suggestions from each cycle are written to the log. Stop the watcher with:
+Suggestions from each cycle are written to the log for operator review. Stop the watcher with:
 
 ```bash
 python start_dev_agents.py --stop
 ```
 
-Set `--planner-model` or the `PLANNER_MODEL` environment variable to choose the
-model endpoint.
+Set `--planner-model`, `--coder-model` or `--reviewer-model` to point each agent
+at a specific model endpoint. These values override the `PLANNER_MODEL`,
+`CODER_MODEL` and `REVIEWER_MODEL` environment variables when provided.
 
 ## Examples
 

--- a/start_dev_agents.py
+++ b/start_dev_agents.py
@@ -32,7 +32,13 @@ def main() -> int:
         "--stop", action="store_true", help="Signal a running watcher to stop"
     )
     parser.add_argument(
-        "--planner-model", help="LLM or endpoint used by the planner agent"
+        "--planner-model", help="Endpoint used by the planner agent"
+    )
+    parser.add_argument(
+        "--coder-model", help="Endpoint used by the coder agent",
+    )
+    parser.add_argument(
+        "--reviewer-model", help="Endpoint used by the reviewer agent",
     )
     parser.add_argument(
         "--log-path", default="logs/dev_agent.log", help="Log file monitored"
@@ -42,6 +48,10 @@ def main() -> int:
     load_env(Path("secrets.env"))
     if args.planner_model:
         os.environ["PLANNER_MODEL"] = args.planner_model
+    if args.coder_model:
+        os.environ["CODER_MODEL"] = args.coder_model
+    if args.reviewer_model:
+        os.environ["REVIEWER_MODEL"] = args.reviewer_model
 
     log_path = Path(args.log_path)
     log_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- extend dev orchestrator with long-running assistant that monitors logs and posts suggestions
- allow per-agent model endpoints via environment variables and CLI flags
- document automated fix workflow for operators

## Testing
- `pytest -q` *(fails: 149 failed, 285 passed, 120 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ac678ba4832ead0658fa27e038c7