### PR TITLE
Remove sample audio and update avatar pipeline docs

### DIFF
--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -47,6 +47,20 @@ for frame in stream_avatar_audio(Path("chant.wav")):
     pass  # render or encode the frame
 ```
 
+The repository previously included a small `sample_voice.wav` clip for quick
+tests. To keep the documentation lightweight the binary asset was removed. You
+can synthesise a silent placeholder instead:
+
+```python
+import numpy as np
+import soundfile as sf
+
+sf.write("sample_voice.wav", np.zeros(16000), 16000)
+```
+
+Any external WAV file can also be used; public domain samples are available at
+[https://people.sc.fsu.edu/~jburkardt/data/wav/](https://people.sc.fsu.edu/~jburkardt/data/wav/).
+
 Generate a short sovereign voice sample from hexadecimal bytes and animate it:
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to synthesize a placeholder voice clip now that `sample_voice.wav` is gone
- point readers to external public domain audio samples for testing

## Testing
- `pytest` *(fails: 32 failed, 122 passed, 447 skipped, 538 warnings, 2 errors)*
- `ruff check .` *(fails: Found 15 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acb63e78d4832ea52941131474d563