### PR TITLE
docs: outline community roles and governance

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -1,5 +1,29 @@
 # Community
 
+## Roles and Contribution Etiquette
+
+- **Maintainers** – steward the repository, review pull requests, and guide
+  project direction. Respect their final decisions on technical and community
+  matters.
+- **Ritual Designers** – craft and iterate on ritual concepts. Discuss ideas in
+  issues before submitting proposals and document any safety considerations.
+- **AI Agents** – assist with planning, coding, and review. Their contributions
+  enter the codebase only after human maintainer approval.
+
+When contributing, stay respectful, cite sources, keep conversations focused,
+and follow the [contribution guide](contribution_guide.md) and pull request
+process.
+
+## Decision-Making and Code of Conduct Enforcement
+
+Project decisions are made through open discussion in issues, pull requests,
+and monthly community calls. Maintainers seek consensus but may make a final
+call when needed.
+
+All participants must follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
+Maintainers moderate discussions, investigate reports, and can remove content or
+restrict access to uphold community safety.
+
 ## Proposing Plugins
 
 1. Navigate to the repository's **Issues** page.
@@ -17,4 +41,12 @@
 ## Open Calls
 
 Community open calls occur on the first Tuesday of each month at 16:00 UTC.
-The agenda and meeting link are posted in [GitHub Discussions](https://github.com/ABZU/ABZU/discussions) the week before each call.
+The agenda and meeting link are posted in
+[GitHub Discussions](https://github.com/ABZU/ABZU/discussions) the week before
+each call.
+
+## Further Reading
+
+- [VISION](VISION.md)
+- [MISSION](MISSION.md)
+- [roadmap](roadmap.md)


### PR DESCRIPTION
## Summary
- document roles for maintainers, ritual designers, and AI agents
- describe decision making and Code of Conduct enforcement
- link to vision, mission, and roadmap documents

## Testing
- `pre-commit run --files docs/community.md`
- `pytest -q` *(fails: module and attribute errors, 32 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acae33b514832e9b59202631bdffaf