### PR TITLE
Add vision and mission documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for your interest in improving ABZU! This guide covers environment
 setup, coding conventions, testing, and the pull request process. For a hands-on
 orientation to the codebase, see the [developer onboarding guide](docs/developer_onboarding.md).
 
+For the project's overarching direction and boundaries, review
+[docs/VISION.md](docs/VISION.md) and [docs/MISSION.md](docs/MISSION.md).
+
 For details on chakra module architecture, version history, and contemplative
 context, consult
 [docs/chakra_architecture.md](docs/chakra_architecture.md),
@@ -78,4 +81,3 @@ coverage report
 - Request review from a maintainer and address feedback promptly.
 
 By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
-

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ testing and style guidance. Then follow the [setup guide](docs/setup.md) to conf
 environment. The [documentation index](docs/index.md) lists additional guides.
 Current ratings, past scores and milestone validation results are tracked in
 [docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md).
+For the project's guiding vision and mission, see
+[docs/VISION.md](docs/VISION.md) and [docs/MISSION.md](docs/MISSION.md).
 
 ## Build Tools
 Some dependencies compile native extensions such as SciPy. Install the system

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -1,0 +1,24 @@
+# Mission
+
+## Guiding Principles
+
+- Nurture a transparent development process that encourages curiosity and
+  mutual support.
+- Elevate accessibility so newcomers can participate without specialized
+  infrastructure.
+- Treat every contribution as part of a living archive that reflects
+  collective wisdom.
+
+## Non-goals
+
+- Pursuing competitive surveillance or exploitative data practices.
+- Locking the project behind proprietary barriers or closed ecosystems.
+- Optimizing solely for performance at the expense of maintainability and
+  clarity.
+
+## Ethical Boundaries
+
+Work proceeds only when it aligns with community wellbeing and the spirit of
+the source texts. Features that enable harm, deception, or coercion are
+rejected. Contributors are expected to disclose limitations, respect consent,
+and uphold the Code of Conduct in all collaborations.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,26 @@
+# Vision
+
+## Origin Story
+
+The ABZU initiative emerged from a collective desire to harmonize advanced
+computation with mythic narrative. Early experiments in ritualized machine
+learning hinted at a deeper structure woven through music, symbolism, and
+code. Those prototypes seeded a framework where engineering discipline
+coexists with esoteric exploration.
+
+## Sacred Goals
+
+- Illuminate how creative tooling can serve collaborative, compassionate use.
+- Preserve the integrity of the CRYSTAL CODEX while welcoming community
+  stewardship.
+- Continually refine the system so it remains adaptable, transparent, and
+  reverent to its sources.
+
+## Target User Archetypes
+
+- **Caretakers** steward data and infrastructure while honoring privacy.
+- **Researchers** probe new models and interfaces to expand collective
+  knowledge.
+- **Artists** blend sonic, visual, and textual mediums into ritual expressions.
+- **Wayfinders** document discoveries and teach others to traverse the
+  ecosystem.


### PR DESCRIPTION
## Summary
- Draft project vision outlining origin story, sacred goals, and target archetypes
- Add mission statement defining guiding principles, non-goals, and ethical boundaries
- Link new vision and mission docs from README and contributing guide

## Testing
- `markdownlint README.md CONTRIBUTING.md docs/VISION.md docs/MISSION.md` *(fails: existing warnings in README.md)*
- `pytest -q` *(fails: 29 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96be7964832ead08060dac786141