### PR TITLE
Clean up ritual music module imports

### DIFF
--- a/src/audio/play_ritual_music.py
+++ b/src/audio/play_ritual_music.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import base64
-from dataclasses import dataclass
+import json
+from functools import lru_cache
 from io import BytesIO
 from pathlib import Path
 from threading import Thread
+from typing import NamedTuple
 
 import numpy as np
 
@@ -78,6 +80,7 @@ ARCHETYPE_MIXES: dict[str, str] = {
 }
 
 
+@lru_cache(maxsize=None)
 def _get_archetype_mix(archetype: str, sample_rate: int = 44100) -> np.ndarray:
     """Return a small overlay sample for ``archetype`` or synthesize one."""
 
@@ -120,8 +123,7 @@ def _write_wav(path: Path, data: np.ndarray, sample_rate: int = 44100) -> None:
         wf.writeframes(pcm.tobytes())
 
 
-@dataclass
-class RitualTrack:
+class RitualTrack(NamedTuple):
     """Container for generated ritual music."""
 
     path: Path


### PR DESCRIPTION
## Summary
- prune leftover merge markers and unused dataclass import in `play_ritual_music`
- add `json` and `lru_cache` imports and cache archetype mix helper
- replace `RitualTrack` dataclass with a `NamedTuple`

## Testing
- `python -m py_compile src/audio/play_ritual_music.py`
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0fe4ec0c832e832b04124f16ee96