### PR TITLE
Automate retraining on tagged releases

### DIFF
--- a/.github/workflows/retraining_pipeline.yml
+++ b/.github/workflows/retraining_pipeline.yml
@@ -8,6 +8,8 @@ on:
     types:
       - completed
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   retrain:

--- a/docs/retraining_log.md
+++ b/docs/retraining_log.md
@@ -1,0 +1,4 @@
+# Retraining Log
+
+| date | outcome | model_hash |
+| --- | --- | --- |


### PR DESCRIPTION
## Summary
- trigger retraining pipeline on published releases
- automate data pull, fine-tune, register model, and log results
- add retraining log document

## Testing
- `python -m py_compile auto_retrain.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.sparse')*


------
https://chatgpt.com/codex/tasks/task_e_68ab905bef90832e98b4c893c719ea04