### PR TITLE
Check GLM health before starting console

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,5 @@ librosa==0.11.0
 soundfile==0.13.1
 openai-whisper==20231117
 opensmile==2.5.1
+chromadb==1.0.17
+ffmpeg-python==0.2.0


### PR DESCRIPTION
## Summary
- add chromadb and ffmpeg-python to development requirements
- poll GLM `/health` before launching the console and guide users if unreachable

## Testing
- `pytest` *(fails: soundfile.LibsndfileError, AttributeError, AssertionError, TypeError, KeyError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6167d7d78832ebab6bdc1eb1bd19b