### PR TITLE
Refactor ritual music helpers and add track dataclass

### DIFF
--- a/rag/music_oracle.py
+++ b/rag/music_oracle.py
@@ -58,9 +58,10 @@ def answer(
     music_path: Optional[Path] = None
     if play and features:
         arch = emotion_analysis.emotion_to_archetype(features["emotion"])
-        music_path = play_ritual_music.compose_ritual_music(
+        track = play_ritual_music.compose_ritual_music(
             features["emotion"], ritual, archetype=arch
         )
+        music_path = track.path
     return text, music_path
 
 

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -59,14 +59,9 @@ def test_play_ritual_music_fallback(tmp_path, monkeypatch):
         "joy", "\u2609", output_dir=tmp_path, sample_rate=8000
     )
 
-    import wave as _wave
-
-    with _wave.open(str(out), "rb") as wf:
-        sample_rate = wf.getframerate()
-
-    assert out.exists()
-    assert out == tmp_path / "ritual.wav"
-    assert sample_rate == 8000
+    assert out.path.exists()
+    assert out.path == tmp_path / "ritual.wav"
+    assert out.sample_rate == 8000
 
 
 def test_synthesize_melody_without_sf(tmp_path, monkeypatch):
@@ -99,7 +94,7 @@ def test_synthesize_melody_without_sf(tmp_path, monkeypatch):
 
     out = prm.compose_ritual_music("joy", "\u2609", output_dir=tmp_path)
 
-    assert out.exists()
+    assert out.path.exists()
     assert called["used"]
 
 
@@ -147,4 +142,4 @@ def test_encode_phrase_increases_size(tmp_path, monkeypatch):
     )
 
     assert calls["count"] == 1
-    assert out_hidden.stat().st_size > out_plain.stat().st_size
+    assert out_hidden.path.stat().st_size > out_plain.path.stat().st_size

--- a/tests/test_play_ritual_music_smoke.py
+++ b/tests/test_play_ritual_music_smoke.py
@@ -55,5 +55,5 @@ def test_compose_and_play(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
         "joy", "\u2609", output_dir=tmp_path, sample_rate=22050
     )
 
-    assert out.exists()
-    assert played and played[0] == out
+    assert out.path.exists()
+    assert played and played[0] == out.path

--- a/tests/test_rag_music_integration.py
+++ b/tests/test_rag_music_integration.py
@@ -19,7 +19,9 @@ from SPIRAL_OS import qnl_engine
 
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
+fake_play.compose_ritual_music = lambda *a, **k: types.SimpleNamespace(
+    path=Path("out.wav"), wave=None, sample_rate=44100
+)
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -67,7 +69,9 @@ def test_rag_music_pipeline(tmp_path, monkeypatch):
 
     def fake_compose(emotion, ritual, archetype=None):
         qnl_engine.hex_to_song("deadbeef")
-        return tmp_path / "out.wav"
+        return types.SimpleNamespace(
+            path=tmp_path / "out.wav", wave=None, sample_rate=44100
+        )
 
     monkeypatch.setattr(rmo.play_ritual_music, "compose_ritual_music", fake_compose)
 

--- a/tests/test_rag_music_oracle.py
+++ b/tests/test_rag_music_oracle.py
@@ -28,7 +28,9 @@ sys.modules.setdefault("config", config_mod)
 # Minimal play_ritual_music stub
 audio_pkg = types.ModuleType("audio")
 fake_play = types.ModuleType("play_ritual_music")
-fake_play.compose_ritual_music = lambda *a, **k: Path("out.wav")
+fake_play.compose_ritual_music = lambda *a, **k: types.SimpleNamespace(
+    path=Path("out.wav"), wave=None, sample_rate=44100
+)
 audio_pkg.play_ritual_music = fake_play
 sys.modules.setdefault("audio", audio_pkg)
 sys.modules.setdefault("audio.play_ritual_music", fake_play)
@@ -57,7 +59,9 @@ def test_answer_with_audio(tmp_path, monkeypatch):
     monkeypatch.setattr(
         rmo.play_ritual_music,
         "compose_ritual_music",
-        lambda e, r, **k: tmp_path / "out.wav",
+        lambda e, r, **k: types.SimpleNamespace(
+            path=tmp_path / "out.wav", wave=None, sample_rate=44100
+        ),
     )
 
     text, out = rmo.answer("How does this MP3 express grief?", audio, play=True)


### PR DESCRIPTION
## Summary
- refactor play_ritual_music into helper functions for emotion mapping, waveform synthesis, stego embedding, and playback
- return a dataclass `RitualTrack` from `compose_ritual_music`
- adjust music oracle and tests for new API

## Testing
- `pre-commit run --files rag/music_oracle.py src/audio/play_ritual_music.py tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py tests/test_rag_music_integration.py tests/test_rag_music_oracle.py`
- `pytest tests/test_play_ritual_music.py tests/test_play_ritual_music_smoke.py tests/test_rag_music_oracle.py tests/test_rag_music_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac855e5ac4832e9fcdd0905e9ac39b