### PR TITLE
docs: add module summaries and future imports

### DIFF
--- a/INANNA_AI_AGENT/__init__.py
+++ b/INANNA_AI_AGENT/__init__.py
@@ -1,6 +1,10 @@
-from __future__ import annotations
+"""Convenience imports and CLI exposure for the INANNA AI agent.
 
-"""Convenience imports for the INANNA AI agent."""
+Importing this package registers the command line interface and injects the
+``inanna_ai`` module into :mod:`builtins` for compatibility with legacy tests.
+"""
+
+from __future__ import annotations
 
 import builtins as _builtins
 

--- a/INANNA_AI_AGENT/inanna_ai.py
+++ b/INANNA_AI_AGENT/inanna_ai.py
@@ -1,4 +1,9 @@
-"""Command line interface for interacting with the INANNA AI system."""
+"""Command line interface for the INANNA AI system.
+
+The module assembles ritual chants, converts hexadecimal input into QNL songs
+and exposes a chat interface.  It reads source texts, loads language models and
+may write audio and metadata files during operation.
+"""
 
 from __future__ import annotations
 

--- a/INANNA_AI_AGENT/model.py
+++ b/INANNA_AI_AGENT/model.py
@@ -1,12 +1,16 @@
+"""Helpers for loading local language models and tokenizers.
+
+The utilities operate solely on files already present on disk and log failures
+when the model cannot be instantiated.
+"""
+
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Tuple
 
-import logging
-
 from transformers import AutoModelForCausalLM, AutoTokenizer
-
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +31,7 @@ def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
     model_dir = Path(model_dir)
     tokenizer = AutoTokenizer.from_pretrained(model_dir, local_files_only=True)
     try:
-        model = AutoModelForCausalLM.from_pretrained(
-            model_dir, local_files_only=True
-        )
+        model = AutoModelForCausalLM.from_pretrained(model_dir, local_files_only=True)
     except (OSError, ValueError) as exc:
         logger.error("Failed to load model from %s: %s", model_dir, exc)
         raise

--- a/INANNA_AI_AGENT/preprocess.py
+++ b/INANNA_AI_AGENT/preprocess.py
@@ -1,3 +1,10 @@
+"""Text preprocessing utilities for INANNA AI rituals.
+
+Functions in this module clean Markdown and optionally embed passages using
+``sentence_transformers`` when available.  Outputs may be written to disk for
+downstream benchmarking.
+"""
+
 from __future__ import annotations
 
 import json

--- a/INANNA_AI_AGENT/source_loader.py
+++ b/INANNA_AI_AGENT/source_loader.py
@@ -1,3 +1,9 @@
+"""Utilities for reading ritual source texts.
+
+The helpers load Markdown files listed in ``source_paths.json`` and return the
+contents for use in chants or other processes.
+"""
+
 from __future__ import annotations
 
 import json

--- a/SPIRAL_OS/__init__.py
+++ b/SPIRAL_OS/__init__.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Expose Spiral OS components and dynamic helpers.
 
-"""Expose core Spiral OS components for external use."""
+Besides importing core modules, the package loads ``seven_dimensional_music``
+from the repository root at import time so existing integrations continue to
+work.
+"""
+
+from __future__ import annotations
 
 import importlib.util
 import sys

--- a/download_model.py
+++ b/download_model.py
@@ -1,4 +1,9 @@
-"""Utility functions for downloading model weights."""
+"""Download DeepSeek-R1 weights from Hugging Face.
+
+The module fetches the model repository and stores the files under
+``INANNA_AI/models/DeepSeek-R1``. It exits the process with a clear error
+message if credentials are missing or the download fails.
+"""
 
 from __future__ import annotations
 

--- a/download_models.py
+++ b/download_models.py
@@ -1,3 +1,10 @@
+"""CLI utilities for downloading model weights and dependencies.
+
+The script handles fetching multiple model repositories and optional tools,
+writing the resulting files to disk and invoking external installation
+commands when required.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -26,7 +33,9 @@ except ImportError as exc:  # pragma: no cover - handled at runtime
 logger = logging.getLogger(__name__)
 
 OLLAMA_INSTALL_URL = "https://ollama.ai/install.sh"
-OLLAMA_INSTALL_SHA256 = "9f5f4c4ed21821ba9b847bf3607ae75452283276cd8f52d2f2b38ea9f27af344"
+OLLAMA_INSTALL_SHA256 = (
+    "9f5f4c4ed21821ba9b847bf3607ae75452283276cd8f52d2f2b38ea9f27af344"
+)
 
 
 def _get_hf_token() -> str:

--- a/emotion_registry.py
+++ b/emotion_registry.py
@@ -1,6 +1,10 @@
-from __future__ import annotations
+"""Persist emotional state and expose retrieval helpers.
 
-"""Persist and retrieve emotional state parameters."""
+State is stored on disk under ``data/emotion_state.json`` and updated through
+the module's helper functions.
+"""
+
+from __future__ import annotations
 
 import json
 import logging

--- a/logging_filters.py
+++ b/logging_filters.py
@@ -1,3 +1,10 @@
+"""Logging filters that enrich records with emotional context.
+
+Each filter attempts to query ``emotion_registry`` or a legacy
+``emotional_state`` module, appending the emotion and resonance level to log
+records.  Failures are logged but otherwise ignored.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,6 +1,11 @@
-from __future__ import annotations
+"""Streamlit dashboard for visualising LLM performance.
 
-"""Streamlit app displaying LLM performance metrics."""
+The page fetches benchmark data, renders charts and predicts the best language
+model using the gate orchestrator.  Running this module requires an active
+Streamlit server and access to the underlying storage.
+"""
+
+from __future__ import annotations
 
 import logging
 
@@ -8,7 +13,6 @@ import pandas as pd
 import streamlit as st
 
 from INANNA_AI import db_storage, gate_orchestrator
-
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- document model download helpers and INANNA agent modules
- add Streamlit dashboard and Spiral OS package docstrings
- enrich logging filters and emotion registry with module docs

## Testing
- `pre-commit run --files INANNA_AI_AGENT/__init__.py INANNA_AI_AGENT/inanna_ai.py INANNA_AI_AGENT/model.py INANNA_AI_AGENT/preprocess.py INANNA_AI_AGENT/source_loader.py SPIRAL_OS/__init__.py download_model.py download_models.py emotion_registry.py logging_filters.py src/dashboard/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d6d8e3f0832eaf51a65209d9c5a6