### PR TITLE
refactor: lazy optional imports and pydantic alias updates

### DIFF
--- a/INANNA_AI/audio_emotion_listener.py
+++ b/INANNA_AI/audio_emotion_listener.py
@@ -8,14 +8,14 @@ from typing import Dict
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import librosa
-except Exception:  # pragma: no cover - optional dependency
+from core.utils.optional_deps import lazy_import
+
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional dependency
     librosa = None  # type: ignore
 
-try:  # pragma: no cover - optional dependency
-    import sounddevice as sd
-except Exception:  # pragma: no cover - optional dependency
+sd = lazy_import("sounddevice")
+if getattr(sd, "__stub__", False):  # pragma: no cover - optional dependency
     sd = None  # type: ignore
 
 import emotional_state

--- a/INANNA_AI/listening_engine.py
+++ b/INANNA_AI/listening_engine.py
@@ -12,25 +12,23 @@ from typing import Dict, Generator, Optional, Tuple
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import librosa
-except Exception:  # pragma: no cover - optional dependency
+from core.utils.optional_deps import lazy_import
+
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional dependency
     librosa = None  # type: ignore
 
-try:
-    import opensmile
-except Exception:  # pragma: no cover - optional dependency
-    opensmile = None
+opensmile = lazy_import("opensmile")
+if getattr(opensmile, "__stub__", False):  # pragma: no cover - optional dependency
+    opensmile = None  # type: ignore
 
-try:
-    import websockets
-except Exception:  # pragma: no cover - optional dependency
-    websockets = None
+websockets = lazy_import("websockets")
+if getattr(websockets, "__stub__", False):  # pragma: no cover - optional dependency
+    websockets = None  # type: ignore
 
-try:
-    import sounddevice as sd
-except Exception:  # pragma: no cover - optional dependency
-    sd = None
+sd = lazy_import("sounddevice")
+if getattr(sd, "__stub__", False):  # pragma: no cover - optional dependency
+    sd = None  # type: ignore
 
 import emotional_state
 

--- a/INANNA_AI/speaking_engine.py
+++ b/INANNA_AI/speaking_engine.py
@@ -9,9 +9,10 @@ from typing import Any, Dict, Iterable, Tuple
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import librosa
-except Exception:  # pragma: no cover - optional dependency
+from core.utils.optional_deps import lazy_import
+
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional dependency
     librosa = None  # type: ignore
 
 from crown_config import settings
@@ -22,19 +23,19 @@ from .emotion_analysis import emotion_to_archetype
 from .utils import load_audio, save_wav, sentiment_score
 from .voice_evolution import get_voice_params, update_voice_from_history
 
-try:
-    from gtts import gTTS
-except Exception:  # pragma: no cover - optional dependency
-    gTTS = None  # type: ignore
+gtts_mod = lazy_import("gtts")
+gTTS = (
+    None
+    if getattr(gtts_mod, "__stub__", False)
+    else getattr(gtts_mod, "gTTS", None)
+)
 
-try:
-    import openvoice
-except Exception:  # pragma: no cover - optional dependency
+openvoice = lazy_import("openvoice")
+if getattr(openvoice, "__stub__", False):  # pragma: no cover - optional dependency
     openvoice = None
 
-try:  # optional playback dependency
-    import sounddevice as sd
-except Exception:  # pragma: no cover - optional dependency
+sd = lazy_import("sounddevice")
+if getattr(sd, "__stub__", False):  # pragma: no cover - optional dependency
     sd = None
 
 logger = logging.getLogger(__name__)

--- a/INANNA_AI/utils.py
+++ b/INANNA_AI/utils.py
@@ -9,14 +9,14 @@ from typing import Iterable, Tuple
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import librosa
-except Exception:  # pragma: no cover - optional dependency
+from core.utils.optional_deps import lazy_import
+
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional dependency
     librosa = None  # type: ignore
 
-try:  # pragma: no cover - optional dependency
-    import soundfile as sf
-except Exception:  # pragma: no cover - optional dependency
+sf = lazy_import("soundfile")
+if getattr(sf, "__stub__", False):  # pragma: no cover - optional dependency
     sf = None  # type: ignore
 
 logger = logging.getLogger(__name__)

--- a/audio/segment.py
+++ b/audio/segment.py
@@ -13,6 +13,7 @@ fades directly on arrays.
 import logging
 import os
 import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -24,9 +25,21 @@ logger = logging.getLogger(__name__)
 
 
 def has_ffmpeg() -> bool:
-    """Return ``True`` if the ``ffmpeg`` binary is available."""
+    """Return ``True`` if the ``ffmpeg`` binary is available and executable."""
 
