### PR TITLE
Add streaming music generation and backend loaders

### DIFF
--- a/docs/music_avatar_architecture.md
+++ b/docs/music_avatar_architecture.md
@@ -26,6 +26,40 @@ For generating test tones during development, the
 `seven_dimensional_music.generate_quantum_music` helper can synthesise a short
 audio clip along with placeholder seven-plane analysis.
 
+## Usage Examples
+
+The `music_generation.py` script exposes a minimal interface for creating short
+audio samples. Generation parameters such as **temperature**, **duration** and
+random **seed** can be configured from the command line or when calling the
+module programmatically. Streaming output is supported to allow incremental
+playback or progressive file writing.
+
+```bash
+# generate a five second clip at low temperature
+python music_generation.py "lofi beat" --duration 5 --temperature 0.7
+
+# stream raw bytes while generating
+python music_generation.py "riff" --stream | aplay -f cd
+```
+
+When used as a library:
+
+```python
+from music_generation import generate_from_text
+
+gen = generate_from_text(
+    "ambient pad",
+    emotion="calm",
+    tempo=90,
+    temperature=0.8,
+    duration=8,
+    seed=42,
+    stream=True,
+)
+for chunk in gen:
+    ...  # handle each audio chunk
+```
+
 ## Evaluation Workflow
 
 Music prompts submitted through the web console are logged via

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@ progress.
 
 ## Upcoming
 
-- **Music command** enabling on‑the‑fly song generation.
+- **Music command** enabling on‑the‑fly song generation and streaming output.
 - **Avatar lip‑sync** for more accurate mouth movement.
 - **Expanded memory search** across cortex and vector layers.
 - **Voice cloning** to mirror user tone within the sonic core.
@@ -52,7 +52,7 @@ quarter‑level goals and owners.
 
 | Milestone | Component | Score |
 | --- | --- | --- |
-| Music command | `music_generation.py` | ⚠️3 |
+| Music command | `music_generation.py` (streaming support) | ⚠️4 |
 | Avatar lip‑sync | `ai_core/avatar/lip_sync.py` | ⚠️2 |
 | Expanded memory search | `memory/cortex.py` | ⚠️1 |
 | Expanded memory search | `vector_memory.py` | ⚠️3 |

--- a/music_generation.py
+++ b/music_generation.py
@@ -9,8 +9,14 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
+from typing import Iterable, Iterator
 
 from src.media.audio.base import AudioProcessor
+
+try:  # pragma: no cover - optional dependency
+    from transformers import pipeline as hf_pipeline  # type: ignore
+except Exception:  # pragma: no cover - dependency guard
+    hf_pipeline = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +41,18 @@ class MusicGenerator(AudioProcessor):
         prompt: str,
         emotion: str | None = None,
         tempo: int | None = None,
-    ) -> Path:
-        """Generate audio from ``prompt`` and return the file path."""
+        *,
+        temperature: float = 1.0,
+        duration: int = 5,
+        seed: int | None = None,
+        stream: bool = False,
+    ) -> Path | Iterable[bytes]:
+        """Generate audio from ``prompt``.
+
+        When ``stream`` is ``True`` the method returns an iterator yielding
+        audio chunks as ``bytes``. Otherwise it returns the path to the written
+        WAV file.
+        """
         model_id = MODEL_IDS.get(self.model)
         if not model_id:
             raise ValueError(f"Unsupported model '{self.model}'")
@@ -46,14 +62,28 @@ class MusicGenerator(AudioProcessor):
         if tempo:
             prompt = f"{prompt} at {tempo} BPM"
 
-        try:  # pragma: no cover - optional dependency
-            from transformers import pipeline as hf_pipeline
-        except Exception as exc:  # pragma: no cover - dependency guard
-            raise ImportError("transformers is required for music generation") from exc
+        if hf_pipeline is None:
+            raise ImportError("transformers is required for music generation")
 
         pipe = hf_pipeline("text-to-audio", model=model_id)
-        result = pipe(prompt)[0]
-        audio: bytes = result.get("audio", b"")
+        gen_params = {
+            "temperature": temperature,
+            "duration": duration,
+            "stream": stream,
+        }
+        if seed is not None:
+            gen_params["seed"] = seed
+
+        result = pipe(prompt, **gen_params)
+        if stream:
+            def _stream() -> Iterator[bytes]:
+                for chunk in result:
+                    yield chunk.get("audio", b"")
+
+            return _stream()
+
+        first = next(iter(result))
+        audio: bytes = first.get("audio", b"")
 
         OUTPUT_DIR.mkdir(exist_ok=True)
         index = sum(1 for _ in OUTPUT_DIR.glob(f"{self.model}_*.wav"))
