### PR TITLE
Skip audio/video tests when ffmpeg missing

### DIFF
--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -1,9 +1,15 @@
 import sys
 import types
 from pathlib import Path
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 from audio import engine as audio_engine
 

--- a/tests/test_dsp_engine.py
+++ b/tests/test_dsp_engine.py
@@ -1,11 +1,16 @@
 import sys
 from pathlib import Path
+import shutil
 
 import numpy as np
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 from audio import dsp_engine
 

--- a/tests/test_full_audio_pipeline.py
+++ b/tests/test_full_audio_pipeline.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 import numpy as np
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -11,6 +13,10 @@ sf_stub = types.ModuleType("soundfile")
 sf_stub.write = lambda *a, **k: None
 sf_stub.read = lambda *a, **k: (np.zeros(1), 44100)
 sys.modules.setdefault("soundfile", sf_stub)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 from SPIRAL_OS import qnl_engine
 from audio import audio_ingestion, dsp_engine

--- a/tests/test_modulation_arrangement.py
+++ b/tests/test_modulation_arrangement.py
@@ -1,11 +1,17 @@
 import sys
 import types
 from pathlib import Path
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import modulation_arrangement as ma
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 
 class DummySeg:

--- a/tests/test_qnl_audio_pipeline.py
+++ b/tests/test_qnl_audio_pipeline.py
@@ -2,9 +2,15 @@ import sys
 from pathlib import Path
 import types
 import numpy as np
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 yaml_mod = types.ModuleType("yaml")
 yaml_mod.safe_load = lambda *a, **k: {"version": 1, "handlers": {}, "root": {"level": "INFO"}}

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,12 +1,18 @@
 import sys
 from pathlib import Path
 import numpy as np
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from core import video_engine, context_tracker
 import emotional_state
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 
 def test_generate_one_frame():

--- a/tests/test_video_stream.py
+++ b/tests/test_video_stream.py
@@ -5,6 +5,7 @@ import sys
 import httpx
 import numpy as np
 import pytest
+import shutil
 from fastapi.testclient import TestClient
 from aiortc import RTCPeerConnection, RTCSessionDescription
 from types import ModuleType
@@ -17,6 +18,10 @@ sys.modules.setdefault("SPIRAL_OS.qnl_utils", ModuleType("qnl_utils"))
 from crown_config import settings
 
 settings.glm_command_token = "token"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 import server
 

--- a/tests/test_video_stream_audio.py
+++ b/tests/test_video_stream_audio.py
@@ -6,6 +6,7 @@ from types import ModuleType
 import httpx
 import numpy as np
 import pytest
+import shutil
 from aiortc import RTCSessionDescription
 from aiortc.mediastreams import AUDIO_PTIME
 from fastapi.testclient import TestClient
@@ -20,6 +21,10 @@ import video_stream  # noqa: E402
 from crown_config import settings  # noqa: E402
 
 settings.glm_command_token = "token"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 
 def test_avatar_audio_track(tmp_path):

--- a/tests/test_voice_aura.py
+++ b/tests/test_voice_aura.py
@@ -2,11 +2,17 @@ import sys
 from pathlib import Path
 import types
 import numpy as np
+import shutil
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import voice_aura
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
 
 
 def test_sox_effect_chain(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Ensure ffmpeg is available in test environments
- Skip audio and video processing tests when ffmpeg is not installed

## Testing
- `ffmpeg -version`
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute '...')*

------
https://chatgpt.com/codex/tasks/task_e_68a7297ba514832e82d71d162981bc12