### PR TITLE
docs: expand onboarding with architecture and troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 Thank you for your interest in improving ABZU! This guide covers environment
 setup, coding conventions, testing, and the pull request process. For a hands-on
-orientation to the codebase, see the [developer onboarding guide](docs/developer_onboarding.md).
+orientation to the codebase—including environment setup, chakra overview,
+architecture diagrams, a CLI quick-start, and troubleshooting tips—see the
+[developer onboarding guide](docs/developer_onboarding.md).
 
 For the project's overarching direction and boundaries, review
 [docs/VISION.md](docs/VISION.md) and [docs/MISSION.md](docs/MISSION.md).

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -1,6 +1,6 @@
 # Developer Onboarding
 
-This guide introduces the ABZU codebase, highlights core entry points, and details the environment setup and chakra architecture while noting common pitfalls.
+This guide introduces the ABZU codebase, highlights core entry points, and details the environment setup, chakra architecture, and troubleshooting tips. For a guided CLI quick‑start run the [onboarding wizard](onboarding/wizard.py). Additional architecture diagrams are available in [architecture.md](architecture.md).
 
 ## Quick Start
 ```bash
@@ -10,6 +10,13 @@ python -m venv .venv && source .venv/bin/activate
 scripts/easy_setup.sh
 python download_models.py glm41v_9b --int8
 bash scripts/smoke_console_interface.sh  # see docs/testing.md for more
+```
+
+### CLI Quick‑Start
+Run the interactive wizard to scaffold the environment and launch the CLI:
+
+```bash
+python docs/onboarding/wizard.py
 ```
 
 ## Repository Layout
@@ -50,6 +57,7 @@ Command-line activation agent. It can recite the birth chant (`--activate`), gen
    ```bash
    python download_models.py glm41v_9b --int8
    ```
+   For system package requirements and optional dependency groups, see [setup.md](setup.md).
 
 ## Chakra Overview
 
@@ -76,6 +84,7 @@ graph LR
 ```
 
 ## System Architecture
+For detailed diagrams and component relationships, see [architecture.md](architecture.md).
 
 ```mermaid
 graph TD
@@ -127,7 +136,7 @@ See [testing.md](testing.md) for detailed instructions.
 - `scripts/easy_setup.sh` / `scripts/setup_repo.sh` – install common dependencies.
 - `download_models.py` – fetches model weights such as GLM and DeepSeek.
 
-## Common Pitfalls
+## Troubleshooting Tips
 Common mistakes and their resolutions:
 
 | Issue | Resolution |


### PR DESCRIPTION
## Summary
- link onboarding to architecture diagrams and add interactive CLI quick-start
- rename pitfall section to troubleshooting tips and expand environment guidance
- cross-link developer onboarding from contributing guide

## Testing
- `scripts/smoke_console_interface.sh` *(fails: No module named 'cli')*
- `pytest -q` *(fails: multiple tests erroring and failing)*

------
https://chatgpt.com/codex/tasks/task_e_68aca0fa97d8832e8dcbc7a94b8b09c3