### PR TITLE
Launch servants with health checks

### DIFF
--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Launch servant LLMs when configured with localhost URLs
+# Launch servant models defined in SERVANT_MODELS and record reachable endpoints
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
@@ -15,6 +15,9 @@ else
     exit 1
 fi
 
+SERVANTS_FILE="${SERVANT_ENDPOINTS_FILE:-$ROOT/servant_endpoints.tmp}"
+: >"$SERVANTS_FILE"
+
 if [ -z "${SERVANT_MODELS:-}" ]; then
     cat <<'EOF' >&2
 Warning: SERVANT_MODELS is not set; no servant models will be launched.
@@ -22,6 +25,21 @@ Define SERVANT_MODELS in secrets.env or export it before running. Example:
   export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
 EOF
 fi
+
+wait_health() {
+    local name="$1"
+    local url="$2"
+    local health="${url%/}/health"
+    local timeout="${SERVANT_TIMEOUT:-60}"
+    for ((i=0; i<timeout; i++)); do
+        if curl -fsS "$health" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Servant $name failed health check at $health" >&2
+    exit 1
+}
 
 launch_model() {
     local name="$1"
@@ -36,7 +54,7 @@ launch_model() {
     if [[ "$url" == http://localhost:* || "$url" == http://127.0.0.1:* ]]; then
         local port="${url##*:}"
         port="${port%%/*}"
-        if [ ! -d "$model_dir" ]; then
+        if [ -n "$model_dir" ] && [ ! -d "$model_dir" ]; then
             case "$name" in
                 deepseek)
                     python download_models.py deepseek_v3 ;;
@@ -46,16 +64,34 @@ launch_model() {
                     python download_models.py kimi_k2 ;;
             esac
         fi
-        if command -v docker >/dev/null 2>&1; then
-            docker run -d --rm -v "$model_dir":/model -p "$port":8000 \
-                --name "${name}_service" "$image"
-        else
-            python -m vllm.entrypoints.openai.api_server \
-                --model "$model_dir" --port "$port" &
+        if [ -n "$model_dir" ]; then
+            if command -v docker >/dev/null 2>&1; then
+                docker pull "$image" >/dev/null 2>&1 || true
+                docker run -d --rm -v "$model_dir":/model -p "$port":8000 \
+                    --name "${name}_service" "$image"
+            else
+                python -m vllm.entrypoints.openai.api_server \
+                    --model "$model_dir" --port "$port" &
+            fi
         fi
     fi
+
+    wait_health "$name" "$url"
+    echo "${name}=${url}" >>"$SERVANTS_FILE"
 }
 
-launch_model deepseek "${DEEPSEEK_URL:-}" "INANNA_AI/models/DeepSeek-V3" "deepseek-service:latest"
-launch_model mistral "${MISTRAL_URL:-}" "INANNA_AI/models/Mistral-8x22B" "mistral-service:latest"
-launch_model kimi_k2 "${KIMI_K2_URL:-}" "INANNA_AI/models/Kimi-K2" "kimi-k2-service:latest"
+IFS=','
+for item in $SERVANT_MODELS; do
+    name="${item%%=*}"
+    url="${item#*=}"
+    case "$name" in
+        deepseek)
+            launch_model "$name" "$url" "INANNA_AI/models/DeepSeek-V3" "deepseek-service:latest" ;;
+        mistral)
+            launch_model "$name" "$url" "INANNA_AI/models/Mistral-8x22B" "mistral-service:latest" ;;
+        kimi_k2)
+            launch_model "$name" "$url" "INANNA_AI/models/Kimi-K2" "kimi-k2-service:latest" ;;
+        *)
+            launch_model "$name" "$url" "" "" ;;
+    esac
+done

--- a/tests/test_launch_servants_script.py
+++ b/tests/test_launch_servants_script.py
@@ -1,0 +1,80 @@
+import os
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # pragma: no cover - called in separate thread
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_launch_servants_records_reachable(tmp_path):
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    endpoints = tmp_path / "endpoints.txt"
+    secret = ROOT / "secrets.env"
+    backup = secret.with_suffix(".bak")
+    secret.rename(backup)
+    try:
+        secret.write_text(f"SERVANT_MODELS=test=http://127.0.0.1:{port}\n")
+        env = os.environ.copy()
+        env.update(
+            {
+                "SERVANT_ENDPOINTS_FILE": str(endpoints),
+                "SERVANT_TIMEOUT": "5",
+            }
+        )
+        result = subprocess.run(["bash", str(ROOT / "launch_servants.sh")], env=env)
+    finally:
+        secret.unlink(missing_ok=True)
+        backup.rename(secret)
+        server.shutdown()
+        thread.join()
+
+    assert result.returncode == 0
+    assert endpoints.read_text().strip() == f"test=http://127.0.0.1:{port}"
+
+
+def test_launch_servants_fails_when_unreachable(tmp_path):
+    port = _free_port()
+    endpoints = tmp_path / "endpoints.txt"
+    secret = ROOT / "secrets.env"
+    backup = secret.with_suffix(".bak")
+    secret.rename(backup)
+    try:
+        secret.write_text(f"SERVANT_MODELS=test=http://127.0.0.1:{port}\n")
+        env = os.environ.copy()
+        env.update(
+            {
+                "SERVANT_ENDPOINTS_FILE": str(endpoints),
+                "SERVANT_TIMEOUT": "1",
+            }
+        )
+        result = subprocess.run(["bash", str(ROOT / "launch_servants.sh")], env=env)
+    finally:
+        secret.unlink(missing_ok=True)
+        backup.rename(secret)
+
+    assert result.returncode != 0
+


### PR DESCRIPTION
## Summary
- Launch SERVANT_MODELS entries, wait for /health and record reachable endpoints
- Let console startup consume temp file and wait for local servant ports
- Test servant launcher success and failure scenarios

## Testing
- `pytest tests/test_launch_servants_script.py`
- `pytest tests/test_crown_console_startup.py tests/test_start_avatar_console.py`
- `pytest` *(fails: soundfile.LibsndfileError, AttributeError and others)*


------
https://chatgpt.com/codex/tasks/task_e_68a6350b0f2c832e9880d5b5f976f48e