### PR TITLE
Add logging for ritual music playback

### DIFF
--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -14,6 +14,9 @@ handlers:
 filters:
   emotion:
     '()': logging_filters.EmotionFilter
+loggers:
+  src.audio.play_ritual_music:
+    level: INFO
 root:
   level: INFO
   handlers: [file]


### PR DESCRIPTION
## Summary
- add module logger and warnings in play_ritual_music
- log archetype and playback backend selection
- register play_ritual_music in logging_config

## Testing
- `pre-commit run --files logging_config.yaml src/audio/play_ritual_music.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scipy.sparse')*

------
https://chatgpt.com/codex/tasks/task_e_68ac17c57140832ea34dc1899ad29996