### PR TITLE
Add hash-verified model installer with tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_lip_sync.py"),
     str(ROOT / "tests" / "test_memory_search.py"),
     str(ROOT / "tests" / "test_gateway.py"),
+    str(ROOT / "tests" / "test_download_models.py"),
     str(ROOT / "tests" / "test_api_endpoints.py"),
     str(ROOT / "tests" / "test_style_selection.py"),
     str(ROOT / "tests" / "test_prompt_engineering.py"),


### PR DESCRIPTION
## Summary
- verify installer downloads in `download_models.py` via SHA256 hash checks and explicit subprocess calls
- log descriptive errors for failed or mismatched downloads
- add unit tests covering download success, network failures, and hash mismatches

## Testing
- `pytest tests/test_download_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8d92ecc90832eb9cbd5be231c5857