### PR TITLE
Refactor network_utils imports

### DIFF
--- a/INANNA_AI/network_utils/__init__.py
+++ b/INANNA_AI/network_utils/__init__.py
@@ -2,39 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import threading
-from importlib import resources
-from pathlib import Path
 
 from .analysis import analyze_capture
 from .capture import capture_packets
-
-CONFIG_FILE = (
-    Path(__file__).resolve().parents[2]
-    / "INANNA_AI_AGENT"
-    / "network_utils_config.json"
-)
-
-_DEFAULT_CONFIG = {
-    "log_dir": "network_logs",
-    "capture_file": "network_logs/capture.pcap",
-}
-
-
-def load_config() -> dict:
-    """Return configuration for network utilities."""
-    if CONFIG_FILE.exists():
-        return json.loads(CONFIG_FILE.read_text())
-
-    try:
-        resource_path = resources.files("INANNA_AI") / "network_utils_config.json"
-        if resource_path.is_file():
-            return json.loads(resource_path.read_text())
-    except Exception:
-        pass
-
-    return _DEFAULT_CONFIG.copy()
+from .config import CONFIG_FILE, load_config
 
 
 def schedule_capture(interface: str, period: float) -> threading.Timer:

--- a/INANNA_AI/network_utils/analysis.py
+++ b/INANNA_AI/network_utils/analysis.py
@@ -13,6 +13,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - fallback
     rdpcap = None
 
+from .config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +38,6 @@ def analyze_capture(pcap_path: str, *, log_dir: Optional[str] = None) -> dict:
         "protocols": dict(proto_counts),
         "top_talkers": top_talkers,
     }
-
-    from . import load_config
 
     cfg = load_config()
     log_directory = Path(log_dir or cfg.get("log_dir", "network_logs"))

--- a/INANNA_AI/network_utils/capture.py
+++ b/INANNA_AI/network_utils/capture.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - fallback
     sniff = None
     wrpcap = None
 
+from .config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +21,6 @@ def capture_packets(
     interface: str, *, count: int = 20, output: Optional[str] = None
 ) -> None:
     """Capture ``count`` packets from ``interface`` and write them to ``output``."""
-    from . import load_config
-
     cfg = load_config()
     out_path = Path(output or cfg.get("capture_file", "capture.pcap"))
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/INANNA_AI/network_utils/config.py
+++ b/INANNA_AI/network_utils/config.py
@@ -1,0 +1,36 @@
+"""Configuration helpers for network utilities."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+
+CONFIG_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "INANNA_AI_AGENT"
+    / "network_utils_config.json"
+)
+
+_DEFAULT_CONFIG = {
+    "log_dir": "network_logs",
+    "capture_file": "network_logs/capture.pcap",
+}
+
+
+def load_config() -> dict:
+    """Return configuration for network utilities."""
+    if CONFIG_FILE.exists():
+        return json.loads(CONFIG_FILE.read_text())
+
+    try:
+        resource_path = resources.files("INANNA_AI") / "network_utils_config.json"
+        if resource_path.is_file():
+            return json.loads(resource_path.read_text())
+    except Exception:
+        pass
+
+    return _DEFAULT_CONFIG.copy()
+
+
+__all__ = ["CONFIG_FILE", "load_config"]


### PR DESCRIPTION
## Summary
- centralize network utilities configuration to avoid circular imports
- expose `load_config` at module level and group standard, third-party, and project imports

## Testing
- `ruff check --select E402,I001 --fix server.py INANNA_AI/network_utils`
- `black server.py INANNA_AI/network_utils`
- `mypy server.py INANNA_AI/network_utils`
- `pytest tests/test_root_chakra_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab623b66bc832e9b69102866d1ee00