### PR TITLE
Ensure core package and editable install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev] --no-deps
+          pip install -e .[dev]
           pip install ruff black mypy pytest jsonschema
 
       - name: Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ abzu = "cli:main"
 where = ["src"]
 exclude = ["tests*", "docs*", "examples*"]
 
+[tool.setuptools.package-dir]
+"" = "src"
+
 
 [tool.black]
 line-length = 88

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,4 +1,7 @@
-"""Core package exposing primary services."""
+"""Core package exposing primary services.
+
+Provides shortcut imports for frequently used components.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify `core` package initialization with shortcut imports
- map `src` as package root in `pyproject.toml`
- install project in editable mode during CI

## Testing
- `pip install -e . --no-deps`
- `python -m cProfile -m task_profiling`
- `pytest tests/test_task_profiling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac9e0bc4bc832e94931827ccb1d9ef