### PR TITLE
Invoke avatar audio updates on new speech

### DIFF
--- a/cli/console_interface.py
+++ b/cli/console_interface.py
@@ -216,8 +216,8 @@ def run_repl(argv: list[str] | None = None) -> None:
                 voice_path = result.get("voice_path")
                 if voice_path:
                     session_logger.log_audio(Path(voice_path))
-                    speaking_engine.play_wav(voice_path)
                     _send_audio_path(Path(voice_path))
+                    speaking_engine.play_wav(voice_path)
                     frames = []
                     if context_tracker.state.avatar_loaded:
                         for frame in avatar_expression_engine.stream_avatar_audio(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_virtual_env_manager.py"),
     str(ROOT / "tests" / "test_sandbox_session.py"),
     str(ROOT / "tests" / "test_dependency_installer.py"),
+    str(ROOT / "tests" / "test_avatar_lipsync.py"),
 }
 
 

--- a/tests/test_avatar_lipsync.py
+++ b/tests/test_avatar_lipsync.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import types
+
+import numpy as np
+
+import video_stream
+
+
+def test_avatar_lipsync(monkeypatch, tmp_path):
+    frames = [np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(4)]
+    monkeypatch.setattr(
+        video_stream.avatar_expression_engine.video_engine,
+        "start_stream",
+        lambda lip_sync_audio=None: iter(frames),
+    )
+    monkeypatch.setattr(
+        video_stream.avatar_expression_engine.audio_engine,
+        "play_sound",
+        lambda path, loop=False: None,
+    )
+    monkeypatch.setattr(
+        video_stream.avatar_expression_engine.emotional_state,
+        "get_last_emotion",
+        lambda: "neutral",
+    )
+    monkeypatch.setattr(
+        video_stream.avatar_expression_engine,
+        "apply_expression",
+        lambda frame, emotion: frame,
+    )
+    wave = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    fake_librosa = types.SimpleNamespace(
+        load=lambda *a, **k: (wave, 4),
+        beat=types.SimpleNamespace(beat_track=lambda y, sr: (0.0, [])),
+    )
+    monkeypatch.setattr(video_stream.avatar_expression_engine, "librosa", fake_librosa)
+
+    audio_path = tmp_path / "speech.wav"
+    track = video_stream.AvatarVideoTrack(audio_path)
+
+    async def grab() -> tuple[np.ndarray, np.ndarray]:
+        first = await track.recv()
+        second = await track.recv()
+        return first.to_ndarray(), second.to_ndarray()
+
+    frame1, frame2 = asyncio.run(grab())
+    assert frame1.sum() > frame2.sum()
+

--- a/video_stream.py
+++ b/video_stream.py
@@ -92,7 +92,7 @@ class AvatarVideoTrack(VideoStreamTrack):
     ) -> None:
         super().__init__()
         if audio_path is not None:
-            self._frames = avatar_expression_engine.stream_avatar_audio(audio_path)
+            self.update_audio(audio_path)
         else:
             self._frames = video_engine.generate_avatar_stream()
         self._cues = cues


### PR DESCRIPTION
## Summary
- ensure `AvatarVideoTrack` reuses `update_audio` so lip-sync refreshes when new speech audio is available
- notify `/avatar-audio` endpoint immediately after TTS generation in the console interface
- add regression test validating that audio amplitude drives frame updates and enable it in the test suite

## Testing
- `pytest tests/test_avatar_lipsync.py -q`
- `pytest tests/test_video_stream_audio.py::test_avatar_audio_endpoint_updates_track -q` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68a8511ddd18832eb9c3d24565ca35dc