### PR TITLE
chore: add module docstrings

### DIFF
--- a/crown_config/__init__.py
+++ b/crown_config/__init__.py
@@ -1,6 +1,12 @@
+"""Load application configuration from environment variables.
+
+The module defines pydantic settings and spiritual constants used across the
+project. Importing it reads environment variables to populate configuration
+fields.
+"""
+
 from __future__ import annotations
 
-"""Application configuration loaded from environment variables."""
 import os
 from pathlib import Path
 

--- a/crown_config/settings/__init__.py
+++ b/crown_config/settings/__init__.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Utilities for reading optional layer configuration.
 
-"""Utilities for reading optional layer configuration."""
+This package loads a YAML file describing enabled personality layers and
+exposes helpers for querying that state. Import time triggers a disk read to
+populate the cached configuration.
+"""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict

--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Lightweight prompt orchestrator for the Crown console.
 
-"""Lightweight orchestrator for the Crown console."""
+It detects emotion, logs interactions, and delegates prompts to language
+models while applying optional personality layers. The functions here read
+and write state to databases and memory logs as part of those duties.
+"""
+
+from __future__ import annotations
 
 import asyncio
 import json

--- a/crown_query_router.py
+++ b/crown_query_router.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Route questions to archetype-specific vector stores.
 
-"""Route questions to the appropriate vector collection."""
+The module maps archetype labels to collection names and delegates
+retrieval to :mod:`rag.retriever`. Calling :func:`route_query` triggers
+lookup requests against the configured vector database.
+"""
+
+from __future__ import annotations
 
 from typing import Dict, List
 

--- a/crown_router.py
+++ b/crown_router.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Coordinate model and expression routing for the Crown agent.
 
-"""Combine model and expression routing for the Crown agent."""
+This module queries orchestrators and recent emotional context to choose an
+LLM and expressive parameters. Importing it touches optional vector memory
+services when available.
+"""
+
+from __future__ import annotations
 
 from typing import Any, Dict
 


### PR DESCRIPTION
## Summary
- clarify Crown module roles with top-level docstrings

## Testing
- `pre-commit run --files crown_config/__init__.py crown_config/settings/__init__.py crown_prompt_orchestrator.py crown_query_router.py crown_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ca8f55e4832ea1f753a550f25509