### PR TITLE
Add log rotation and timing metrics

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,24 @@
+# Monitoring
+
+The application writes JSON-formatted logs to `logs/INANNA_AI.log` and rotates the file when it grows beyond 1 MB. Each rotated copy is suffixed with a number (for example, `INANNA_AI.log.1`).
+
+## Tailing logs
+
+```bash
+tail -F logs/INANNA_AI.log
+```
+
+Use `tail -F` to follow the active log file across rotations. The output uses JSON, making it easy to filter with tools such as `jq`:
+
+```bash
+tail -F logs/INANNA_AI.log | jq '.duration? // empty'
+```
+
+## Timing metrics
+
+Two parts of the system emit a `duration` field measured in seconds using `time.perf_counter()`:
+
+- `invocation_engine.invoke` reports how long pattern matching and callbacks take.
+- The FastAPI server middleware logs the processing time for every HTTP request along with its path and method.
+
+Higher durations indicate slower operations. Watching these metrics helps identify performance bottlenecks.

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -4,11 +4,13 @@ formatters:
     '()': pythonjsonlogger.jsonlogger.JsonFormatter
 handlers:
   file:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     formatter: json
     filename: logs/INANNA_AI.log
     encoding: utf-8
     filters: [emotion]
+    maxBytes: 1048576
+    backupCount: 5
 filters:
   emotion:
     '()': logging_filters.EmotionFilter


### PR DESCRIPTION
## Summary
- add rotating file handler and JSON log config
- log request and invocation durations via time.perf_counter
- document tailing logs and timing metrics

## Testing
- `pre-commit run --files logging_config.yaml invocation_engine.py server.py docs/monitoring.md` *(fails: pre-commit not installed)*
- `pytest tests/test_invocation_engine.py tests/test_server.py` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8df85300832e8e16ab7360894531