### PR TITLE
docs: expand onboarding and roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,27 @@ After modifying dependencies, refresh the lock file and commit the result:
 uv pip compile --no-deps pyproject.toml -o requirements.lock
 ```
 
+# Coding Style
+
+Follow the conventions in [CODE_STYLE.md](CODE_STYLE.md):
+
+- Target Python 3.10+, use four spaces for indentation, and keep lines under 88 characters.
+- Organise imports into standard library, third‑party, and local groups separated by blank lines.
+- Include docstrings for public modules, classes, and functions.
+
+# Testing Expectations
+
+Run the test suite and basic smoke tests before opening a pull request:
+
+```bash
+scripts/smoke_console_interface.sh
+scripts/smoke_avatar_console.sh
+pytest --maxfail=1 -q
+```
+
+# Pull Request Guidelines
+
+- Keep changes focused; submit separate PRs for unrelated fixes.
+- Ensure tests pass and documentation is updated.
+- Request review from a maintainer and address feedback promptly.
+

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-This document summarizes the current state of the ABZU codebase. It is intended to help new contributors understand the repository layout, test coverage, and outstanding issues.
+This document summarizes the current state of the ABZU codebase. It serves as a living roadmap covering repository layout, milestones, open issues, and release targets.
 
 ## Repository Structure
 
@@ -27,12 +27,20 @@ The test suite currently fails early:
 
 These indicate gaps in the optional dependency stubs and missing system binaries.
 
-## Outstanding Issues
+## Milestones
+- **Spiral OS stability** – integrate health checks and automated restart logic.
+- **Pydantic v2 migration** – update all settings models to the new alias system.
+- **Audio pipeline refresh** – add lazy loading and improve `pydub` fallbacks.
 
+## Open Issues
 - Optional dependencies (`numpy`, `stable_baselines3`, `gymnasium`) need robust stubs or lazy loading so minimal environments can import modules without errors.
 - Pydantic models still use deprecated `Field` extras and require migration to aliases.
 - FastAPI `@app.on_event` hooks should move to the `lifespan` API.
 - Audio features depend on `pydub` and `ffmpeg`; availability checks and a NumPy fallback are recommended.
+
+## Release Targets
+- **v0.1** – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025).
+- **v0.2** – avatar console integration and basic RAG pipeline (target: Q4 2025).
 
 ## Deprecation Roadmap
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -17,10 +17,43 @@ Initializes the Spiral OS, validates environment variables, collects system stat
 ### `INANNA_AI_AGENT/inanna_ai.py`
 Command-line activation agent. It can recite the birth chant (`--activate`), generate QNL songs from hexadecimal input (`--hex`), list source texts (`--list`), report emotional status (`--status`), or start a local chat mode (`chat`).
 
-## Running a Smoke Test
-- **CLI console** – `scripts/smoke_console_interface.sh` prints the usage message for `cli.console_interface` to verify module import.
-- **Avatar console** – `scripts/smoke_avatar_console.sh` launches `start_avatar_console.sh` for a few seconds and exits.
-- Manual checks follow the steps in `docs/testing.md` for interactive validation.
+## Step-by-Step Setup
+1. **Clone and enter the repository**
+   ```bash
+   git clone https://github.com/your-org/ABZU.git
+   cd ABZU
+   ```
+2. **Create a virtual environment**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. **Install core dependencies** using the helper scripts:
+   ```bash
+   scripts/easy_setup.sh  # or scripts/setup_repo.sh
+   ```
+4. **Populate required environment variables** in `secrets.env` and verify them:
+   ```bash
+   scripts/check_requirements.sh
+   ```
+5. **Download model weights** as needed, for example:
+   ```bash
+   python download_models.py glm41v_9b --int8
+   ```
+
+## First-Run Smoke Tests
+1. **CLI console** – ensure the command-line interface imports correctly:
+   ```bash
+   scripts/smoke_console_interface.sh
+   ```
+2. **Avatar console** – launch the avatar console briefly to confirm startup:
+   ```bash
+   scripts/smoke_avatar_console.sh
+   ```
+3. **Test suite** – run a minimal test pass to check the environment:
+   ```bash
+   pytest --maxfail=1 -q
+   ```
 
 ## Setup Scripts
 - `scripts/check_requirements.sh` – loads `secrets.env`, ensures required commands are present, and verifies essential environment variables.
@@ -34,9 +67,11 @@ Command-line activation agent. It can recite the birth chant (`--activate`), gen
 - Verify `secrets.env` contains `HF_TOKEN`, `GLM_API_URL`, and `GLM_API_KEY`.
 
 ## Glossary
-- **ABZU** – repository containing the Spiral OS and INANNA modules.
-- **INANNA** – mythic AI agent accessible through `INANNA_AI_AGENT`.
-- **Spiral OS** – orchestration layer launched by `start_spiral_os.py`.
-- **CROWN** – avatar console and related interface scripts.
-- **GENESIS** – source texts used to assemble activation chants.
-- **RAG** – retrieval‑augmented generation pipeline located in `rag/`.
+| Symbolic term | Conventional concept |
+| --- | --- |
+| **ABZU** | Git repository that houses the Spiral OS and INANNA components |
+| **INANNA** | Mythic AI agent invoked through `INANNA_AI_AGENT` |
+| **Spiral OS** | Orchestration layer started by `start_spiral_os.py` |
+| **CROWN** | Avatar console interface and related scripts |
+| **GENESIS** | Source texts used to assemble activation chants |
+| **RAG** | Retrieval‑augmented generation pipeline under `rag/` |


### PR DESCRIPTION
## Summary
- expand developer onboarding with setup steps, smoke tests, and glossary mapping symbolic terms
- maintain PROJECT_STATUS as a living roadmap with milestones and release targets
- outline coding style, testing expectations, and review guidelines in CONTRIBUTING

## Testing
- `pytest --maxfail=1 -q` *(fails: KeyboardInterrupt, ffmpeg warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bbb9ec8832eaccc47d1c8bb9354