### PR TITLE
Document secrets loading and provide sample secrets file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Required packages:
 - wget
 - aria2c
 
+Before running the check, copy `secrets.env.template` to `secrets.env` and fill in `HF_TOKEN`, `GLM_API_URL`, and `GLM_API_KEY`. `scripts/check_requirements.sh` sources `secrets.env` automatically so the variables are loaded during verification.
+
 Verify installation with:
 
 ```bash

--- a/secrets.env
+++ b/secrets.env
@@ -1,0 +1,30 @@
+# Template for required environment variables.
+# Copy this file to secrets.env and replace the placeholder values.
+# Scripts like crown_model_launcher.sh will source secrets.env at runtime.
+HF_TOKEN=hf_example_token123
+GITHUB_TOKEN=your-github-token
+OPENAI_API_KEY=your-openai-api-key
+GLM_API_URL=https://api.example.com/glm
+GLM_API_KEY=glm_example_key_ABC
+GLM_SHELL_URL=http://localhost:8001
+GLM_SHELL_KEY=your-glm-shell-key
+GLM_COMMAND_TOKEN=your-command-token
+REFLECTION_INTERVAL=60
+CORPUS_PATH=./INANNA_AI
+QNL_EMBED_MODEL=all-MiniLM-L6-v2
+QNL_MODEL_PATH=./models/qnl
+EMBED_MODEL_PATH=./models/embed
+VOICE_TONE_PATH=./data/voice_tone
+VECTOR_DB_PATH=./vector_db
+RETRAIN_THRESHOLD=0.8
+VOICE_CONFIG_PATH=voice_config.yaml
+EMOTION_STATE_PATH=emotional_state.yaml
+DEEPSEEK_URL=http://localhost:8002
+MISTRAL_URL=http://localhost:8003
+KIMI_K2_URL=http://localhost:8010
+# Optional comma-separated list of servant model endpoints used by launch_servants.sh.
+# Sample enabling common models locally.
+SERVANT_MODELS=deepseek=http://localhost:8002,mistral=http://localhost:8003,kimi_k2=http://localhost:8010
+LLM_ROTATION_PERIOD=300
+LLM_MAX_FAILURES=3
+ARCHETYPE_STATE=ALBEDO


### PR DESCRIPTION
## Summary
- add `secrets.env` with sample values for required HF and GLM credentials
- note in README that `scripts/check_requirements.sh` loads `secrets.env` automatically

## Testing
- `./scripts/check_requirements.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7252fc9d0832e94710a980d6d8b93