### PR TITLE
Handle optional vector memory and invocation engine

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from typing import Any, Iterable, List, Dict
 
 import feedback_logging
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 
 INSIGHT_FILE = Path("insight_matrix.json")
 
@@ -69,6 +74,8 @@ def build_dataset(feedback: Iterable[dict]) -> list[dict]:
 
 
 def _load_vector_logs() -> List[Dict[str, Any]]:
+    if vector_memory is None:
+        return []
     if not vector_memory.LOG_FILE.exists():
         return []
     entries = []

--- a/crown_decider.py
+++ b/crown_decider.py
@@ -9,7 +9,12 @@ from task_profiling import classify_task
 import servant_model_manager as smm
 from INANNA_AI import emotional_memory
 import emotional_state
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 import voice_aura
 
 import config
@@ -91,9 +96,12 @@ def recommend_llm(task_type: str, emotion: str) -> str:
 def decide_expression_options(emotion: str) -> Dict[str, Any]:
     """Return TTS backend, avatar style and aura amount."""
     soul = (emotional_state.get_soul_state() or "").lower()
-    try:
-        history = vector_memory.query_vectors(filter={"type": "emotion"}, limit=10)
-    except Exception:
+    if vector_memory is not None:
+        try:
+            history = vector_memory.query_vectors(filter={"type": "emotion"}, limit=10)
+        except Exception:
+            history = []
+    else:
         history = []
 
     valences = [float(h.get("valence", 0.5)) for h in history if h.get("valence") is not None]

--- a/crown_router.py
+++ b/crown_router.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Dict
 
 import emotional_state
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 
 from rag.orchestrator import MoGEOrchestrator
 from crown_decider import decide_expression_options
