### PR TITLE
feat: add inanna cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Current ratings, past scores and milestone validation results are tracked in
 
 See [docs/roadmap.md](docs/roadmap.md) for details.
 
+## `inanna` CLI
+The project bundles a lightweight command line interface that wraps common
+developer tasks. After installing the package, invoke the tool using
+``inanna``:
+
+```bash
+inanna start            # Launch the Spiral OS stack
+inanna test             # Run the test suite
+inanna profile          # Profile system startup
+inanna play-music song.wav  # Analyze an audio file with the music demo
+```
+
 ## Agent Updates
 - [docs/release_notes.md](docs/release_notes.md) – recent changes and fixes.
 - [docs/roadmap.md](docs/roadmap.md) – upcoming agent enhancements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ crown-console = "cli.console_interface:run_repl"
 spiral-cortex = "cli.spiral_cortex_terminal:main"
 voice-cli = "cli.voice:main"
 spiral-os = "spiral_os.__main__:main"
+inanna = "cli:main"
 
 [tool.poetry.scripts]
 abzu = "cli:main"

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,8 +1,17 @@
 """Unified command line interface for Spiral OS tools.
 
-This module exposes a small wrapper around common developer tasks. It is
-lightweight and avoids importing heavy dependencies until a command is
-invoked.
+The :mod:`inanna` command provides a lightweight wrapper around common
+developer tasks.  Heavy dependencies are imported lazily when a subcommand is
+invoked.  Available subcommands are:
+
+``start``
+    Launch the Spiral OS startup sequence.
+``test``
+    Run the project's unit tests using :mod:`pytest`.
+``profile``
+    Profile the startup sequence with :mod:`cProfile`.
+``play-music``
+    Analyse a local audio file with the music demo.
 """
 
 from __future__ import annotations
@@ -44,7 +53,9 @@ def _play_music(args: argparse.Namespace) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Spiral OS helper commands")
+    parser = argparse.ArgumentParser(
+        prog="inanna", description="Spiral OS helper commands"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     start_p = sub.add_parser("start", help="Launch the Spiral OS stack")


### PR DESCRIPTION
## Summary
- expand `src/cli.py` with documentation of start/test/profile/play-music commands
- expose `inanna` command via project scripts
- document CLI usage in README

## Testing
- `pytest` *(fails: No module named 'scipy.sparse'; 'scipy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2931e53c832ea92d3be9759adb90