### PR TITLE
Pin numpy, scipy and OpenCV versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,8 @@ markdown==3.8.2
     # via spiral-os (pyproject.toml)
 numpy==1.26.4
     # via spiral-os (pyproject.toml)
+opencv-python==4.10.0.84
+    # via spiral-os (pyproject.toml)
 omegaconf==2.3.0
     # via spiral-os (pyproject.toml)
 pre-commit==4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml --no-deps -o requirements.txt
 numpy==1.26.4
     # via spiral-os (pyproject.toml)
+opencv-python==4.10.0.84
+    # via spiral-os (pyproject.toml)
 prometheus-client==0.20.0
     # via spiral-os (pyproject.toml)
 prometheus-fastapi-instrumentator==6.1.0
@@ -13,4 +15,6 @@ python-json-logger==3.3.0
 pyyaml==6.0.2
     # via spiral-os (pyproject.toml)
 requests==2.32.4
+    # via spiral-os (pyproject.toml)
+scipy==1.11.4
     # via spiral-os (pyproject.toml)

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -7,6 +7,7 @@ from .contracts import EmotionAnalyzerService, MemoryLoggerService
 from .emotion_analyzer import EmotionAnalyzer
 from .feedback_logging import append_feedback, load_feedback
 from .memory_logger import MemoryLogger
+from .task_profiler import TaskProfiler
 
 __all__ = [
     "EmotionAnalyzer",
@@ -16,4 +17,5 @@ __all__ = [
     "append_feedback",
     "load_feedback",
     "load_config",
+    "TaskProfiler",
 ]

--- a/task_profiling.py
+++ b/task_profiling.py
@@ -12,14 +12,17 @@ from typing import Any, Dict, List
 
 ROOT = Path(__file__).resolve().parent
 SRC_DIR = ROOT / "src"
-if str(SRC_DIR) not in sys.path:
-    sys.path.insert(0, str(SRC_DIR))
+CORE_DIR = SRC_DIR / "core"
+for path in (SRC_DIR, CORE_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
-# Ensure subprocesses also resolve modules from ``src``
+# Ensure subprocesses also resolve modules from ``src`` and ``core``
 env_paths = os.environ.get("PYTHONPATH", "").split(os.pathsep)
-if str(SRC_DIR) not in env_paths:
-    env_paths.insert(0, str(SRC_DIR))
-    os.environ["PYTHONPATH"] = os.pathsep.join(filter(None, env_paths))
+for path in (SRC_DIR, CORE_DIR):
+    if str(path) not in env_paths:
+        env_paths.insert(0, str(path))
+os.environ["PYTHONPATH"] = os.pathsep.join(filter(None, env_paths))
 
 from core.task_profiler import TaskProfiler
 


### PR DESCRIPTION
## Summary
- pin numpy, scipy and opencv versions in dev and runtime requirements
- ensure src/core is included on PYTHONPATH for task_profiling

## Testing
- `pre-commit run --files dev-requirements.txt requirements.txt task_profiling.py`
- `pytest` *(fails: No module named 'scipy.sparse')*
- `python -m cProfile -m task_profiling`


------
https://chatgpt.com/codex/tasks/task_e_68ab83d900c0832e8eb5185cf52460ce