### PR TITLE
Notify video stream of new speech audio

### DIFF
--- a/tests/test_crown_initialization.py
+++ b/tests/test_crown_initialization.py
@@ -245,9 +245,15 @@ def test_console_speak(monkeypatch, capsys):
     monkeypatch.setitem(
         sys.modules, "INANNA_AI.speech_loopback_reflector", dummy_reflector
     )
+    monkeypatch.setattr(
+        console_interface.requests,
+        "post",
+        lambda url, json, timeout=5: calls.setdefault("post", {"url": url, "json": json}),
+    )
 
     console_interface.run_repl(["--speak"])
     out = capsys.readouterr().out
     assert "ok" in out
     assert calls["play"] == "out.wav"
     assert calls["reflect"] == "out.wav"
+    assert calls["post"]["json"] == {"path": "out.wav"}

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -142,6 +142,11 @@ def test_logging_files_created(tmp_path, monkeypatch):
         sys.modules, "INANNA_AI.speech_loopback_reflector", dummy_reflector
     )
     monkeypatch.setattr(console_interface.context_tracker.state, "avatar_loaded", True)
+    monkeypatch.setattr(
+        console_interface.requests,
+        "post",
+        lambda url, json, timeout=5: None,
+    )
 
     monkeypatch.setattr(session_logger, "AUDIO_DIR", tmp_path / "audio")
     monkeypatch.setattr(session_logger, "VIDEO_DIR", tmp_path / "video")


### PR DESCRIPTION
## Summary
- add `/avatar-audio` API to `video_stream` and allow updating active `AvatarVideoTrack`
- push synthesized speech paths from the console to the video stream for lip‑sync
- cover audio update path in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83986b038832eb91f2625b8038bf7