### PR TITLE
docs: log console test results

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,5 +14,5 @@
 3. Use `Ctrl+C` to terminate the services.
 
 ## Notes
-- During this test run, the CLI setup encountered dependency initialization issues, preventing the prompt from appearing.
-- `start_avatar_console.sh` reported a permission error for `start_crown_console.sh` and the WebRTC video stream did not start.
+- The CLI console repeatedly attempted to reach the GLM service at `http://localhost:8000/health` and never displayed a prompt before being interrupted.
+- `start_avatar_console.sh` could not execute `start_crown_console.sh` (permission denied), so the WebRTC video feed did not initialize.


### PR DESCRIPTION
## Summary
- Document results of CLI and avatar console smoke tests in testing guide

## Testing
- `pre-commit run --all-files` *(fails: line-length, unused imports, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a212a238832e984a2572087e210e