### PR TITLE
Add smoke tests for emotion logging and ritual music

### DIFF
--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -326,6 +326,7 @@ Generated automatically. Lists each Python file with its description and externa
 | `tests/test_emotion_registry.py` | Tests for emotion registry. | pytest, yaml |
 | `tests/test_emotional_memory.py` | Tests for emotional memory. | INANNA_AI |
 | `tests/test_emotional_state.py` | Tests for emotional state. | pytest |
+| `tests/test_emotional_state_logging.py` | Smoke test for emotion event logging. | emotional_state, pytest |
 | `tests/test_emotional_synaptic_engine.py` | Tests for emotional synaptic engine. | INANNA_AI |
 | `tests/test_emotional_voice.py` | Tests for emotional voice. | INANNA_AI |
 | `tests/test_env_validation.py` | Tests for env validation. | pytest |
@@ -399,6 +400,7 @@ Generated automatically. Lists each Python file with its description and externa
 | `tests/test_personality_layers.py` | Tests for personality layers. | INANNA_AI, pytest |
 | `tests/test_pipeline_cli.py` | Tests for pipeline cli. | None |
 | `tests/test_play_ritual_music.py` | Tests for play ritual music. | audio, numpy, soundfile |
+| `tests/test_play_ritual_music_smoke.py` | Smoke test for ritual music playback. | audio, numpy, soundfile |
 | `tests/test_predictive_gate.py` | Tests for predictive gate. | INANNA_AI |
 | `tests/test_preprocess.py` | Tests for preprocess. | INANNA_AI_AGENT, numpy |
 | `tests/test_project_audit.py` | Tests for project audit. | tools |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_media_avatar.py"),
     str(ROOT / "tests" / "test_introspection_api.py"),
     str(ROOT / "tests" / "test_lwm.py"),
+    str(ROOT / "tests" / "test_emotional_state_logging.py"),
+    str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
 }
 
 

--- a/tests/test_emotional_state_logging.py
+++ b/tests/test_emotional_state_logging.py
@@ -1,0 +1,35 @@
+"""Smoke test for emotion event logging."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import emotional_state
+
+
+def test_event_log_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_file = tmp_path / "state.json"
+    registry_file = tmp_path / "registry.json"
+    event_log = tmp_path / "events.jsonl"
+    monkeypatch.setattr(emotional_state, "STATE_FILE", state_file)
+    monkeypatch.setattr(emotional_state, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(emotional_state, "EVENT_LOG", event_log)
+    emotional_state._STATE.clear()
+    emotional_state._REGISTRY[:] = ["joy"]
+    emotional_state._save_state()
+    emotional_state._save_registry()
+
+    emotional_state.set_last_emotion("joy")
+
+    lines = event_log.read_text().strip().splitlines()
+    assert lines, "event log should contain at least one entry"
+    entry = json.loads(lines[-1])
+    assert entry["event"] == "set_last_emotion"
+    assert entry["emotion"] == "joy"

--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -1,0 +1,51 @@
+"""Smoke test for ritual music playback."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
+sys.modules.setdefault("gtts", types.ModuleType("gtts"))
+sys.modules.setdefault("openvoice", types.ModuleType("openvoice"))
+sys.modules.setdefault("sounddevice", types.ModuleType("sounddevice"))
+
+import audio.play_ritual_music as prm
+
+
+def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def dummy_compose(
+        tempo: float,
+        melody: list[int],
+        *,
+        wav_path: str | None = None,
+        wave_type: str = "sine",
+    ) -> np.ndarray:
+        wave: np.ndarray = np.zeros(100, dtype=np.float32)
+        if wav_path:
+            sf.write(wav_path, wave, 44100)
+        return wave
+
+    monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
+
+    played: list[Path] = []
+
+    def fake_play_audio(path: Path, loop: bool = False) -> None:
+        played.append(Path(path))
+
+    monkeypatch.setattr(prm.expressive_output, "play_audio", fake_play_audio)
+
+    out = tmp_path / "ritual.wav"
+    prm.compose_ritual_music("joy", "\u2609", out_path=out)
+
+    assert out.exists()
+    assert played and played[0] == out


### PR DESCRIPTION
## Summary
- add targeted smoke test verifying emotion events are logged
- add smoke test for ritual music composition and playback
- document new tests in component index and allow their execution

## Testing
- `ruff check --select E402,I001 --fix emotional_state.py src/audio/play_ritual_music.py`
- `black emotional_state.py src/audio/play_ritual_music.py tests/test_emotional_state_logging.py tests/test_play_ritual_music_smoke.py`
- `mypy emotional_state.py src/audio/play_ritual_music.py tests/test_emotional_state_logging.py tests/test_play_ritual_music_smoke.py`
- `pytest tests/test_emotional_state_logging.py tests/test_play_ritual_music_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab63b1b82c832ebbd50c9a2ebcb39c