### PR TITLE
feat: add data validation pipeline and security docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ logs/
 
 # Database files
 *.db
+# DVC
+.dvc/config
+.dvc/tmp/
+
+# Training data managed by DVC
+data/training/

--- a/docs/data_security.md
+++ b/docs/data_security.md
@@ -1,0 +1,34 @@
+# Data Security and Compliance
+
+This document outlines how training data should be handled with respect to
+GDPR and HIPAA regulations.
+
+## GDPR Considerations
+
+- Collect only data with explicit user consent and document the purpose of
+  processing.
+- Apply data minimization so that no unnecessary personal information is
+  stored.
+- Support the right to access and delete personal data on request.
+- Encrypt data at rest and in transit when storing or transferring
+  information.
+- Maintain records of processing activities and breach‑notification
+  procedures.
+
+## HIPAA Considerations
+
+- Treat all protected health information (PHI) as confidential and limit
+  access to authorized personnel.
+- Use secure authentication and audit logging to track data access.
+- Ensure data is encrypted both at rest and during transmission.
+- Provide business associate agreements (BAAs) with any third‑party service
+  that processes PHI.
+- Implement policies for timely breach reporting and incident response.
+
+## Best Practices
+
+- Regularly review datasets for sensitive information before uploading to
+  shared storage.
+- Rotate credentials for data storage backends and restrict access using
+  least‑privilege principles.
+- Document data retention periods and remove obsolete records.

--- a/dvc.config.example
+++ b/dvc.config.example
@@ -1,0 +1,5 @@
+[core]
+    remote = training-storage
+
+['remote "training-storage"']
+    url = s3://example-bucket/training-data

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,10 @@
+stages:
+  validate:
+    cmd: python scripts/data_validate.py data/training
+    deps:
+      - scripts/data_validate.py
+      - data/training
+    outs:
+      - data/validation/schema.pbtxt
+      - data/validation/stats.tfrecord
+      - data/validation/anomalies.pbtxt

--- a/scripts/data_validate.py
+++ b/scripts/data_validate.py
@@ -1,0 +1,63 @@
+"""Validate training data schema using TensorFlow Data Validation.
+
+This script computes statistics for a CSV dataset and either infers a
+schema or validates the data against an existing schema. Outputs are
+written under ``data/validation`` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import tensorflow_data_validation as tfdv
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "data",
+        help="Path to training data in CSV format.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="data/validation/schema.pbtxt",
+        help="Path to an existing schema or where to write an inferred one.",
+    )
+    parser.add_argument(
+        "--stats",
+        default="data/validation/stats.tfrecord",
+        help="Where to write computed statistics.",
+    )
+    parser.add_argument(
+        "--anomalies",
+        default="data/validation/anomalies.pbtxt",
+        help="Where to write detected anomalies, if any.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(os.path.dirname(args.stats), exist_ok=True)
+
+    stats = tfdv.generate_statistics_from_csv(data_location=args.data)
+    tfdv.write_stats_text(stats, args.stats)
+
+    if os.path.exists(args.schema):
+        schema = tfdv.load_schema_text(args.schema)
+        anomalies = tfdv.validate_statistics(statistics=stats, schema=schema)
+        if anomalies.anomaly_info:
+            tfdv.write_anomalies_text(anomalies, args.anomalies)
+            print(f"Anomalies written to {args.anomalies}")
+        else:
+            print("No anomalies found.")
+    else:
+        schema = tfdv.infer_schema(stats)
+        tfdv.write_schema_text(schema, args.schema)
+        print(f"Schema written to {args.schema}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- track training data with a new dvc.yaml pipeline and sample remote config
- validate CSV training data using new `scripts/data_validate.py`
- document GDPR and HIPAA considerations for datasets

## Testing
- `pre-commit run --files .gitignore dvc.yaml dvc.config.example scripts/data_validate.py docs/data_security.md`
- `dvc doctor`
- `pytest -q` *(fails: tests/test_dashboard_app.py::test_dashboard_app_renders_metrics, tests/test_dashboard_app.py::test_dashboard_app_multiple_metrics, tests/test_dashboard_app.py::test_dashboard_app_large_metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2518143c832eb3ae4405b8f318a9