### PR TITLE
Ensure runtime scripts load core package

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -14,11 +14,16 @@ import logging
 import os
 import subprocess
 import hashlib
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
 import yaml
+
+project_root = Path(__file__).resolve().parent / "src"
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 from core import feedback_logging
 from core.utils.seed import seed_all
@@ -92,9 +97,7 @@ def log_retraining(outcome: str, model_path: Path | None) -> None:
             encoding="utf-8",
         )
     with LOG_FILE.open("a", encoding="utf-8") as fh:
-        fh.write(
-            f"| {datetime.utcnow().isoformat()} | {outcome} | {model_hash} |\n"
-        )
+        fh.write(f"| {datetime.utcnow().isoformat()} | {outcome} | {model_hash} |\n")
 
 
 def _load_permissions() -> List[Dict[str, List[str]]]:

--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -15,6 +15,11 @@ from datetime import datetime
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict
+import sys
+
+project_root = Path(__file__).resolve().parent / "src"
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 import crown_decider
 import emotional_state

--- a/ritual_trainer.py
+++ b/ritual_trainer.py
@@ -6,8 +6,13 @@ import argparse
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Iterable, List
+
+project_root = Path(__file__).resolve().parent / "src"
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 import auto_retrain
 from core.utils.seed import seed_all

--- a/start_spiral_os.py
+++ b/start_spiral_os.py
@@ -7,12 +7,17 @@ import json
 import logging
 import logging.config
 import os
+import sys
 import threading
 from pathlib import Path
 from typing import List, Optional, cast
 
 import uvicorn
 import yaml
+
+project_root = Path(__file__).resolve().parent / "src"
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 import emotion_registry
 import emotional_state

--- a/video_stream.py
+++ b/video_stream.py
@@ -11,12 +11,17 @@ import fractions
 import importlib
 import logging
 import time
+import sys
 from pathlib import Path
 from typing import Any, Optional, Set, cast
 
 import numpy as np
 from fastapi import APIRouter, HTTPException, Request
 from numpy.typing import NDArray
+
+project_root = Path(__file__).resolve().parent / "src"
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 from core import avatar_expression_engine, video_engine
 from src.media.video.base import VideoProcessor


### PR DESCRIPTION
## Summary
- Add repository `src` path to PYTHONPATH for runtime scripts
- Allow task profiling and other utilities to import core modules without installation

## Testing
- `pre-commit run --files auto_retrain.py crown_prompt_orchestrator.py ritual_trainer.py`
- `pre-commit run --files server.py start_spiral_os.py video_stream.py`
- `python -m cProfile -m task_profiling`
- `pytest tests/test_task_profiling.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac542448e8832ea0fdef56e82b536e