### PR TITLE
docs: expand GLM launcher troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ bash crown_model_launcher.sh > glm_launch.log 2>&1
   `curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/health`. A
   non-`200` response or connection error indicates the model failed to start;
   inspect `glm_launch.log` for details.
+- If `glm_launch.log` shows `jq: error (at <stdin>:1): Cannot iterate over null`,
+  the metadata request to Hugging Face failed. Verify the `HF_TOKEN` value and
+  that your network connection is active.
+- Confirm port `8001` is free before launching; an existing process on that port
+  prevents the health endpoint from becoming ready.
 
 ## Codex GPU Deployment
 


### PR DESCRIPTION
## Summary
- document expected GLM launcher startup time and health check behavior
- add troubleshooting tips for missing HF token, network issues, and port conflicts

## Testing
- `bash crown_model_launcher.sh > glm_launch.log 2>&1 &`
- `for i in {1..30}; do status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/health || true); echo "Attempt $i: $status"; if [ "$status" = "200" ]; then break; fi; sleep 2; done`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a62699dae4832e842259afeaeb5f1d