### PR TITLE
Log vector memory failures

### DIFF
--- a/invocation_engine.py
+++ b/invocation_engine.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Pattern-based invocation engine."""
+
+from __future__ import annotations
 
 import json
 import logging
@@ -53,7 +53,11 @@ def register_invocation(
             symbols, {"symbols": symbols, "emotion": emotion or ""}
         )
     except Exception:
-        pass
+        logger.warning(
+            "vector_memory.add_vector failed",
+            extra={"symbols": symbols, "emotion": emotion},
+            exc_info=True,
+        )
 
 
 def clear_registry() -> None:

--- a/tests/test_invocation_engine.py
+++ b/tests/test_invocation_engine.py
@@ -30,7 +30,7 @@ stub_orch.MoGEOrchestrator = StubMoGE
 rag_pkg.orchestrator = stub_orch
 sys.modules.setdefault("rag.orchestrator", stub_orch)
 
-import invocation_engine
+import invocation_engine  # noqa: E402
 
 
 class DummyOrchestrator:
@@ -60,6 +60,22 @@ def test_known_invocation(monkeypatch):
 
     assert res == ["ok"]
     assert called == [("∴⟐+🜂", "joy")]
+
+
+def test_add_vector_logs_warning(monkeypatch, caplog):
+    invocation_engine.clear_registry()
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(invocation_engine.vector_memory, "add_vector", fail)
+
+    with caplog.at_level(logging.WARNING):
+        invocation_engine.register_invocation("∴⟐+🜂", "joy", lambda *a: None)
+
+    record = next(r for r in caplog.records if r.levelno == logging.WARNING)
+    assert record.symbols == "∴⟐+🜂"
+    assert record.emotion == "joy"
 
 
 def test_fuzzy_invocation(monkeypatch):


### PR DESCRIPTION
## Summary
- log vector memory registration failures with symbol and emotion context
- test warning behavior when vector memory add_vector raises an exception

## Testing
- `ruff check --fix invocation_engine.py tests/test_invocation_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_invocation_engine.py` *(fails: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68aad6f4da58832e8e3f7620d11f951e