### PR TITLE
feat: expose src on PYTHONPATH for task profiling

### DIFF
--- a/task_profiling.py
+++ b/task_profiling.py
@@ -5,13 +5,20 @@ Instantiates a shared profiler at import time for quick access.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
 project_root = Path(__file__).resolve().parent / "src"
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
+src_path = str(project_root)
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+    # also expose src on PYTHONPATH for subprocesses
+    current = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = (
+        f"{src_path}{os.pathsep}{current}" if current else src_path
+    )
 
 from core.task_profiler import TaskProfiler
 


### PR DESCRIPTION
## Summary
- ensure `src/` is injected into `PYTHONPATH` when using the task profiler

## Testing
- `pre-commit run --files task_profiling.py`
- `python -m cProfile -m task_profiling`

------
https://chatgpt.com/codex/tasks/task_e_68ac7adca790832e9b0f08b02dfcda13