### PR TITLE
Document SERVANT_MODELS variable

### DIFF
--- a/config/INANNA_CORE.yaml
+++ b/config/INANNA_CORE.yaml
@@ -7,6 +7,7 @@
 #   DEEPSEEK_URL  -> servant_models.deepseek
 #   MISTRAL_URL   -> servant_models.mistral
 #   KIMI_K2_URL   -> servant_models.kimi_k2
+#   SERVANT_MODELS -> servant_models
 
 glm_api_url: https://glm.example.com/glm41v_9b
 glm_api_key: your-api-key

--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -24,6 +24,8 @@ Copy `secrets.env.template` to `secrets.env` and fill out the variables required
 - `VOICE_CONFIG_PATH` – override path to `voice_config.yaml`
 - `EMOTION_STATE_PATH` – file used to persist emotion state
 - `KIMI_K2_URL` – optional Kimi-K2 servant endpoint
+- `SERVANT_MODELS` – optional comma-separated list of servant model endpoints
+  (e.g. `deepseek=http://localhost:8002,mistral=http://localhost:8003`)
 - `LLM_ROTATION_PERIOD` – rotation period for active models
 - `LLM_MAX_FAILURES` – allowed failures before rotation
 - `ARCHETYPE_STATE` – starting archetype layer

--- a/docs/deployment_overview.md
+++ b/docs/deployment_overview.md
@@ -10,6 +10,8 @@ Copy `secrets.env.template` to `secrets.env` and provide values for the required
 - `OPENAI_API_KEY` – optional OpenAI key
 - `GLM_API_URL` / `GLM_API_KEY` – GLM service endpoint and key
 - `GLM_SHELL_URL` / `GLM_SHELL_KEY` – shell service endpoint and key
+- `SERVANT_MODELS` – optional comma‑separated list of servant model endpoints
+  (e.g. `deepseek=http://localhost:8002,mistral=http://localhost:8003`)
 
 See `secrets.env.template` for the full list.
 

--- a/init_crown_agent.py
+++ b/init_crown_agent.py
@@ -48,6 +48,18 @@ def _load_config() -> dict:
             logger.info("%s loaded from env %s", key, env)
 
     servant = cfg.get("servant_models", {})
+    env_servants = os.getenv("SERVANT_MODELS")
+    if env_servants:
+        for item in env_servants.split(","):
+            name, _, url = item.partition("=")
+            if name and url:
+                servant[name.strip()] = url.strip()
+        if servant:
+            cfg["servant_models"] = servant
+            logger.info(
+                "servant models loaded from SERVANT_MODELS: %s",
+                ", ".join(servant),
+            )
     for name, env in (
         ("deepseek", "DEEPSEEK_URL"),
         ("mistral", "MISTRAL_URL"),

--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -15,6 +15,11 @@ else
     exit 1
 fi
 
+if [ -z "${SERVANT_MODELS:-}" ]; then
+    echo "SERVANT_MODELS is not set. Example:" >&2
+    echo "  export SERVANT_MODELS=\"deepseek=http://localhost:8002,mistral=http://localhost:8003\"" >&2
+fi
+
 launch_model() {
     local name="$1"
     local url="$2"

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -18,6 +18,7 @@ RETRAIN_THRESHOLD=0.8
 VOICE_CONFIG_PATH=voice_config.yaml
 EMOTION_STATE_PATH=emotional_state.yaml
 KIMI_K2_URL=http://localhost:9000
+SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3
 ARCHETYPE_STATE=ALBEDO


### PR DESCRIPTION
## Summary
- document `SERVANT_MODELS` env variable across deployment docs and sample secrets
- warn in `launch_servants.sh` when `SERVANT_MODELS` is missing
- support `SERVANT_MODELS` parsing during crown initialization and add regression test

## Testing
- `pytest` *(fails: 58 failed, 140 passed)*
- `pytest tests/test_crown_servant_registration.py::test_servant_models_env -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f7caac68832eb309d36c26bfaadd