### PR TITLE
Organize packages and add service contracts

### DIFF
--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Audio processing utilities and playback helpers."""
+
+from .engine import (
+    play_sound,
+    stop_all,
+    get_asset_path,
+    pitch_shift,
+    time_stretch,
+    compress,
+    rave_encode,
+    rave_decode,
+    rave_morph,
+    nsynth_interpolate,
+)
+
+__all__ = [
+    'play_sound',
+    'stop_all',
+    'get_asset_path',
+    'pitch_shift',
+    'time_stretch',
+    'compress',
+    'rave_encode',
+    'rave_decode',
+    'rave_morph',
+    'nsynth_interpolate',
+]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+"""Core package exposing primary services."""
+
+from .emotion_analyzer import EmotionAnalyzer
+from .memory_logger import MemoryLogger
+from .contracts import EmotionAnalyzerService, MemoryLoggerService
+
+__all__ = [
+    'EmotionAnalyzer',
+    'MemoryLogger',
+    'EmotionAnalyzerService',
+    'MemoryLoggerService',
+]

--- a/core/contracts.py
+++ b/core/contracts.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Protocol definitions for cross-module services."""
+
+from typing import Any, Dict, List, Protocol
+
+
+class EmotionAnalyzerService(Protocol):
+    """Analyze emotional content and maintain mood state."""
+
+    def analyze(self, emotion: str) -> Dict[str, Any]: ...
+    def update_mood(self, emotion: str) -> None: ...
+
+
+class MemoryLoggerService(Protocol):
+    """Persist interaction history and ritual results."""
+
+    def log_interaction(self, text: str, meta: Dict[str, Any], result: Dict[str, Any], status: str) -> None: ...
+    def load_interactions(self) -> List[Dict[str, Any]]: ...
+    def log_ritual_result(self, name: str, steps: List[Any]) -> None: ...

--- a/core/emotion_analyzer.py
+++ b/core/emotion_analyzer.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from .contracts import EmotionAnalyzerService
+
 import emotional_state
 from INANNA_AI import emotion_analysis
 
 
-class EmotionAnalyzer:
+class EmotionAnalyzer(EmotionAnalyzerService):
     """Track recent emotions and expose analysis helpers.
 
     The analyzer maintains an exponential moving average of emotion weights and

--- a/core/memory_logger.py
+++ b/core/memory_logger.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from .contracts import MemoryLoggerService
+
 from corpus_memory_logging import load_interactions, log_interaction, log_ritual_result
 
 
-class MemoryLogger:
+class MemoryLogger(MemoryLoggerService):
     """Provide methods for storing interaction history."""
 
     def log_interaction(

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,10 @@
+"""Dashboard components for monitoring and mixing."""
+
+from . import app, qnl_mixer, rl_metrics, usage
+
+__all__ = [
+    'app',
+    'qnl_mixer',
+    'rl_metrics',
+    'usage',
+]

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -33,11 +33,31 @@ graph TD
     Router --> "labs.cortex_sigil"
 ```
 
+### Package Layout
+
+```mermaid
+graph TD
+    subgraph core
+        EA[EmotionAnalyzer]
+        ML[MemoryLogger]
+    end
+    subgraph audio
+        EN[Engine]
+    end
+    subgraph dashboard
+        APP[Metrics Dashboard]
+    end
+    EA --> ML
+    EN --> APP
+```
+
 ### Service Contracts
 
+- `core.contracts.EmotionAnalyzerService` – protocol for mood analysis.
 - `core.emotion_analyzer.EmotionAnalyzer` – classify mood of incoming text.
-- `core.model_selector.ModelSelector` – choose the appropriate language model.
+- `core.contracts.MemoryLoggerService` – protocol for persistence.
 - `core.memory_logger.MemoryLogger` – persist events to the memory stores.
+- `core.model_selector.ModelSelector` – choose the appropriate language model.
 - `memory.cortex` – `record_spiral` / `query_spirals` for spiral decisions.
 - `memory.spiral_cortex` – `log_insight` / `load_insights` for retrieval traces.
 - `labs.cortex_sigil` – `interpret_sigils` to extract symbolic triggers.


### PR DESCRIPTION
## Summary
- add package exports for core, audio, and dashboard modules
- define EmotionAnalyzerService and MemoryLoggerService protocols
- document package layout and service contracts

## Testing
- `python -m pytest tests/test_core_services.py -q`
- `python -m pytest tests/test_core_services.py tests/test_audio_engine.py tests/test_dashboard_app.py -q` *(fails: ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68a8668b75f8832eb3fc3ed32c6be67e