### PR TITLE
Refactor ritual music audio fallback and logging

### DIFF
--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -11,12 +11,21 @@ handlers:
     filters: [emotion]
     maxBytes: 1048576
     backupCount: 5
+  audio:
+    class: logging.handlers.RotatingFileHandler
+    formatter: json
+    filename: logs/audio.log
+    encoding: utf-8
+    maxBytes: 1048576
+    backupCount: 5
 filters:
   emotion:
     '()': logging_filters.EmotionFilter
 loggers:
   src.audio.play_ritual_music:
     level: INFO
+    handlers: [file, audio]
+    propagate: false
 root:
   level: INFO
   handlers: [file]

--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import soundfile as sf
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
@@ -32,7 +31,7 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     ) -> np.ndarray:
         wave: np.ndarray = np.zeros(100, dtype=np.float32)
         if wav_path:
-            sf.write(wav_path, wave, 44100)
+            prm.backends._write_wav(Path(wav_path), wave, 44100)
         return wave
 
     monkeypatch.setattr(
@@ -47,6 +46,8 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
             prm.backends._write_wav(path, wave, sample_rate)
 
     monkeypatch.setattr(prm.backends, "get_backend", lambda: DummyBackend())
+    monkeypatch.setattr(prm.backends, "sf", None)
+    monkeypatch.setattr(prm.waveform, "sf", object())
 
     out = prm.compose_ritual_music(
         "joy", "\u2609", output_dir=tmp_path, sample_rate=22050


### PR DESCRIPTION
## Summary
- synthesize archetype overlays with NumPy when soundfile isn't available
- log the selected audio backend
- add dedicated audio handler to logging configuration and tests for soundfile fallback

## Testing
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c1c06f8832e861ff8f89fcbac9b