@@ -68,10 +98,23 @@ def generate_from_text(
     model: str = "musicgen",
     emotion: str | None = None,
     tempo: int | None = None,
-) -> Path:
+    *,
+    temperature: float = 1.0,
+    duration: int = 5,
+    seed: int | None = None,
+    stream: bool = False,
+) -> Path | Iterable[bytes]:
     """Backward compatible wrapper around :class:`MusicGenerator`."""
     generator = MusicGenerator(model)
-    return generator.process(prompt, emotion, tempo)
+    return generator.process(
+        prompt,
+        emotion,
+        tempo,
+        temperature=temperature,
+        duration=duration,
+        seed=seed,
+        stream=stream,
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -86,9 +129,29 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--emotion", help="Optional emotion to guide style")
     parser.add_argument("--tempo", type=int, help="Optional tempo in BPM")
+    parser.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")
+    parser.add_argument("--duration", type=int, default=5, help="Approximate duration in seconds")
+    parser.add_argument("--seed", type=int, help="Random seed for reproducibility")
+    parser.add_argument("--stream", action="store_true", help="Stream audio chunks to stdout")
     args = parser.parse_args(argv)
-    path = generate_from_text(args.prompt, args.model, args.emotion, args.tempo)
-    print(path)
+
+    result = generate_from_text(
+        args.prompt,
+        args.model,
+        args.emotion,
+        args.tempo,
+        temperature=args.temperature,
+        duration=args.duration,
+        seed=args.seed,
+        stream=args.stream,
+    )
+    if args.stream:
+        import sys
+
+        for chunk in result:  # type: ignore[assignment]
+            sys.stdout.buffer.write(chunk)
+    else:
+        print(result)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/seven_dimensional_music.py
+++ b/seven_dimensional_music.py
@@ -12,10 +12,7 @@ from pathlib import Path
 
 import numpy as np
 
-try:  # pragma: no cover - optional dependency
-    import soundfile as sf
-except Exception:  # pragma: no cover - optional dependency
-    sf = None  # type: ignore
+from src.media.audio.backends import load_backend
 
 from typing import Any
 
@@ -61,6 +58,7 @@ def generate_quantum_music(
     t = np.linspace(0, duration, int(sr * duration), endpoint=False)
     wave = 0.5 * np.sin(2 * np.pi * 220 * t)
     out = Path(output_dir) / "quantum.wav"
+    sf = load_backend("soundfile")
     if sf is None:
         raise RuntimeError("soundfile library not installed")
     sf.write(out, wave, sr, subtype="PCM_16")
@@ -83,6 +81,10 @@ def main(args: list[str] | None = None) -> None:
     parser.add_argument("--output", required=True)
     parser.add_argument("--secret")
     opts = parser.parse_args(args)
+
+    sf = load_backend("soundfile")
+    if sf is None:
+        raise RuntimeError("soundfile library not installed")
 
     data, sr = sf.read(opts.input, always_2d=False)
     sf.write(opts.output, data, sr, subtype="PCM_16")

--- a/src/media/audio/backends.py
+++ b/src/media/audio/backends.py
@@ -1,0 +1,27 @@
+"""Utilities for loading optional audio backends."""
+
+from __future__ import annotations
+
+import importlib
+from functools import lru_cache
+from typing import Any
+
+
+@lru_cache(maxsize=None)
+def load_backend(name: str) -> Any | None:
+    """Return imported module ``name`` or ``None`` if unavailable.
+
+    Parameters
+    ----------
+    name:
+        Module path to import.
+
+    Returns
+    -------
+    module | None
+        The imported module instance, or ``None`` when the import fails.
+    """
+    try:
+        return importlib.import_module(name)
+    except Exception:
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,10 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_interactions_jsonl.py"),
     str(ROOT / "tests" / "test_interactions_jsonl_integrity.py"),
     str(ROOT / "tests" / "test_corpus_memory_logging.py"),
+    str(ROOT / "tests" / "test_music_generation.py"),
+    str(ROOT / "tests" / "test_music_generation_emotion.py"),
+    str(ROOT / "tests" / "test_music_generation_streaming.py"),
+    str(ROOT / "tests" / "test_music_backends_missing.py"),
 }
 
 

--- a/tests/test_music_backends_missing.py
+++ b/tests/test_music_backends_missing.py
@@ -1,0 +1,27 @@
+"""Tests for graceful backend fallbacks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("omegaconf")
+
+import music_llm_interface as mli
+import seven_dimensional_music as sdm
+
+
+def test_analyze_midi_requires_pretty_midi(monkeypatch):
+    monkeypatch.setattr(mli, "load_backend", lambda name: None)
+    with pytest.raises(RuntimeError, match="pretty_midi"):
+        mli._analyze_midi(Path("dummy.mid"))
+
+
+def test_generate_quantum_music_requires_soundfile(monkeypatch, tmp_path):
+    monkeypatch.setattr(sdm, "load_backend", lambda name: None)
+    monkeypatch.setattr(sdm, "quantum_embed", lambda text: np.zeros(1, dtype=float))
+    monkeypatch.setattr(sdm, "embedding_to_params", lambda emb: (0.0, 1.0, 1.0))
+    with pytest.raises(RuntimeError, match="soundfile"):
+        sdm.generate_quantum_music("ctx", "joy", output_dir=tmp_path)

--- a/tests/test_music_generation.py
+++ b/tests/test_music_generation.py
@@ -23,8 +23,9 @@ def test_generate_from_text_creates_file(tmp_path, monkeypatch):
         calls["model"] = model
 
         class P:
-            def __call__(self, prompt):
+            def __call__(self, prompt, **params):
                 calls["prompt"] = prompt
+                calls["params"] = params
                 return [{"audio": b"WAV"}]
 
         return P()
@@ -40,4 +41,5 @@ def test_generate_from_text_creates_file(tmp_path, monkeypatch):
         "task": "text-to-audio",
         "model": mg.MODEL_IDS["musicgen"],
         "prompt": "beat",
+        "params": {"temperature": 1.0, "duration": 5, "stream": False},
     }

--- a/tests/test_music_generation_emotion.py
+++ b/tests/test_music_generation_emotion.py
@@ -13,7 +13,7 @@ def test_generate_from_text_includes_emotion_and_tempo(monkeypatch, tmp_path):
     captured = {}
 
     class DummyPipe:
-        def __call__(self, prompt: str):
+        def __call__(self, prompt: str, **_params):
             captured["prompt"] = prompt
             return [{"audio": b"data"}]
 

--- a/tests/test_music_generation_streaming.py
+++ b/tests/test_music_generation_streaming.py
@@ -1,0 +1,68 @@
+"""Additional tests for music generation streaming and parameters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("omegaconf")
+
+import music_generation as mg
+
+
+@pytest.fixture()
+def tmp_output(tmp_path, monkeypatch):
+    monkeypatch.setattr(mg, "OUTPUT_DIR", tmp_path)
+    return tmp_path
+
+
+def test_duration_and_seed_parameters(tmp_output, monkeypatch):
+    captured = {}
+
+    def fake_pipeline(task, model):
+        assert task == "text-to-audio"
+        assert model == mg.MODEL_IDS["musicgen"]
+
+        def call(prompt, **params):
+            captured["prompt"] = prompt
+            captured["params"] = params
+            length = params["duration"]
+            return [{"audio": b"x" * length}]
+
+        return call
+
+    monkeypatch.setattr(mg, "hf_pipeline", fake_pipeline)
+
+    out = mg.generate_from_text(
+        "beat",
+        duration=4,
+        seed=123,
+        temperature=0.5,
+    )
+    assert isinstance(out, Path)
+    assert out.read_bytes() == b"x" * 4
+    assert captured["params"] == {
+        "temperature": 0.5,
+        "duration": 4,
+        "stream": False,
+        "seed": 123,
+    }
+
+
+def test_streaming_yields_chunks(tmp_output, monkeypatch):
+    def fake_pipeline(task, model):
+        assert task == "text-to-audio"
+        assert model == mg.MODEL_IDS["musicgen"]
+
+        def gen(prompt, **params):
+            assert params["stream"] is True
+            yield {"audio": b"a"}
+            yield {"audio": b"b"}
+
+        return gen
+
+    monkeypatch.setattr(mg, "hf_pipeline", fake_pipeline)
+
+    stream = mg.generate_from_text("beat", stream=True)
+    assert list(stream) == [b"a", b"b"]


### PR DESCRIPTION
## Summary
- support streaming audio output and configurable generation parameters
- add backend loading utility with caching for optional music dependencies
- document music avatar usage and update roadmap

## Testing
- `pytest tests/test_music_generation.py tests/test_music_generation_emotion.py tests/test_music_generation_streaming.py tests/test_music_backends_missing.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68acb117cfc4832ea792673105987c31