### PR TITLE
Add utility and parser tests with performance benchmark

### DIFF
--- a/tests/performance/test_task_parser_performance.py
+++ b/tests/performance/test_task_parser_performance.py
@@ -1,0 +1,24 @@
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "task_parser", ROOT / "src" / "core" / "task_parser.py"
+)
+task_parser = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(task_parser)
+
+
+def test_task_parser_performance():
+    text = "appear to me and initiate sacred communion" * 20
+    start = time.perf_counter()
+    for _ in range(1000):
+        task_parser.parse(text)
+    duration = time.perf_counter() - start
+    # Ensure the parser remains efficient
+    assert duration < 0.5

--- a/tests/test_task_parser.py
+++ b/tests/test_task_parser.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "task_parser", ROOT / "src" / "core" / "task_parser.py"
+)
+task_parser = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(task_parser)
+
+
+def test_parse_detects_intents():
+    text = "Please appear to me and initiate sacred communion."
+    intents = task_parser.parse(text)
+    assert {"intent": "appear", "action": "show_avatar"} in intents
+    assert {"intent": "communion", "action": "start_call"} in intents
+
+
+def test_parse_returns_empty_for_unknown():
+    assert task_parser.parse("just a normal message") == []
+
+
+def test_parse_case_insensitive():
+    intents = task_parser.parse("APPEAR TO ME")
+    assert intents == [{"intent": "appear", "action": "show_avatar"}]


### PR DESCRIPTION
## Summary
- extend download_models coverage for token loading and DeepSeek-V3 path
- test dashboard app with multiple metric entries
- add regression and performance tests for core task parser

## Testing
- `pre-commit run --files tests/test_download_models.py tests/test_dashboard_app.py tests/test_task_parser.py tests/performance/test_task_parser_performance.py`
- `pytest tests/test_download_models.py tests/test_dashboard_app.py tests/test_task_parser.py tests/performance/test_task_parser_performance.py -m "not hardware" -q`

------
https://chatgpt.com/codex/tasks/task_e_68a878449e24832e8bb256e411ddfbc3