### PR TITLE
Add tests for model downloads and dashboard, enable coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
       - name: Test
         run: pytest -m "not hardware" --cov=./ --cov-report=xml
+      - name: Coverage report
+        run: coverage report -m
       - name: Generate coverage badge
         run: coverage-badge -o coverage.svg -f
       - name: Upload coverage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_prompt_engineering.py"),
     str(ROOT / "tests" / "test_model.py"),
     str(ROOT / "tests" / "test_logging_filters.py"),
+    str(ROOT / "tests" / "performance" / "test_task_parser_performance.py"),
+    str(ROOT / "tests" / "performance" / "test_vector_memory_performance.py"),
 }
 
 

--- a/tests/performance/test_vector_memory_performance.py
+++ b/tests/performance/test_vector_memory_performance.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+vector_memory = importlib.import_module("vector_memory")
+
+
+def test_vector_memory_search_performance(monkeypatch):
+    monkeypatch.setattr(vector_memory, "np", None, raising=False)
+    monkeypatch.setattr(
+        vector_memory.qnl_utils, "quantum_embed", lambda text: [1.0, 0.0, 0.5]
+    )
+
+    class DummyCollection:
+        def query(self, query_embeddings, n_results):
+            embeddings = [[1.0, float(i), 0.5] for i in range(n_results)]
+            metas = [
+                {"timestamp": "2024-01-01T00:00:00", "text": f"t{i}"}
+                for i in range(n_results)
+            ]
+            return {"embeddings": [embeddings], "metadatas": [metas]}
+
+    monkeypatch.setattr(vector_memory, "_get_collection", lambda: DummyCollection())
+    start = time.perf_counter()
+    results = vector_memory.search("query", k=100)
+    duration = time.perf_counter() - start
+    assert len(results) == 100
+    assert duration < 0.5

--- a/tests/test_logging_filters.py
+++ b/tests/test_logging_filters.py
@@ -42,3 +42,36 @@ def test_emotion_filter_logs_when_state_fails(monkeypatch, caplog):
     assert record.emotion is None
     assert record.resonance is None
     assert "emotional_state fetch failed" in caplog.text
+
+
+def test_emotion_filter_enriches_record(monkeypatch):
+    class DummyRegistry:
+        def get_last_emotion(self):
+            return "joy"
+
+        def get_resonance_level(self):
+            return 0.75
+
+    monkeypatch.setattr(logging_filters, "emotion_registry", DummyRegistry())
+    record = logging.LogRecord("name", logging.INFO, "", 0, "msg", (), None)
+    flt = logging_filters.EmotionFilter()
+    assert flt.filter(record)
+    assert record.emotion == "joy"
+    assert record.resonance == 0.75
+
+
+def test_emotion_filter_uses_emotional_state(monkeypatch):
+    class DummyState:
+        def get_last_emotion(self):
+            return "calm"
+
+        def get_resonance_level(self):
+            return 0.1
+
+    monkeypatch.setattr(logging_filters, "emotion_registry", None)
+    monkeypatch.setattr(logging_filters, "emotional_state", DummyState(), raising=False)
+    record = logging.LogRecord("name", logging.INFO, "", 0, "msg", (), None)
+    flt = logging_filters.EmotionFilter()
+    assert flt.filter(record)
+    assert record.emotion == "calm"
+    assert record.resonance == 0.1


### PR DESCRIPTION
## Summary
- extend model download tests with Gemma pull failure case
- cover dashboard prediction-none path and logging filter success cases
- add vector memory performance test and enable coverage report in CI

## Testing
- `pre-commit run --files tests/conftest.py tests/test_download_models.py tests/test_dashboard_app.py tests/test_logging_filters.py tests/performance/test_vector_memory_performance.py .github/workflows/ci.yml`
- `pytest tests/test_download_models.py tests/test_dashboard_app.py tests/test_logging_filters.py tests/performance/test_vector_memory_performance.py -m "not hardware"`


------
https://chatgpt.com/codex/tasks/task_e_68a8fbfaa508832e84738d8274c4573c