### PR TITLE
Add avatar animation utilities and lip sync tests

### DIFF
--- a/ai_core/avatar/__init__.py
+++ b/ai_core/avatar/__init__.py
@@ -1,0 +1,12 @@
+"""Avatar animation utilities."""
+
+from .ltx_avatar import LTXAvatar, LTXDistilledModel
+from .expression_controller import generate_landmarks
+from .lip_sync import align_phonemes
+
+__all__ = [
+    "LTXAvatar",
+    "LTXDistilledModel",
+    "generate_landmarks",
+    "align_phonemes",
+]

--- a/ai_core/avatar/expression_controller.py
+++ b/ai_core/avatar/expression_controller.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Generate rudimentary facial landmarks based on dialogue cues."""
+
+from typing import Dict, List, Tuple
+
+Landmarks = Dict[str, List[Tuple[int, int]]]
+
+# Predefined landmark templates.  Coordinates assume a 100x100 canvas for
+# simplicity; callers are expected to scale as required.
+_NEUTRAL: Landmarks = {
+    "eyes": [(30, 40), (70, 40)],
+    "mouth": [(40, 70), (50, 75), (60, 70)],
+}
+_HAPPY: Landmarks = {
+    "eyes": [(30, 35), (70, 35)],  # slightly raised eyebrows
+    "mouth": [(40, 65), (50, 80), (60, 65)],
+}
+_SAD: Landmarks = {
+    "eyes": [(30, 45), (70, 45)],
+    "mouth": [(40, 75), (50, 60), (60, 75)],
+}
+
+
+def generate_landmarks(dialogue: str) -> Landmarks:
+    """Return facial landmarks inferred from ``dialogue``.
+
+    The heuristic implementation looks for simple emotional cues.  If no cues
+    are detected the neutral template is returned.  The function is intentionally
+    lightweight and deterministic to keep unit tests fast and predictable.
+    """
+
+    cue = dialogue.lower()
+    if any(word in cue for word in {"smile", "happy", "joy"}):
+        return _HAPPY
+    if any(word in cue for word in {"sad", "frown", "cry"}):
+        return _SAD
+    return _NEUTRAL
+
+
+__all__ = ["generate_landmarks", "Landmarks"]

--- a/ai_core/avatar/lip_sync.py
+++ b/ai_core/avatar/lip_sync.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Utilities for aligning phonemes with video frame indices."""
+
+from typing import Iterable, List, Sequence, Tuple
+
+
+FramePhoneme = Tuple[int, str]
+
+
+def align_phonemes(
+    phonemes: Sequence[str], durations: Sequence[float], fps: int
+) -> List[FramePhoneme]:
+    """Map ``phonemes`` to frame indices based on ``durations``.
+
+    Parameters
+    ----------
+    phonemes:
+        Ordered collection of phoneme symbols.
+    durations:
+        Duration of each phoneme in seconds.  Must match ``phonemes`` in
+        length.
+    fps:
+        Frames per second of the target video.
+
+    Returns
+    -------
+    List[Tuple[int, str]]
+        Sequence where each tuple contains the frame index and the phoneme that
+        should be displayed.  The last frame index is ``len(result) - 1``.
+    """
+
+    if len(phonemes) != len(durations):  # pragma: no cover - defensive
+        raise ValueError("phonemes and durations must be the same length")
+
+    frame_map: List[FramePhoneme] = []
+    frame_index = 0
+    for phoneme, dur in zip(phonemes, durations):
+        count = max(1, int(round(dur * fps)))
+        for _ in range(count):
+            frame_map.append((frame_index, phoneme))
+            frame_index += 1
+    return frame_map
+
+
+__all__ = ["align_phonemes", "FramePhoneme"]

