### PR TITLE
test: extend ritual music tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_emotion_state.py"),
     str(ROOT / "tests" / "test_orchestrator.py"),
     str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
+    str(ROOT / "tests" / "test_play_ritual_music.py"),
     str(ROOT / "tests" / "test_transformation_smoke.py"),
     str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),
 }


### PR DESCRIPTION
## Summary
- verify melody synthesis falls back when `soundfile` is missing
- ensure phrase embedding enlarges output when hide is enabled
- allow play_ritual_music tests to run in CI

## Testing
- `pytest tests/test_play_ritual_music.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1c8072a0832ebcf249aaf2fd07fb