### PR TITLE
Fix sample rate in ritual music smoke test

### DIFF
--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -47,7 +47,7 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(prm.expressive_output, "play_audio", fake_play_audio)
 
     out = prm.compose_ritual_music(
-        "joy", "\u2609", output_dir=tmp_path, sample_rate=8000
+        "joy", "\u2609", output_dir=tmp_path, sample_rate=22050
     )
 
     assert out.exists()


### PR DESCRIPTION
## Summary
- update smoke test to compose ritual music at 22050 Hz

## Testing
- `pre-commit run --files tests/test_play_ritual_music_smoke.py`
- `pytest tests/test_play_ritual_music_smoke.py::test_compose_and_play -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1204de7c832e983d8368fb27c7f5