### PR TITLE
Add chakra version manifest and bumping logic

### DIFF
--- a/docs/chakra_koan_system.md
+++ b/docs/chakra_koan_system.md
@@ -37,3 +37,5 @@ The sky wonders about its height.
 A petal falls into nothing and finds it full.
 Emptiness crowns the temple.
 
+For version tracking of chakra modules, see [chakra_versions.json](chakra_versions.json).
+

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -1,0 +1,9 @@
+{
+  "root": "0.1.0",
+  "sacral": "0.1.0",
+  "solar_plexus": "0.1.0",
+  "heart": "0.1.0",
+  "throat": "0.1.0",
+  "third_eye": "0.1.0",
+  "crown": "0.1.0"
+}

--- a/release.py
+++ b/release.py
@@ -7,11 +7,24 @@ newly dated release heading.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from datetime import date
 from pathlib import Path
 
 import tomllib
+
+# Mapping of chakra names to associated module paths.
+# Paths ending with a slash are treated as directory prefixes.
+CHAKRA_MODULES: dict[str, list[str]] = {
+    "root": ["server.py", "INANNA_AI/network_utils/"],
+    "sacral": ["emotional_state.py", "emotion_registry.py"],
+    "solar_plexus": ["learning_mutator.py", "state_transition_engine.py"],
+    "heart": ["voice_avatar_config.yaml", "vector_memory.py"],
+    "throat": ["crown_prompt_orchestrator.py", "INANNA_AI_AGENT/inanna_ai.py"],
+    "third_eye": ["insight_compiler.py", "SPIRAL_OS/qnl_engine.py", "seven_dimensional_music.py"],
+    "crown": ["init_crown_agent.py", "start_spiral_os.py", "crown_model_launcher.sh"],
+}
 
 
 def run(cmd: list[str]) -> None:
@@ -48,8 +61,68 @@ def build_wheel() -> None:
     run(["python", "-m", "build", "--wheel"])
 
 
+def _changed_files() -> list[str]:
+    """Return files changed since the last git tag.
+
+    If no tag is found, fall back to listing tracked files.
+    """
+    try:
+        tag = (
+            subprocess.run(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        )
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", f"{tag}..HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        files = [f for f in diff.splitlines() if f]
+    except subprocess.CalledProcessError:
+        files = (
+            subprocess.run(
+                ["git", "ls-files"], capture_output=True, text=True, check=True
+            ).stdout.splitlines()
+        )
+    return files
+
+
+def _chakra_changed(changed: list[str], paths: list[str]) -> bool:
+    """Return ``True`` if any ``paths`` appear in ``changed`` files."""
+    for p in paths:
+        if p.endswith("/"):
+            if any(f.startswith(p) for f in changed):
+                return True
+        else:
+            if p in changed:
+                return True
+    return False
+
+
+def bump_chakra_versions() -> None:
+    """Increment versions for chakras with modified modules."""
+    path = Path("docs/chakra_versions.json")
+    if not path.exists():
+        return
+    versions = json.loads(path.read_text())
+    changed = _changed_files()
+    updated = False
+    for chakra, modules in CHAKRA_MODULES.items():
+        if _chakra_changed(changed, modules):
+            major, minor, patch = map(int, versions[chakra].split("."))
+            versions[chakra] = f"{major}.{minor}.{patch + 1}"
+            updated = True
+    if updated:
+        path.write_text(json.dumps(versions, indent=2) + "\n")
+
+
 def main() -> None:
     """Update changelog, tag the release and build a wheel."""
+    bump_chakra_versions()
     version = get_version()
     update_changelog(version)
     tag_version(version)


### PR DESCRIPTION
## Summary
- document chakra versions in `docs/chakra_versions.json`
- link koan documentation to chakra manifest
- enhance `release.py` to bump chakra versions when related modules change

## Testing
- `python -m py_compile release.py`
- `pytest tests/test_root_chakra_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab81985804832e86ff3745b21e5beb