### PR TITLE
Add src directory to task profiling path

### DIFF
--- a/task_profiling.py
+++ b/task_profiling.py
@@ -5,7 +5,14 @@ Instantiates a shared profiler at import time for quick access.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parent
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 
 from core.task_profiler import TaskProfiler
 


### PR DESCRIPTION
## Summary
- ensure task_profiling adds the repository's `src` directory to `sys.path` so `core` can be imported when run as a module

## Testing
- `python -m task_profiling && echo "success"`
- `pytest tests/test_task_profiling.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a0ec88c832ea91736ba46ca2241