### PR TITLE
Add voice cloning interfaces

### DIFF
--- a/docs/assets/voice_sample_workflow.svg
+++ b/docs/assets/voice_sample_workflow.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 60">
+  <rect x="5" y="5" width="90" height="30" fill="#eef" stroke="#99f" />
+  <text x="10" y="25" font-size="12">Capture</text>
+  <rect x="105" y="5" width="90" height="30" fill="#efe" stroke="#9f9" />
+  <text x="115" y="25" font-size="12">EmotiVoice</text>
+  <rect x="205" y="5" width="90" height="30" fill="#fee" stroke="#f99" />
+  <text x="215" y="25" font-size="12">Output</text>
+  <line x1="95" y1="20" x2="105" y2="20" stroke="#000" />
+  <line x1="195" y1="20" x2="205" y2="20" stroke="#000" />
+</svg>

--- a/docs/voice_aura.md
+++ b/docs/voice_aura.md
@@ -17,3 +17,28 @@ The module checks if the `sox` command is available to process effects.
 If not, it falls back to `pydub`.  Optional RAVE or NSynth checkpoints can
 morph the timbre via `dsp_engine.rave_morph` or `nsynth_interpolate`.
 
+## Sample Workflow
+
+Voice capture and synthesis can be driven from either the command line or a
+REST interface.
+
+```bash
+# record a 2s sample for speaker "alice"
+python -m src.cli.voice_clone capture alice.wav --speaker alice --seconds 2
+
+# synthesize text using the recorded sample
+python -m src.cli.voice_clone synthesize "Hello" out.wav --sample alice.wav --speaker alice --emotion joy
+```
+
+The FastAPI server exposes matching endpoints:
+
+- `POST /voice/capture` – records a sample on the host.  Parameters: `speaker`,
+  `seconds`, `sr` and `path`.
+- `POST /voice/synthesize` – generates speech for `text` with optional
+  `emotion` and `speaker` fields.
+
+![Voice flow](assets/voice_sample_workflow.svg)
+
+These utilities handle missing optional dependencies such as `sounddevice` and
+`EmotiVoice` gracefully, returning informative errors when unavailable.
+

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import List, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from pathlib import Path
+
+from audio.voice_cloner import VoiceCloner
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from style_engine import style_library
@@ -17,6 +20,7 @@ Instrumentator().instrument(app).expose(app)
 # Core logic functions
 
 _connections: Set[WebSocket] = set()
+voice_cloner = VoiceCloner()
 
 
 async def generate_video(prompt: str) -> dict[str, str]:
@@ -68,4 +72,42 @@ async def styles_endpoint() -> dict[str, List[str]]:
     return {"styles": await list_styles()}
 
 
-__all__ = ["app", "generate_video", "list_styles", "broadcast_avatar_update"]
+@app.post("/voice/capture")  # type: ignore[misc]
+async def capture_voice(data: dict[str, object]) -> dict[str, str]:
+    """Record a short voice sample for a speaker profile."""
+
+    path = Path(str(data.get("path", "sample.wav")))
+    seconds = float(data.get("seconds", 3.0))
+    sr = int(data.get("sr", 22_050))
+    speaker = str(data.get("speaker", "user"))
+    try:
+        voice_cloner.capture_sample(path, seconds=seconds, sr=sr, speaker=speaker)
+    except RuntimeError as exc:
+        return {"error": str(exc)}
+    return {"sample": str(path), "speaker": speaker}
+
+
+@app.post("/voice/synthesize")  # type: ignore[misc]
+async def synthesize_voice(data: dict[str, object]) -> dict[str, str]:
+    """Generate speech for ``text`` with a cloned voice."""
+
+    text = str(data.get("text", ""))
+    out_path = Path(str(data.get("out", "speech.wav")))
+    speaker = str(data.get("speaker", "user"))
+    emotion = str(data.get("emotion", "neutral"))
+    try:
+        voice_cloner.synthesize(text, out_path, speaker=speaker, emotion=emotion)
+    except RuntimeError as exc:
+        return {"error": str(exc)}
+    return {"audio": str(out_path), "speaker": speaker, "emotion": emotion}
+
+
+__all__ = [
+    "app",
+    "generate_video",
+    "list_styles",
+    "broadcast_avatar_update",
+    "capture_voice",
+    "synthesize_voice",
+    "voice_cloner",
+]

