### PR TITLE
Add GPU detection and benchmarking utilities

### DIFF
--- a/benchmarks/train_infer.py
+++ b/benchmarks/train_infer.py
@@ -1,0 +1,38 @@
+"""Benchmark a minimal training and inference step."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+
+
+def train_step(device: str) -> None:
+    model = torch.nn.Linear(10, 1).to(device)
+    opt = torch.optim.SGD(model.parameters(), lr=0.01)
+    data = torch.randn(16, 10, device=device)
+    target = torch.randn(16, 1, device=device)
+
+    opt.zero_grad()
+    out = model(data)
+    loss = torch.nn.functional.mse_loss(out, target)
+    loss.backward()
+    opt.step()
+
+
+def test_train_infer(benchmark) -> None:
+    """Benchmark a single training step and log the result."""
+    device = (
+        "cuda"
+        if torch.cuda.is_available()
+        else ("xpu" if hasattr(torch, "xpu") and torch.xpu.is_available() else "cpu")
+    )
+    benchmark(lambda: train_step(device))
+    stats = benchmark.stats.stats
+
+    out_dir = Path("data/benchmarks")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "train_infer.json"
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump({"mean": stats.mean, "stddev": stats.stddev}, f)

--- a/data/benchmarks/.gitignore
+++ b/data/benchmarks/.gitignore
@@ -1,0 +1,4 @@
+# Ignore benchmark output files
+*
+!.gitignore
+

--- a/docs/hardware_support.md
+++ b/docs/hardware_support.md
@@ -1,0 +1,6 @@
+# Hardware Support
+
+- CUDA available: False
+- ROCm available: False
+- Intel GPU available: False
+- Selected device: cpu

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import subprocess
 import sys
+import warnings
+from pathlib import Path
 from typing import Dict
 
 from env_validation import check_required
@@ -41,11 +43,59 @@ def validate_env() -> None:
     check_required(REQUIRED_VARS)
 
 
+def detect_device() -> str:
+    """Detect available GPU acceleration and warn on CPU fallback."""
+    try:
+        import torch
+    except Exception:  # pragma: no cover - torch may not be installed
+        warnings.warn("PyTorch is not installed; defaulting to CPU")
+        return "cpu"
+
+    if torch.cuda.is_available():
+        if getattr(torch.version, "hip", None):
+            print("ROCm GPU detected")
+            return "rocm"
+        if getattr(torch.version, "cuda", None):
+            print("CUDA GPU detected")
+            return "cuda"
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        print("Intel GPU detected")
+        return "xpu"
+
+    warnings.warn("No supported GPU detected; using CPU")
+    return "cpu"
+
+
+def log_hardware_support(
+    device: str, path: str | Path = "docs/hardware_support.md"
+) -> None:
+    """Record hardware probe results to a Markdown file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import torch
+
+        cuda_available = torch.cuda.is_available()
+        rocm_available = bool(getattr(torch.version, "hip", None)) and cuda_available
+        intel_available = hasattr(torch, "xpu") and torch.xpu.is_available()
+    except Exception:  # pragma: no cover - torch may not be installed
+        cuda_available = rocm_available = intel_available = False
+
+    with path.open("w", encoding="utf-8") as f:
+        f.write("# Hardware Support\n\n")
+        f.write(f"- CUDA available: {cuda_available}\n")
+        f.write(f"- ROCm available: {rocm_available}\n")
+        f.write(f"- Intel GPU available: {intel_available}\n")
+        f.write(f"- Selected device: {device}\n")
+
+
 def main() -> None:
     """Run all bootstrap checks."""
     check_python()
     ensure_optional_deps()
     validate_env()
+    device = detect_device()
+    log_hardware_support(device)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add CUDA/ROCm/Intel GPU detection with CPU fallback in bootstrap
- record torch hardware probe results in `docs/hardware_support.md`
- add pytest-benchmark-based training/inference benchmark logging to `data/benchmarks/`

## Testing
- `python -m pre_commit run --files scripts/bootstrap.py docs/hardware_support.md benchmarks/train_infer.py data/benchmarks/.gitignore`
- `pytest benchmarks/train_infer.py --benchmark-json=data/benchmarks/train_infer.json`


------
https://chatgpt.com/codex/tasks/task_e_68ab222f8c64832e8933be8cbc6ab141