### PR TITLE
ci: run quality scoring and gate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 # Reusable anchors keep the workflow maintainable
 jobs:
@@ -60,15 +64,35 @@ jobs:
           coverage run -m pytest
           coverage html
           coverage report --fail-under=85
-      - name: Component inventory
-        run: python scripts/component_inventory.py
       - name: Upload coverage HTML
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov
-      - name: Upload component status
+      - name: Component inventory
+        run: python scripts/component_inventory.py
+      - name: Quality score
+        env:
+          CI_ARTIFACTS_DIR: ci_artifacts
+        run: python scripts/quality_score.py
+      - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
-          name: component-status
-          path: docs/component_status.md
+          name: documentation
+          path: |
+            docs/component_status.md
+            docs/component_index.md
+            docs/component_status.json
+            CHANGELOG*.md
+      - name: Gate release on quality threshold
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          python - <<'PY'
+          import json, sys
+          data = json.load(open('data/quality_history.json'))[-1]['results']
+          threshold = 7
+          bad = [n for n, m in data.items() if m['overall'] < threshold]
+          if bad:
+            print('Components below threshold:', ', '.join(bad))
+            sys.exit(1)
+          PY


### PR DESCRIPTION
## Summary
- run component inventory and quality scoring for pull requests and v* tags
- upload component status and changelogs as workflow artifacts
- block releases when any component scores below threshold

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: tests/test_dashboard_app.py::test_dashboard_app_multiple_metrics, tests/test_dashboard_app.py::test_dashboard_app_large_metrics, tests/test_deployment_configs.py::test_kubernetes_manifest, tests/test_deployment_configs.py::test_docker_compose_production, tests/test_memory_snapshot.py::test_emotional_state_snapshot_restore, tests/test_memory_snapshot.py::test_vector_memory_snapshot_restore, tests/test_sandbox_session.py::test_apply_patch_isolated, tests/test_server.py::test_health_and_ready_return_200, tests/test_server.py::test_glm_command_endpoint, tests/test_server.py::test_glm_command_requires_authorization, tests/test_server.py::test_glm_command_unavailable_without_token, tests/test_server_endpoints.py::test_glm_command_authorized, tests/test_video_stream_helpers.py::test_cue_colour_deterministic, tests/test_video_stream_helpers.py::test_apply_cue_marks_corners, tests/test_video_stream_helpers.py::test_close_peers_clears_state, tests/test_video_stream_helpers.py::test_avatar_audio_track_recv, tests/test_video_stream_helpers.py::test_avatar_video_track_from_file, tests/test_video_stream_helpers.py::test_avatar_audio_update_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0acca8a0832ea042c7db0a9114a7