### PR TITLE
Add deployment configs, monitoring stack, roadmap, and examples

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  api:
+    build: ..
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    depends_on:
+      - model
+      - mediasoup
+  model:
+    image: model-service:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+    volumes:
+      - ../INANNA_AI/models:/models
+    ports:
+      - "8001:8000"
+  mediasoup:
+    image: mediasoup:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - MEDIASOUP_LISTEN_IP=0.0.0.0

--- a/deployment/kubernetes/api-deployment.yaml
+++ b/deployment/kubernetes/api-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: api-image:latest
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/deployment/kubernetes/mediasoup-deployment.yaml
+++ b/deployment/kubernetes/mediasoup-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mediasoup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mediasoup
+  template:
+    metadata:
+      labels:
+        app: mediasoup
+    spec:
+      containers:
+        - name: mediasoup
+          image: mediasoup:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mediasoup
+spec:
+  selector:
+    app: mediasoup
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/deployment/kubernetes/model-deployment.yaml
+++ b/deployment/kubernetes/model-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model
+  template:
+    metadata:
+      labels:
+        app: model
+    spec:
+      containers:
+        - name: model
+          image: model-service:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model
+spec:
+  selector:
+    app: model
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,3 +17,8 @@ This roadmap tracks progress toward the Spiral OS vision. See
 - **Avatar lip‑sync** for more accurate mouth movement.
 - **Expanded memory search** across cortex and vector layers.
 - **Voice cloning** to mirror user tone within the sonic core.
+
+## Future Enhancements
+- **Community Discord channel** to coordinate contributors and gather feedback.
+- **New style packs** expanding avatar and video generation aesthetics.
+- **Hardware scaling strategy** for larger GPU clusters and edge devices.

--- a/examples/avatar_generation.ipynb
+++ b/examples/avatar_generation.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Avatar Generation Workflow\n",
+    "Demonstrates creating an avatar from text prompts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from api.avatar import generate_avatar\n",
+    "avatar = generate_avatar(text='Hello world')\n",
+    "avatar.save('avatar.png')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/video_generation.ipynb
+++ b/examples/video_generation.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Video Generation Workflow\n",
+    "Produces a short animated clip from an avatar and soundtrack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from api.video import generate_video\n",
+    "video = generate_video(avatar='avatar.png', audio='song.wav')\n",
+    "video.save('demo.mp4')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,10 @@
+# Monitoring
+
+This stack launches Prometheus and Grafana alongside an NVIDIA GPU exporter.
+Metrics include frames per second (FPS), API latency, and GPU utilization.
+
+```bash
+docker compose up
+```
+
+Prometheus listens on port `9090` and Grafana on `3000`.

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+  gpu-exporter:
+    image: nvidia/dcgm-exporter:3.2.6
+    runtime: nvidia
+    ports:
+      - "9400:9400"
+volumes:
+  grafana-data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'api'
+    static_configs:
+      - targets: ['api:8000']
+  - job_name: 'mediasoup'
+    static_configs:
+      - targets: ['mediasoup:3000']
+  - job_name: 'gpu'
+    static_configs:
+      - targets: ['gpu-exporter:9400']


### PR DESCRIPTION
## Summary
- Add Docker Compose deployment for API, model service with GPU reservation, and MediaSoup
- Provide Kubernetes manifests with GPU scheduling hints
- Introduce Prometheus/Grafana monitoring stack and GPU exporter
- Update roadmap with community, style, and hardware scaling goals
- Include example notebooks for avatar and video generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a85e794a68832eb1a08cebea67b631