### PR TITLE
Refine model loading and logging error handling

### DIFF
--- a/INANNA_AI_AGENT/model.py
+++ b/INANNA_AI_AGENT/model.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Tuple
 
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+import logging
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
@@ -22,18 +27,12 @@ def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
     model_dir = Path(model_dir)
     tokenizer = AutoTokenizer.from_pretrained(model_dir, local_files_only=True)
     try:
-        model = AutoModelForCausalLM.from_pretrained(model_dir, local_files_only=True)
-    except Exception:
-        config = AutoConfig.from_pretrained(model_dir, local_files_only=True)
-
-        class DummyModel:
-            def __init__(self, cfg):
-                self.config = cfg
-
-            def generate(self, **kwargs):  # pragma: no cover - placeholder
-                return [[0]]
-
-        model = DummyModel(config)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_dir, local_files_only=True
+        )
+    except (OSError, ValueError) as exc:
+        logger.error("Failed to load model from %s: %s", model_dir, exc)
+        raise
     return model, tokenizer
 
 

--- a/logging_filters.py
+++ b/logging_filters.py
@@ -12,6 +12,9 @@ except Exception:  # pragma: no cover - fallback
         emotional_state = None  # type: ignore
 
 
+logger = logging.getLogger(__name__)
+
+
 class EmotionFilter(logging.Filter):
     """Append emotion and resonance fields to log records."""
 
@@ -22,14 +25,14 @@ class EmotionFilter(logging.Filter):
             try:
                 emotion = emotion_registry.get_last_emotion()
                 resonance = emotion_registry.get_resonance_level()
-            except Exception:
-                pass
+            except (AttributeError, RuntimeError) as exc:
+                logger.warning("emotion_registry fetch failed: %s", exc)
         elif emotional_state is not None:
             try:
                 emotion = emotional_state.get_last_emotion()
                 resonance = emotional_state.get_resonance_level()
-            except Exception:
-                pass
+            except (AttributeError, RuntimeError) as exc:
+                logger.warning("emotional_state fetch failed: %s", exc)
         record.emotion = emotion
         record.resonance = resonance
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_api_endpoints.py"),
     str(ROOT / "tests" / "test_style_selection.py"),
     str(ROOT / "tests" / "test_prompt_engineering.py"),
+    str(ROOT / "tests" / "test_model.py"),
+    str(ROOT / "tests" / "test_logging_filters.py"),
 }
 
 

--- a/tests/test_logging_filters.py
+++ b/tests/test_logging_filters.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import logging_filters
+
+
+def test_emotion_filter_logs_when_registry_fails(monkeypatch, caplog):
+    class DummyRegistry:
+        def get_last_emotion(self):
+            raise RuntimeError("boom")
+
+        def get_resonance_level(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(logging_filters, "emotion_registry", DummyRegistry())
+    with caplog.at_level(logging.WARNING):
+        record = logging.LogRecord("name", logging.INFO, "", 0, "msg", (), None)
+        flt = logging_filters.EmotionFilter()
+        assert flt.filter(record)
+    assert record.emotion is None
+    assert record.resonance is None
+    assert "emotion_registry fetch failed" in caplog.text


### PR DESCRIPTION
## Summary
- tighten `load_model` to log and raise errors instead of returning a dummy model
- log and narrow exceptions in `EmotionFilter.filter`
- test failure paths for model loading and emotion filter

## Testing
- `pytest tests/test_model.py::test_load_model_returns_objects tests/test_model.py::test_load_model_logs_error_on_missing_weights tests/test_logging_filters.py::test_emotion_filter_logs_when_registry_fails -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d19b8868832e9a771cc734f2006e