### PR TITLE
Graceful fallback when soundfile is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ bash crown_model_launcher.sh > glm_launch.log 2>&1
   that your network connection is active.
 - Confirm port `8001` is free before launching; an existing process on that port
   prevents the health endpoint from becoming ready.
+- If `soundfile` is missing, `play_ritual_music.py` synthesizes tones with
+  NumPy and plays them through `simpleaudio`. Install `simpleaudio` to hear
+  this fallback output.
 
 ## Codex GPU Deployment
 

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -49,6 +49,16 @@ def test_play_ritual_music_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
     monkeypatch.setattr(prm.expressive_output, "play_audio", lambda p, loop=False: None)
 
+    class _DummyPB:
+        def wait_done(self):
+            return None
+
+    class _DummySA:
+        def play_buffer(self, *args, **kwargs):
+            return _DummyPB()
+
+    monkeypatch.setattr(prm, "sa", _DummySA())
+
     out = tmp_path / "ritual.wav"
     prm.compose_ritual_music("joy", "\u2609", out_path=out)
 


### PR DESCRIPTION
## Summary
- Add a NumPy/simpleaudio fallback to `play_ritual_music.py` when `soundfile` is unavailable
- Document the `soundfile` fallback in the module and README troubleshooting section
- Adjust play_ritual_music tests to mock the simpleaudio backend

## Testing
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py tests/test_rag_music_integration.py tests/test_rag_music_oracle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab8cd94078832ebbe591288833a8c1