### PR TITLE
Refactor import order in memory modules

### DIFF
--- a/INANNA_AI/corpus_memory.py
+++ b/INANNA_AI/corpus_memory.py
@@ -12,6 +12,9 @@ from typing import Dict, Iterable, List, Tuple
 
 import numpy as np
 
+import corpus_memory_logging
+import crown_config
+
 try:
     import chromadb
     from chromadb.api import Collection
@@ -51,9 +54,6 @@ except ImportError:  # pragma: no cover - optional dependency
 
         return types.SimpleNamespace(encode=_encode)
 
-
-import corpus_memory_logging
-import crown_config
 
 try:  # pragma: no cover - optional dependency
     import vector_memory as _vector_memory

--- a/vector_memory.py
+++ b/vector_memory.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import json
 import logging
 import math
+import threading
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, cast
+
+from MUSIC_FOUNDATION import qnl_utils
+from crown_config import settings
 
 try:  # pragma: no cover - optional dependency
     from distributed_memory import DistributedMemory
@@ -32,12 +37,6 @@ except Exception:  # pragma: no cover - optional dependency
             raise RuntimeError("memory_store backend unavailable")
 
     _MemoryStore = _MemoryStoreStub  # type: ignore[misc,assignment]
-
-import threading
-from dataclasses import dataclass
-
-from crown_config import settings
-from MUSIC_FOUNDATION import qnl_utils
 
 
 def _default_embed(text: str) -> Any:


### PR DESCRIPTION
## Summary
- tidy imports in `vector_memory` and `INANNA_AI.corpus_memory`
- ensure imports live at top of module

## Testing
- `ruff check memory distributed_memory.py memory_store.py spiral_memory.py vector_memory.py corpus_memory_logging.py INANNA_AI/corpus_memory.py INANNA_AI/emotional_memory.py src/core/memory_logger.py src/core/memory_physical.py`
- `black memory distributed_memory.py memory_store.py spiral_memory.py vector_memory.py corpus_memory_logging.py INANNA_AI/corpus_memory.py INANNA_AI/emotional_memory.py src/core/memory_logger.py src/core/memory_physical.py`
- `mypy memory distributed_memory.py memory_store.py spiral_memory.py vector_memory.py corpus_memory_logging.py INANNA_AI/corpus_memory.py INANNA_AI/emotional_memory.py src/core/memory_logger.py src/core/memory_physical.py` *(fails: Function is missing a type annotation for one or more arguments)*
- `pytest tests -k memory` *(fails: AttributeError: namespace(set_last_emotion=<function ...>, get_last_emotion=<function ...>) has no attribute 'snapshot')*

------
https://chatgpt.com/codex/tasks/task_e_68ab4baff1ec832eac976e5bf4021a89