### PR TITLE
Handle crown and stream process exit codes

### DIFF
--- a/start_crown_console.py
+++ b/start_crown_console.py
@@ -67,6 +67,15 @@ def main() -> None:
     finally:
         _terminate()
 
+    crown_code = getattr(crown_proc, "returncode", 0) or 0
+    stream_code = getattr(stream_proc, "returncode", 0) or 0
+    if crown_code:
+        print(f"Error: crown process exited with code {crown_code}")
+        raise SystemExit(crown_code)
+    if stream_code:
+        print(f"Error: stream process exited with code {stream_code}")
+        raise SystemExit(stream_code)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Check `crown_proc` and `stream_proc` exit codes after the monitoring loop
- Report non-zero exit statuses and propagate the first error code

## Testing
- `pytest -q` *(fails: module and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a71d58b130832ea40a9373623824f5