### PR TITLE
feat: add numpy audio fallback

### DIFF
--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -37,3 +37,19 @@ def test_play_ritual_music_cli(tmp_path, monkeypatch):
     prm.main(["--emotion", "joy", "--ritual", "\u2609", "--output", str(out)])
 
     assert out.exists()
+
+
+def test_play_ritual_music_fallback(tmp_path, monkeypatch):
+    def dummy_compose(
+        tempo, melody, *, sample_rate=44100, wav_path=None, wave_type="sine"
+    ):
+        return np.zeros(100, dtype=np.float32)
+
+    monkeypatch.setattr(prm, "sf", None)
+    monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
+    monkeypatch.setattr(prm.expressive_output, "play_audio", lambda p, loop=False: None)
+
+    out = tmp_path / "ritual.wav"
+    prm.compose_ritual_music("joy", "\u2609", out_path=out)
+
+    assert out.exists()


### PR DESCRIPTION
## Summary
- use NumPy and the `wave` module to write ritual audio when `soundfile` is missing
- document fallback behaviour for ritual playback
- test fallback path without `soundfile`

## Testing
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ee685e4832ebbb82092147181c8