### PR TITLE
feat: ensure crown console waits for healthy services

### DIFF
--- a/tests/test_crown_console_startup.py
+++ b/tests/test_crown_console_startup.py
@@ -27,9 +27,10 @@ def test_crown_console_startup(monkeypatch):
         if cmd[0] == "bash" and str(cmd[1]).endswith("start_crown_console.sh"):
             calls.extend(
                 [
+                    "check_requirements",
                     "crown_model_launcher",
                     "launch_servants",
-                    "nc -z localhost 8000",
+                    "curl http://localhost:8000/health",
                     "python -m cli.console_interface",
                 ]
             )
@@ -45,8 +46,10 @@ def test_crown_console_startup(monkeypatch):
     result = subprocess.run(["bash", str(ROOT / "start_crown_console.sh")])
 
     assert result.returncode == 0
+    assert "check_requirements" in calls
     assert "crown_model_launcher" in calls
     assert "launch_servants" in calls
+    assert "curl http://localhost:8000/health" in calls
     assert "python -m cli.console_interface" in calls
     launcher_idx = calls.index("crown_model_launcher")
     servants_idx = calls.index("launch_servants")

--- a/tests/test_start_crown_console_trap.py
+++ b/tests/test_start_crown_console_trap.py
@@ -21,10 +21,10 @@ def test_launch_servants_failure_cleans_temp_file(tmp_path):
     servants.write_text("#!/bin/bash\nexit 1\n")
     servants.chmod(0o755)
 
-    # stub scripts/check_prereqs.sh
+    # stub scripts/check_requirements.sh
     scripts_dir = tmp_dir / "scripts"
     scripts_dir.mkdir()
-    check = scripts_dir / "check_prereqs.sh"
+    check = scripts_dir / "check_requirements.sh"
     check.write_text("#!/bin/bash\nexit 0\n")
     check.chmod(0o755)
 


### PR DESCRIPTION
## Summary
- verify system requirements before starting Crown console
- poll GLM and servant services' health endpoints before launching REPL
- clean up servant endpoint temp files and adjust startup tests

## Testing
- `./scripts/check_requirements.sh >/tmp/requirements.log && tail -n 20 /tmp/requirements.log`
- `pytest -q` *(fails: TypeError: 'str' object is not callable, AttributeError: <module 'video_stream'> has no attribute 'RTCPeerConnection', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a705c721c8832e8f008b6cb9d430d3