### PR TITLE
Refactor ritual music API to return path

### DIFF
--- a/rag/music_oracle.py
+++ b/rag/music_oracle.py
@@ -55,14 +55,13 @@ def answer(
         text = f"Detected emotion {features['emotion']} at {features['tempo']} BPM. "
     text += snippet or "No related passages found."
 
-    out_path: Optional[Path] = None
+    music_path: Optional[Path] = None
     if play and features:
         arch = emotion_analysis.emotion_to_archetype(features["emotion"])
-        track = play_ritual_music.compose_ritual_music(
+        music_path = play_ritual_music.compose_ritual_music(
             features["emotion"], ritual, archetype=arch
         )
-        out_path = track.path
-    return text, out_path
+    return text, music_path
 
 
 def main(argv: List[str] | None = None) -> int:

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -64,7 +64,9 @@ def test_play_ritual_music_fallback(tmp_path, monkeypatch):
 
     monkeypatch.setattr(prm, "sa", _DummySA())
 
-    out = tmp_path / "ritual.wav"
-    track = prm.compose_ritual_music("joy", "\u2609", out_path=out)
+    out = prm.compose_ritual_music(
+        "joy", "\u2609", output_dir=tmp_path, sample_rate=8000
+    )
 
-    assert track.path.exists()
+    assert out.exists()
+    assert out == tmp_path / "ritual.wav"

--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -46,8 +46,9 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(prm.expressive_output, "play_audio", fake_play_audio)
 
-    out = tmp_path / "ritual.wav"
-    track = prm.compose_ritual_music("joy", "\u2609", out_path=out)
+    out = prm.compose_ritual_music(
+        "joy", "\u2609", output_dir=tmp_path, sample_rate=8000
+    )
 
-    assert track.path.exists()
-    assert played and played[0] == track.path
+    assert out.exists()
+    assert played and played[0] == out

--- a/tests/test_rag_music_integration.py
+++ b/tests/test_rag_music_integration.py
@@ -19,14 +19,7 @@ from SPIRAL_OS import qnl_engine
 
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-
-
-class _Track:
-    def __init__(self, path: Path):
-        self.path = path
-
-
-fake_play.compose_ritual_music = lambda *a, **k: _Track(Path("out.wav"))
+fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -74,7 +67,7 @@ def test_rag_music_pipeline(tmp_path, monkeypatch):
 
     def fake_compose(emotion, ritual, archetype=None):
         qnl_engine.hex_to_song("deadbeef")
-        return _Track(tmp_path / "out.wav")
+        return tmp_path / "out.wav"
 
     monkeypatch.setattr(rmo.play_ritual_music, "compose_ritual_music", fake_compose)
 

--- a/tests/test_rag_music_oracle.py
+++ b/tests/test_rag_music_oracle.py
@@ -28,14 +28,7 @@ sys.modules.setdefault("config", config_mod)
 # Minimal play_ritual_music stub
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-
-
-class _Track:
-    def __init__(self, path: Path):
-        self.path = path
-
-
-fake_play.compose_ritual_music = lambda *a, **k: _Track(Path("out.wav"))
+fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -64,7 +57,7 @@ def test_answer_with_audio(tmp_path, monkeypatch):
     monkeypatch.setattr(
         rmo.play_ritual_music,
         "compose_ritual_music",
-        lambda e, r, **k: _Track(tmp_path / "out.wav"),
+        lambda e, r, **k: tmp_path / "out.wav",
     )
 
     text, out = rmo.answer("How does this MP3 express grief?", audio, play=True)


### PR DESCRIPTION
## Summary
- refactor `compose_ritual_music` to accept `output_dir`, `sample_rate`, and return a `Path`
- update `rag.music_oracle` and tests to use path return value

## Testing
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py tests/test_rag_music_integration.py tests/test_rag_music_oracle.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac109c3098832eb959b20783e120c2