### PR TITLE
Add interaction logging tests and rotate core logs

### DIFF
--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -4,13 +4,13 @@ formatters:
     '()': pythonjsonlogger.jsonlogger.JsonFormatter
 handlers:
   file:
-    class: logging.handlers.RotatingFileHandler
+    class: logging.handlers.TimedRotatingFileHandler
     formatter: json
     filename: logs/INANNA_AI.log
     encoding: utf-8
     filters: [emotion]
-    maxBytes: 1048576
-    backupCount: 5
+    when: midnight
+    backupCount: 7
   audio:
     class: logging.handlers.RotatingFileHandler
     formatter: json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_play_ritual_music.py"),
     str(ROOT / "tests" / "test_transformation_smoke.py"),
     str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),
+    str(ROOT / "tests" / "test_interactions_jsonl.py"),
 }
 
 

--- a/tests/test_interactions_jsonl.py
+++ b/tests/test_interactions_jsonl.py
@@ -1,0 +1,39 @@
+"""Tests for logging sample interactions to JSONL."""
+
+from __future__ import annotations
+
+import json
+
+import corpus_memory_logging as cml
+
+
+def test_append_and_parse_json_lines(tmp_path, monkeypatch):
+    interactions = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", interactions)
+
+    cml.log_interaction("hello", {"intent": "greet"}, {}, "ok")
+    cml.log_interaction("bye", {"intent": "farewell"}, {}, "done")
+
+    lines = interactions.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    records = [json.loads(line) for line in lines]
+    assert records[0]["input"] == "hello"
+    assert records[1]["outcome"] == "done"
+
+    loaded = cml.load_interactions()
+    assert loaded == records
+
+
+def test_ritual_result_logging(tmp_path, monkeypatch):
+    interactions = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", interactions)
+
+    cml.log_ritual_result("dance", ["step1", "step2"])
+
+    line = interactions.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["ritual"] == "dance"
+    assert record["steps"] == ["step1", "step2"]
+
+    entries = cml.load_interactions()
+    assert entries[0]["ritual"] == "dance"

--- a/tests/test_start_dev_agents_triage.py
+++ b/tests/test_start_dev_agents_triage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 import start_dev_agents
@@ -45,4 +46,8 @@ def test_triage_writes_transcript(monkeypatch, tmp_path):
 
     files = list(triage_dir.glob("*.jsonl"))
     assert len(files) == 1
-    assert files[0].read_text().strip()
+    content = files[0].read_text().strip()
+    assert content
+    for line in content.splitlines():
+        record = json.loads(line)
+        assert record["outcome"] == "ok"


### PR DESCRIPTION
## Summary
- test sample interactions by appending to a JSONL log and parsing the lines
- ensure start_dev_agents triage transcript contains valid JSON
- rotate core log daily with backup retention in `logging_config.yaml`

## Testing
- `pytest tests/test_interactions_jsonl.py tests/test_start_dev_agents_triage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4db4da40832e80e392122021df78