### PR TITLE
Document SERVANT_MODELS configuration and warn when missing

### DIFF
--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -32,6 +32,9 @@ Copy `secrets.env.template` to `secrets.env` and fill out the variables required
   export DEEPSEEK_URL=http://localhost:8002
   export MISTRAL_URL=http://localhost:8003
   ```
+Define `SERVANT_MODELS` in `secrets.env` or export it before invoking
+`launch_servants.sh`. The script reads this mapping and launches the referenced
+models. When unset it will emit a warning and skip servant startup.
 - `LLM_ROTATION_PERIOD` – rotation period for active models
 - `LLM_MAX_FAILURES` – allowed failures before rotation
 - `ARCHETYPE_STATE` – starting archetype layer

--- a/docs/deployment_overview.md
+++ b/docs/deployment_overview.md
@@ -19,6 +19,11 @@ Copy `secrets.env.template` to `secrets.env` and provide values for the required
   export MISTRAL_URL=http://localhost:8003
   ```
 
+The variable can be defined in `secrets.env` or exported in the shell. Each
+entry maps a short name to the model's base URL. `launch_servants.sh` reads this
+configuration and starts the corresponding Docker or vLLM processes. If the
+variable is unset the script warns and skips launching servants.
+
 See `secrets.env.template` for the full list.
 
 ## Download model weights

--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -16,9 +16,11 @@ else
 fi
 
 if [ -z "${SERVANT_MODELS:-}" ]; then
-    echo "Warning: SERVANT_MODELS is not set; no servant models will be launched." >&2
-    echo "Set it before running, for example:" >&2
-    echo "  export SERVANT_MODELS=\"deepseek=http://localhost:8002,mistral=http://localhost:8003\"" >&2
+    cat <<'EOF' >&2
+Warning: SERVANT_MODELS is not set; no servant models will be launched.
+Define SERVANT_MODELS in secrets.env or export it before running. Example:
+  export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
+EOF
 fi
 
 launch_model() {

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -22,7 +22,8 @@ EMOTION_STATE_PATH=emotional_state.yaml
 DEEPSEEK_URL=http://localhost:8002
 MISTRAL_URL=http://localhost:8003
 KIMI_K2_URL=http://localhost:8010
-# Optional comma-separated list of servant model endpoints
+# Optional comma-separated list of servant model endpoints.
+# Used by launch_servants.sh to start local models when defined.
 SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3


### PR DESCRIPTION
## Summary
- clarify how to set `SERVANT_MODELS` in deployment docs with sample configuration
- warn in `launch_servants.sh` when `SERVANT_MODELS` is unset and show example setup
- note in `secrets.env.template` that `SERVANT_MODELS` drives servant launches

## Testing
- `pytest` *(fails: soundfile.LibsndfileError, AttributeError, AssertionError, TypeError, NameError)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ea3d210832e9bd1b6a82fceda30