--- a/src/audio/voice_cloner.py
+++ b/src/audio/voice_cloner.py
@@ -26,34 +26,76 @@ class VoiceCloner:
     """
 
     def __init__(self) -> None:
-        self.sample: Optional[Path] = None
+        self.samples: dict[str, Path] = {}
         self._model: Optional[object] = None
 
     def capture_sample(
-        self, path: Path, seconds: float = 3.0, sr: int = 22_050
+        self,
+        path: Path,
+        seconds: float = 3.0,
+        sr: int = 22_050,
+        speaker: str = "user",
     ) -> Path:
-        """Record ``seconds`` of audio from the microphone into ``path``."""
+        """Record ``seconds`` of audio from the microphone into ``path``.
+
+        Parameters
+        ----------
+        path:
+            Location to store the recorded WAV file.
+        seconds:
+            Duration of the recording.
+        sr:
+            Target sample rate.
+        speaker:
+            Identifier for the speaker profile.
+        """
 
         if getattr(sd, "__stub__", False):
             raise RuntimeError("sounddevice library not installed")
-        logger.info("Recording voice sample for %.1f seconds", seconds)
+        logger.info(
+            "Recording voice sample for %.1f seconds (sr=%d) as '%s'",
+            seconds,
+            sr,
+            speaker,
+        )
         audio = sd.rec(int(seconds * sr), samplerate=sr, channels=1, dtype="float32")
         sd.wait()
         save_wav(np.asarray(audio).flatten(), str(path), sr=sr)
-        self.sample = path
+        self.samples[speaker] = path
+        if self._model is not None and not getattr(emotivoice, "__stub__", False):
+            self._model.register_voice(speaker, str(path))
         return path
 
-    def synthesize(self, text: str, out_path: Path, emotion: str = "neutral") -> Path:
-        """Generate ``text`` with the cloned voice."""
+    def synthesize(
+        self,
+        text: str,
+        out_path: Path,
+        speaker: str = "user",
+        emotion: str = "neutral",
+    ) -> Path:
+        """Generate ``text`` with the cloned voice.
+
+        Parameters
+        ----------
+        text:
+            Text to be spoken.
+        out_path:
+            Destination WAV path.
+        speaker:
+            Speaker profile to use.
+        emotion:
+            Emotion hint for the synthesizer.
+        """
 
         if getattr(emotivoice, "__stub__", False):
             raise RuntimeError("EmotiVoice library not installed")
-        if self.sample is None:
-            raise RuntimeError("No voice sample captured")
+        if speaker not in self.samples:
+            raise RuntimeError(f"No voice sample captured for speaker '{speaker}'")
         if self._model is None:
             self._model = emotivoice.TTS()
-            self._model.register_voice("user", str(self.sample))
-        self._model.tts_to_file(text, str(out_path), speaker="user", emotion=emotion)
+            for name, samp in self.samples.items():
+                self._model.register_voice(name, str(samp))
+        self._model.tts_to_file(text, str(out_path), speaker=speaker, emotion=emotion)
         return out_path
 
 

--- a/src/cli/voice_clone.py
+++ b/src/cli/voice_clone.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""CLI for recording samples and synthesizing speech via :mod:`EmotiVoice`."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from audio.voice_cloner import VoiceCloner
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture voice samples and synthesize speech",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    rec = sub.add_parser("capture", help="Record a voice sample")
+    rec.add_argument("path", help="Output WAV path")
+    rec.add_argument("--speaker", default="user", help="Speaker profile name")
+    rec.add_argument("--seconds", type=float, default=3.0, help="Recording length")
+    rec.add_argument("--sr", type=int, default=22_050, help="Sample rate")
+
+    syn = sub.add_parser("synthesize", help="Generate speech using a sample")
+    syn.add_argument("text", help="Text to speak")
+    syn.add_argument("out", help="Output WAV path")
+    syn.add_argument("--sample", required=True, help="Path to captured sample")
+    syn.add_argument("--speaker", default="user", help="Speaker profile name")
+    syn.add_argument("--emotion", default="neutral", help="Emotion for TTS")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the voice cloning utility."""
+
+    args = _build_parser().parse_args(argv)
+    cloner = VoiceCloner()
+
+    if args.cmd == "capture":
+        try:
+            cloner.capture_sample(
+                Path(args.path),
+                seconds=args.seconds,
+                sr=args.sr,
+                speaker=args.speaker,
+            )
+        except RuntimeError as exc:  # pragma: no cover - missing deps
+            logger.error("%s", exc)
+    elif args.cmd == "synthesize":
+        cloner.samples[args.speaker] = Path(args.sample)
+        try:
+            cloner.synthesize(
+                args.text,
+                Path(args.out),
+                speaker=args.speaker,
+                emotion=args.emotion,
+            )
+        except RuntimeError as exc:  # pragma: no cover - missing deps
+            logger.error("%s", exc)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()
+

