### PR TITLE
Annotate helper functions and clean docstrings

### DIFF
--- a/INANNA_AI_AGENT/model.py
+++ b/INANNA_AI_AGENT/model.py
@@ -10,6 +10,8 @@ import logging
 from pathlib import Path
 from typing import Tuple
 
+_TRANSFORMERS_IMPORT_ERROR: ImportError | None
+
 try:  # pragma: no cover - import guarded for optional dependency
     from transformers import AutoModelForCausalLM, AutoTokenizer
 except ImportError as exc:  # pragma: no cover - handled at runtime
@@ -33,6 +35,7 @@ def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
     -------
     Tuple[AutoModelForCausalLM, AutoTokenizer]
         The loaded model and tokenizer.
+
     """
     if AutoModelForCausalLM is None or AutoTokenizer is None:
         raise ImportError(

--- a/seven_dimensional_music.py
+++ b/seven_dimensional_music.py
@@ -18,14 +18,20 @@ except Exception:  # pragma: no cover - optional dependency
     sf = None  # type: ignore
 
 from MUSIC_FOUNDATION.qnl_utils import quantum_embed
+from numpy.typing import NDArray
+from typing import Any
 
 
-def embedding_to_params(_emb):
-    """Return pitch, tempo and volume from embedding."""
+def embedding_to_params(_emb: NDArray[np.floating]) -> tuple[float, float, float]:
+    """Return pitch, tempo, and volume from an embedding.
+
+    The mapping currently returns constant values and serves as a placeholder
+    for more sophisticated audio parameter extraction.
+    """
     return 0.0, 1.0, 1.0
 
 
-def analyze_seven_planes(*_args, **_kwargs) -> dict:
+def analyze_seven_planes(*_args: Any, **_kwargs: Any) -> dict:
     """Return dummy plane analysis."""
     return {
         "physical": {"element": "bass"},
@@ -41,6 +47,11 @@ def analyze_seven_planes(*_args, **_kwargs) -> dict:
 def generate_quantum_music(
     context: str, emotion: str, *, output_dir: Path = Path(".")
 ) -> Path:
+    """Generate a simple quantum-inspired tone.
+
+    Saves a short sine wave as ``quantum.wav`` under ``output_dir`` and writes
+    a companion JSON file with placeholder seven-plane analysis.
+    """
     embed = quantum_embed(context)
     _pitch, _tempo, _vol = embedding_to_params(embed)
     sr = 44100
@@ -60,6 +71,11 @@ def generate_quantum_music(
 
 
 def main(args: list[str] | None = None) -> None:
+    """Run the command-line interface for quantum music generation.
+
+    Parses arguments, copies audio, optionally embeds hidden data, and writes a
+    JSON analysis file alongside the output.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("input")
     parser.add_argument("--output", required=True)

--- a/task_profiling.py
+++ b/task_profiling.py
@@ -1,10 +1,11 @@
 """Compatibility wrappers around :class:`core.task_profiler.TaskProfiler`.
 
-Instantiates a shared profiler at import time for quick access."""
+Instantiates a shared profiler at import time for quick access.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from core.task_profiler import TaskProfiler
 
@@ -16,8 +17,12 @@ def classify_task(text: str | Dict[str, Any]) -> str:
     return _profiler.classify(text)
 
 
-def ritual_action_sequence(condition: str, emotion: str):
-    """Return ritual actions for ``condition`` and ``emotion``."""
+def ritual_action_sequence(condition: str, emotion: str) -> List[str]:
+    """Return ritual action names for ``condition`` and ``emotion``.
+
+    Delegates to the shared :class:`TaskProfiler` instance which maps the
+    inputs to a sequence of actions defined in the ritual profile.
+    """
     return _profiler.ritual_action_sequence(condition, emotion)
 
 


### PR DESCRIPTION
## Summary
- type and document the `embedding_to_params`, `generate_quantum_music`, and `main` helpers
- add return typing and description to `task_profiling.ritual_action_sequence`
- define optional transformer import error placeholder in model loader

## Testing
- `mypy --hide-error-context --hide-error-codes --no-color-output`
- `mypy seven_dimensional_music.py task_profiling.py --hide-error-context --hide-error-codes --no-color-output`
- `ruff check --select D INANNA_AI_AGENT/model.py seven_dimensional_music.py task_profiling.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4070ea44832ea9d5dc60a999be01