### PR TITLE
Automate chakra version tracking and changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Verified repository passes `ruff` and `black` checks.
 
+### Chakra Versions
+
+- Track semantic versions for each chakra layer in `docs/chakra_versions.json`.
+
 ## [0.1.0] - 2025-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ inanna play-music song.wav  # Analyze an audio file with the music demo
 - [docs/release_notes.md](docs/release_notes.md) – recent changes and fixes.
 - [docs/roadmap.md](docs/roadmap.md) – upcoming agent enhancements.
 - [docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md) – component ratings, past scores, milestone validation results and remediation checklists.
+- [CHANGELOG.md](CHANGELOG.md) – chakra version history.
 
 ## Additional Documentation
 - For a quick start geared toward non-technical users, see


### PR DESCRIPTION
## Summary
- generate chakra version file when missing and log updated chakra versions in the changelog
- document chakra version history in README and changelog
- link project changelog from README

## Testing
- `pre-commit run --files release.py CHANGELOG.md README.md docs/chakra_versions.json`

------
https://chatgpt.com/codex/tasks/task_e_68ac3fa516e0832eba3ae45e5d3123e1