### PR TITLE
Add latency metrics and log rotation

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,8 @@
 # Monitoring
 
-The application writes JSON-formatted logs to `logs/INANNA_AI.log` and rotates the file when it grows beyond 1 MB. Each rotated copy is suffixed with a number (for example, `INANNA_AI.log.1`).
+The application writes JSON-formatted logs to `logs/INANNA_AI.log`. The file
+rotates when it reaches roughly 10 MB, keeping seven backups
+(`INANNA_AI.log.1`, `INANNA_AI.log.2`, ...).
 
 ## Tailing logs
 
@@ -8,17 +10,30 @@ The application writes JSON-formatted logs to `logs/INANNA_AI.log` and rotates t
 tail -F logs/INANNA_AI.log
 ```
 
-Use `tail -F` to follow the active log file across rotations. The output uses JSON, making it easy to filter with tools such as `jq`:
+Use `tail -F` to follow the active log file across rotations. The output uses
+JSON, making it easy to filter with tools such as `jq`:
 
 ```bash
 tail -F logs/INANNA_AI.log | jq '.duration? // empty'
 ```
 
+## Log fields
+
+Several JSON fields are emitted by the system:
+
+- `symbols` and `emotion` from `invocation_engine.invoke`.
+- `ritual` from `invocation_engine.invoke_ritual`.
+- `path` and `method` for HTTP requests handled by the FastAPI middleware.
+- `duration` in seconds for any of the above operations.
+
 ## Timing metrics
 
-Two parts of the system emit a `duration` field measured in seconds using `time.perf_counter()`:
+Latency histograms are exported via Prometheus:
 
-- `invocation_engine.invoke` reports how long pattern matching and callbacks take.
-- The FastAPI server middleware logs the processing time for every HTTP request along with its path and method.
+- `invocation_duration_seconds` – pattern invocation latency.
+- `ritual_invocation_duration_seconds` – ritual lookup latency.
+- `http_request_duration_seconds` – FastAPI request latency labelled by path and method.
 
-Higher durations indicate slower operations. Watching these metrics helps identify performance bottlenecks.
+All timings use `time.perf_counter()`. Higher values indicate slower operations
+and can highlight performance bottlenecks.
+

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -4,12 +4,12 @@ formatters:
     '()': pythonjsonlogger.jsonlogger.JsonFormatter
 handlers:
   file:
-    class: logging.handlers.TimedRotatingFileHandler
+    class: logging.handlers.RotatingFileHandler
     formatter: json
     filename: logs/INANNA_AI.log
     encoding: utf-8
     filters: [emotion]
-    when: midnight
+    maxBytes: 10485760
     backupCount: 7
   audio:
     class: logging.handlers.RotatingFileHandler


### PR DESCRIPTION
## Summary
- rotate main log file with JSON formatter
- record invocation and HTTP request latencies using Prometheus histograms
- document log fields and metrics

## Testing
- `pre-commit run --files logging_config.yaml invocation_engine.py server.py docs/monitoring.md`
- `pytest` *(fails: Duplicated timeseries in CollectorRegistry and missing module attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68aca346692c832ebf67a22d56ff708a