### PR TITLE
Link chakra docs and note changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chakra Versions
 
-- Track semantic versions for each chakra layer in `docs/chakra_versions.json`.
-- Changelog automatically records chakra version bumps.
+- Track semantic versions for each chakra layer in
+  `docs/chakra_versions.json`.
+- Record each chakra version bump in this changelog.
 
 ### Insight Matrix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ context, consult
 [docs/chakra_versions.json](docs/chakra_versions.json), and
 [docs/chakra_koan_system.md](docs/chakra_koan_system.md).
 
+When bumping versions in
+[docs/chakra_versions.json](docs/chakra_versions.json), record the change in
+[CHANGELOG.md](CHANGELOG.md).
+
 ## Setup
 
 Use Python 3.10 or later. Install development dependencies with:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ inanna play-music song.wav  # Analyze an audio file with the music demo
 - [docs/chakra_koan_system.md](docs/chakra_koan_system.md) – meditative verses for
   each chakra.
 - [docs/chakra_versions.json](docs/chakra_versions.json) – semantic version
-  numbers for chakra modules.
+  numbers for chakra modules. Record each bump in
+  [CHANGELOG.md](CHANGELOG.md).
 
 ## Additional Documentation
 - For a quick start geared toward non-technical users, see
@@ -106,7 +107,8 @@ inanna play-music song.wav  # Analyze an audio file with the music demo
 - For chakra module architecture and quality notes, see
   [docs/chakra_architecture.md](docs/chakra_architecture.md).
 - For semantic version numbers of each chakra layer, refer to
-  [docs/chakra_versions.json](docs/chakra_versions.json).
+  [docs/chakra_versions.json](docs/chakra_versions.json); record any version
+  bump in [CHANGELOG.md](CHANGELOG.md).
 - For a plain-language architecture map with a request flow diagram covering the LLM router, audio pipeline and model registry, see
   [docs/architecture_overview.md](docs/architecture_overview.md).
 - For a detailed map of package responsibilities, see [docs/architecture.md](docs/architecture.md) and [docs/packages_overview.md](docs/packages_overview.md).


### PR DESCRIPTION
## Summary
- link chakra koan and version files from README and CONTRIBUTING
- remind contributors to update CHANGELOG for chakra version bumps
- mention chakra version tracking in changelog

## Testing
- `ruff check README.md CONTRIBUTING.md CHANGELOG.md`
- `npx markdownlint README.md CONTRIBUTING.md CHANGELOG.md` *(fails: multiple style issues)*
- `black --check README.md CONTRIBUTING.md CHANGELOG.md` *(fails: Cannot parse markdown as Python)*
- `mypy`
- `scripts/smoke_console_interface.sh` *(fails: ModuleNotFoundError: No module named 'cli')*
- `scripts/smoke_avatar_console.sh` *(fails: Permission denied/ModuleNotFoundError)*
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'scipy.sparse')*
- `npx markdown-link-check README.md`
- `npx markdown-link-check CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_e_68ac7359c6bc832eb32d354aec0193a7