### PR TITLE
test: cover audio backends without soundfile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_insight_compiler.py"),
     str(ROOT / "tests" / "test_glm_command.py"),
     str(ROOT / "tests" / "test_media_audio.py"),
+    str(ROOT / "tests" / "test_audio_backends.py"),
     str(ROOT / "tests" / "test_video_stream_helpers.py"),
     str(ROOT / "tests" / "test_media_video.py"),
     str(ROOT / "tests" / "test_media_avatar.py"),

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -1,0 +1,54 @@
+"""Tests for audio backends when soundfile is absent."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import types
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+# Ensure optional dependency placeholders
+sys.modules.setdefault("simpleaudio", types.ModuleType("simpleaudio"))
+
+import audio.backends as backends
+import audio.play_ritual_music as prm
+
+
+def test_get_backend_simpleaudio(monkeypatch):
+    """SimpleAudioBackend is selected when soundfile is missing."""
+    monkeypatch.setattr(backends, "sf", None)
+    monkeypatch.setattr(backends, "sa", object())
+
+    backend = backends.get_backend()
+
+    assert isinstance(backend, backends.SimpleAudioBackend)
+
+
+def test_get_backend_noop(monkeypatch, caplog):
+    """NoOpBackend is selected when both soundfile and simpleaudio are missing."""
+    monkeypatch.setattr(backends, "sf", None)
+    monkeypatch.setattr(backends, "sa", None)
+
+    with caplog.at_level("WARNING"):
+        backend = backends.get_backend()
+
+    assert isinstance(backend, backends.NoOpBackend)
+    assert "No audio playback backend" in caplog.text
+
+
+def test_archetype_mix_logs_when_soundfile_missing(monkeypatch, caplog):
+    """_get_archetype_mix logs when soundfile is unavailable."""
+    monkeypatch.setattr(prm.backends, "sf", None)
+    prm._get_archetype_mix.cache_clear()
+
+    with caplog.at_level("INFO"):
+        mix = prm._get_archetype_mix("nigredo")
+
+    assert isinstance(mix, np.ndarray)
+    assert mix.size > 0
+    assert "soundfile not available" in caplog.text


### PR DESCRIPTION
## Summary
- add tests for audio backends when soundfile is absent
- ensure SimpleAudioBackend and NoOpBackend paths are exercised and log warnings are captured
- allow new tests to run in pytest configuration

## Testing
- `pytest tests/test_audio_backends.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac461f9690832e8a20830c1a119a99