### PR TITLE
Graceful fallbacks for optional ML dependencies

### DIFF
--- a/INANNA_AI/adaptive_learning.py
+++ b/INANNA_AI/adaptive_learning.py
@@ -67,9 +67,9 @@ try:  # pragma: no cover - import side effects
     from stable_baselines3 import PPO as _PPO
 
     if isinstance(np, types.SimpleNamespace):
-        raise RuntimeError("NumPy stub in use")
+        raise ImportError("NumPy stub in use")
     PPO = _PPO
-except Exception:  # pragma: no cover - allow stubbing in tests
+except ImportError:  # pragma: no cover - allow stubbing in tests
 
     class PPO:  # type: ignore
         def __init__(self, *a, **k):
@@ -81,7 +81,7 @@ except Exception:  # pragma: no cover - allow stubbing in tests
 
 try:  # pragma: no cover - import side effects
     import gymnasium as gym
-except Exception:  # pragma: no cover - allow stubbing in tests
+except ImportError:  # pragma: no cover - allow stubbing in tests
 
     class _Box:
         def __init__(self, *a, **k):

--- a/tests/test_optional_imports.py
+++ b/tests/test_optional_imports.py
@@ -1,0 +1,41 @@
+import importlib
+import builtins
+import sys
+
+
+def _fake_import(name, globals=None, locals=None, fromlist=(), level=0, missing=()):
+    if name in missing:
+        raise ImportError(name)
+    return _real_import(name, globals, locals, fromlist, level)
+
+
+_real_import = builtins.__import__
+
+
+def test_adaptive_learning_import_without_optional_deps(monkeypatch):
+    for mod in ['INANNA_AI.adaptive_learning', 'stable_baselines3', 'gymnasium', 'numpy']:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.setattr(
+        builtins,
+        '__import__',
+        lambda name, *a, **k: _fake_import(name, *a, missing={'stable_baselines3', 'gymnasium', 'numpy'}, **k),
+    )
+    importlib.import_module('INANNA_AI.adaptive_learning')
+
+
+def test_sentence_transformer_modules_import(monkeypatch):
+    missing = {'sentence_transformers'}
+    monkeypatch.setattr(
+        builtins,
+        '__import__',
+        lambda name, *a, **k: _fake_import(name, *a, missing=missing, **k),
+    )
+    monkeypatch.delitem(sys.modules, 'sentence_transformers', raising=False)
+    for mod in [
+        'INANNA_AI.corpus_memory',
+        'INANNA_AI.learning.github_scraper',
+        'INANNA_AI.learning.project_gutenberg',
+        'INANNA_AI.ethical_validator',
+    ]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+        importlib.import_module(mod)


### PR DESCRIPTION
## Summary
- Guard SentenceTransformer usage across learning and validation modules with import stubs
- Stub stable_baselines3 and gymnasium in adaptive learning to allow import without extras
- Add tests exercising module imports when optional dependencies are missing

## Testing
- `pytest tests/test_optional_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76a6e5700832e865ae7ca508fe639