### PR TITLE
Add secrets env template reference and startup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ The manual steps are outlined below.
    `OPENAI_API_KEY`, `GLM_API_URL`, `GLM_API_KEY`, `GLM_SHELL_URL`,
    `GLM_SHELL_KEY`, `REFLECTION_INTERVAL`, `CORPUS_PATH`,
    `QNL_EMBED_MODEL`, `QNL_MODEL_PATH`, `EMBED_MODEL_PATH`, `VOICE_TONE_PATH`,
-   `VECTOR_DB_PATH`, `WEB_CONSOLE_API_URL` (`QNL_EMBED_MODEL` is the
+   `VECTOR_DB_PATH`, `WEB_CONSOLE_API_URL`, `KIMI_K2_URL`,
+   `SERVANT_MODELS` (`QNL_EMBED_MODEL` is the
    SentenceTransformer used for QNL embeddings). `VECTOR_DB_PATH`
    points to the ChromaDB directory used for document storage.
   `WEB_CONSOLE_API_URL` points the web console at the FastAPI endpoint. Set it
   to the base URL such as `http://localhost:8000/glm-command` – the operator
   console automatically strips the trailing path when establishing WebRTC and
-  REST connections.
+  REST connections. See `secrets.env.template` for the full list.
 2. Download the required model weights before first launch:
 
    ```bash

--- a/crown_model_launcher.sh
+++ b/crown_model_launcher.sh
@@ -11,7 +11,7 @@ if [ -f "secrets.env" ]; then
     source "secrets.env"
     set +a
 else
-    echo "secrets.env not found. Copy secrets.env.template to secrets.env and provide your values." >&2
+    echo "secrets.env not found. Copy secrets.env.template to secrets.env and provide your API keys and URLs." >&2
     exit 1
 fi
 

--- a/secrets.env
+++ b/secrets.env
@@ -18,6 +18,7 @@ RETRAIN_THRESHOLD=0.8
 VOICE_CONFIG_PATH=voice_config.yaml
 EMOTION_STATE_PATH=emotional_state.yaml
 KIMI_K2_URL=http://localhost:9000
+SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3
 ARCHETYPE_STATE=ALBEDO

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -18,6 +18,7 @@ RETRAIN_THRESHOLD=0.8
 VOICE_CONFIG_PATH=voice_config.yaml
 EMOTION_STATE_PATH=emotional_state.yaml
 KIMI_K2_URL=http://localhost:9000
+# Optional comma-separated list of servant model endpoints
 SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3


### PR DESCRIPTION
## Summary
- document `SERVANT_MODELS` in setup instructions and point to `secrets.env.template`
- include example `SERVANT_MODELS` in `secrets.env` and template
- clarify `crown_model_launcher.sh` error when `secrets.env` is missing

## Testing
- `pytest -q --maxfail=1`
- `pytest tests/test_crown_servant_registration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60fbbd374832e9f72e4693080d11b