### PR TITLE
Add dashboard tests and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 
 'on':
   push:
-    branches: [main]
   pull_request:
 
 jobs:
@@ -25,13 +24,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev] --no-deps
-          pip install pre-commit pytest pytest-cov
+          pip install pre-commit pytest pytest-cov coverage-badge
       - name: Lint
         run: pre-commit run --all-files --show-diff-on-failure
       - name: Test
         run: pytest -m "not hardware" --cov=./ --cov-report=xml
+      - name: Generate coverage badge
+        run: coverage-badge -o coverage.svg -f
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
-          path: coverage.xml
+          path: |
+            coverage.xml
+            coverage.svg
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # THE CRYSTAL CODEX
 
+![Coverage](coverage.svg)
+
 Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
 ## Getting Started
@@ -105,6 +107,16 @@ Verify installation with:
 ```bash
 ./scripts/check_requirements.sh
 ```
+
+## Testing and Coverage
+
+Run the test suite with coverage reporting:
+
+```bash
+pytest --cov=./ --cov-report=term-missing
+```
+
+The badge above reflects the latest coverage generated in CI.
 
 1. **Docker**
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#e05d44" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">19%</text>
+        <text x="80" y="14">19%</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- test dashboard Streamlit app with mocked modules
- generate coverage badge and upload coverage in CI
- expose test coverage badge and instructions in README

## Testing
- `pre-commit run --files tests/test_dashboard_app.py .github/workflows/ci.yml README.md coverage.svg`
- `pytest tests/test_download_models.py tests/test_dashboard_app.py --cov=download_models --cov=dashboard --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86807bdfc832e8277f8eba06714f9