--- a/ai_core/avatar/ltx_avatar.py
+++ b/ai_core/avatar/ltx_avatar.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Lightweight wrapper for an imaginary LTX distilled avatar model.
+
+The implementation purposely avoids external dependencies.  The goal is to
+provide a tiny, synchronous interface that yields ``numpy`` frames at a steady
+frame rate.  The underlying ``LTXDistilledModel`` is a minimal stub that simply
+creates greyscale images whose intensity encodes the frame index.  The behaviour
+is sufficient for unit tests and documentation examples and mirrors the API a
+real model might expose.
+"""
+
+from dataclasses import dataclass
+from typing import Iterator, List
+import time
+
+import numpy as np
+
+
+class LTXDistilledModel:
+    """Trivial stand in for the real LTX distilled model.
+
+    ``render`` generates ``frame_count`` square RGB frames where each frame is a
+    solid colour.  The pixel value cycles between 0 and 254 and therefore the
+    frames are deterministic and lightweight.
+    """
+
+    def render(self, prompt: str, frame_count: int) -> List[np.ndarray]:
+        frames: List[np.ndarray] = []
+        for i in range(frame_count):
+            value = i % 255
+            frame = np.full((64, 64, 3), value, dtype=np.uint8)
+            frames.append(frame)
+        return frames
+
+
+@dataclass
+class LTXAvatar:
+    """Generate avatar frames at a fixed frame rate using ``LTXDistilledModel``."""
+
+    model: LTXDistilledModel | None = None
+    fps: int = 30
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        if self.model is None:
+            self.model = LTXDistilledModel()
+
+    def stream(self, prompt: str, seconds: float = 1.0) -> Iterator[np.ndarray]:
+        """Yield frames for ``seconds`` seconds at the configured frame rate."""
+
+        frame_count = int(self.fps * seconds)
+        frames = self.model.render(prompt, frame_count)
+        interval = 1.0 / self.fps if self.fps > 0 else 0.0
+        for frame in frames:
+            if interval:
+                time.sleep(interval)
+            yield frame
+
+
+__all__ = ["LTXAvatar", "LTXDistilledModel"]

--- a/docs/avatar_animation.md
+++ b/docs/avatar_animation.md
@@ -1,0 +1,35 @@
+# Avatar Animation Modules
+
+This document describes the lightweight avatar animation helpers found in
+`ai_core.avatar`.
+
+## LTXAvatar
+
+```python
+from ai_core.avatar import LTXAvatar
+
+avatar = LTXAvatar()
+# Produce two seconds of frames.
+for frame in avatar.stream("Hello there", seconds=2):
+    pass  # send frame to your video pipeline
+```
+
+## Expression Controller
+
+```python
+from ai_core.avatar import generate_landmarks
+
+landmarks = generate_landmarks("smile please")
+print(landmarks["mouth"])
+```
+
+## Lip Sync
+
+```python
+from ai_core.avatar import align_phonemes
+
+phonemes = ["a", "b", "c"]
+durations = [0.5, 0.25, 0.25]  # seconds
+mapping = align_phonemes(phonemes, durations, fps=30)
+print(mapping[:5])
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_sandbox_session.py"),
     str(ROOT / "tests" / "test_dependency_installer.py"),
     str(ROOT / "tests" / "test_avatar_lipsync.py"),
+    str(ROOT / "tests" / "test_lip_sync.py"),
     str(ROOT / "tests" / "test_memory_search.py"),
     str(ROOT / "tests" / "test_gateway.py"),
 }

--- a/tests/test_lip_sync.py
+++ b/tests/test_lip_sync.py
@@ -1,0 +1,21 @@
+from ai_core.avatar.lip_sync import align_phonemes
+
+
+def test_align_phonemes_basic():
+    phonemes = ["A", "B", "C"]
+    durations = [0.5, 0.25, 0.25]
+    fps = 20
+    mapping = align_phonemes(phonemes, durations, fps)
+    # Total frames = 20 fps * 1s
+    assert len(mapping) == 20
+    # First phoneme spans 10 frames, second and third span 5 each
+    assert mapping[0] == (0, "A")
+    assert mapping[9] == (9, "A")
+    assert mapping[10] == (10, "B")
+    assert mapping[14] == (14, "B")
+    assert mapping[15] == (15, "C")
+    assert mapping[-1] == (19, "C")
+    # Verify counts
+    assert sum(1 for _, p in mapping if p == "A") == 10
+    assert sum(1 for _, p in mapping if p == "B") == 5
+    assert sum(1 for _, p in mapping if p == "C") == 5


### PR DESCRIPTION
## Summary
- Implement lightweight LTX avatar wrapper for 30 FPS frame generation
- Add dialogue-based expression controller and phoneme-to-frame lip sync utilities
- Document avatar animation modules and provide unit tests for phoneme alignment

## Testing
- `pytest tests/test_lip_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85a73e64c832e919078b64351d0b0