### PR TITLE
chore: split heavy deps into extras

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -1,0 +1,29 @@
+# Dependency Graph
+
+Generated with `pipdeptree --packages spiral-os`.
+
+```
+spiral-os==0.1.0
+├── numpy [required: ==1.26.4, installed: 1.26.4]
+├── requests [required: ==2.32.4, installed: 2.32.4]
+│   ├── charset-normalizer [required: >=2,<4, installed: 3.4.3]
+│   ├── idna [required: >=2.5,<4, installed: 3.10]
+│   ├── urllib3 [required: >=1.21.1,<3, installed: 2.5.0]
+│   └── certifi [required: >=2017.4.17, installed: 2025.8.3]
+├── python-json-logger [required: ==3.3.0, installed: 3.3.0]
+├── PyYAML [required: ==6.0.2, installed: 6.0.2]
+└── psutil [required: ==7.0.0, installed: 7.0.0]
+```
+
+## Security and Licensing Notes
+
+`pip-audit` reported no known vulnerabilities.
+
+Licenses of core dependencies (`pip-licenses`):
+
+- numpy 1.26.4 — BSD License
+- requests 2.32.4 — Apache Software License
+- python-json-logger 3.3.0 — BSD License
+- PyYAML 6.0.2 — MIT License
+- psutil 7.0.0 — BSD License
+

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,6 +2,24 @@
 
 This guide lists the system packages and environment variables required to run the project.
 
+## Installation
+
+### Minimal installation
+
+Install only the core Spiral OS utilities:
+
+```bash
+pip install .
+```
+
+### Full installation
+
+Include all optional features (LLM, audio, ML, vision, web, network):
+
+```bash
+pip install .[llm,audio,ml,vision,web,network]
+```
+
 ## Required Packages
 
 The [scripts/check_requirements.sh](../scripts/check_requirements.sh) script expects the following commands to be available:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,7 @@ dependencies = [
     "requests==2.32.4",
     "python-json-logger==3.3.0",
     "pyyaml==6.0.2",
-    "psutil==7.0.0",
-    "fastapi==0.116.1",
-    "pymediasoup==0.3.1",
-    "torch==2.8.0",
+    "psutil==7.0.0"
 ]
 
 [project.optional-dependencies]
@@ -67,6 +64,7 @@ vision = [
 
 web = [
     "fastapi==0.116.1",
+    "pymediasoup==0.3.1",
     "uvicorn==0.35.0",
     "streamlit==1.48.1",
     "beautifulsoup4==4.13.4",


### PR DESCRIPTION
## Summary
- keep core dependencies lightweight and move `torch`/`pymediasoup` to optional extras
- add minimal and full installation instructions
- document dependency graph with security and licensing notes

## Testing
- `pip-audit --skip-editable`
- `pip-licenses --packages numpy requests python-json-logger pyyaml psutil`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a86494cd50832e95f76fe24a34d82f