### PR TITLE
Expand prerequisite checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ Ensure required system tools are available before running the setup scripts.
 Required packages:
 
 - Docker
+- Netcat (`nc`)
 - SoX
 - FFmpeg
+- curl
+- jq
+- wget
+- aria2c
 
 Verify installation with:
 
@@ -79,16 +84,46 @@ Verify installation with:
    sudo apt-get install -y docker.io
    ```
 
-2. **SoX**
+2. **Netcat**
+
+   ```bash
+   sudo apt-get install -y netcat
+   ```
+
+3. **SoX**
 
    ```bash
    sudo apt-get install -y sox
    ```
 
-3. **FFmpeg**
+4. **FFmpeg**
 
    ```bash
    sudo apt-get install -y ffmpeg
+   ```
+
+5. **curl**
+
+   ```bash
+   sudo apt-get install -y curl
+   ```
+
+6. **jq**
+
+   ```bash
+   sudo apt-get install -y jq
+   ```
+
+7. **wget**
+
+   ```bash
+   sudo apt-get install -y wget
+   ```
+
+8. **aria2c**
+
+   ```bash
+   sudo apt-get install -y aria2
    ```
 
 Install the runtime dependencies and optional development tools using

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -2,15 +2,16 @@
 # Verify that required external commands are available
 set -e
 
-missing=()
-for cmd in docker nc sox ffmpeg; do
+missing=0
+
+for cmd in docker nc sox ffmpeg curl jq wget aria2c; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
-        missing+=("$cmd")
+        echo "Missing required command: $cmd" >&2
+        missing=1
     fi
 done
 
-if [ "${#missing[@]}" -ne 0 ]; then
-    echo "Missing required command(s): ${missing[*]}" >&2
+if [ "$missing" -ne 0 ]; then
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- broaden prerequisite script to warn for missing curl, jq, wget and aria2c along with existing tools
- document these additional system requirements in setup instructions

## Testing
- `bash scripts/check_prereqs.sh`
- `bash scripts/check_requirements.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6d9b9ced4832ea579915d6e7e3199