### PR TITLE
Ensure task_profiling adds src to PYTHONPATH

### DIFF
--- a/task_profiling.py
+++ b/task_profiling.py
@@ -5,6 +5,7 @@ Instantiates a shared profiler at import time for quick access.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -13,6 +14,12 @@ ROOT = Path(__file__).resolve().parent
 SRC_DIR = ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+# Ensure subprocesses also resolve modules from ``src``
+env_paths = os.environ.get("PYTHONPATH", "").split(os.pathsep)
+if str(SRC_DIR) not in env_paths:
+    env_paths.insert(0, str(SRC_DIR))
+    os.environ["PYTHONPATH"] = os.pathsep.join(filter(None, env_paths))
 
 from core.task_profiler import TaskProfiler
 


### PR DESCRIPTION
## Summary
- Update task_profiling to insert `src` into both `sys.path` and the `PYTHONPATH` environment variable so subprocesses can locate `core` modules

## Testing
- `pytest tests/test_task_profiling.py`
- `python -m task_profiling`


------
https://chatgpt.com/codex/tasks/task_e_68ab7de7ee18832ebb857471268713ae