### PR TITLE
Refactor ritual music helpers

### DIFF
--- a/rag/music_oracle.py
+++ b/rag/music_oracle.py
@@ -58,9 +58,10 @@ def answer(
     out_path: Optional[Path] = None
     if play and features:
         arch = emotion_analysis.emotion_to_archetype(features["emotion"])
-        out_path = play_ritual_music.compose_ritual_music(
+        track = play_ritual_music.compose_ritual_music(
             features["emotion"], ritual, archetype=arch
         )
+        out_path = track.path
     return text, out_path
 
 

--- a/src/audio/emotion_params.py
+++ b/src/audio/emotion_params.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Emotion to music parameter resolution helpers."""
+
+from pathlib import Path
+from typing import List, Tuple
+
+from INANNA_AI import emotion_analysis, sonic_emotion_mapper
+from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import (
+    SCALE_MELODIES,
+    load_emotion_music_map,
+    select_music_params,
+)
+
+EMOTION_MAP = Path(__file__).resolve().parent / "emotion_music_map.yaml"
+
+
+def resolve(emotion: str, archetype: str | None = None) -> Tuple[float, List[str], str, str]:
+    """Return tempo, melody, wave type and resolved archetype."""
+
+    if archetype is None:
+        try:  # pragma: no cover
+            archetype = emotion_analysis.get_current_archetype()
+        except Exception:  # pragma: no cover
+            archetype = "Everyman"
+
+    mapping = load_emotion_music_map(EMOTION_MAP)
+    params = sonic_emotion_mapper.map_emotion_to_sound(emotion, archetype)
+
+    tempo, _scale, melody, _rhythm = select_music_params(
+        emotion, mapping, params["tempo"]
+    )
+
+    if params.get("scale"):
+        melody = SCALE_MELODIES.get(params["scale"], melody)
+
+    wave_type = (
+        "square"
+        if any("guitar" in t or "trumpet" in t for t in params.get("timbre", []))
+        else "sine"
+    )
+
+    return tempo, melody, wave_type, archetype

--- a/src/audio/stego.py
+++ b/src/audio/stego.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Steganography helpers for ritual music."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from MUSIC_FOUNDATION.synthetic_stego_engine import encode_phrase
+
+RITUAL_PROFILE = Path(__file__).resolve().parent / "ritual_profile.json"
+
+
+def load_ritual_profile(path: Path = RITUAL_PROFILE) -> dict:
+    """Return ritual mappings loaded from ``path`` if available."""
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return {k: v for k, v in data.items() if isinstance(v, dict)}
+    return {}
+
+
+def embed_phrase(wave: np.ndarray, ritual: str, emotion: str) -> np.ndarray:
+    """Embed ritual phrase for ``emotion`` into ``wave`` if configured."""
+
+    profile = load_ritual_profile()
+    phrase = " ".join(profile.get(ritual, {}).get(emotion, []))
+    if not phrase:
+        return wave
+
+    stego_wave = encode_phrase(phrase)
+    if stego_wave.size < wave.size:
+        stego_wave = np.pad(stego_wave, (0, wave.size - stego_wave.size))
+    combined = wave[: stego_wave.size] + stego_wave[: wave.size]
+    max_val = float(np.max(np.abs(combined)))
+    if max_val > 0:
+        combined /= max_val
+    return combined.astype(np.float32)

--- a/src/audio/waveform.py
+++ b/src/audio/waveform.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Waveform synthesis utilities."""
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import soundfile as sf
+except Exception:  # pragma: no cover - optional dependency
+    sf = None  # type: ignore
+
+from MUSIC_FOUNDATION import layer_generators
+
+
+def _note_to_freq_simple(note: str) -> float:
+    """Convert a basic note name like ``C4`` to a frequency in Hertz."""
+
+    offsets = {
+        "C": -9,
+        "C#": -8,
+        "Db": -8,
+        "D": -7,
+        "D#": -6,
+        "Eb": -6,
+        "E": -5,
+        "F": -4,
+        "F#": -3,
+        "Gb": -3,
+        "G": -2,
+        "G#": -1,
+        "Ab": -1,
+        "A": 0,
+        "A#": 1,
+        "Bb": 1,
+        "B": 2,
+    }
+    name = note[:-1]
+    octave = int(note[-1])
+    semitone = offsets.get(name, 0) + 12 * (octave - 4)
+    return 440.0 * (2 ** (semitone / 12))
+
+
+def _synthesize_melody(
+    tempo: float,
+    melody: list[str],
+    *,
+    wave_type: str = "sine",
+    sample_rate: int = 44100,
+) -> np.ndarray:
+    """Generate a simple waveform for ``melody`` without ``soundfile``."""
+
+    beat_duration = 60.0 / float(tempo)
+    segments: list[np.ndarray] = []
+    for note in melody:
+        freq = _note_to_freq_simple(str(note))
+        t = np.linspace(0, beat_duration, int(sample_rate * beat_duration), endpoint=False)
+        if wave_type == "square":
+            seg = 0.5 * np.sign(np.sin(2 * np.pi * freq * t))
+        else:
+            seg = 0.5 * np.sin(2 * np.pi * freq * t)
+        segments.append(seg.astype(np.float32))
+    wave = np.concatenate(segments) if segments else np.zeros(1, dtype=np.float32)
+    max_val = float(np.max(np.abs(wave)))
+    if max_val > 0:
+        wave /= max_val
+    return wave.astype(np.float32)
+
+
+def synthesize(melody: list[str], tempo: float, wave_type: str = "sine") -> np.ndarray:
+    """Return a waveform for ``melody`` at ``tempo`` using ``wave_type``."""
+
+    if sf is not None:
+        return layer_generators.compose_human_layer(
+            tempo, melody, wav_path=None, wave_type=wave_type
+        )
+    return _synthesize_melody(tempo, melody, wave_type=wave_type)

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -10,7 +10,7 @@ import numpy as np
 import soundfile as sf
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
 
 sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
 sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
@@ -30,7 +30,9 @@ def test_play_ritual_music_cli(tmp_path, monkeypatch):
             sf.write(wav_path, wave, sample_rate)
         return wave
 
-    monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
+    monkeypatch.setattr(
+        prm.waveform.layer_generators, "compose_human_layer", dummy_compose
+    )
     monkeypatch.setattr(prm.expressive_output, "play_audio", lambda p, loop=False: None)
 
     out = tmp_path / "ritual.wav"
@@ -46,7 +48,10 @@ def test_play_ritual_music_fallback(tmp_path, monkeypatch):
         return np.zeros(100, dtype=np.float32)
 
     monkeypatch.setattr(prm, "sf", None)
-    monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
+    monkeypatch.setattr(prm.waveform, "sf", None)
+    monkeypatch.setattr(
+        prm.waveform.layer_generators, "compose_human_layer", dummy_compose
+    )
     monkeypatch.setattr(prm.expressive_output, "play_audio", lambda p, loop=False: None)
 
     class _DummyPB:
@@ -60,6 +65,6 @@ def test_play_ritual_music_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(prm, "sa", _DummySA())
 
     out = tmp_path / "ritual.wav"
-    prm.compose_ritual_music("joy", "\u2609", out_path=out)
+    track = prm.compose_ritual_music("joy", "\u2609", out_path=out)
 
-    assert out.exists()
+    assert track.path.exists()

--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -11,7 +11,7 @@ import pytest
 import soundfile as sf
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
 
 sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
 sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
@@ -35,7 +35,9 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
             sf.write(wav_path, wave, 44100)
         return wave
 
-    monkeypatch.setattr(prm.layer_generators, "compose_human_layer", dummy_compose)
+    monkeypatch.setattr(
+        prm.waveform.layer_generators, "compose_human_layer", dummy_compose
+    )
 
     played: list[Path] = []
 
@@ -45,7 +47,7 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(prm.expressive_output, "play_audio", fake_play_audio)
 
     out = tmp_path / "ritual.wav"
-    prm.compose_ritual_music("joy", "\u2609", out_path=out)
+    track = prm.compose_ritual_music("joy", "\u2609", out_path=out)
 
-    assert out.exists()
-    assert played and played[0] == out
+    assert track.path.exists()
+    assert played and played[0] == track.path

--- a/tests/test_rag_music_integration.py
+++ b/tests/test_rag_music_integration.py
@@ -7,7 +7,7 @@ import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
 
 # Stub heavy optional packages
 sys.modules.setdefault("librosa", types.ModuleType("librosa"))
@@ -19,7 +19,14 @@ from SPIRAL_OS import qnl_engine
 
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
+
+
+class _Track:
+    def __init__(self, path: Path):
+        self.path = path
+
+
+fake_play.compose_ritual_music = lambda *a, **k: _Track(Path("out.wav"))
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -67,7 +74,7 @@ def test_rag_music_pipeline(tmp_path, monkeypatch):
 
     def fake_compose(emotion, ritual, archetype=None):
         qnl_engine.hex_to_song("deadbeef")
-        return tmp_path / "out.wav"
+        return _Track(tmp_path / "out.wav")
 
     monkeypatch.setattr(rmo.play_ritual_music, "compose_ritual_music", fake_compose)
 

--- a/tests/test_rag_music_oracle.py
+++ b/tests/test_rag_music_oracle.py
@@ -10,7 +10,7 @@ from tests.helpers import emotion_stub
 from tests.helpers.config_stub import build_settings
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
 
 # Stub heavy dependencies before importing the module
 sys.modules.setdefault("librosa", types.ModuleType("librosa"))
@@ -28,7 +28,14 @@ sys.modules.setdefault("config", config_mod)
 # Minimal play_ritual_music stub
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
+
+
+class _Track:
+    def __init__(self, path: Path):
+        self.path = path
+
+
+fake_play.compose_ritual_music = lambda *a, **k: _Track(Path("out.wav"))
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -57,7 +64,7 @@ def test_answer_with_audio(tmp_path, monkeypatch):
     monkeypatch.setattr(
         rmo.play_ritual_music,
         "compose_ritual_music",
-        lambda e, r, **k: tmp_path / "out.wav",
+        lambda e, r, **k: _Track(tmp_path / "out.wav"),
     )
 
     text, out = rmo.answer("How does this MP3 express grief?", audio, play=True)


### PR DESCRIPTION
## Summary
- extract emotion parameter resolution into dedicated helper
- centralize waveform synthesis and steganographic embedding
- return structured RitualTrack from compose_ritual_music and adapt RAG oracle

## Testing
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py tests/test_rag_music_integration.py tests/test_rag_music_oracle.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac09192f60832e81f5064b70d4136c