### PR TITLE
Add secrets template and env guidance

### DIFF
--- a/crown_model_launcher.sh
+++ b/crown_model_launcher.sh
@@ -11,7 +11,7 @@ if [ -f "secrets.env" ]; then
     source "secrets.env"
     set +a
 else
-    echo "secrets.env not found. Copy secrets.env.template to secrets.env and provide your API keys and URLs." >&2
+    echo "secrets.env not found. Create it by copying secrets.env.template: cp secrets.env.template secrets.env, then edit it with your API keys and URLs." >&2
     exit 1
 fi
 

--- a/secrets.env
+++ b/secrets.env
@@ -1,4 +1,6 @@
 # Environment variables for local development
+# Copy from secrets.env.template and replace placeholder values before use.
+# Do not commit real secrets to version control.
 HF_TOKEN=your-huggingface-token
 GITHUB_TOKEN=your-github-token
 OPENAI_API_KEY=your-openai-api-key

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -1,4 +1,6 @@
-# Copy this file to secrets.env and replace placeholder values
+# Template for required environment variables.
+# Copy this file to secrets.env and replace the placeholder values.
+# Scripts like crown_model_launcher.sh will source secrets.env at runtime.
 HF_TOKEN=your-huggingface-token
 GITHUB_TOKEN=your-github-token
 OPENAI_API_KEY=your-openai-api-key


### PR DESCRIPTION
## Summary
- document how to populate `secrets.env` from a template and warn against committing real credentials
- provide a `secrets.env.template` with placeholders and instructions
- improve `crown_model_launcher.sh` message when `secrets.env` is missing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; No module named 'aiortc.mediastreams')*

------
https://chatgpt.com/codex/tasks/task_e_68a6229339fc832e82ef0dee4eee31f3