### PR TITLE
feat(memory): add symbol mapping wrappers

### DIFF
--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -15,7 +15,7 @@ from state_transition_engine import StateTransitionEngine
 
 from core.memory_physical import PhysicalEvent, store_physical_event
 from memory_mental import record_task_flow
-from memory_spiritual import set_event_symbol
+from memory_spiritual import map_to_symbol
 from memory_sacred import generate_sacred_glyph
 from spiral_memory import REGISTRY_DB, spiral_recall
 
@@ -129,7 +129,7 @@ def crown_prompt_orchestrator(message: str, glm: GLMIntegration) -> Dict[str, An
     ]
     symbol = symbols[abs(hash(message)) % len(symbols)]
     try:
-        set_event_symbol(message, symbol)
+        map_to_symbol((message, symbol))
     except Exception:
         logging.exception("symbol mapping failed")
 

--- a/memory_spiritual.py
+++ b/memory_spiritual.py
@@ -3,6 +3,11 @@
 On import the module ensures ``data/ontology.db`` exists, creating it from
 ``data/ontology_schema.sql`` if necessary. This keeps the ontology database
 out of version control while providing a lightweight persistent mapping.
+
+Legacy helpers :func:`set_event_symbol` and :func:`get_event_symbol` are kept
+for backward compatibility. The specification-aligned names are
+``map_to_symbol`` for storing mappings and ``lookup_symbol_history`` for
+querying the reverse direction.
 """
 
 from __future__ import annotations
@@ -50,7 +55,10 @@ def get_connection(db_path: Path | str = DB_PATH) -> sqlite3.Connection:
 def set_event_symbol(
     event: str, symbol: str, conn: Optional[sqlite3.Connection] = None
 ) -> None:
-    """Store or update the symbol associated with ``event``."""
+    """Legacy name for storing the symbol associated with ``event``.
+
+    The specification refers to this operation as :func:`map_to_symbol`.
+    """
 
     analyze_phonetic(event)
     analyze_semantic(symbol)
@@ -68,10 +76,37 @@ def set_event_symbol(
             conn.close()
 
 
+def map_to_symbol(
+    event_metadata: tuple[str, str] | dict[str, str],
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """Spec-aligned wrapper around :func:`set_event_symbol`.
+
+    Parameters
+    ----------
+    event_metadata:
+        Either a ``(event, symbol)`` tuple or a mapping with ``"event"`` and
+        ``"symbol"`` keys.
+    conn:
+        Optional SQLite connection to use.
+    """
+
+    if isinstance(event_metadata, dict):
+        event = event_metadata["event"]
+        symbol = event_metadata["symbol"]
+    else:
+        event, symbol = event_metadata
+    set_event_symbol(event, symbol, conn=conn)
+
+
 def get_event_symbol(
     event: str, conn: Optional[sqlite3.Connection] = None
 ) -> Optional[str]:
-    """Return the symbol associated with ``event`` or ``None``."""
+    """Legacy lookup returning the symbol associated with ``event``.
+
+    This direction is retained for backward compatibility; the specification
+    adds :func:`lookup_symbol_history` for reverse queries.
+    """
 
     analyze_phonetic(event)
     analyze_semantic(event)
@@ -89,6 +124,29 @@ def get_event_symbol(
             conn.close()
 
 
+def lookup_symbol_history(
+    symbol: str, conn: Optional[sqlite3.Connection] = None
+) -> list[str]:
+    """Return all events previously mapped to ``symbol``.
+
+    This is the specification-aligned inverse of :func:`get_event_symbol`.
+    """
+
+    analyze_phonetic(symbol)
+    analyze_semantic(symbol)
+    analyze_ritual(symbol)
+    own_conn = conn is None
+    conn = conn or get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT event FROM event_symbol WHERE symbol = ?", (symbol,)
+        )
+        return [row[0] for row in cur.fetchall()]
+    finally:
+        if own_conn:
+            conn.close()
+
+
 # Ensure DB exists when module is imported
 _ensure_db_file()
 
@@ -96,7 +154,9 @@ _ensure_db_file()
 __all__ = [
     "get_connection",
     "set_event_symbol",
+    "map_to_symbol",
     "get_event_symbol",
+    "lookup_symbol_history",
     "DB_PATH",
     "SCHEMA_PATH",
 ]

--- a/tests/test_memory_spiritual.py
+++ b/tests/test_memory_spiritual.py
@@ -2,8 +2,9 @@
 
 from memory_spiritual import (
     get_connection,
-    set_event_symbol,
+    map_to_symbol,
     get_event_symbol,
+    lookup_symbol_history,
 )
 
 
@@ -22,7 +23,8 @@ def test_event_symbol_roundtrip():
     """Storing and retrieving a symbol works with in-memory DB."""
 
     conn = get_connection(":memory:")
-    set_event_symbol("rain", "☔", conn=conn)
+    map_to_symbol(("rain", "☔"), conn=conn)
     assert get_event_symbol("rain", conn=conn) == "☔"
+    assert lookup_symbol_history("☔", conn=conn) == ["rain"]
     conn.close()
 


### PR DESCRIPTION
## Summary
- add spec-aligned `map_to_symbol` and `lookup_symbol_history` helpers in spiritual memory layer
- switch Crown prompt orchestrator to use new `map_to_symbol` name
- expand spiritual memory tests for reverse symbol lookups

## Testing
- `pytest tests/test_memory_spiritual.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60d1ee5a0832eac3231407da5c3b1