### PR TITLE
Handle signals and surface child exit codes

### DIFF
--- a/start_avatar_console.sh
+++ b/start_avatar_console.sh
@@ -5,6 +5,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT"
 
+CROWN_PID=""
+STREAM_PID=""
+TAIL_PID=""
+
+cleanup() {
+    [[ -n "$CROWN_PID" ]] && kill "$CROWN_PID" >/dev/null 2>&1 || true
+    [[ -n "$STREAM_PID" ]] && kill "$STREAM_PID" >/dev/null 2>&1 || true
+    [[ -n "$TAIL_PID" ]] && kill "$TAIL_PID" >/dev/null 2>&1 || true
+}
+
+trap 'cleanup; exit 1' INT TERM
+
 # Start Crown services in the background
 ./start_crown_console.sh &
 CROWN_PID=$!
@@ -26,5 +38,22 @@ done
 tail -f "$LOG_FILE" &
 TAIL_PID=$!
 
-wait "$CROWN_PID" "$STREAM_PID"
-kill "$TAIL_PID"
+set +e
+wait "$CROWN_PID"
+CROWN_STATUS=$?
+wait "$STREAM_PID"
+STREAM_STATUS=$?
+set -e
+
+kill "$TAIL_PID" >/dev/null 2>&1 || true
+wait "$TAIL_PID" 2>/dev/null || true
+
+if (( CROWN_STATUS != 0 )); then
+    echo "Crown process exited with status $CROWN_STATUS" >&2
+fi
+if (( STREAM_STATUS != 0 )); then
+    echo "Stream process exited with status $STREAM_STATUS" >&2
+fi
+if (( CROWN_STATUS != 0 || STREAM_STATUS != 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Ensure `start_avatar_console.sh` cleans up background processes on INT and TERM signals.
- Report non-zero exit statuses from Crown and stream processes to surface errors.

## Testing
- `bash -n start_avatar_console.sh`
- `pytest` *(fails: 25 failed, 39 passed, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e865a348832e9e8294d86e85e08d