### PR TITLE
docs: reference chakra docs and track version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation Audit
 
 - Ensure components have descriptions and data-flow references.
+- Linked chakra koan and version files from README and CONTRIBUTING.
 
 ### Quality
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Chakra Versions
 
 - Track semantic versions for each chakra layer in `docs/chakra_versions.json`.
+- Changelog automatically records chakra version bumps.
 
 ## [0.1.0] - 2025-08-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,11 @@ Thank you for your interest in improving ABZU! This guide covers environment
 setup, coding conventions, testing, and the pull request process. For a hands-on
 orientation to the codebase, see the [developer onboarding guide](docs/developer_onboarding.md).
 
-For details on chakra module architecture and version history, consult
-[docs/chakra_architecture.md](docs/chakra_architecture.md) and
-[docs/chakra_versions.json](docs/chakra_versions.json).
+For details on chakra module architecture, version history, and contemplative
+context, consult
+[docs/chakra_architecture.md](docs/chakra_architecture.md),
+[docs/chakra_versions.json](docs/chakra_versions.json), and
+[docs/chakra_koan_system.md](docs/chakra_koan_system.md).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ inanna play-music song.wav  # Analyze an audio file with the music demo
 - [docs/roadmap.md](docs/roadmap.md) – upcoming agent enhancements.
 - [docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md) – component ratings, past scores, milestone validation results and remediation checklists.
 - [CHANGELOG.md](CHANGELOG.md) – chakra version history.
+- [docs/chakra_koan_system.md](docs/chakra_koan_system.md) – meditative verses for
+  each chakra.
+- [docs/chakra_versions.json](docs/chakra_versions.json) – semantic version
+  numbers for chakra modules.
 
 ## Additional Documentation
 - For a quick start geared toward non-technical users, see


### PR DESCRIPTION
## Summary
- link chakra koan and version JSON from README and CONTRIBUTING
- record chakra version bumps in changelog and clear entries on release
- note new documentation and version tracking in changelog

## Testing
- `ruff check release.py`
- `black release.py -q`
- `pytest --maxfail=1 -q` *(fails: No module named 'scipy.sparse')*


------
https://chatgpt.com/codex/tasks/task_e_68ac4ef615a0832e8f35af56fe42a02b