### PR TITLE
Add Triton inference deployment with Prometheus metrics

### DIFF
--- a/deployment/k8s/deployment.yaml
+++ b/deployment/k8s/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abzu-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: abzu-inference
+  template:
+    metadata:
+      labels:
+        app: abzu-inference
+    spec:
+      containers:
+        - name: triton
+          image: abzu-inference:latest
+          ports:
+            - containerPort: 8000
+            - containerPort: 8001
+            - containerPort: 8002
+          resources:
+            limits:
+              nvidia.com/gpu: 1

--- a/deployment/k8s/hpa.yaml
+++ b/deployment/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: abzu-inference
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: abzu-inference
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/deployment/k8s/service.yaml
+++ b/deployment/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: abzu-inference
+spec:
+  selector:
+    app: abzu-inference
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+    - name: grpc
+      port: 8001
+      targetPort: 8001
+    - name: metrics
+      port: 8002
+      targetPort: 8002

--- a/docker/Dockerfile.inference
+++ b/docker/Dockerfile.inference
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+# Base image providing NVIDIA Triton Inference Server
+FROM nvcr.io/nvidia/tritonserver:24.03-py3
+
+# Copy model repository into the image
+ARG MODEL_REPO=./models
+ENV MODEL_REPOSITORY=/models
+COPY ${MODEL_REPO} ${MODEL_REPOSITORY}
+
+# Expose Triton HTTP, gRPC and metrics ports
+EXPOSE 8000 8001 8002
+
+# Launch Triton server with the model repository
+CMD ["tritonserver", "--model-repository=/models"]

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: abzu-inference
+description: Deploy ABZU Triton inference server with autoscaling
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abzu-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: abzu-inference
+  template:
+    metadata:
+      labels:
+        app: abzu-inference
+    spec:
+      containers:
+        - name: triton
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.httpPort }}
+            - containerPort: {{ .Values.service.grpcPort }}
+            - containerPort: {{ .Values.service.metricsPort }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: abzu-inference
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: abzu-inference
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: abzu-inference
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: abzu-inference
+  ports:
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: {{ .Values.service.httpPort }}
+    - name: grpc
+      port: {{ .Values.service.grpcPort }}
+      targetPort: {{ .Values.service.grpcPort }}
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: {{ .Values.service.metricsPort }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: abzu-inference
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  httpPort: 8000
+  grpcPort: 8001
+  metricsPort: 8002
+
+resources: {}
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80

--- a/introspection_api.py
+++ b/introspection_api.py
@@ -6,11 +6,14 @@ import ast
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 
 from src.lwm import default_lwm
 
 app = FastAPI()
+
+Instrumentator().instrument(app).expose(app)
 
 # Allowed directories for module inspection; defaults to repository root.
 ALLOWED_DIRS = [Path(__file__).resolve().parent]

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,25 @@
+{
+  "title": "ABZU FastAPI Metrics",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Request Rate",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[1m]))",
+          "legendFormat": "requests"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Request Duration",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "psutil==7.0.0",
     "omegaconf==2.3.0",
     "pydantic==2.9.2",
-    "uvicorn==0.35.0"
+    "uvicorn==0.35.0",
+    "prometheus-fastapi-instrumentator==6.1.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,10 @@
 #    uv pip compile pyproject.toml --no-deps -o requirements.txt
 numpy==1.26.4
     # via spiral-os (pyproject.toml)
+prometheus-client==0.20.0
+    # via spiral-os (pyproject.toml)
+prometheus-fastapi-instrumentator==6.1.0
+    # via spiral-os (pyproject.toml)
 psutil==7.0.0
     # via spiral-os (pyproject.toml)
 python-json-logger==3.3.0

--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ import numpy as np
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 from PIL import Image
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, Field
 
 import corpus_memory_logging
@@ -38,6 +39,8 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 app.include_router(video_stream.router)
 app.include_router(webrtc_connector.router)
+
+Instrumentator().instrument(app).expose(app)
 
 _avatar_stream: Optional[Iterator[np.ndarray]] = None
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from typing import List, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from style_engine import style_library
 
 app = FastAPI()
+
+Instrumentator().instrument(app).expose(app)
 
 # ---------------------------------------------------------------------------
 # Core logic functions


### PR DESCRIPTION
## Summary
- containerize inference with Triton Server
- add Kubernetes manifests and Helm chart with autoscaling
- instrument FastAPI apps with Prometheus metrics and provide Grafana dashboard

## Testing
- `pre-commit run --files docker/Dockerfile.inference deployment/k8s/deployment.yaml deployment/k8s/service.yaml deployment/k8s/hpa.yaml helm/Chart.yaml helm/values.yaml helm/templates/deployment.yaml helm/templates/service.yaml helm/templates/hpa.yaml server.py src/api/server.py introspection_api.py pyproject.toml requirements.txt monitoring/grafana-dashboard.json`
- `pytest` *(fails: assert False, KeyError: 'kind', AttributeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab2add5a64832e97b27bdf1aa74a1b