### PR TITLE
feat: simulate optional dependency failures with severity scoring

### DIFF
--- a/docs/dependency_risks.md
+++ b/docs/dependency_risks.md
@@ -1,0 +1,12 @@
+# Dependency Risks
+
+This document outlines the impact of missing optional dependencies and ways to mitigate them.
+
+## Optional Components
+
+| Component | Dependency | Severity | Mitigation |
+| --- | --- | --- | --- |
+| vector_memory | faiss | high | Install `faiss-cpu` or `faiss-gpu` to enable efficient vector search. |
+| rag | omegaconf | medium | `pip install omegaconf` to restore configuration support. |
+
+Missing dependencies reduce component scores in `scripts/dependency_check.py` and may degrade functionality. Ensure optional packages are available or provide fallbacks when operating in constrained environments.

--- a/scripts/dependency_check.py
+++ b/scripts/dependency_check.py
@@ -1,96 +1,136 @@
-from __future__ import annotations
-
 """Verify package imports and optional dependencies.
+
+from __future__ import annotations
 
 Run from the repository root:
 
     python scripts/dependency_check.py
 
 The script executes ``pip check`` to validate installed packages, attempts to
-import core components and reports missing optional modules such as FAISS or
-OmegaConf.
+import core components and simulates missing optional dependencies. Each
+component receives a score out of 10 with deductions applied for absent
+optional modules. Severity levels are logged for quick triage.
 """
 
 import importlib
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-# Mapping of label -> module import path
-COMPONENTS = {
-    "vector_memory": "vector_memory",
-    "rag": "rag",
-    "spiral_os": "SPIRAL_OS",  # package name used for import
-    "INANNA_AI": "INANNA_AI",
-}
 
-# Optional third-party dependencies
-OPTIONAL_DEPS = ["faiss", "omegaconf"]
+@dataclass
+class OptionalDep:
+    name: str
+    severity: str
+    deduction: int
+
+
+# Component configuration with optional dependency metadata
+COMPONENTS = {
+    "vector_memory": {
+        "module": "vector_memory",
+        "optional": [OptionalDep("faiss", "high", 3)],
+    },
+    "rag": {
+        "module": "rag",
+        "optional": [OptionalDep("omegaconf", "medium", 2)],
+    },
+    "spiral_os": {"module": "SPIRAL_OS", "optional": []},
+    "INANNA_AI": {"module": "INANNA_AI", "optional": []},
+}
 
 
 def run_pip_check() -> tuple[bool, str]:
     """Run ``pip check`` and return success flag and combined output."""
-    proc = subprocess.run([
-        sys.executable,
-        "-m",
-        "pip",
-        "check",
-    ], capture_output=True, text=True)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "check",
+        ],
+        capture_output=True,
+        text=True,
+    )
     output = proc.stdout.strip() or proc.stderr.strip()
     return proc.returncode == 0, output
 
 
-def check_components() -> dict[str, bool]:
-    """Attempt to import each component and return success flags."""
-    results: dict[str, bool] = {}
-    for label, module in COMPONENTS.items():
+def evaluate_components() -> dict[str, dict]:
+    """Import components and assess optional dependency availability.
+
+    Returns a mapping of component label to a dictionary containing:
+
+    ``ok``: Whether the component imported successfully.
+    ``missing``: List of tuples ``(dependency, severity)`` for each absent
+        optional dependency.
+    ``score``: Final score after deductions for missing optional dependencies.
+    """
+
+    results: dict[str, dict] = {}
+    for label, data in COMPONENTS.items():
+        module = data["module"]
+        optional = data.get("optional", [])
+
         try:
             importlib.import_module(module)
+            ok = True
         except Exception:  # pragma: no cover - import error handled
-            results[label] = False
-        else:
-            results[label] = True
+            ok = False
+
+        score = 10 if ok else 0
+        missing: list[tuple[str, str]] = []
+
+        if ok:
+            for dep in optional:
+                try:
+                    importlib.import_module(dep.name)
+                except Exception:  # pragma: no cover - import error handled
+                    missing.append((dep.name, dep.severity))
+                    score -= dep.deduction
+
+        results[label] = {
+            "ok": ok,
+            "missing": missing,
+            "score": max(score, 0),
+        }
+
     return results
-
-
-def missing_optional() -> list[str]:
-    """Return a list of optional modules that are not installed."""
-    missing: list[str] = []
-    for name in OPTIONAL_DEPS:
-        try:
-            importlib.import_module(name)
-        except Exception:  # pragma: no cover - import error handled
-            missing.append(name)
-    return missing
 
 
 def main() -> None:
     pip_ok, pip_output = run_pip_check()
-    comp_results = check_components()
-    optional_missing = missing_optional()
+    comp_results = evaluate_components()
 
     print("pip check:", "passed" if pip_ok else "failed")
     if pip_output:
         print(pip_output)
 
     print("\nComponent status:")
-    for name, ok in comp_results.items():
-        if ok and not optional_missing:
-            icon, extra = "✅", ""
-        elif ok:
-            icon, extra = "⚠️", " - optional deps missing"
+    for name, data in comp_results.items():
+        if data["ok"] and not data["missing"]:
+            icon = "✅"
+            extra = f" score={data['score']}"
+        elif data["ok"]:
+            icon = "⚠️"
+            miss = ", ".join(f"{dep} ({sev})" for dep, sev in data["missing"])
+            extra = f" score={data['score']} - missing {miss}"
         else:
-            icon, extra = "❌", " - import failed"
+            icon = "❌"
+            extra = " - import failed score=0"
         print(f"- {name}: {icon}{extra}")
 
-    if optional_missing:
-        print("\nMissing optional modules:", ", ".join(optional_missing))
+    # Aggregate list of missing optional modules for summary
+    all_missing = sorted(
+        {dep for v in comp_results.values() for dep, _ in v["missing"]}
+    )
+    if all_missing:
+        print("\nMissing optional modules:", ", ".join(all_missing))
 
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- simulate optional dependency failures in dependency check with per-component severity and score deductions
- log missing optional modules and component scores
- document mitigation strategies for optional dependencies

## Testing
- `pre-commit run --files scripts/dependency_check.py docs/dependency_risks.md`
- `pytest -k dependency_check -q`
- `python scripts/dependency_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab097a6f10832ea5b265af3b0422aa