### PR TITLE
Add sandbox session utility and tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_download_deepseek.py"),
     str(ROOT / "tests" / "test_dashboard_app.py"),
     str(ROOT / "tests" / "test_virtual_env_manager.py"),
+    str(ROOT / "tests" / "test_sandbox_session.py"),
 }
 
 

--- a/tests/test_sandbox_session.py
+++ b/tests/test_sandbox_session.py
@@ -1,0 +1,43 @@
+"""Tests for tools.sandbox_session."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from tools import virtual_env_manager
+from tools.sandbox_session import apply_patch, create_sandbox
+
+
+def _git_status(path: Path) -> str:
+    cp = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return cp.stdout.strip()
+
+
+def test_create_sandbox_creates_temp_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sandbox = create_sandbox(repo_root, virtual_env_manager)
+    assert sandbox.exists()
+    assert sandbox != repo_root
+    assert Path(tempfile.gettempdir()) in sandbox.parents
+    assert (sandbox / ".venv").exists()
+
+
+def test_apply_patch_isolated() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sandbox = create_sandbox(repo_root, virtual_env_manager)
+
+    patch = """diff --git a/NEW_FILE.txt b/NEW_FILE.txt\nnew file mode 100644\nindex 0000000..e69de29\n--- /dev/null\n+++ b/NEW_FILE.txt\n@@ -0,0 +1 @@\n+hello sandbox\n"""
+    apply_patch(sandbox, patch)
+
+    assert (sandbox / "NEW_FILE.txt").exists()
+    assert not (repo_root / "NEW_FILE.txt").exists()
+    assert _git_status(repo_root) == ""
+    assert _git_status(sandbox) != ""

--- a/tools/sandbox_session.py
+++ b/tools/sandbox_session.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Helpers for working with sandboxed repository copies."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def create_sandbox(repo_root: Path, env_manager) -> Path:
+    """Copy *repo_root* into a temporary directory and set up a venv.
+
+    The repository is cloned into a fresh temporary directory and a virtual
+    environment is created inside it using *env_manager*.
+    """
+    temp_dir = Path(tempfile.mkdtemp(prefix="sandbox-"))
+    sandbox_root = temp_dir / repo_root.name
+    subprocess.run(["git", "clone", str(repo_root), str(sandbox_root)], check=True)
+    env_path = sandbox_root / ".venv"
+    env_manager.create_env(env_path)
+    return sandbox_root
+
+
+def apply_patch(sandbox_root: Path, patch_text: str) -> None:
+    """Apply a unified diff *patch_text* to the sandbox repository."""
+    subprocess.run(
+        ["git", "apply"],
+        cwd=sandbox_root,
+        input=patch_text,
+        text=True,
+        check=True,
+    )


### PR DESCRIPTION
## Summary
- add tools.sandbox_session with helpers to clone repo into temp dir and apply patches
- test sandbox creation and patch isolation from host repo
- allow sandbox test in test whitelist

## Testing
- `pytest tests/test_sandbox_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83fa02120832eac0ab90b4d38026a