### PR TITLE
Sort imports and update music avatar docs

### DIFF
--- a/INANNA_AI_AGENT/__init__.py
+++ b/INANNA_AI_AGENT/__init__.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import builtins as _builtins
 
-from . import benchmark_preprocess
+from . import benchmark_preprocess, model, preprocess, source_loader
 from . import inanna_ai as _inanna_ai
-from . import model, preprocess, source_loader
 
 # Re-export the CLI entry point for convenience
 INANNA_AI = _inanna_ai.main

--- a/docs/music_avatar_architecture.md
+++ b/docs/music_avatar_architecture.md
@@ -3,7 +3,8 @@
 The Crown agent can reflect on musical input by combining feature extraction
 with language model reasoning.  The `music_llm_interface.py` helper analyses an
 audio or MIDI file, packages the findings and forwards them to the Crown LLM
-through `rag.orchestrator.MoGEOrchestrator`.
+through `rag.orchestrator.MoGEOrchestrator`, which can optionally persist
+context using the `vector_memory` subsystem.
 
 ```bash
 python music_llm_interface.py path/to/song.wav
@@ -20,6 +21,10 @@ The script performs the following steps:
 
 The JSON printed to `stdout` combines the analysis with the LLM response, making
 it easy to feed musical context into higher level agents or pipelines.
+
+For generating test tones during development, the
+`seven_dimensional_music.generate_quantum_music` helper can synthesise a short
+audio clip along with placeholder seven-plane analysis.
 
 ## Evaluation Workflow
 

--- a/download_models.py
+++ b/download_models.py
@@ -21,7 +21,6 @@ import requests
 
 from download_model import download_deepseek  # reuse logic
 
-
 LOG_PATH = Path("logs") / "model_audit.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(

--- a/rag/orchestrator.py
+++ b/rag/orchestrator.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import logging
 import tempfile
 import threading
-from dataclasses import dataclass
 from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Callable, Deque, Dict, List

--- a/scripts/component_inventory.py
+++ b/scripts/component_inventory.py
@@ -14,13 +14,13 @@ quality score. Results are written to three files under ``docs``:
 * ``component_status.json`` – JSON snapshot for historical comparisons.
 """
 
-from dataclasses import dataclass
-from datetime import date
-from pathlib import Path
 import ast
 import json
 import subprocess
 import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
 from typing import Iterator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/seven_dimensional_music.py
+++ b/seven_dimensional_music.py
@@ -17,9 +17,11 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     sf = None  # type: ignore
 
-from MUSIC_FOUNDATION.qnl_utils import quantum_embed
-from numpy.typing import NDArray
 from typing import Any
+
+from numpy.typing import NDArray
+
+from MUSIC_FOUNDATION.qnl_utils import quantum_embed
 
 
 def embedding_to_params(_emb: NDArray[np.floating]) -> tuple[float, float, float]:

--- a/src/core/video_engine.py
+++ b/src/core/video_engine.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 """Avatar video generation utilities."""
 
 import logging
-import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
 import numpy as np
+import tomllib
 
 from core.utils.optional_deps import lazy_import
 

--- a/tests/test_existential_reflector.py
+++ b/tests/test_existential_reflector.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -11,8 +10,8 @@ from types import ModuleType
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from INANNA_AI_AGENT import inanna_ai
 from INANNA_AI.existential_reflector import ExistentialReflector
+from INANNA_AI_AGENT import inanna_ai
 
 
 class DummyResponse:

--- a/tests/test_inanna_ai.py
+++ b/tests/test_inanna_ai.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import sys
 from pathlib import Path
 
@@ -14,9 +13,9 @@ pytestmark = pytest.mark.skip(reason="requires unavailable resources")
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from INANNA_AI_AGENT import inanna_ai
-
 import json
+
+from INANNA_AI_AGENT import inanna_ai
 
 
 def test_activate_returns_chant(tmp_path, monkeypatch):

--- a/tests/test_introspection_api.py
+++ b/tests/test_introspection_api.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
-
 import pytest
+from fastapi.testclient import TestClient
 
 pytest.importorskip("omegaconf")
 

--- a/tests/test_lwm.py
+++ b/tests/test_lwm.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import sys
 import types
 
-from fastapi.testclient import TestClient
-
 import pytest
+from fastapi.testclient import TestClient
 
 pytest.importorskip("omegaconf")
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,6 +17,7 @@ from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
 from tokenizers.trainers import WordLevelTrainer
+
 from transformers import GPT2Config, GPT2LMHeadModel, PreTrainedTokenizerFast
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_qnl_audio_pipeline.py
+++ b/tests/test_qnl_audio_pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import sys
 import types
 from pathlib import Path
@@ -14,9 +13,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from INANNA_AI_AGENT import inanna_ai
-
 import env_validation
+from INANNA_AI_AGENT import inanna_ai
 
 pytestmark = pytest.mark.skipif(
     not env_validation.check_audio_binaries(require=False),

--- a/tests/test_root_chakra_integration.py
+++ b/tests/test_root_chakra_integration.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import json
 import sys
 import types

--- a/tests/test_suggest_enhancement.py
+++ b/tests/test_suggest_enhancement.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import sys
 from pathlib import Path
 

--- a/tests/test_voice_avatar_pipeline.py
+++ b/tests/test_voice_avatar_pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # mypy: ignore-errors
-
 import sys
 import types
 from pathlib import Path

--- a/vector_memory.py
+++ b/vector_memory.py
@@ -15,8 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, cast
 
-from MUSIC_FOUNDATION import qnl_utils
 from crown_config import settings
+from MUSIC_FOUNDATION import qnl_utils
 
 try:  # pragma: no cover - optional dependency
     from distributed_memory import DistributedMemory


### PR DESCRIPTION
## Summary
- Sort and group imports at file tops with ruff
- Document vector memory support and tone generator in music avatar architecture

## Testing
- `ruff check --select I001 INANNA_AI_AGENT/__init__.py download_models.py rag/orchestrator.py scripts/component_inventory.py seven_dimensional_music.py src/core/video_engine.py tests/test_existential_reflector.py tests/test_inanna_ai.py tests/test_introspection_api.py tests/test_lwm.py tests/test_model.py tests/test_qnl_audio_pipeline.py tests/test_root_chakra_integration.py tests/test_suggest_enhancement.py tests/test_voice_avatar_pipeline.py vector_memory.py`
- `black INANNA_AI_AGENT/__init__.py download_models.py rag/orchestrator.py scripts/component_inventory.py seven_dimensional_music.py src/core/video_engine.py tests/test_existential_reflector.py tests/test_inanna_ai.py tests/test_introspection_api.py tests/test_lwm.py tests/test_model.py tests/test_qnl_audio_pipeline.py tests/test_root_chakra_integration.py tests/test_suggest_enhancement.py tests/test_voice_avatar_pipeline.py vector_memory.py`
- `pytest tests/test_qnl_audio_pipeline.py tests/test_voice_avatar_pipeline.py tests/test_orchestrator.py tests/test_orchestrator_routing.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4d991c84832e8ff55196258b6571