### PR TITLE
Validate SERVANT_MODELS entries

### DIFF
--- a/env_validation.py
+++ b/env_validation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from typing import Iterable
+from typing import Dict, Iterable
 
 
 logger = logging.getLogger(__name__)
@@ -38,3 +38,63 @@ def check_optional_packages(packages: Iterable[str]) -> None:
             importlib.import_module(name)
         except Exception as exc:  # pragma: no cover - import errors vary
             logger.warning("Optional package %s not available: %s", name, exc)
+
+
+def parse_servant_models(env: str | None = None, *, require: bool = False) -> Dict[str, str]:
+    """Return a mapping parsed from ``SERVANT_MODELS``.
+
+    Parameters
+    ----------
+    env:
+        Optional raw value of ``SERVANT_MODELS``. If omitted, ``os.environ`` is
+        consulted.
+    require:
+        When ``True`` and ``SERVANT_MODELS`` is set but no valid ``name=url``
+        pairs are found, :class:`SystemExit` is raised.
+
+    Returns
+    -------
+    dict
+        Mapping of servant names to URLs.
+    """
+
+    if env is None:
+        env = os.getenv("SERVANT_MODELS")
+
+    servants: Dict[str, str] = {}
+    if not env:
+        return servants
+
+    for item in env.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            logger.warning(
+                "Skipping malformed SERVANT_MODELS entry '%s'; expected name=url",
+                item,
+            )
+            continue
+        name, url = item.split("=", 1)
+        name = name.strip()
+        url = url.strip()
+        if not name or not url:
+            logger.warning(
+                "Skipping malformed SERVANT_MODELS entry '%s'; expected name=url",
+                item,
+            )
+            continue
+        if name in servants:
+            logger.warning(
+                "Duplicate servant model name '%s' in SERVANT_MODELS; keeping first",
+                name,
+            )
+            continue
+        servants[name] = url
+
+    if require and env and not servants:
+        raise SystemExit(
+            "SERVANT_MODELS is set but contains no valid name=url pairs"
+        )
+
+    return servants

--- a/tests/test_crown_servant_registration.py
+++ b/tests/test_crown_servant_registration.py
@@ -1,6 +1,9 @@
 import sys
+import logging
 from types import ModuleType
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -66,3 +69,58 @@ def test_servant_models_env(monkeypatch, tmp_path):
     init_crown_agent.initialize_crown()
     models = smm.list_models()
     assert set(["alpha", "beta"]).issubset(models)
+
+
+def test_servant_models_validation(monkeypatch, tmp_path, caplog):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    import yaml
+    monkeypatch.setattr(yaml, "safe_load", lambda f: {}, raising=False)
+
+    monkeypatch.setattr(init_crown_agent, "CONFIG_FILE", cfg)
+    monkeypatch.setattr(init_crown_agent, "_check_glm", lambda i: None)
+
+    dummy = ModuleType("requests")
+    dummy.post = lambda *a, **k: type(
+        "R", (), {"raise_for_status": lambda self: None, "json": lambda self: {"text": "pong"}}
+    )()
+    dummy.RequestException = Exception
+
+    monkeypatch.setattr(gi, "requests", dummy)
+    monkeypatch.setattr(init_crown_agent, "requests", dummy)
+
+    smm._REGISTRY.clear()
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setenv(
+        "SERVANT_MODELS",
+        "alpha=http://a,brokenpair,beta=http://b,alpha=http://c",
+    )
+    init_crown_agent.initialize_crown()
+    models = smm.list_models()
+    assert set(["alpha", "beta"]) == set(models)
+    assert any("Skipping malformed SERVANT_MODELS entry" in m for m in caplog.messages)
+    assert any("Duplicate servant model name" in m for m in caplog.messages)
+
+
+def test_servant_models_requires_valid_pair(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    import yaml
+    monkeypatch.setattr(yaml, "safe_load", lambda f: {}, raising=False)
+
+    monkeypatch.setattr(init_crown_agent, "CONFIG_FILE", cfg)
+    monkeypatch.setattr(init_crown_agent, "_check_glm", lambda i: None)
+
+    dummy = ModuleType("requests")
+    dummy.post = lambda *a, **k: type(
+        "R", (), {"raise_for_status": lambda self: None, "json": lambda self: {"text": "pong"}}
+    )()
+    dummy.RequestException = Exception
+
+    monkeypatch.setattr(gi, "requests", dummy)
+    monkeypatch.setattr(init_crown_agent, "requests", dummy)
+
+    smm._REGISTRY.clear()
+    monkeypatch.setenv("SERVANT_MODELS", "brokenpair")
+    with pytest.raises(SystemExit):
+        init_crown_agent.initialize_crown()


### PR DESCRIPTION
## Summary
- add `parse_servant_models` helper for strict `SERVANT_MODELS` parsing and validation
- warn and ignore malformed or duplicate servant entries
- enforce at least one valid servant when `SERVANT_MODELS` is set and add coverage

## Testing
- `python -m pytest tests/test_crown_servant_registration.py tests/test_launch_servants_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6eae96ccc832e822abd2e926851db