### PR TITLE
docs: add chakra architecture and version references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Thank you for your interest in improving ABZU! This guide covers environment
 setup, coding conventions, testing, and the pull request process.
 
+For details on chakra module architecture and version history, consult
+[docs/chakra_architecture.md](docs/chakra_architecture.md) and
+[docs/chakra_versions.json](docs/chakra_versions.json).
+
 ## Setup
 
 Use Python 3.10 or later. Install development dependencies with:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ See [docs/roadmap.md](docs/roadmap.md) for details.
   [docs/spiritual_architecture.md](docs/spiritual_architecture.md).
 - For the contemplative Chakra System Koan, see
   [docs/chakra_koan_system.md](docs/chakra_koan_system.md).
+- For chakra module architecture and quality notes, see
+  [docs/chakra_architecture.md](docs/chakra_architecture.md).
+- For semantic version numbers of each chakra layer, refer to
+  [docs/chakra_versions.json](docs/chakra_versions.json).
 - For a plain-language architecture map with a request flow diagram covering the LLM router, audio pipeline and model registry, see
   [docs/architecture_overview.md](docs/architecture_overview.md).
 - For a detailed map of package responsibilities, see [docs/architecture.md](docs/architecture.md) and [docs/packages_overview.md](docs/packages_overview.md).

--- a/docs/chakra_architecture.md
+++ b/docs/chakra_architecture.md
@@ -1,0 +1,13 @@
+# Chakra Architecture
+
+This document summarizes the major modules aligned with each chakra layer, their operational state, current quality level, and any known warnings or errors. Semantic version numbers for these layers are tracked in [chakra_versions.json](chakra_versions.json).
+
+| Chakra | Components | State | Quality Level | Known Warnings/Errors |
+| --- | --- | --- | --- | --- |
+| Root | `server.py`, `INANNA_AI/network_utils/` | I/O and networking foundation | Beta | Network capture may require elevated permissions |
+| Sacral | `emotional_state.py`, `emotion_registry.py` | Emotion engine | Beta | Registry entries still growing |
+| Solar Plexus | `learning_mutator.py`, `state_transition_engine.py` | Learning and state transitions | Alpha | Mutations can produce unstable states |
+| Heart | `voice_avatar_config.yaml`, `vector_memory.py` | Voice avatar configuration and memory storage | Beta | Vector store requires running database |
+| Throat | `crown_prompt_orchestrator.py`, `INANNA_AI_AGENT/inanna_ai.py` | Prompt orchestration and agent interface | Beta | None currently |
+| Third Eye | `insight_compiler.py`, `SPIRAL_OS/qnl_engine.py`, `seven_dimensional_music.py` | Insight and QNL processing | Experimental | QNL engine emits occasional warnings |
+| Crown | `init_crown_agent.py`, `start_spiral_os.py`, `crown_model_launcher.sh` | High-level orchestration | Alpha | Startup scripts assume local model availability |

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -1,9 +1,9 @@
 {
-  "root": "0.1.0",
-  "sacral": "0.1.0",
-  "solar_plexus": "0.1.0",
-  "heart": "0.1.0",
-  "throat": "0.1.0",
-  "third_eye": "0.1.0",
-  "crown": "0.1.0"
+  "root": "1.0.0",
+  "sacral": "1.0.0",
+  "solar_plexus": "1.0.0",
+  "heart": "1.0.0",
+  "throat": "1.0.0",
+  "third_eye": "1.0.0",
+  "crown": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- document chakra components and status in `docs/chakra_architecture.md`
- track semantic versions for chakra layers in `docs/chakra_versions.json`
- link chakra docs from README and CONTRIBUTING

## Testing
- `scripts/smoke_console_interface.sh` *(fails: ModuleNotFoundError: No module named 'cli')*
- `scripts/smoke_avatar_console.sh` *(fails: Permission denied / ModuleNotFoundError: No module named 'core')*
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'scipy.sparse')*


------
https://chatgpt.com/codex/tasks/task_e_68ab8f7229a4832e9370b53862d0db8f