--- a/tests/test_voice_cloner_cli.py
+++ b/tests/test_voice_cloner_cli.py
@@ -1,0 +1,100 @@
+"""Tests for voice cloning CLI and API using stubbed dependencies."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Stub optional dependencies before importing modules under test
+
+
+sd = types.SimpleNamespace(__stub__=False)
+
+
+def _rec(n, samplerate, channels, dtype):  # pragma: no cover - trivial
+    return np.zeros((n, channels), dtype=np.float32)
+
+
+sd.rec = _rec
+sd.wait = lambda: None
+sys.modules.setdefault("sounddevice", sd)
+
+
+ev = types.SimpleNamespace(__stub__=False)
+
+
+class _DummyTTS:  # pragma: no cover - simple behaviour
+    def __init__(self) -> None:
+        self.voices = {}
+
+    def register_voice(self, name: str, path: str) -> None:
+        self.voices[name] = path
+
+    def tts_to_file(self, text: str, out: str, speaker: str, emotion: str) -> None:
+        Path(out).write_text(f"{speaker}:{emotion}:{text}")
+
+
+ev.TTS = _DummyTTS
+sys.modules.setdefault("emotivoice", ev)
+
+
+sf = types.SimpleNamespace(write=lambda p, d, sr, subtype=None: Path(p).write_bytes(b""))
+sys.modules.setdefault("soundfile", sf)
+
+
+from src.cli.voice_clone import main as cli_main
+from src.api.server import app
+
+
+def test_cli_capture_and_synthesize(tmp_path):
+    sample = tmp_path / "sample.wav"
+    out = tmp_path / "out.wav"
+    cli_main([
+        "capture",
+        str(sample),
+        "--speaker",
+        "alice",
+        "--seconds",
+        "0.1",
+        "--sr",
+        "8000",
+    ])
+    cli_main(
+        [
+            "synthesize",
+            "hi",
+            str(out),
+            "--sample",
+            str(sample),
+            "--speaker",
+            "alice",
+            "--emotion",
+            "joy",
+        ]
+    )
+    assert out.exists()
+
+
+def test_api_capture_and_synthesize(tmp_path):
+    client = TestClient(app)
+    sample = tmp_path / "sample.wav"
+    out = tmp_path / "out.wav"
+    r = client.post(
+        "/voice/capture",
+        json={"path": str(sample), "speaker": "bob", "seconds": 0.1, "sr": 8000},
+    )
+    assert r.status_code == 200 and r.json()["speaker"] == "bob"
+    r = client.post(
+        "/voice/synthesize",
+        json={"text": "ok", "speaker": "bob", "emotion": "sad", "out": str(out)},
+    )
+    assert r.status_code == 200
+    assert out.exists()
+
+


### PR DESCRIPTION
## Summary
- extend `VoiceCloner` to handle multiple speaker profiles and adjustable recording parameters
- add CLI and REST endpoints for capturing voice samples and synthesizing speech
- document voice cloning workflow and provide example asset

## Testing
- `pytest tests/test_voice_cloner_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acc2d67ea0832eafd257f7a969d9fe