### PR TITLE
Document SERVANT_MODELS env variable and servant model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,20 @@ The manual steps are outlined below.
    `GLM_SHELL_KEY`, `REFLECTION_INTERVAL`, `CORPUS_PATH`,
    `QNL_EMBED_MODEL`, `QNL_MODEL_PATH`, `EMBED_MODEL_PATH`, `VOICE_TONE_PATH`,
    `VECTOR_DB_PATH`, `WEB_CONSOLE_API_URL`, `KIMI_K2_URL`,
-   `SERVANT_MODELS` (`QNL_EMBED_MODEL` is the
-   SentenceTransformer used for QNL embeddings). `VECTOR_DB_PATH`
+   `SERVANT_MODELS` (e.g. `deepseek=http://localhost:8002,mistral=http://localhost:8003`;
+   `QNL_EMBED_MODEL` is the SentenceTransformer used for QNL embeddings). `VECTOR_DB_PATH`
    points to the ChromaDB directory used for document storage.
   `WEB_CONSOLE_API_URL` points the web console at the FastAPI endpoint. Set it
   to the base URL such as `http://localhost:8000/glm-command` – the operator
   console automatically strips the trailing path when establishing WebRTC and
-  REST connections. See `secrets.env.template` for the full list.
+  REST connections. See `secrets.env.template` for the full list. To enable
+  local servant models during development, you can use:
+
+  ```bash
+  export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
+  export DEEPSEEK_URL=http://localhost:8002
+  export MISTRAL_URL=http://localhost:8003
+  ```
 2. Download the required model weights before first launch:
 
    ```bash

--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -24,8 +24,14 @@ Copy `secrets.env.template` to `secrets.env` and fill out the variables required
 - `VOICE_CONFIG_PATH` – override path to `voice_config.yaml`
 - `EMOTION_STATE_PATH` – file used to persist emotion state
 - `KIMI_K2_URL` – optional Kimi-K2 servant endpoint
-- `SERVANT_MODELS` – optional comma-separated list of servant model endpoints
-  (e.g. `deepseek=http://localhost:8002,mistral=http://localhost:8003`)
+- `SERVANT_MODELS` – optional comma-separated list of servant model endpoints,
+  written as `name=url`. To start local servants, set for example:
+
+  ```bash
+  export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
+  export DEEPSEEK_URL=http://localhost:8002
+  export MISTRAL_URL=http://localhost:8003
+  ```
 - `LLM_ROTATION_PERIOD` – rotation period for active models
 - `LLM_MAX_FAILURES` – allowed failures before rotation
 - `ARCHETYPE_STATE` – starting archetype layer

--- a/docs/deployment_overview.md
+++ b/docs/deployment_overview.md
@@ -10,8 +10,14 @@ Copy `secrets.env.template` to `secrets.env` and provide values for the required
 - `OPENAI_API_KEY` – optional OpenAI key
 - `GLM_API_URL` / `GLM_API_KEY` – GLM service endpoint and key
 - `GLM_SHELL_URL` / `GLM_SHELL_KEY` – shell service endpoint and key
-- `SERVANT_MODELS` – optional comma‑separated list of servant model endpoints
-  (e.g. `deepseek=http://localhost:8002,mistral=http://localhost:8003`)
+- `SERVANT_MODELS` – optional comma‑separated list of servant model endpoints,
+  written as `name=url`. To launch local servants, set for example:
+
+  ```bash
+  export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
+  export DEEPSEEK_URL=http://localhost:8002
+  export MISTRAL_URL=http://localhost:8003
+  ```
 
 See `secrets.env.template` for the full list.
 

--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -16,7 +16,8 @@ else
 fi
 
 if [ -z "${SERVANT_MODELS:-}" ]; then
-    echo "SERVANT_MODELS is not set. Example:" >&2
+    echo "Warning: SERVANT_MODELS is not set; no servant models will be launched." >&2
+    echo "Set it before running, for example:" >&2
     echo "  export SERVANT_MODELS=\"deepseek=http://localhost:8002,mistral=http://localhost:8003\"" >&2
 fi
 

--- a/secrets.env
+++ b/secrets.env
@@ -17,7 +17,9 @@ VECTOR_DB_PATH=./vector_db
 RETRAIN_THRESHOLD=0.8
 VOICE_CONFIG_PATH=voice_config.yaml
 EMOTION_STATE_PATH=emotional_state.yaml
-KIMI_K2_URL=http://localhost:9000
+DEEPSEEK_URL=http://localhost:8002
+MISTRAL_URL=http://localhost:8003
+KIMI_K2_URL=http://localhost:8010
 SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -17,7 +17,9 @@ VECTOR_DB_PATH=./vector_db
 RETRAIN_THRESHOLD=0.8
 VOICE_CONFIG_PATH=voice_config.yaml
 EMOTION_STATE_PATH=emotional_state.yaml
-KIMI_K2_URL=http://localhost:9000
+DEEPSEEK_URL=http://localhost:8002
+MISTRAL_URL=http://localhost:8003
+KIMI_K2_URL=http://localhost:8010
 # Optional comma-separated list of servant model endpoints
 SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300


### PR DESCRIPTION
## Summary
- document SERVANT_MODELS in deployment docs and README with example settings
- warn in launch_servants.sh when SERVANT_MODELS is unset
- provide sample servant model configuration in secrets template

## Testing
- `pytest tests/test_crown_servant_registration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a61a5b6850832e9c2a2304690f16f9