### PR TITLE
Add isolated unit tests for auto retrain and learning mutator modules

### DIFF
--- a/tests/test_learning_mutator.py
+++ b/tests/test_learning_mutator.py
@@ -60,3 +60,18 @@ def test_main_rolls_back_on_write_error(tmp_path, monkeypatch):
     with pytest.raises(OSError):
         lm.main(["--run"])
     assert mfile.read_text(encoding="utf-8") == "old"
+
+
+def test_propose_mutations_emotion_driven(monkeypatch):
+    matrix = {"meh": {"counts": {"total": 4, "success": 1}}}
+    monkeypatch.setattr(lm, "load_intents", lambda path=lm.INTENT_FILE: {})
+    monkeypatch.setattr(
+        lm.emotion_registry, "get_current_layer", lambda: "rubedo_layer"
+    )
+    monkeypatch.setattr(lm.emotion_registry, "get_last_emotion", lambda: "anger")
+    monkeypatch.setattr(lm.emotion_registry, "get_resonance_level", lambda: 0.9)
+
+    suggestions = lm.propose_mutations(matrix)
+
+    assert any("nigredo_layer" in s for s in suggestions)
+    assert any("Fuse rubedo_layer with citrinitas_layer" in s for s in suggestions)


### PR DESCRIPTION
## Summary
- test compute_metrics and build_dataset logic with mocked validator and mutations
- verify emotion-driven mutation suggestions with mocked emotion registry

## Testing
- `pre-commit run --files tests/test_auto_retrain.py tests/test_learning_mutator.py`
- `pytest tests/test_auto_retrain.py::test_compute_metrics_returns_expected_values tests/test_auto_retrain.py::test_build_dataset_respects_validator tests/test_learning_mutator.py::test_propose_mutations_emotion_driven -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6aef3564832ea99b74cabe3afcc4