### PR TITLE
ci: enforce ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           pip install ruff black mypy pytest
 
       - name: Ruff
-        run: ruff check --exit-zero .
+        run: ruff check .
 
       - name: Black
         run: black --check --exclude tests .

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -41,7 +41,20 @@ bash scripts/smoke_console_interface.sh
 
 Additional guidance is available in [testing.md](testing.md).
 
+## Linting
+
+Continuous integration runs [Ruff](https://docs.astral.sh/ruff/) and fails if any
+lint errors are detected. Check your changes locally with:
+
+```bash
+ruff check .
+```
+
+Fix any reported issues before pushing to ensure the CI pipeline remains
+green.
+
 ## Style and Contribution
 
-Code follows the guidelines in [CODE_STYLE.md](../CODE_STYLE.md). Commits should be small and include descriptive messages.
+Code follows the guidelines in [CODE_STYLE.md](../CODE_STYLE.md). Commits should
+be small and include descriptive messages.
 


### PR DESCRIPTION
## Summary
- fail CI on ruff violations by removing `--exit-zero`
- document ruff linting requirement in development workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/development_workflow.md`
- `if ruff check . > /tmp/ruff.log; then tail -n 20 /tmp/ruff.log && echo 'ruff passed'; else tail -n 20 /tmp/ruff.log && echo 'ruff failed'; fi` (fails with temporary lint error)


------
https://chatgpt.com/codex/tasks/task_e_68ab46464968832e8c35316054e6a640