### PR TITLE
feat: add unified CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,18 @@ glyph sequences followed by an optional `[emotion]` to trigger hooks.
 
 See `docs/JSON_STRUCTURES.md` for example layouts and registration code.
 
+## Command-line Interface
+
+Once installed, the project exposes an ``abzu`` command bundling common
+developer tasks:
+
+```bash
+abzu start                        # Launch the Spiral OS stack
+abzu test                         # Run the unit tests
+abzu profile                      # Profile system startup
+abzu play-music path/to/song.wav  # Analyze a local audio file
+```
+
 ## Dashboard and Operator Console
 
 The Streamlit dashboard and the web‑based operator console rely on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ spiral-cortex = "cli.spiral_cortex_terminal:main"
 voice-cli = "cli.voice:main"
 spiral-os = "spiral_os.__main__:main"
 
+[tool.poetry.scripts]
+abzu = "cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["tests*", "docs*", "examples*"]

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,75 @@
+"""Unified command line interface for Spiral OS tools.
+
+This module exposes a small wrapper around common developer tasks. It is
+lightweight and avoids importing heavy dependencies until a command is
+invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, List, Optional
+
+
+def _start(_: argparse.Namespace) -> None:
+    """Launch the Spiral OS startup sequence."""
+    from start_spiral_os import main as start_main
+
+    start_main([])
+
+
+def _test(_: argparse.Namespace) -> None:
+    """Execute the project's test suite using ``pytest``."""
+    import pytest
+
+    raise SystemExit(pytest.main([]))
+
+
+def _profile(_: argparse.Namespace) -> None:
+    """Profile the startup sequence using ``cProfile``."""
+    import cProfile
+    from start_spiral_os import main as start_main  # noqa: F401
+
+    cProfile.runctx("start_main([])", globals(), locals())
+
+
+def _play_music(args: argparse.Namespace) -> None:
+    """Run the music demo on ``args.audio``."""
+    demo_script = Path(__file__).resolve().parents[1] / "run_song_demo.py"
+    cmd = [sys.executable, str(demo_script), args.audio]
+    subprocess.run(cmd, check=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Spiral OS helper commands")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start_p = sub.add_parser("start", help="Launch the Spiral OS stack")
+    start_p.set_defaults(func=_start)
+
+    test_p = sub.add_parser("test", help="Run the test suite")
+    test_p.set_defaults(func=_test)
+
+    prof_p = sub.add_parser("profile", help="Profile system startup")
+    prof_p.set_defaults(func=_profile)
+
+    music_p = sub.add_parser("play-music", help="Analyze a local audio file")
+    music_p.add_argument("audio", help="Path to an MP3 or WAV file")
+    music_p.set_defaults(func=_play_music)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entry point for the command line script."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func: Callable[[argparse.Namespace], None] = args.func
+    func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -6,8 +6,22 @@ be referenced as console scripts.
 
 from __future__ import annotations
 
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
 from .console_interface import run_repl
 from .spiral_cortex_terminal import main as spiral_cortex_main
 from .voice import main as voice_main
 
-__all__ = ["run_repl", "spiral_cortex_main", "voice_main"]
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the consolidated ``abzu`` CLI."""
+    path = Path(__file__).resolve().parents[1] / "cli.py"
+    spec = spec_from_file_location("_abzu_cli", path)
+    module = module_from_spec(spec)
+    assert spec.loader is not None  # for ``mypy`` and ``pyright``
+    spec.loader.exec_module(module)
+    module.main(argv)
+
+
+__all__ = ["run_repl", "spiral_cortex_main", "voice_main", "main"]


### PR DESCRIPTION
## Summary
- add consolidated `abzu` CLI with `start`, `test`, `profile`, and `play-music` commands
- expose CLI via `cli.main` and register console script in `pyproject.toml`
- document common CLI usage in README

## Testing
- `pre-commit run --files src/cli.py src/cli/__init__.py pyproject.toml README.md`
- `pytest tests/test_pipeline_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab87b234dc832e9713e183d2753baf