### PR TITLE
Document vector memory dependencies and annotate spiral accumulator

### DIFF
--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -32,17 +32,20 @@ in a lightweight ontology stored in SQLite.
 ## Spiral registry
 
 [`spiral_memory.py`](../spiral_memory.py) aggregates multi‑layer data and logs
-major events with optional sacred glyphs.
+major events with optional sacred glyphs. When available, a small PyTorch
+transformer refines cross‑layer aggregates.
 
 ## Vector memory
 
-[`vector_memory.py`](../vector_memory.py) embeds text through ChromaDB and
-applies exponential decay so recent conversations have more influence.
+[`vector_memory.py`](../vector_memory.py) embeds text through a
+FAISS/SQLite-backed `MemoryStore`, optionally replicating to Redis. It applies
+exponential decay so recent conversations have more influence. Dependencies
+include `faiss`, `numpy` and optional `redis` for distributed backups.
 
 ```mermaid
 flowchart LR
     T[Text input] --> E[embed_text]
-    E --> C[(ChromaDB store)]
+    E --> C[(MemoryStore)]
     C --> D[Decay scheduler]
     C --> R[search]
     D --> C

--- a/spiral_memory.py
+++ b/spiral_memory.py
@@ -104,7 +104,7 @@ class SpiralMemory:
             result = self._model(tensor)
             return result.mean(dim=0).tolist()
         length = max(len(layer) for layer in self.layers)
-        acc = [[] for _ in range(length)]
+        acc: List[List[float]] = [[] for _ in range(length)]
         for layer in self.layers:
             for idx, val in enumerate(layer):
                 acc[idx].append(float(val))


### PR DESCRIPTION
## Summary
- annotate SpiralMemory aggregate accumulator to satisfy type checking
- document vector memory's FAISS/SQLite backend and optional Redis backup

## Testing
- `ruff --config /tmp/ruff_imports.toml check --fix vector_memory.py spiral_memory.py memory_store.py`
- `black vector_memory.py spiral_memory.py memory_store.py`
- `mypy vector_memory.py spiral_memory.py memory_store.py`
- `pytest tests/test_vector_memory.py tests/test_spiral_memory.py tests/test_memory_store.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6994e09c832eb457e03d9daee562