### PR TITLE
Add concurrency and orchestrator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - *checkout
       - *setup-python
       - *install-deps
-      - name: Smoke tests
-        run: pytest tests/test_prompt_engineering.py
+      - name: Run tests
+        run: pytest
       - name: Profiling
         run: python -m cProfile -m task_profiling

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_introspection_api.py"),
     str(ROOT / "tests" / "test_lwm.py"),
     str(ROOT / "tests" / "test_emotional_state_logging.py"),
+    str(ROOT / "tests" / "test_emotion_state.py"),
+    str(ROOT / "tests" / "test_orchestrator.py"),
     str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
     str(ROOT / "tests" / "test_transformation_smoke.py"),
     str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),

--- a/tests/test_emotion_state.py
+++ b/tests/test_emotion_state.py
@@ -1,0 +1,62 @@
+"""Concurrency and persistence tests for emotional_state."""
+
+from __future__ import annotations
+
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import emotional_state
+
+
+@pytest.fixture(autouse=True)
+def _temp_state_files(tmp_path, monkeypatch):
+    """Redirect persistence files to a temporary directory."""
+    state_file = tmp_path / "state.json"
+    registry_file = tmp_path / "registry.json"
+    event_file = tmp_path / "events.log"
+    monkeypatch.setattr(emotional_state, "STATE_FILE", state_file)
+    monkeypatch.setattr(emotional_state, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(emotional_state, "EVENT_LOG", event_file)
+    emotional_state._STATE.clear()
+    emotional_state._REGISTRY.clear()
+    emotional_state._save_state()
+    emotional_state._save_registry()
+
+
+def test_concurrent_updates():
+    def worker(emotion: str) -> str | None:
+        emotional_state.set_last_emotion(emotion)
+        return emotional_state.get_last_emotion()
+
+    with ThreadPoolExecutor() as ex:
+        results = list(ex.map(worker, ("joy", "calm")))
+
+    assert set(results) <= {"joy", "calm"}
+    assert emotional_state.get_last_emotion() in {"joy", "calm"}
+    registry = emotional_state.get_registered_emotions()
+    assert "joy" in registry and "calm" in registry
+
+
+def test_state_persistence_round_trip():
+    emotional_state.set_last_emotion("joy")
+    emotional_state.set_current_layer("albedo_layer")
+
+    data = json.loads(emotional_state.STATE_FILE.read_text())
+    assert data["last_emotion"] == "joy"
+    assert data["current_layer"] == "albedo_layer"
+
+    emotional_state._STATE.clear()
+    emotional_state._REGISTRY.clear()
+    emotional_state._load_state()
+    emotional_state._load_registry()
+
+    assert emotional_state.get_last_emotion() == "joy"
+    assert emotional_state.get_current_layer() == "albedo_layer"
+    assert "joy" in emotional_state.get_registered_emotions()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -226,3 +226,17 @@ def test_schedule_action_executes(monkeypatch):
     timer.join(0.1)
 
     assert called == [True]
+
+
+def test_select_plane_logic():
+    assert MoGEOrchestrator._select_plane(0.7, "villain") == "ascension"
+    assert MoGEOrchestrator._select_plane(0.2, "hero") == "ascension"
+    assert MoGEOrchestrator._select_plane(0.2, "villain") == "underworld"
+
+
+def test_version_metadata():
+    v = orchestrator.__version__
+    assert isinstance(v, orchestrator.VersionInfo)
+    assert v.major >= 0
+    assert v.minor >= 0
+    assert v.patch >= 0


### PR DESCRIPTION
## Summary
- add concurrency and persistence tests for emotional_state
- cover plane selection and version metadata in orchestrator tests
- run full pytest suite in CI workflow

## Testing
- `ruff check tests/test_emotion_state.py tests/test_orchestrator.py tests/conftest.py`
- `black --check tests/test_emotion_state.py tests/test_orchestrator.py tests/conftest.py`
- `pytest tests/test_emotion_state.py tests/test_orchestrator.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8aa07474832e8ae01ef7f60eaa75