### PR TITLE
Add EmotiVoice voice cloning and CLI command

### DIFF
--- a/audio/voice_cloner.py
+++ b/audio/voice_cloner.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Clone a user's voice using the optional EmotiVoice library."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from core.utils.optional_deps import lazy_import
+from INANNA_AI.utils import save_wav
+
+sd = lazy_import("sounddevice")
+emotivoice = lazy_import("emotivoice")
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceCloner:
+    """Capture a short sample and synthesise cloned speech.
+
+    The implementation relies on ``sounddevice`` for recording and
+    ``EmotiVoice`` for speech synthesis.  Both dependencies are optional and
+    a :class:`RuntimeError` is raised when they are unavailable.
+    """
+
+    def __init__(self) -> None:
+        self.sample: Optional[Path] = None
+        self._model: Optional[object] = None
+
+    def capture_sample(
+        self, path: Path, seconds: float = 3.0, sr: int = 22_050
+    ) -> Path:
+        """Record ``seconds`` of audio from the microphone into ``path``."""
+
+        if getattr(sd, "__stub__", False):
+            raise RuntimeError("sounddevice library not installed")
+        logger.info("Recording voice sample for %.1f seconds", seconds)
+        audio = sd.rec(int(seconds * sr), samplerate=sr, channels=1, dtype="float32")
+        sd.wait()
+        save_wav(np.asarray(audio).flatten(), str(path), sr=sr)
+        self.sample = path
+        return path
+
+    def synthesize(
+        self, text: str, out_path: Path, emotion: str = "neutral"
+    ) -> Path:
+        """Generate ``text`` with the cloned voice."""
+
+        if getattr(emotivoice, "__stub__", False):
+            raise RuntimeError("EmotiVoice library not installed")
+        if self.sample is None:
+            raise RuntimeError("No voice sample captured")
+        if self._model is None:
+            self._model = emotivoice.TTS()
+            self._model.register_voice("user", str(self.sample))
+        self._model.tts_to_file(text, str(out_path), speaker="user", emotion=emotion)
+        return out_path
+
+
+__all__ = ["VoiceCloner"]
+

--- a/docs/sonic_core_harmonics.md
+++ b/docs/sonic_core_harmonics.md
@@ -16,7 +16,8 @@ The Sonic Core layers audio synthesis and expression modules on top of Spiral OS
 
 - `librosa` for audio analysis
 - `soundfile` for WAV I/O
-- `opensmile` and `EmotiVoice` for emotion detection
+- `opensmile` for emotion detection
+- `EmotiVoice` and `sounddevice` for optional voice cloning
 - Optional: `pydub` and the `ffmpeg` binary for the full `AudioSegment` backend. Set `AUDIO_BACKEND=pydub` when both are available.
 
 ## From QNL Phrase to Sound
@@ -65,3 +66,22 @@ from INANNA_AI.audio_emotion_listener import listen_for_emotion
 info = listen_for_emotion(2.0)
 print(info["emotion"])
 ```
+
+### Voice cloning with EmotiVoice
+
+Install the optional dependencies and record a reference sample:
+
+```bash
+pip install emotivoice sounddevice soundfile
+python cli/console_interface.py --speak
+/clone-voice "The clone is alive."
+```
+
+The command captures a short microphone sample, generates a confirmation
+phrase and stores the voice for later synthesis.
+
+#### Ethical guidelines
+
+- Clone only your own voice or with explicit permission from the owner.
+- Inform listeners that audio was generated and avoid deceptive usage.
+- Comply with local laws and respect privacy when storing or sharing samples.


### PR DESCRIPTION
## Summary
- integrate EmotiVoice-based `VoiceCloner` for recording samples and synthesizing cloned speech
- add `/clone-voice` command to console interface to register cloned voice for replies
- document EmotiVoice setup and ethical guidelines in sonic core harmonics docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a854171430832eba06924712b93b72