### PR TITLE
refactor: move imports above code

### DIFF
--- a/INANNA_AI/network_utils/__init__.py
+++ b/INANNA_AI/network_utils/__init__.py
@@ -7,6 +7,9 @@ import threading
 from importlib import resources
 from pathlib import Path
 
+from .analysis import analyze_capture
+from .capture import capture_packets
+
 CONFIG_FILE = (
     Path(__file__).resolve().parents[2]
     / "INANNA_AI_AGENT"
@@ -51,13 +54,6 @@ def schedule_capture(interface: str, period: float) -> threading.Timer:
     timer.start()
     return timer
 
-
-from .analysis import (  # noqa: E402 - imported late to avoid circular import
-    analyze_capture,
-)
-from .capture import (  # noqa: E402 - imported late to avoid circular import
-    capture_packets,
-)
 
 __all__ = [
     "capture_packets",

--- a/INANNA_AI/network_utils/analysis.py
+++ b/INANNA_AI/network_utils/analysis.py
@@ -8,8 +8,6 @@ from collections import Counter
 from pathlib import Path
 from typing import Optional
 
-from . import load_config
-
 try:  # pragma: no cover - optional dependency
     from scapy.all import rdpcap  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -39,6 +37,8 @@ def analyze_capture(pcap_path: str, *, log_dir: Optional[str] = None) -> dict:
         "protocols": dict(proto_counts),
         "top_talkers": top_talkers,
     }
+
+    from . import load_config
 
     cfg = load_config()
     log_directory = Path(log_dir or cfg.get("log_dir", "network_logs"))

--- a/INANNA_AI/network_utils/capture.py
+++ b/INANNA_AI/network_utils/capture.py
@@ -6,8 +6,6 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from . import load_config
-
 try:  # pragma: no cover - optional dependency
     from scapy.all import sniff, wrpcap  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -22,6 +20,8 @@ def capture_packets(
     interface: str, *, count: int = 20, output: Optional[str] = None
 ) -> None:
     """Capture ``count`` packets from ``interface`` and write them to ``output``."""
+    from . import load_config
+
     cfg = load_config()
     out_path = Path(output or cfg.get("capture_file", "capture.pcap"))
     out_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- load network utility submodules before definitions and clean up circular imports
- tighten server token typing and annotate lifespan for mypy

## Testing
- `ruff check server.py INANNA_AI/network_utils/__init__.py INANNA_AI/network_utils/capture.py INANNA_AI/network_utils/analysis.py`
- `black server.py INANNA_AI/network_utils/__init__.py INANNA_AI/network_utils/capture.py INANNA_AI/network_utils/analysis.py`
- `mypy server.py INANNA_AI/network_utils/__init__.py INANNA_AI/network_utils/capture.py INANNA_AI/network_utils/analysis.py`
- `pytest tests/test_root_chakra_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab472a7668832eb3b95f5e10a90d40