### PR TITLE
feat: customizable archetype score webhooks

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -71,6 +71,8 @@ file so you don't need to export the variables manually:
   scores as JSON
 - `ARCHETYPE_SCORE_QUEUE_PATH` – optional file path where archetypal scores
   are appended as JSON lines when the webhook is not set
+- `ARCHETYPE_SCORE_WEBHOOK_HEADERS` – JSON object of HTTP headers added when
+  posting archetypal scores to the webhook
 
 Provide `GLM_API_URL` and `GLM_API_KEY` in `secrets.env` to point to your
 production GLM service.  The helper scripts read these variables on startup.


### PR DESCRIPTION
## Summary
- allow insight compiler to send archetype scores with custom webhook headers
- document and expose `ARCHETYPE_SCORE_WEBHOOK_HEADERS` env var
- test webhook posting using mocked request

## Testing
- `pre-commit run --files insight_compiler.py tests/test_insight_compiler.py README_OPERATOR.md`
- `pytest tests/test_insight_compiler.py::test_connector_invoked -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca61cb490832eba2c2bc1e803a97e