### PR TITLE
Organize imports across modules

### DIFF
--- a/src/lwm/config_model.py
+++ b/src/lwm/config_model.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Configuration model for the Large World Model."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/lwm/large_world_model.py
+++ b/src/lwm/large_world_model.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Minimal Large World Model converting 2D frames into a 3D scene."""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Iterable

--- a/src/spiral_os/start_spiral_os.py
+++ b/src/spiral_os/start_spiral_os.py
@@ -11,9 +11,8 @@ import threading
 from pathlib import Path
 from typing import List, Optional
 
-import yaml
-
 import uvicorn
+import yaml
 
 import emotion_registry
 import emotional_state
@@ -23,11 +22,11 @@ from connectors import webrtc_connector
 from core import language_engine, self_correction_engine
 from dashboard import system_monitor
 from env_validation import check_optional_packages, check_required
-from INANNA_AI_AGENT import inanna_ai
 from INANNA_AI import defensive_network_utils as dnu
 from INANNA_AI import glm_analyze, glm_init, listening_engine
 from INANNA_AI.ethical_validator import EthicalValidator
 from INANNA_AI.personality_layers import REGISTRY, list_personalities
+from INANNA_AI_AGENT import inanna_ai
 from rag.orchestrator import MoGEOrchestrator
 from tools import reflection_loop
 

--- a/start_dev_agents.py
+++ b/start_dev_agents.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Command line launcher for the development agent cycle."""
+
+from __future__ import annotations
 
 import argparse
 import json

--- a/tools/virtual_env_manager.py
+++ b/tools/virtual_env_manager.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for working with Python virtual environments."""
+
+from __future__ import annotations
 
 import os
 import subprocess

--- a/tools/voice_conversion.py
+++ b/tools/voice_conversion.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Command line wrappers for voice conversion tools."""
+
+from __future__ import annotations
 
 import subprocess
 import tempfile

--- a/training_guide.py
+++ b/training_guide.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Log intent outcomes for reinforcement learning.
 
 Entries are appended to ``data/feedback.json`` as dictionaries with the
@@ -10,6 +8,8 @@ following keys:
 ``tone`` tonal label if provided,
 ``success`` boolean result indicator.
 """
+
+from __future__ import annotations
 
 import json
 from datetime import datetime


### PR DESCRIPTION
## Summary
- reorder imports and move module docstrings to top across several modules
- sort Spiral OS launcher imports into standard, third-party, and local groups

## Testing
- `ruff check --select E402,I001,F401 start_dev_agents.py tools/virtual_env_manager.py tools/voice_conversion.py training_guide.py src/lwm/config_model.py src/lwm/large_world_model.py src/spiral_os/start_spiral_os.py`
- `black start_dev_agents.py tools/virtual_env_manager.py tools/voice_conversion.py training_guide.py src/lwm/config_model.py src/lwm/large_world_model.py src/spiral_os/start_spiral_os.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_fastapi_instrumentator')*

------
https://chatgpt.com/codex/tasks/task_e_68ab303750cc832e80790420145e5941