### PR TITLE
Guard audio utilities against missing ffmpeg

### DIFF
--- a/audio/dsp_engine.py
+++ b/audio/dsp_engine.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Tuple
 import subprocess
 import tempfile
+import shutil
 
 import numpy as np
 
@@ -36,8 +37,15 @@ except Exception:  # pragma: no cover - optional dependency
 # ffmpeg based helpers
 # ---------------------------------------------------------------------------
 
+def _has_ffmpeg() -> bool:
+    """Return ``True`` when ``ffmpeg`` is available on the system path."""
+    return shutil.which("ffmpeg") is not None
+
+
 def _apply_ffmpeg_filter(data: np.ndarray, sr: int, filters: str) -> Tuple[np.ndarray, int]:
     """Run ``filters`` on ``data`` using ``ffmpeg``."""
+    if not _has_ffmpeg():
+        raise RuntimeError("ffmpeg not installed")
     if sf is None:
         raise RuntimeError("soundfile library not installed")
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as inp:

--- a/audio/engine.py
+++ b/audio/engine.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 from io import BytesIO
 import base64
+import shutil
 
 import numpy as np
 
@@ -35,6 +36,11 @@ except Exception:  # pragma: no cover - optional dependency
     _play_with_simpleaudio = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+def _has_ffmpeg() -> bool:
+    """Return ``True`` when ``ffmpeg`` is available on the system path."""
+    return shutil.which("ffmpeg") is not None
 
 _loops: list[Thread] = []
 _playbacks: list[Any] = []
@@ -101,6 +107,9 @@ def play_sound(path: Path, loop: bool = False, *, loops: int | None = None) -> N
     """
     if AudioSegment is None or _play_with_simpleaudio is None:
         logger.warning("pydub not installed; cannot play audio")
+        return
+    if not _has_ffmpeg():
+        logger.warning("ffmpeg not installed; cannot play audio")
         return
     audio = AudioSegment.from_file(path)
     if loop:

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -30,6 +30,7 @@ def test_play_sound_uses_pydub(monkeypatch, tmp_path):
 
     monkeypatch.setattr(audio_engine, 'AudioSegment', types.SimpleNamespace(from_file=dummy_from_file))
     monkeypatch.setattr(audio_engine, '_play_with_simpleaudio', dummy_play)
+    monkeypatch.setattr(audio_engine, '_has_ffmpeg', lambda: True)
 
     audio_engine.play_sound(tmp_path / 'x.wav')
 


### PR DESCRIPTION
## Summary
- check for ffmpeg before loading audio in `audio.engine.play_sound`
- verify ffmpeg availability in `audio.dsp_engine._apply_ffmpeg_filter`
- patch tests to bypass ffmpeg check

## Testing
- `pytest tests/test_audio_engine.py tests/test_dsp_engine.py tests/test_full_audio_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5c0325cf4832ebed93d1312be7e39