### PR TITLE
React to music features and real-time style cues

### DIFF
--- a/guides/visual_customization.md
+++ b/guides/visual_customization.md
@@ -32,3 +32,25 @@ sigil = "spiral"
 
 Save the file after editing and restart any running scripts to apply the new
 traits.
+
+## 4. Asset requirements
+
+The avatar pipeline expects a small set of support assets:
+
+- **Skins and overlays** – additional PNG images or CSS classes can be
+  referenced from `avatar_config.toml` under the `skins` table. Place image
+  files alongside your model in `INANNA_AI/AVATAR/`.
+- **Style cues** – real‑time style changes sent by the language model or audio
+  mixer are mapped to CSS classes named `style-<cue>` in the web console. Add
+  matching rules to your console stylesheet or provide overlay images.
+- **Audio hooks** – when streaming audio with `stream_avatar_audio` the engine
+  analyses tempo and intensity to drive mouth motion and visual bars. Ensure
+  the WAV file is available on disk before starting playback.
+
+## 5. Real‑time configuration
+
+`video_stream.AvatarVideoTrack` accepts an optional `asyncio.Queue[str]` of
+style cues. Push short tokens such as `"glitch"` or `"calm"` to the queue to
+change the avatar's appearance while streaming. The web console listens for
+these cues over the WebRTC data channel and updates the video element's CSS
+class accordingly.

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -15,6 +15,19 @@ const GLYPHS = {
     neutral: '🌀'
 };
 
+function applyStyle(style) {
+    const video = document.getElementById('avatar');
+    let overlay = document.getElementById('style-indicator');
+    if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.id = 'style-indicator';
+        overlay.style.marginTop = '0.5rem';
+        video.insertAdjacentElement('afterend', overlay);
+    }
+    overlay.textContent = style ? `Style: ${style}` : '';
+    video.className = style ? `style-${style}` : '';
+}
+
 document.getElementById('send-btn').addEventListener('click', sendCommand);
 document.getElementById('command-input').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
@@ -40,6 +53,9 @@ function sendCommand() {
             const emotion = data.emotion || 'neutral';
             document.getElementById('emotion').textContent = emotion;
             document.getElementById('glyph').textContent = GLYPHS[emotion] || GLYPHS.neutral;
+            if (data.style) {
+                applyStyle(data.style);
+            }
         })
         .catch((err) => {
             document.getElementById('output').textContent = 'Error: ' + err;
@@ -67,7 +83,17 @@ async function startStream() {
 
     pc.ondatachannel = (ev) => {
         ev.channel.onmessage = (msg) => {
-            document.getElementById('transcript').textContent = msg.data;
+            try {
+                const payload = JSON.parse(msg.data);
+                if (payload.transcript) {
+                    document.getElementById('transcript').textContent = payload.transcript;
+                }
+                if (payload.style) {
+                    applyStyle(payload.style);
+                }
+            } catch (e) {
+                document.getElementById('transcript').textContent = msg.data;
+            }
         };
     };
 


### PR DESCRIPTION
## Summary
- react to tempo and intensity when streaming avatar audio
- allow avatar video track to consume real-time style cues
- show and document avatar style changes in the web console

## Testing
- `pytest` *(fails: soundfile.LibsndfileError: Error opening '/tmp/pytest-of-root/pyte...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b6017590832e9fda9f652e5207a0