### PR TITLE
refactor import order

### DIFF
--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -184,7 +184,7 @@ Generated automatically. Lists each Python file with its description and externa
 | `src/audio/dsp_engine.py` | No description | magenta, numpy, rave, soundfile, torch |
 | `src/audio/engine.py` | No description | MUSIC_FOUNDATION, audio, numpy, pydub, simpleaudio, soundfile |
 | `src/audio/mix_tracks.py` | No description | MUSIC_FOUNDATION, numpy, soundfile, yaml |
-| `src/audio/play_ritual_music.py` | No description | INANNA_AI, MUSIC_FOUNDATION, core, numpy, soundfile |
+| `src/audio/play_ritual_music.py` | Compose short ritual music based on emotion and play it. | core, INANNA_AI, MUSIC_FOUNDATION, numpy, soundfile |
 | `src/audio/segment.py` | No description | core, numpy |
 | `src/audio/voice_aura.py` | No description | audio, soundfile |
 | `src/audio/voice_cloner.py` | No description | INANNA_AI, core, numpy |

--- a/src/audio/play_ritual_music.py
+++ b/src/audio/play_ritual_music.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Compose short ritual music based on emotion and play it."""
+
+from __future__ import annotations
 
 import argparse
 import base64
@@ -154,7 +154,7 @@ def compose_ritual_music(
         if mix.size < wave.size:
             mix = np.pad(mix, (0, wave.size - mix.size))
         wave = wave + mix[: wave.size]
-        max_val = np.max(np.abs(wave))
+        max_val = float(np.max(np.abs(wave)))
         if max_val > 0:
             wave /= max_val
         if sf is None:
@@ -169,7 +169,7 @@ def compose_ritual_music(
             if stego_wave.size < wave.size:
                 stego_wave = np.pad(stego_wave, (0, wave.size - stego_wave.size))
             mixed = wave[: stego_wave.size] + stego_wave[: wave.size]
-            max_val = np.max(np.abs(mixed))
+            max_val = float(np.max(np.abs(mixed)))
             if max_val > 0:
                 mixed /= max_val
             if sf is None:


### PR DESCRIPTION
## Summary
- ensure `play_ritual_music` imports are grouped at top and typed normalization
- update component index entry for `play_ritual_music`

## Testing
- `ruff check emotional_state.py src/audio/play_ritual_music.py`
- `black emotional_state.py src/audio/play_ritual_music.py`
- `mypy emotional_state.py src/audio/play_ritual_music.py`
- `pytest tests/test_emotional_state.py tests/test_play_ritual_music.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab488d42b0832eb56d02b6414cf4c1