### PR TITLE
ci: enforce component health and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Bandit
         run: bandit -r . -x tests  # Security analysis
 
+      - name: Dependency check
+        run: |
+          python scripts/dependency_check.py | tee dependency_check.log
+          if grep -F '❌' dependency_check.log; then
+            echo 'Detected failing components'
+            exit 1
+          fi
+
   tests:
     runs-on: ubuntu-latest
     needs: lint
@@ -51,9 +59,16 @@ jobs:
         run: |
           coverage run -m pytest
           coverage html
-          coverage report
+          coverage report --fail-under=85
+      - name: Component inventory
+        run: python scripts/component_inventory.py
       - name: Upload coverage HTML
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov
+      - name: Upload component status
+        uses: actions/upload-artifact@v4
+        with:
+          name: component-status
+          path: docs/component_status.md

--- a/release.py
+++ b/release.py
@@ -29,7 +29,11 @@ def update_changelog(version: str) -> None:
     """Insert a release heading into ``CHANGELOG.md``."""
     path = Path("CHANGELOG.md")
     text = path.read_text()
-    heading = f"## [{version}] - {date.today().isoformat()}"
+    heading = (
+        f"## [{version}] - {date.today().isoformat()}\n"
+        "\n"
+        "- Component health report: see `component_status.md`\n"
+    )
     updated = text.replace("## [Unreleased]", f"## [Unreleased]\n\n{heading}")
     path.write_text(updated)
 


### PR DESCRIPTION
## Summary
- run dependency_check and component_inventory in CI
- fail if coverage below 85% or dependency_check reports a ❌
- upload component_status.md artifact and reference it in release notes

## Testing
- `pre-commit run --files release.py .github/workflows/ci.yml`
- `pytest -q` *(fails: 19 failed, 91 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf3bc0eb8832eaafeaa10f8135dc9