### PR TITLE
Add deployment manifests and production compose

### DIFF
--- a/deployment/kubernetes/deployment.yaml
+++ b/deployment/kubernetes/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abzu-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: abzu
+  template:
+    metadata:
+      labels:
+        app: abzu
+    spec:
+      containers:
+        - name: abzu
+          image: registry.example.com/abzu:${APP_VERSION}
+          ports:
+            - containerPort: 8000

--- a/deployment/serverless/function.json
+++ b/deployment/serverless/function.json
@@ -1,0 +1,13 @@
+{
+  "name": "abzuFunction",
+  "runtime": "python3.11",
+  "handler": "handler.main",
+  "events": [
+    {
+      "http": {
+        "path": "/",
+        "method": "get"
+      }
+    }
+  ]
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  app:
+    build:
+      context: .
+    image: registry.example.com/abzu:${APP_VERSION}
+    ports:
+      - "8000:8000"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,34 @@
+# Deployment
+
+This guide covers building versioned images and deploying them using Kubernetes or a serverless platform.
+
+## Build and publish images
+
+1. Set the desired version:
+   ```bash
+   export APP_VERSION=1.0.0
+   ```
+2. Build the production image and tag it with the version:
+   ```bash
+   docker compose -f docker-compose.production.yml build
+   ```
+3. Publish the image to your registry:
+   ```bash
+   docker push registry.example.com/abzu:${APP_VERSION}
+   ```
+
+## Kubernetes
+
+Reference manifests live in `deployment/kubernetes`. Apply them with:
+
+```bash
+kubectl apply -f deployment/kubernetes/
+```
+
+## Serverless
+
+Sample function definitions reside in `deployment/serverless`. Deploy using your provider's tooling, e.g.:
+
+```bash
+sls deploy
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_model.py"),
     str(ROOT / "tests" / "test_logging_filters.py"),
     str(ROOT / "tests" / "test_data_pipeline.py"),
+    str(ROOT / "tests" / "test_deployment_configs.py"),
     str(ROOT / "tests" / "test_memory_snapshot.py"),
     str(ROOT / "tests" / "performance" / "test_task_parser_performance.py"),
     str(ROOT / "tests" / "performance" / "test_vector_memory_performance.py"),

--- a/tests/test_deployment_configs.py
+++ b/tests/test_deployment_configs.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import yaml
+
+
+def test_kubernetes_manifest():
+    data = yaml.safe_load(Path("deployment/kubernetes/deployment.yaml").read_text())
+    assert data["kind"] == "Deployment"
+    containers = data["spec"]["template"]["spec"]["containers"]
+    assert containers and "image" in containers[0]
+
+
+def test_serverless_manifest():
+    data = json.loads(Path("deployment/serverless/function.json").read_text())
+    assert data["runtime"].startswith("python")
+    assert data["events"]
+
+
+def test_docker_compose_production():
+    data = yaml.safe_load(Path("docker-compose.production.yml").read_text())
+    assert "services" in data
+    image = data["services"]["app"]["image"]
+    assert "${APP_VERSION}" in image


### PR DESCRIPTION
## Summary
- add reference Kubernetes and serverless manifests
- add production docker-compose for versioned registry images
- document deployment workflow and validate configs with tests

## Testing
- `pre-commit run --files deployment/kubernetes/deployment.yaml deployment/serverless/function.json docker-compose.production.yml docs/deployment.md tests/test_deployment_configs.py tests/conftest.py`
- `pytest tests/test_deployment_configs.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa55d0a87c832ea10f33ca298de3ae