### PR TITLE
test: ensure interaction JSONL integrity is validated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,7 @@ jobs:
       - *install-deps
       - name: Run tests
         run: pytest
+      - name: Run interaction log tests
+        run: pytest tests/test_interactions_jsonl_integrity.py
       - name: Profiling
         run: python -m cProfile -m task_profiling

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_transformation_smoke.py"),
     str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),
     str(ROOT / "tests" / "test_interactions_jsonl.py"),
+    str(ROOT / "tests" / "test_interactions_jsonl_integrity.py"),
 }
 
 

--- a/tests/test_interactions_jsonl_integrity.py
+++ b/tests/test_interactions_jsonl_integrity.py
@@ -1,0 +1,55 @@
+"""Additional JSONL integrity tests for interaction logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import corpus_memory_logging as cml
+
+
+def test_log_interaction_with_metadata(tmp_path, monkeypatch):
+    interactions = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", interactions)
+
+    cml.log_interaction(
+        "hi",
+        {"intent": "greet"},
+        {"emotion": "joy"},
+        "ok",
+        source_type="unit",
+        genre="rock",
+        instrument="guitar",
+        feedback="great",
+        rating=4.2,
+    )
+
+    data = interactions.read_text(encoding="utf-8")
+    assert data.endswith("\n")
+    record = json.loads(data.strip())
+    assert record["genre"] == "rock"
+    assert record["instrument"] == "guitar"
+    assert record["feedback"] == "great"
+    assert record["rating"] == 4.2
+
+    loaded = cml.load_interactions()
+    assert loaded == [record]
+
+
+def test_load_interactions_skips_invalid_json_and_limit(tmp_path, monkeypatch, caplog):
+    interactions = tmp_path / "interactions.jsonl"
+    interactions.write_text(
+        '{"input":"a"}\nnot json\n{"input":"b"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", interactions)
+
+    with caplog.at_level(logging.ERROR):
+        records = cml.load_interactions()
+    assert len(records) == 2
+    assert records[0]["input"] == "a"
+    assert records[1]["input"] == "b"
+    assert "invalid json line" in caplog.text.lower()
+
+    limited = cml.load_interactions(limit=1)
+    assert limited == [records[1]]


### PR DESCRIPTION
## Summary
- expand interaction logging tests with metadata and malformed line handling
- allow JSONL interaction tests to run and include them in CI

## Testing
- `pytest tests/test_interactions_jsonl.py tests/test_interactions_jsonl_integrity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac726a18c4832eaffdc4c025282b87