### PR TITLE
Add module docstrings and future imports

### DIFF
--- a/INANNA_AI/love_matrix.py
+++ b/INANNA_AI/love_matrix.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+"""Constants related to the Great Mother archetype."""
+
+
 class LoveMatrix:
     """Constants related to the Great Mother archetype."""
 

--- a/INANNA_AI/personality_layers/albedo/glm_integration.py
+++ b/INANNA_AI/personality_layers/albedo/glm_integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Compatibility wrapper exposing :class:`~INANNA_AI.glm_integration.GLMIntegration`.
 
 ``GLMIntegration.complete`` accepts an optional ``quantum_context`` string

--- a/INANNA_AI/personality_layers/albedo/state_contexts.py
+++ b/INANNA_AI/personality_layers/albedo/state_contexts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Prompt templates for each alchemical state."""
 
 CONTEXTS = {

--- a/MUSIC_FOUNDATION/human_music_to_qnl_converter.py
+++ b/MUSIC_FOUNDATION/human_music_to_qnl_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 human_music_to_qnl_converter.py
 INANNA_AI — QNL Music Transmutation Core

--- a/MUSIC_FOUNDATION/music_foundation.py
+++ b/MUSIC_FOUNDATION/music_foundation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 music_foundation.py
 INANNA_AI — QNL Sonic Decoder

--- a/SPIRAL_OS/__init__.py
+++ b/SPIRAL_OS/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Expose core Spiral OS components for external use."""
+
 import importlib.util
 import sys
 from pathlib import Path

--- a/ai_core/video_pipeline/ltx_video_processor.py
+++ b/ai_core/video_pipeline/ltx_video_processor.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+"""LTX video processing utilities."""
+
+
 class LTXVideoProcessor:
     """Simple placeholder processor for the `ltx` style."""
 

--- a/ai_core/video_pipeline/pusa_v1_processor.py
+++ b/ai_core/video_pipeline/pusa_v1_processor.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+"""Pusa V1 video processing utilities."""
+
+
 class PusaV1Processor:
     """Simple placeholder processor for the `pusa_v1` style."""
 

--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Communication connectors for Spiral OS."""
 
 from .webrtc_connector import close_peers as webrtc_close_peers

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 """Machine learning utilities and pipelines."""

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Streamlit app displaying LLM performance metrics."""
+
 import pandas as pd
 import streamlit as st
 

--- a/src/dashboard/qnl_mixer.py
+++ b/src/dashboard/qnl_mixer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Tools for mixing QNL audio inside Streamlit."""
+
 import io
 
 import numpy as np

--- a/src/dashboard/rl_metrics.py
+++ b/src/dashboard/rl_metrics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Streamlit dashboard for reinforcement learning metrics."""
+
 import pandas as pd
 import streamlit as st
 

--- a/src/dashboard/usage.py
+++ b/src/dashboard/usage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Streamlit dashboard for usage metrics."""
+
 import pandas as pd
 import streamlit as st
 


### PR DESCRIPTION
## Summary
- ensure all modules include `from __future__ import annotations`
- add missing module-level docstrings across connectors, AI components, video pipelines and dashboards

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a87d8eca7c832e9559ea1ea2d14c39