### PR TITLE
Add server healthcheck and Docker compose docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 # Install pinned dependencies
 COPY requirements.lock ./
-RUN python -m pip install --no-cache-dir -r requirements.lock
+RUN python -m pip install --no-cache-dir --require-hashes -r requirements.lock
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ These packages provide the compilers and headers required to build wheels for
 the local platform. See [docs/setup.md](docs/setup.md) for additional system
 packages.
 
+## Docker Compose
+Launch the simple FastAPI server with:
+
+```bash
+docker compose up server
+```
+
+The service exposes `http://localhost:8000/health` for health checks.
+
 ## Seven-Milestone Roadmap
 1. Virtual environment manager ✅
 2. Sandbox repository ✅

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,17 @@
 version: '3.8'
 services:
+  server:
+    build: .
+    entrypoint: ["python", "server.py"]
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+
   INANNA_AI:
     build: .
     env_file:


### PR DESCRIPTION
## Summary
- install dependencies from requirements.lock using hash verification
- add server service with HTTP healthcheck to docker-compose
- document `docker compose up` workflow in README

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml README.md`
- `pytest` *(fails: soundfile.LibsndfileError: Error opening 'rubedo.wav': Format not recognised.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bc505b8832e88b66bd2053f6394