### PR TITLE
Log optional dependency failures in RAG engine

### DIFF
--- a/rag/engine.py
+++ b/rag/engine.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 """Retrieval helper for vector memory documents."""
+# ruff: noqa: E402
 
 import argparse
 import importlib.util
+import logging
 from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - optional dependency
@@ -16,14 +18,15 @@ _LLAMA_AVAILABLE = (
     importlib.util.find_spec("llama_index") is not None
     or importlib.util.find_spec("llamaindex") is not None
 )
+logger = logging.getLogger(__name__)
 
 
 def _make_item(text: str, meta: Dict[str, Any], score: float) -> Any:
     if _HAYSTACK_AVAILABLE:
         try:
             from haystack import Document
-        except Exception:  # pragma: no cover - optional dep missing at runtime
-            pass
+        except Exception as exc:  # pragma: no cover - optional dep missing at runtime
+            logger.warning("Haystack import failed: %s", exc)
         else:
             doc = Document(content=text, meta=meta)
             doc.score = score  # type: ignore[attr-defined]
@@ -31,8 +34,8 @@ def _make_item(text: str, meta: Dict[str, Any], score: float) -> Any:
     if _LLAMA_AVAILABLE:
         try:
             from llama_index.core.schema import NodeWithScore, TextNode
-        except Exception:  # pragma: no cover - optional dep missing at runtime
-            pass
+        except Exception as exc:  # pragma: no cover - optional dep missing at runtime
+            logger.warning("LlamaIndex import failed: %s", exc)
         else:
             node = TextNode(text=text, metadata=meta)
             return NodeWithScore(node=node, score=score)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_prompt_engineering.py"),
     str(ROOT / "tests" / "test_model.py"),
     str(ROOT / "tests" / "test_logging_filters.py"),
+    str(ROOT / "tests" / "test_rag_engine.py"),
     str(ROOT / "tests" / "test_data_pipeline.py"),
     str(ROOT / "tests" / "test_deployment_configs.py"),
     str(ROOT / "tests" / "test_memory_snapshot.py"),


### PR DESCRIPTION
## Summary
- Log haystack and LlamaIndex import errors with warnings in the RAG engine
- Add parametrized tests ensuring warnings emit when optional dependencies are missing
- Enable running rag engine tests in the suite

## Testing
- `ruff check --fix rag/engine.py`
- `pytest -q tests/test_rag_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaa795c620832eae683f93500cb238