### PR TITLE
Install ffmpeg and sox in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ARG EXTRA_REQUIREMENTS=""
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg sox && \
+    rm -rf /var/lib/apt/lists/*
 RUN useradd --create-home --shell /bin/bash inanna
 WORKDIR /home/inanna/app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
   [docs/quick_start_non_technical.md](docs/quick_start_non_technical.md).
 - For required system packages and environment variables, see
   [docs/setup.md](docs/setup.md).
+- For Docker image build steps and audio binary checks, see
+  [docs/docker_build_audio_tools.md](docs/docker_build_audio_tools.md).
 - Before running any scripts, copy `secrets.env.template` to `secrets.env`,
   fill in the required tokens, and keep the file out of version control
   (`secrets.env` is listed in `.gitignore`).

--- a/docs/docker_build_audio_tools.md
+++ b/docs/docker_build_audio_tools.md
@@ -1,0 +1,27 @@
+# Docker Image with Audio Tools
+
+This project provides a Docker image that bundles the audio utilities **FFmpeg**
+and **SoX**. The `Dockerfile` installs these binaries alongside the Python
+dependencies.
+
+## Build
+
+```bash
+docker build -t abzu .
+```
+
+## Validate
+
+Run the environment check inside the container to confirm the binaries are
+available:
+
+```bash
+docker run --rm abzu python - <<'PY'
+import env_validation
+env_validation.check_audio_binaries()
+print("ffmpeg and sox available")
+PY
+```
+
+The script exits without error when both tools are present.
+


### PR DESCRIPTION
## Summary
- install ffmpeg and sox in runtime Docker image
- document building the Docker image and validating audio tools

## Testing
- `docker build -t abzu_test .` (fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)
- `python - <<'PY'
import env_validation
env_validation.check_audio_binaries()
print('audio binaries check passed')
PY`
- `pytest` (fails: Module AttributeError and other assertion failures)


------
https://chatgpt.com/codex/tasks/task_e_68a79667e50c832e9ed586b0530fc893