### PR TITLE
feat: versioned insight manifest and tests

### DIFF
--- a/insight_manifest.json
+++ b/insight_manifest.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Tracks semantic versioning for insight matrix updates",
+  "version": "0.1.0",
+  "updated": ""
+}


### PR DESCRIPTION
## Summary
- track semantic versions of `insight_matrix.json` in a companion manifest
- increment manifest version after each insight update
- add regression tests for `update_insights` including version bump

## Testing
- `pytest`
- `pytest tests/test_insight_compiler.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac49f8d050832eab23965111e57068