### PR TITLE
Add logging and configurable output directory to mix tracks CLI

### DIFF
--- a/tests/test_mix_tracks.py
+++ b/tests/test_mix_tracks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import logging
 import numpy as np
 import soundfile as sf
 
@@ -14,7 +15,8 @@ sys.path.insert(0, str(ROOT))
 from audio.mix_tracks import main
 
 
-def test_mix_tracks_cli(tmp_path):
+def test_mix_tracks_cli(tmp_path, caplog):
+    caplog.set_level(logging.INFO)
     sr = 44100
     t = np.linspace(0, 0.25, sr // 4, endpoint=False)
     tone1 = 0.5 * np.sin(2 * np.pi * 220 * t)
@@ -49,6 +51,8 @@ def test_mix_tracks_cli(tmp_path):
     info = sf.info(out)
     assert info.samplerate == 44100
     assert info.subtype.startswith("PCM_16")
+    assert any("Wrote mix to" in r.message for r in caplog.records)
+    assert any("Wrote preview to" in r.message for r in caplog.records)
 
 
 def test_mix_tracks_with_qnl_text(tmp_path, monkeypatch):

--- a/tests/test_mix_tracks_emotion.py
+++ b/tests/test_mix_tracks_emotion.py
@@ -10,7 +10,7 @@ from audio import mix_tracks
 
 
 def test_mix_audio_emotion_guides_tempo(monkeypatch):
-    monkeypatch.setattr(mix_tracks, "_load", lambda p: (np.zeros(10), 44100))
+    monkeypatch.setattr(mix_tracks, "_load", lambda p, logger=None: (np.zeros(10), 44100))
     monkeypatch.setattr(mix_tracks.audio_ingestion, "extract_tempo", lambda d, s: 100.0)
     monkeypatch.setattr(mix_tracks.audio_ingestion, "extract_key", lambda d: "C:maj")
 
@@ -20,7 +20,7 @@ def test_mix_audio_emotion_guides_tempo(monkeypatch):
 
 
 def test_mix_audio_averages_analysis(monkeypatch):
-    monkeypatch.setattr(mix_tracks, "_load", lambda p: (np.zeros(10), 44100))
+    monkeypatch.setattr(mix_tracks, "_load", lambda p, logger=None: (np.zeros(10), 44100))
     tempos = iter([100.0, 120.0])
     monkeypatch.setattr(
         mix_tracks.audio_ingestion, "extract_tempo", lambda d, s: next(tempos)

--- a/tests/test_mix_tracks_instructions.py
+++ b/tests/test_mix_tracks_instructions.py
@@ -43,13 +43,19 @@ def test_mix_tracks_json_instructions(tmp_path, monkeypatch):
     monkeypatch.setattr(dsp_engine, "compress", lambda d, s, th, ra: (d, s))
 
     argv_backup = sys.argv.copy()
+    out_dir = tmp_path / "custom_out"
     monkeypatch.chdir(tmp_path)
-    sys.argv = ["mix_tracks.py", "--instructions", str(inst_path)]
+    sys.argv = [
+        "mix_tracks.py",
+        "--instructions",
+        str(inst_path),
+        "--output-dir",
+        str(out_dir),
+    ]
     try:
         main()
     finally:
         sys.argv = argv_backup
 
-    out_dir = tmp_path / "output"
     assert (out_dir / "final.wav").exists()
     assert (out_dir / "preview.wav").exists()


### PR DESCRIPTION
## Summary
- inject logger into mix_tracks helpers and CLI
- allow specifying output directory via `--output-dir`
- test logging output and configurable file placement

## Testing
- `pytest tests/test_mix_tracks.py tests/test_mix_tracks_emotion.py tests/test_mix_tracks_instructions.py -vv` *(fails: skipped due to unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68ac841dcfd0832e875fc7e78a97a715