### PR TITLE
Cache emotion music map loading

### DIFF
--- a/INANNA_AI/voice_evolution.py
+++ b/INANNA_AI/voice_evolution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable
+from functools import lru_cache
 
 import yaml
 
@@ -53,6 +54,7 @@ def load_voice_config(path: Path = CONFIG_PATH) -> Dict[str, Dict[str, Any]]:
     return {}
 
 
+@lru_cache(maxsize=None)
 def load_emotion_music_map(path: Path = MUSIC_MAP_PATH) -> Dict[str, Dict[str, Any]]:
     """Return emotion-to-music mapping loaded from ``path``."""
     if path.exists():

--- a/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
+++ b/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from functools import lru_cache
 
 import numpy as np
 import yaml
@@ -49,6 +50,7 @@ SCALE_MELODIES = {
 }
 
 
+@lru_cache(maxsize=None)
 def load_emotion_music_map(path: Path = CONFIG_PATH) -> dict:
     """Return emotion-to-music mapping loaded from ``path`` if available."""
     if path.exists():

--- a/tests/test_emotion_music_map.py
+++ b/tests/test_emotion_music_map.py
@@ -18,6 +18,7 @@ sys.modules.setdefault("yaml", dummy_yaml)
 from MUSIC_FOUNDATION import inanna_music_COMPOSER_ai as composer
 
 
+composer.load_emotion_music_map.cache_clear()
 def test_get_emotion_music_params(monkeypatch):
     mapping = {"joy": {"tempo": 150, "scale": "C_major", "rhythm": "swing"}}
     monkeypatch.setattr(composer.emotional_state, "get_last_emotion", lambda: "joy")

--- a/tests/test_emotional_voice.py
+++ b/tests/test_emotional_voice.py
@@ -44,6 +44,7 @@ sys.modules.setdefault("numpy", dummy_np)
 from INANNA_AI import emotional_synaptic_engine, speaking_engine, voice_evolution
 
 voice_evolution.vector_memory.query_vectors = lambda *a, **k: []
+voice_evolution.load_emotion_music_map.cache_clear()
 import corpus_memory_logging
 import emotional_state
 

--- a/tests/test_voice_evolution.py
+++ b/tests/test_voice_evolution.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(ROOT))
 from INANNA_AI import voice_evolution
 
 voice_evolution.vector_memory.query_vectors = lambda *a, **k: []
+voice_evolution.load_emotion_music_map.cache_clear()
 
 
 def test_update_from_history_modifies_style(monkeypatch):

--- a/tests/test_voice_evolution_memory.py
+++ b/tests/test_voice_evolution_memory.py
@@ -22,6 +22,7 @@ import emotional_state
 from INANNA_AI import voice_evolution
 
 
+voice_evolution.load_emotion_music_map.cache_clear()
 def test_evolve_with_memory_updates_styles(tmp_path, monkeypatch, mock_emotion_state):
     log_file = tmp_path / "log.jsonl"
     monkeypatch.setattr(corpus_memory_logging, "INTERACTIONS_FILE", log_file)

--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(ROOT))
 from INANNA_AI import db_storage, utils, voice_evolution
 
 voice_evolution.vector_memory.query_vectors = lambda *a, **k: []
+voice_evolution.load_emotion_music_map.cache_clear()
 
 
 def test_voice_profile_storage(tmp_path):


### PR DESCRIPTION
## Summary
- cache emotion music map loading for composer and voice evolution modules
- clear cached emotion map in voice-related tests

## Testing
- `pytest` *(fails: soundfile LibsndfileError, server endpoints missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac81078860832eb97776f3854d3b7b