### PR TITLE
Add virtual environment manager module with tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_crown_config.py"),
     str(ROOT / "tests" / "test_download_deepseek.py"),
     str(ROOT / "tests" / "test_dashboard_app.py"),
+    str(ROOT / "tests" / "test_virtual_env_manager.py"),
 }
 
 

--- a/tests/test_virtual_env_manager.py
+++ b/tests/test_virtual_env_manager.py
@@ -1,0 +1,58 @@
+"""Tests for tools.virtual_env_manager."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.virtual_env_manager import create_env, install_requirements, run
+
+
+def test_create_env(tmp_path: Path) -> None:
+    env_dir = tmp_path / "env"
+    create_env(env_dir)
+    python_bin = env_dir / ("Scripts" if os.name == "nt" else "bin") / (
+        "python.exe" if os.name == "nt" else "python"
+    )
+    assert python_bin.exists()
+
+
+def test_install_requirements_isolated(tmp_path: Path) -> None:
+    env_dir = tmp_path / "env"
+    create_env(env_dir)
+
+    pkg_dir = tmp_path / "dummy_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "setup.py").write_text(
+        "from setuptools import setup\nsetup(name='dummy_pkg', version='0.0.0')\n"
+    )
+    (pkg_dir / "dummy_pkg").mkdir()
+    (pkg_dir / "dummy_pkg" / "__init__.py").write_text("")
+
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text(str(pkg_dir))
+    install_requirements(env_dir, req_file)
+
+    run(env_dir, ["python", "-c", "import dummy_pkg"])
+    proc = subprocess.run(
+        [sys.executable, "-c", "import dummy_pkg"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+
+
+def test_run_isolated_sys_path(tmp_path: Path) -> None:
+    env_dir = tmp_path / "env"
+    create_env(env_dir)
+    cp = run(
+        env_dir,
+        ["python", "-c", "import sys, json; print(json.dumps(sys.path))"],
+    )
+    paths = json.loads(cp.stdout.strip())
+    site_paths = [p for p in paths if "site-packages" in p]
+    assert site_paths
+    assert all(p.startswith(str(env_dir)) for p in site_paths)

--- a/tools/virtual_env_manager.py
+++ b/tools/virtual_env_manager.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utilities for working with Python virtual environments."""
+
+from pathlib import Path
+import os
+import subprocess
+import sys
+from typing import Sequence
+
+
+def _bin_dir(env: Path) -> Path:
+    """Return the scripts directory for the virtual environment."""
+    return env / ("Scripts" if os.name == "nt" else "bin")
+
+
+def create_env(path: Path) -> None:
+    """Create a virtual environment at *path* using ``python -m venv``."""
+    subprocess.run([sys.executable, "-m", "venv", str(path)], check=True)
+
+
+def install_requirements(env: Path, requirements_file: Path) -> None:
+    """Install packages listed in *requirements_file* into *env*."""
+    run(env, ["pip", "install", "-r", str(requirements_file)])
+
+
+def run(env: Path, command: Sequence[str] | str, **kwargs) -> subprocess.CompletedProcess:
+    """Execute *command* inside *env*.
+
+    Returns the ``subprocess.CompletedProcess`` instance. Additional keyword
+    arguments are forwarded to ``subprocess.run``.
+    """
+    env_vars = os.environ.copy()
+    bin_path = _bin_dir(env)
+    env_vars["VIRTUAL_ENV"] = str(env)
+    env_vars["PATH"] = f"{bin_path}{os.pathsep}" + env_vars.get("PATH", "")
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("check", True)
+    return subprocess.run(command, env=env_vars, **kwargs)


### PR DESCRIPTION
## Summary
- add `tools.virtual_env_manager` for creating venvs, installing requirements and running commands
- add tests verifying venv creation, isolated installation and sys.path isolation
- whitelist the new test in `tests/conftest.py`

## Testing
- `pytest tests/test_virtual_env_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83d486c70832eae0ba467e384c26b