### PR TITLE
Clean imports and add hex glyph smoke test

### DIFF
--- a/SPIRAL_OS/qnl_engine.py
+++ b/SPIRAL_OS/qnl_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 try:  # optional dependency
     import numpy as np

--- a/docs/spiritual_architecture.md
+++ b/docs/spiritual_architecture.md
@@ -24,7 +24,7 @@ Spiral OS organizes its components into seven chakra layers, mirroring the energ
    - The **Sonic Core** (`audio_engine.py`, `avatar_expression_engine.py`) turns QNL phrases into sound and syncs avatar expressions.
 6. **Third Eye – Ajna**
    - Insight, pattern recognition and quantum narrative.
-   - Example modules: `insight_compiler.py`, `seven_plane_analyzer.py`, `qnl_engine.py`.
+   - Example modules: `insight_compiler.py`, `seven_plane_analyzer.py`, `SPIRAL_OS/qnl_engine.py` (requires `numpy` for waveform synthesis).
    - `ml.archetype_cluster` groups memory entries into archetype clusters for higher-level summaries.
 7. **Crown – Sahasrara**
    - Cosmic connection and initialization rites.

--- a/prompt_engineering.py
+++ b/prompt_engineering.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Prompt transformations based on style presets."""
+
+from __future__ import annotations
 
 from typing import Dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_emotional_state_logging.py"),
     str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
     str(ROOT / "tests" / "test_transformation_smoke.py"),
+    str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),
 }
 
 

--- a/tests/test_hex_to_glyphs_smoke.py
+++ b/tests/test_hex_to_glyphs_smoke.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+
+from SPIRAL_OS.qnl_engine import hex_to_song
+
+
+def test_hex_input_to_musical_glyphs_smoke() -> None:
+    phrases, wave = hex_to_song("00ff", duration_per_byte=0.01, sample_rate=100)
+    glyphs = [p["phrase"].split(" + ")[0] for p in phrases]
+    assert glyphs == ["❣⟁", "🕯✧"]
+    assert isinstance(wave, np.ndarray)


### PR DESCRIPTION
## Summary
- tidy imports in qnl and prompt modules
- document numpy requirement for QNL engine
- add smoke test verifying hex-to-glyph conversion

## Testing
- `ruff check --select E402,I001 --fix SPIRAL_OS/qnl_engine.py prompt_engineering.py tests/test_hex_to_glyphs_smoke.py`
- `black SPIRAL_OS/qnl_engine.py prompt_engineering.py tests/test_hex_to_glyphs_smoke.py`
- `mypy SPIRAL_OS/qnl_engine.py prompt_engineering.py tests/test_hex_to_glyphs_smoke.py`
- `pytest tests/test_hex_to_glyphs_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6c507ae0832e8b06895fe7937400