### PR TITLE
Add prompt engineering and style transfer utilities

### DIFF
--- a/docs/style_management.md
+++ b/docs/style_management.md
@@ -1,0 +1,28 @@
+# Style Management
+
+This document describes how to add new video styles to the system.
+
+## Adding a Style Preset
+
+1. **Create a YAML preset** under `style_engine/styles` with the style name.
+   The file must define a `processor` field:
+   ```yaml
+   processor: my_style
+   ```
+2. **Update prompt presets** in `prompt_engineering.py` if the style requires
+   custom prompt wording. Use `{prompt}` as a placeholder for the user input.
+3. **Blend frames** using `style_engine.neural_style_transfer`. Provide a style
+   embedding and call `apply_style_transfer` to process video frames.
+
+## Example
+
+```python
+from prompt_engineering import apply_style_preset
+from style_engine import neural_style_transfer
+
+styled_prompt = apply_style_preset("render the scene", "my_style")
+stylised_frames = neural_style_transfer.apply_style_transfer(frames, embedding)
+```
+
+This workflow ensures new styles can influence both text prompts and frame
+appearance consistently.

--- a/prompt_engineering.py
+++ b/prompt_engineering.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Prompt transformations based on style presets."""
+
+from typing import Dict
+
+from style_engine.style_library import load_style_config
+
+_PRESETS: Dict[str, str] = {
+    "ltx": "Render with LTX flair: {prompt}",
+    "pusa_v1": "Channeling PUSA V1 vibe: {prompt}",
+}
+
+
+def apply_style_preset(
+    prompt: str, style: str, presets: Dict[str, str] | None = None
+) -> str:
+    """Apply a style preset to ``prompt``.
+
+    Parameters
+    ----------
+    prompt:
+        Base user prompt.
+    style:
+        Name of the style preset defined in ``style_engine/styles``.
+    presets:
+        Optional mapping of processor name to template string containing
+        ``{prompt}`` placeholder.
+
+    Returns
+    -------
+    str
+        Transformed prompt with style instructions.
+    """
+    config = load_style_config(style)
+    mapping = presets or _PRESETS
+    template = mapping.get(config.processor)
+    if not template:
+        return prompt
+    return template.format(prompt=prompt)

--- a/style_engine/neural_style_transfer.py
+++ b/style_engine/neural_style_transfer.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Simple neural style transfer utilities."""
+
+from typing import Iterable
+
+import numpy as np
+
+
+def blend_frame_with_embedding(
+    base_frame: np.ndarray, style_embedding: np.ndarray, alpha: float = 0.6
+) -> np.ndarray:
+    """Blend ``base_frame`` with ``style_embedding``.
+
+    Parameters
+    ----------
+    base_frame:
+        Frame to stylise.
+    style_embedding:
+        Style representation broadcastable to ``base_frame``.
+    alpha:
+        Blend factor in ``[0, 1]`` where higher values favour the style.
+
+    Returns
+    -------
+    np.ndarray
+        Stylised frame with the same dtype as ``base_frame``.
+    """
+    if base_frame.shape != style_embedding.shape:
+        style_embedding = np.broadcast_to(style_embedding, base_frame.shape)
+    blended = (1 - alpha) * base_frame + alpha * style_embedding
+    return blended.astype(base_frame.dtype)
+
+
+def apply_style_transfer(
+    frames: Iterable[np.ndarray], style_embedding: np.ndarray, alpha: float = 0.6
+) -> list[np.ndarray]:
+    """Apply style transfer to an iterable of frames."""
+    return [blend_frame_with_embedding(f, style_embedding, alpha) for f in frames]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_memory_search.py"),
     str(ROOT / "tests" / "test_gateway.py"),
     str(ROOT / "tests" / "test_style_selection.py"),
+    str(ROOT / "tests" / "test_prompt_engineering.py"),
 }
 
 

--- a/tests/test_prompt_engineering.py
+++ b/tests/test_prompt_engineering.py
@@ -1,0 +1,19 @@
+from prompt_engineering import apply_style_preset
+
+
+def test_ltx_preset_applied():
+    prompt = "paint a sunset"
+    result = apply_style_preset(prompt, "ltx")
+    assert result == "Render with LTX flair: paint a sunset"
+
+
+def test_pusa_preset_applied():
+    prompt = "compose a melody"
+    result = apply_style_preset(prompt, "pusa_v1")
+    assert result == "Channeling PUSA V1 vibe: compose a melody"
+
+
+def test_unknown_preset_returns_prompt():
+    prompt = "draw a tree"
+    result = apply_style_preset(prompt, "unknown")
+    assert result == prompt


### PR DESCRIPTION
## Summary
- implement neural style transfer helpers to blend frames with style embeddings
- introduce prompt engineering module for applying style presets
- document workflow for adding new styles
- test prompt presets and enable test collection

## Testing
- `pytest tests/test_prompt_engineering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85bec83e4832ea3963ed52ec9c2f3