-    return shutil.which("ffmpeg") is not None
+    path = shutil.which("ffmpeg")
+    if not path:
+        return False
+    try:  # pragma: no cover - runtime environment check
+        subprocess.run(
+            [path, "-version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except Exception:
+        return False
+    return True
 
 
 _backend = os.environ.get("AUDIO_BACKEND", "numpy").lower()

--- a/core/avatar_expression_engine.py
+++ b/core/avatar_expression_engine.py
@@ -9,9 +9,10 @@ from typing import Iterator
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import librosa
-except Exception:  # pragma: no cover - optional dependency
+from core.utils.optional_deps import lazy_import
+
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional dependency
     librosa = None  # type: ignore
 
 import emotional_state

--- a/core/memory_physical.py
+++ b/core/memory_physical.py
@@ -9,22 +9,24 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
-from aspect_processor import (analyze_phonetic, analyze_semantic,
-                              analyze_spatial)
+from aspect_processor import (
+    analyze_phonetic,
+    analyze_semantic,
+    analyze_spatial,
+)
 
-try:  # pragma: no cover - optional
-    import cv2  # type: ignore
-except Exception:  # pragma: no cover - optional
+from core.utils.optional_deps import lazy_import
+
+cv2 = lazy_import("cv2")
+if getattr(cv2, "__stub__", False):  # pragma: no cover - optional
     cv2 = None  # type: ignore
 
-try:  # pragma: no cover - optional
-    import librosa  # type: ignore
-except Exception:  # pragma: no cover - optional
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional
     librosa = None  # type: ignore
 
-try:  # pragma: no cover - optional
-    import whisper  # type: ignore
-except Exception:  # pragma: no cover - optional
+whisper = lazy_import("whisper")
+if getattr(whisper, "__stub__", False):  # pragma: no cover - optional
     whisper = None  # type: ignore
 
 

--- a/core/video_engine.py
+++ b/core/video_engine.py
@@ -10,24 +10,28 @@ from typing import Iterator, Optional
 
 import numpy as np
 
-try:  # pragma: no cover - optional
-    import cv2  # type: ignore
-except Exception:  # pragma: no cover - optional
+from core.utils.optional_deps import lazy_import
+
+cv2 = lazy_import("cv2")
+if getattr(cv2, "__stub__", False):  # pragma: no cover - optional
     cv2 = None  # type: ignore
 
-try:  # pragma: no cover - optional
-    from wav2lip import Wav2LipPredictor  # type: ignore
-except Exception:  # pragma: no cover - optional
-    Wav2LipPredictor = None  # type: ignore
+wav2lip = lazy_import("wav2lip")
+Wav2LipPredictor = (
+    None
+    if getattr(wav2lip, "__stub__", False)
+    else getattr(wav2lip, "Wav2LipPredictor", None)
+)
 
-try:  # pragma: no cover - optional
-    from sadtalker import SadTalkerPipeline  # type: ignore
-except Exception:  # pragma: no cover - optional
-    SadTalkerPipeline = None  # type: ignore
+sadtalker = lazy_import("sadtalker")
+SadTalkerPipeline = (
+    None
+    if getattr(sadtalker, "__stub__", False)
+    else getattr(sadtalker, "SadTalkerPipeline", None)
+)
 
-try:  # pragma: no cover - optional
-    import librosa
-except Exception:  # pragma: no cover - optional
+librosa = lazy_import("librosa")
+if getattr(librosa, "__stub__", False):  # pragma: no cover - optional
     librosa = None  # type: ignore
 
 import emotional_state
@@ -35,19 +39,16 @@ import emotional_state
 from . import context_tracker
 from .facial_expression_controller import apply_expression
 
-try:  # pragma: no cover - optional dependency
-    import mediapipe as mp
-except Exception:  # pragma: no cover - optional dependency
+mp = lazy_import("mediapipe")
+if getattr(mp, "__stub__", False):  # pragma: no cover - optional dependency
     mp = None  # type: ignore
 
-try:  # pragma: no cover - optional gesture backends
-    import controlnet  # type: ignore
-except Exception:  # pragma: no cover - optional gesture backends
+controlnet = lazy_import("controlnet")
+if getattr(controlnet, "__stub__", False):  # pragma: no cover - optional gesture backends
     controlnet = None  # type: ignore
 
-try:  # pragma: no cover - optional gesture backends
-    import animatediff  # type: ignore
-except Exception:  # pragma: no cover - optional gesture backends
+animatediff = lazy_import("animatediff")
+if getattr(animatediff, "__stub__", False):  # pragma: no cover - optional gesture backends
     animatediff = None  # type: ignore
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def pytest_collectstart(collector):
 ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_adaptive_learning_stub.py"),
     str(ROOT / "tests" / "test_env_validation.py"),
+    str(ROOT / "tests" / "test_crown_config.py"),
 }
 
 

--- a/tests/test_crown_config.py
+++ b/tests/test_crown_config.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import crown_config
+
+
+def test_env_aliases(monkeypatch):
+    monkeypatch.setenv("GLM_COMMAND_TOKEN", "tok")
+    monkeypatch.setenv("VECTOR_DB_PATH", str(Path("/tmp/vector")))
+    crown_config.reload()
+    assert crown_config.settings.glm_command_token == "tok"
+    assert crown_config.settings.vector_db_path == Path("/tmp/vector")


### PR DESCRIPTION
## Summary
- add lazy optional imports for heavy libs across INANNA_AI and core modules
- refactor audio segment to use numpy/soundfile backend and verify ffmpeg presence
- modernize crown_config settings with Pydantic v2 validation aliases and add tests

## Testing
- `pytest tests/test_crown_config.py -q`
- `ffmpeg -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a7a5c7fc90832e90c5ddb1a272147f