### PR TITLE
Move module docstrings above imports

### DIFF
--- a/feedback_logging.py
+++ b/feedback_logging.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+"""Manage feedback logs and thresholds with on-disk persistence."""
 
-"""Simple feedback log reader with retraining thresholds."""
+from __future__ import annotations
 
 import json
 import logging

--- a/task_profiling.py
+++ b/task_profiling.py
@@ -1,6 +1,8 @@
-from __future__ import annotations
+"""Compatibility wrappers around :class:`core.task_profiler.TaskProfiler`.
 
-"""Backward compatible wrappers for :class:`core.task_profiler.TaskProfiler`."""
+Instantiates a shared profiler at import time for quick access."""
+
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/vector_memory.py
+++ b/vector_memory.py
@@ -1,11 +1,9 @@
+"""ChromaDB-backed text vector store with decay and operation logging.
+
+Persists entries under ``settings.vector_db_path`` and logs to
+``data/vector_memory.log`` on each modification."""
+
 from __future__ import annotations
-
-"""Lightweight text vector memory built on ChromaDB.
-
-The database location defaults to ``data/vector_memory`` next to this file but
-can be overridden by setting the ``VECTOR_DB_PATH`` environment variable.  Each
-stored entry is timestamped so query results decay in relevance over time.
-"""
 
 import json
 import logging


### PR DESCRIPTION
## Summary
- Move feedback logging module docstring above imports
- Describe TaskProfiler wrappers and shared instance
- Add persistent vector memory description with logging details

## Testing
- `pre-commit run --files feedback_logging.py task_profiling.py vector_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68a82883c574832ea62a479793b1f86e