### PR TITLE
chore: reorder imports and add transformation smoke test

### DIFF
--- a/archetype_shift_engine.py
+++ b/archetype_shift_engine.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Determine when to switch personality layers based on ritual cues or emotion."""
+
+from __future__ import annotations
 
 import logging
 from typing import Iterable
@@ -54,13 +54,13 @@ def maybe_shift_archetype(event: str, emotion: str) -> str | None:
     resonance = emotion_registry.get_resonance_level()
     current = emotion_registry.get_current_layer()
     if resonance >= 0.8:
-        layer = EMOTION_LAYER_MAP.get(emotion.lower())
-        if layer and layer != current:
+        target: str | None = EMOTION_LAYER_MAP.get(emotion.lower())
+        if target and target != current:
             try:
-                soul_state_manager.update_archetype(layer)
+                soul_state_manager.update_archetype(target)
             except Exception:
                 logger.exception("Failed to update archetype")
-            return layer
+            return target
     return None
 
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -31,6 +31,7 @@ These results indicate optional dependencies and system binaries are still missi
 
 - Standardized import order in `tools.session_logger`, `tools.sandbox_session`, and `tools.reflection_loop`.
 - Added smoke tests covering reflection and session logging utilities.
+- Reordered imports in `learning_mutator`, `state_transition_engine`, and `archetype_shift_engine` and added transformation smoke tests.
 
 ## Completed Milestones
 - [Sovereign voice pipeline](https://github.com/DINGIRABZU/ABZU/pull/38) — owner: @DINGIRABZU.

--- a/learning_mutator.py
+++ b/learning_mutator.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Suggest mutations to the intent matrix based on insight metrics."""
+
+from __future__ import annotations
 
 import argparse
 import json

--- a/state_transition_engine.py
+++ b/state_transition_engine.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Simple finite state engine based on emotional cues."""
+
+from __future__ import annotations
 
 from typing import List
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_lwm.py"),
     str(ROOT / "tests" / "test_emotional_state_logging.py"),
     str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
+    str(ROOT / "tests" / "test_transformation_smoke.py"),
 }
 
 

--- a/tests/test_transformation_smoke.py
+++ b/tests/test_transformation_smoke.py
@@ -1,0 +1,31 @@
+"""Smoke tests for transformation engines."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import archetype_shift_engine as ase  # noqa: E402
+import learning_mutator as lm  # noqa: E402
+from state_transition_engine import StateTransitionEngine  # noqa: E402
+
+
+def test_transformation_smoke(monkeypatch):
+    matrix = {"bad": {"counts": {"total": 4, "success": 1}}}
+    monkeypatch.setattr(
+        lm, "load_intents", lambda path=None: {"bad": {"synonyms": ["awful"]}}
+    )
+    suggestions = lm.propose_mutations(matrix)
+    assert suggestions
+
+    ste = StateTransitionEngine()
+    ste.update_state("begin the ritual now")
+    assert ste.current_state() == "ritual"
+
+    monkeypatch.setattr(ase.emotion_registry, "get_resonance_level", lambda: 0.9)
+    monkeypatch.setattr(ase.emotion_registry, "get_current_layer", lambda: "albedo")
+    layer = ase.maybe_shift_archetype("hello", "anger")
+    assert layer == "nigredo_layer"


### PR DESCRIPTION
## Summary
- reorder imports in learning, state transition, and archetype shift engines
- add transformation smoke test and allow it in pytest configuration
- document refactoring work in project status

## Testing
- `ruff check learning_mutator.py state_transition_engine.py archetype_shift_engine.py --select E402,I001 --fix`
- `black learning_mutator.py state_transition_engine.py archetype_shift_engine.py`
- `mypy learning_mutator.py state_transition_engine.py archetype_shift_engine.py`
- `pytest tests/test_transformation_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6856a364832e88ff295b22e151c0