@@ -54,13 +59,16 @@ def route_decision(
     opts = decide_expression_options(emotion)
 
     soul = emotional_state.get_soul_state()
-    try:
-        records = vector_memory.search(
-            "",
-            filter={"type": "expression_decision", "emotion": emotion},
-            k=20,
-        )
-    except Exception:
+    if vector_memory is not None:
+        try:
+            records = vector_memory.search(
+                "",
+                filter={"type": "expression_decision", "emotion": emotion},
+                k=20,
+            )
+        except Exception:
+            records = []
+    else:
         records = []
 
     backend_weights: Dict[str, float] = {opts.get("tts_backend", ""): 1.0}

--- a/init_crown_agent.py
+++ b/init_crown_agent.py
@@ -10,7 +10,12 @@ import yaml
 
 from INANNA_AI.glm_integration import GLMIntegration
 from INANNA_AI import glm_integration as gi
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 from INANNA_AI import corpus_memory
 import servant_model_manager as smm
 try:  # pragma: no cover - optional dependency
@@ -70,11 +75,14 @@ def _init_memory(cfg: dict) -> None:
 
         os.environ["VECTOR_DB_PATH"] = str(vec_path)
         logger.info("initializing vector memory at %s", vec_path)
-        try:
-            vector_memory._get_collection()
-            logger.info("Vector memory loaded from %s", vec_path)
-        except Exception as exc:  # pragma: no cover - optional deps
-            logger.warning("Vector memory unavailable: %s", exc)
+        if vector_memory is not None:
+            try:
+                vector_memory._get_collection()
+                logger.info("Vector memory loaded from %s", vec_path)
+            except Exception as exc:  # pragma: no cover - optional deps
+                logger.warning("Vector memory unavailable: %s", exc)
+        else:  # pragma: no cover - optional dependency missing
+            logger.warning("Vector memory module missing; related features disabled")
 
         corpus_memory.CHROMA_DIR = corpus_path
         logger.info("initializing corpus memory at %s", corpus_path)

--- a/invocation_engine.py
+++ b/invocation_engine.py
@@ -8,7 +8,12 @@ import logging
 from pathlib import Path
 import re
 
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 
 if TYPE_CHECKING:  # pragma: no cover - avoid circular import at runtime
     from rag.orchestrator import MoGEOrchestrator

--- a/ml/archetype_cluster.py
+++ b/ml/archetype_cluster.py
@@ -13,7 +13,12 @@ import numpy as np
 from sklearn.cluster import KMeans
 
 from MUSIC_FOUNDATION import qnl_utils
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 
 _OUTPUT_PATH = Path(__file__).resolve().parents[1] / "data" / "archetype_clusters.json"
 
@@ -24,6 +29,8 @@ def _tokenize(text: str) -> Iterable[str]:
 
 def cluster_vectors(k: int = 5, limit: int = 100) -> list[dict[str, Any]]:
     """Cluster recent vectors and return summary data."""
+    if vector_memory is None:
+        return []
     records = vector_memory.query_vectors(limit=limit)
     if not records:
         return []

--- a/rag/engine.py
+++ b/rag/engine.py
@@ -6,7 +6,11 @@ from typing import Any, Dict, List, Optional
 import argparse
 import importlib.util
 
-from vector_memory import search as vm_search
+try:  # pragma: no cover - optional dependency
+    from vector_memory import search as vm_search  # type: ignore[assignment]
+except ImportError:  # pragma: no cover - optional dependency
+    vm_search = None  # type: ignore[assignment]
+"""Optional vector memory search function; ``None`` if unavailable."""
 _HAYSTACK_AVAILABLE = importlib.util.find_spec("haystack") is not None
 _LLAMA_AVAILABLE = importlib.util.find_spec("llama_index") is not None or importlib.util.find_spec("llamaindex") is not None
 
@@ -40,6 +44,8 @@ def _get_score(item: Any) -> float:
 
 def query(text: str, filters: Optional[Dict[str, Any]] = None, *, top_n: int = 5) -> List[Any]:
     """Return ranked snippets for ``text``."""
+    if vm_search is None:
+        return []
     res = vm_search(text, filter=filters, k=top_n)
     items = [_make_item(r.get("text", ""), r, r.get("score", 0.0)) for r in res]
     items.sort(key=_get_score, reverse=True)

--- a/recursive_emotion_router.py
+++ b/recursive_emotion_router.py
@@ -6,7 +6,12 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, Iterable, Protocol
 import json
 
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 import cortex_memory
 import cortex_sigil_logic
 
@@ -68,9 +73,10 @@ def _cycle(node: SpiralNode) -> Dict[str, Any]:
             triggers = cortex_sigil_logic.interpret_sigils(text)
             if triggers:
                 decision["sigil_triggers"] = triggers
-        vector_memory.add_vector(
-            _state_text(node), {"type": "spiral_step", "stage": stage}
-        )
+        if vector_memory is not None:
+            vector_memory.add_vector(
+                _state_text(node), {"type": "spiral_step", "stage": stage}
+            )
     return decision or {}
 
 

--- a/scripts/ingest_music_books.py
+++ b/scripts/ingest_music_books.py
@@ -6,7 +6,12 @@ import argparse
 from pathlib import Path
 from typing import List, Dict
 
-import vector_memory
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except ImportError:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+vector_memory = _vector_memory
+"""Optional vector memory subsystem; ``None`` if unavailable."""
 
 try:  # pragma: no cover - optional dependency
     from unstructured.partition.text import partition_text
@@ -48,6 +53,8 @@ def _chunk(text: str, max_words: int = 200) -> List[str]:
 
 
 def ingest(path: Path, metadata: Dict[str, str]) -> None:
+    if vector_memory is None:
+        raise RuntimeError("vector_memory module not available")
     ext = path.suffix.lower()
     if ext == ".pdf":
         text = _read_pdf(path)

--- a/tools/reflection_loop.py
+++ b/tools/reflection_loop.py
@@ -16,7 +16,12 @@ except Exception:  # pragma: no cover - optional dependency
 import numpy as np
 
 from core import video_engine, self_correction_engine
-from invocation_engine import invoke_ritual
+try:  # pragma: no cover - optional dependency
+    from invocation_engine import invoke_ritual as _invoke_ritual
+except ImportError:  # pragma: no cover - optional dependency
+    _invoke_ritual = None  # type: ignore[assignment]
+invoke_ritual = _invoke_ritual
+"""Optional ritual invocation; ``None`` if invocation engine is unavailable."""
 from corpus_memory_logging import log_ritual_result
 import emotional_state
 from INANNA_AI import adaptive_learning
@@ -74,7 +79,7 @@ def run_reflection_loop(iterations: int = 10) -> None:
         if detected == "citrinitas":
             citrinitas_count += 1
             tol = thresholds.get("citrinitas", thresholds.get("default", 0.0))
-            if citrinitas_count > tol:
+            if citrinitas_count > tol and invoke_ritual is not None:
                 steps = invoke_ritual("citrinitas_rite")
                 log_ritual_result("citrinitas_rite", steps)
                 citrinitas_count = 0


### PR DESCRIPTION
## Summary
- Guard `vector_memory` and `invocation_engine` imports across the project, setting them to `None` when unavailable
- Add checks around vector memory and invocation engine usage so related features are skipped when modules are missing
- Document disabled functionality when optional subsystems are absent

## Testing
- `pytest` *(fails: soundfile.LibsndfileError: Error opening '/tmp/pytest-of-root/pytest-0/test_embed_extract0/input.wav', AttributeError: 'types.SimpleNamespace' object has no attribute 'sample_rate', AssertionError: assert 'gtts.wav' == 'coqui.wav', TypeError: 'str' object is not callable, AttributeError: <module 'video_stream'> has no attribute 'offer', AttributeError: <module 'INANNA_AI.corpus_memory' has no attribute 'search'>, AssertionError: assert [] == ['aaa', 'aaaa'], assert np.False_, AttributeError: <module 'video_stream'> has no attribute 'offer', AttributeError: module 'video_stream' has no attribute 'video_track', AttributeError: module 'video_stream' has no attribute 'AvatarAudioStream', AttributeError: <module 'video_stream'> has no attribute 'offer', AttributeError: <module 'video_stream'> has no attribute 'video_track', AttributeError: module 'video_stream' has no attribute 'AvatarAudioStream', NameError: name 'inanna_ai' is not defined, AttributeError: module 'INANNA_AI' has no attribute '__path__', AttributeError: module 'INANNA_AI' has no attribute '__path__', KeyError: 'rvc', AttributeError: 'DummyPC' object has no attribute 'createDataChannel', AttributeError: 'DummyPC' object has no attribute 'createDataChannel', assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68a593d09c9c832ebabbb8a186c5b187