### PR TITLE
docs: reference chakra version file in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linked chakra koan and version files from README and CONTRIBUTING.
 - Added chakra status table in `docs/chakra_status.md` outlining capabilities,
   limitations and planned evolutions for each layer.
+- Linked release notes to `docs/chakra_versions.json` and `CHANGELOG.md`.
 
 ### Quality
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Track semantic versions for each chakra layer in
   `docs/chakra_versions.json`.
 - Record each chakra version bump in this changelog.
+- Bumped `root` and `crown` chakras to `1.0.1`.
 
 ### Insight Matrix
 

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -1,9 +1,9 @@
 {
-  "root": "1.0.0",
+  "root": "1.0.1",
   "sacral": "1.0.0",
   "solar_plexus": "1.0.0",
   "heart": "1.0.0",
   "throat": "1.0.0",
   "third_eye": "1.0.0",
-  "crown": "1.0.0"
+  "crown": "1.0.1"
 }

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -5,3 +5,4 @@
 - Removed root-level compatibility shims `qnl_engine.py` and `symbolic_parser.py`. Import these modules via `SPIRAL_OS.qnl_engine` and `SPIRAL_OS.symbolic_parser` instead.
 - Marked audio pipeline refresh milestone as complete in `PROJECT_STATUS.md`; release targets remain unchanged.
 - Added agent instructions and dependency group summaries to `CRYSTAL_CODEX.md`.
+- Referenced chakra version tracking via [chakra_versions.json](chakra_versions.json) and documented bumps in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
## Summary
- cross-reference chakra version tracking in release notes
- bump root and crown chakra layers to 1.0.1 and log the change

## Testing
- `pre-commit run --files docs/chakra_versions.json CHANGELOG.md docs/release_notes.md`
- `pytest` *(fails: AttributeError in various modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aca7840210832ebc5a418ec123d056