### PR TITLE
Add timeout to log wait in avatar console script

### DIFF
--- a/start_avatar_console.sh
+++ b/start_avatar_console.sh
@@ -52,9 +52,16 @@ python video_stream.py "${ARGS[@]}" &
 STREAM_PID=$!
 
 LOG_FILE="logs/INANNA_AI.log"
-while [ ! -f "$LOG_FILE" ]; do
+LOG_TIMEOUT=${LOG_TIMEOUT:-30}
+elapsed=0
+while [[ ! -f "$LOG_FILE" && $elapsed -lt $LOG_TIMEOUT ]]; do
     sleep 1
+    elapsed=$((elapsed + 1))
 done
+if [[ ! -f "$LOG_FILE" ]]; then
+    echo "Log file $LOG_FILE not found after $LOG_TIMEOUT seconds" >&2
+    exit 1
+fi
 
 tail -f "$LOG_FILE" &
 TAIL_PID=$!


### PR DESCRIPTION
## Summary
- add configurable timeout (default 30s) for waiting on INANNA log file
- emit error and exit non-zero when log file does not appear

## Testing
- `bash -n start_avatar_console.sh`
- `pytest` *(fails: 25 failed, 39 passed; missing dependencies and KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a7122785d4832e8dc11c9f055e716a