### PR TITLE
Add corpus memory logging tests and nightly insight compiler workflow

### DIFF
--- a/.github/workflows/insight_compiler.yml
+++ b/.github/workflows/insight_compiler.yml
@@ -1,0 +1,44 @@
+name: Insight matrix update
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run insight compiler
+        run: |
+          python - <<'PY'
+          from corpus_memory_logging import load_interactions
+          from insight_compiler import update_insights
+          update_insights(load_interactions())
+          PY
+      - name: Commit insight matrix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add insight_matrix.json insight_manifest.json CHANGELOG_insight_matrix.md || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update insight matrix"
+            git push
+          fi

--- a/CHANGELOG_insight_matrix.md
+++ b/CHANGELOG_insight_matrix.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Track history of insight matrix updates in `insight_manifest.json`.
+- Nightly GitHub Actions job runs `insight_compiler.py` and commits matrix updates.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_hex_to_glyphs_smoke.py"),
     str(ROOT / "tests" / "test_interactions_jsonl.py"),
     str(ROOT / "tests" / "test_interactions_jsonl_integrity.py"),
+    str(ROOT / "tests" / "test_corpus_memory_logging.py"),
 }
 
 

--- a/tests/test_corpus_memory_logging.py
+++ b/tests/test_corpus_memory_logging.py
@@ -63,9 +63,13 @@ def test_optional_metadata(tmp_path, monkeypatch):
         source_type="score",
         genre="jazz",
         instrument="piano",
+        feedback="great session",
+        rating=4.5,
     )
 
     entry = cml.load_interactions()[0]
     assert entry["source_type"] == "score"
     assert entry["genre"] == "jazz"
     assert entry["instrument"] == "piano"
+    assert entry["feedback"] == "great session"
+    assert entry["rating"] == 4.5


### PR DESCRIPTION
## Summary
- add tests for corpus memory logging to verify appending and reading optional metadata
- schedule nightly workflow to run insight compiler and commit matrix updates
- document insight matrix automation in changelog

## Testing
- `ruff check tests/test_corpus_memory_logging.py`
- `ruff check tests/conftest.py`
- `pytest tests/test_corpus_memory_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac925dadb4832ebe6965b9b554ff98