### PR TITLE
Handle optional audio binaries and expand tests

### DIFF
--- a/env_validation.py
+++ b/env_validation.py
@@ -66,15 +66,16 @@ def check_audio_binaries(*, require: bool = True) -> bool:
 
     binaries = ["ffmpeg", "sox"]
     missing = [name for name in binaries if shutil.which(name) is None]
-    if not missing:
-        return True
-
-    names = ", ".join(missing)
-    plural = "ies" if len(missing) > 1 else "y"
-    if require:
-        raise SystemExit(f"Missing required audio binar{plural}: {names}")
-    logger.warning("Missing audio binar%s: %s", plural, names)
-    return False
+    if missing:
+        names = ", ".join(missing)
+        plural = "ies" if len(missing) > 1 else "y"
+        if require:
+            raise SystemExit(
+                f"Missing required audio binar{plural}: {names}"
+            )
+        logger.warning("Missing optional audio binar%s: %s", plural, names)
+        return False
+    return True
 
 
 def parse_servant_models(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def pytest_collectstart(collector):
 # Skip tests that rely on unavailable heavy resources unless explicitly allowed
 ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_adaptive_learning_stub.py"),
+    str(ROOT / "tests" / "test_env_validation.py"),
 }
 
 

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import types
 from pathlib import Path
@@ -8,8 +7,11 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 from audio import engine as audio_engine

--- a/tests/test_dsp_engine.py
+++ b/tests/test_dsp_engine.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 from pathlib import Path
 
@@ -8,8 +7,11 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 from audio import dsp_engine

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -55,3 +55,17 @@ def test_check_required_binaries_missing(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         env_validation.check_required_binaries(["ffmpeg", "sox"])
     assert "ffmpeg, sox" in str(exc.value)
+
+
+def test_check_audio_binaries_required(monkeypatch):
+    monkeypatch.setattr(env_validation.shutil, "which", lambda n: None)
+    with pytest.raises(SystemExit):
+        env_validation.check_audio_binaries(require=True)
+
+
+def test_check_audio_binaries_optional(monkeypatch, caplog):
+    monkeypatch.setattr(env_validation.shutil, "which", lambda n: None)
+    with caplog.at_level(logging.WARNING):
+        ok = env_validation.check_audio_binaries(require=False)
+    assert not ok
+    assert "Missing optional audio" in caplog.text

--- a/tests/test_full_audio_pipeline.py
+++ b/tests/test_full_audio_pipeline.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 from pathlib import Path
 
@@ -15,8 +14,11 @@ sf_stub.write = lambda *a, **k: None
 sf_stub.read = lambda *a, **k: (np.zeros(1), 44100)
 sys.modules.setdefault("soundfile", sf_stub)
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 import music_generation

--- a/tests/test_modulation_arrangement.py
+++ b/tests/test_modulation_arrangement.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import types
 from pathlib import Path
@@ -10,8 +9,11 @@ sys.path.insert(0, str(ROOT))
 
 import modulation_arrangement as ma
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 

--- a/tests/test_qnl_audio_pipeline.py
+++ b/tests/test_qnl_audio_pipeline.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import types
 from pathlib import Path
@@ -9,8 +8,11 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 yaml_mod = types.ModuleType("yaml")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 from pathlib import Path
 
@@ -11,8 +10,11 @@ sys.path.insert(0, str(ROOT))
 import emotional_state
 from core import context_tracker, video_engine
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 

--- a/tests/test_video_stream.py
+++ b/tests/test_video_stream.py
@@ -1,5 +1,4 @@
 import asyncio
-import shutil
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -19,8 +18,11 @@ from crown_config import settings
 
 settings.glm_command_token = "token"
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 import server

--- a/tests/test_video_stream_audio.py
+++ b/tests/test_video_stream_audio.py
@@ -1,5 +1,4 @@
 import asyncio
-import shutil
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -22,8 +21,11 @@ from crown_config import settings  # noqa: E402
 
 settings.glm_command_token = "token"
 
+import env_validation
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 

--- a/tests/test_voice_aura.py
+++ b/tests/test_voice_aura.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import types
 from pathlib import Path
@@ -9,10 +8,12 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import env_validation
 import voice_aura
 
 pytestmark = pytest.mark.skipif(
-    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+    not env_validation.check_audio_binaries(require=False),
+    reason="audio tools not installed",
 )
 
 


### PR DESCRIPTION
## Summary
- warn and return False when optional audio binaries are missing
- skip audio-dependent tests when ffmpeg/sox not installed
- add unit tests for strict vs optional audio checks

## Testing
- `pytest tests/test_env_validation.py tests/test_voice_aura.py tests/test_dsp_engine.py tests/test_audio_engine.py tests/test_full_audio_pipeline.py tests/test_video_stream.py tests/test_video.py tests/test_video_stream_audio.py tests/test_qnl_audio_pipeline.py tests/test_modulation_arrangement.py`

------
https://chatgpt.com/codex/tasks/task_e_68a79df6959c832eaea2b0b5111616d8