### PR TITLE
Add phoneme extraction and blendshape mapping

### DIFF
--- a/ai_core/avatar/__init__.py
+++ b/ai_core/avatar/__init__.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from .expression_controller import generate_landmarks
+from .expression_controller import generate_landmarks, map_phonemes_to_blendshapes
 from .lip_sync import align_phonemes
+from .phonemes import extract_phonemes
 from .ltx_avatar import LTXAvatar, LTXDistilledModel
 
 __all__ = [
@@ -11,4 +12,6 @@ __all__ = [
     "LTXDistilledModel",
     "generate_landmarks",
     "align_phonemes",
+    "extract_phonemes",
+    "map_phonemes_to_blendshapes",
 ]

--- a/ai_core/avatar/expression_controller.py
+++ b/ai_core/avatar/expression_controller.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Generate rudimentary facial landmarks based on dialogue cues."""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Sequence, Tuple
 
 Landmarks = Dict[str, List[Tuple[int, int]]]
 
@@ -38,4 +38,30 @@ def generate_landmarks(dialogue: str) -> Landmarks:
     return _NEUTRAL
 
 
-__all__ = ["generate_landmarks", "Landmarks"]
+# --- Phoneme to blendshape mapping -------------------------------------------------
+
+_VOWELS = set("aeiouəɐɑæʌɔʊɪe")
+
+_CONSONANT_BLENDSHAPES = {
+    "m": "closed",
+    "b": "closed",
+    "p": "closed",
+    "f": "teeth",
+    "v": "teeth",
+}
+
+
+def _phoneme_to_blendshape(phoneme: str) -> str:
+    base = phoneme.lower()[0]
+    if base in _VOWELS:
+        return "open"
+    return _CONSONANT_BLENDSHAPES.get(base, "rest")
+
+
+def map_phonemes_to_blendshapes(phonemes: Sequence[str]) -> List[str]:
+    """Map IPA phonemes to simple facial blendshape labels."""
+
+    return [_phoneme_to_blendshape(p) for p in phonemes]
+
+
+__all__ = ["generate_landmarks", "Landmarks", "map_phonemes_to_blendshapes"]

--- a/ai_core/avatar/phonemes.py
+++ b/ai_core/avatar/phonemes.py
@@ -1,0 +1,25 @@
+"""Phoneme extraction utilities."""
+
+from __future__ import annotations
+
+from typing import List
+
+from phonemizer import phonemize
+from phonemizer.separator import Separator
+
+
+def extract_phonemes(text: str, lang: str = "en-us") -> List[str]:
+    """Return IPA phonemes for ``text``.
+
+    The function uses :mod:`phonemizer` with the ``espeak`` backend and
+    separates phonemes with spaces.  Word boundaries are ignored which keeps the
+    result easy to align with audio frames.
+    """
+
+    separator = Separator(phone=" ", word="|")
+    phoneme_str = phonemize(text, language=lang, separator=separator, strip=True)
+    return [p for p in phoneme_str.split() if p and p != "|"]
+
+
+__all__ = ["extract_phonemes"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ requests==2.32.4
     # via spiral-os (pyproject.toml)
 scipy==1.13.1
     # via spiral-os (pyproject.toml)
+phonemizer==3.3.0
+    # for phoneme extraction

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,6 +18,7 @@ pydantic
 opensmile
 aiortc
 uvicorn
+phonemizer
 gymnasium
 psutil
 beautifulsoup4

--- a/tests/test_phoneme_blendshape_alignment.py
+++ b/tests/test_phoneme_blendshape_alignment.py
@@ -1,0 +1,16 @@
+"""Integration tests for phoneme extraction and blendshape mapping."""
+
+from __future__ import annotations
+
+from ai_core.avatar.lip_sync import align_phonemes
+from ai_core.avatar.phonemes import extract_phonemes
+from ai_core.avatar.expression_controller import map_phonemes_to_blendshapes
+
+
+def test_phoneme_blendshape_alignment_cycle():
+    phonemes = extract_phonemes("mama")
+    durations = [0.1] * len(phonemes)
+    frame_map = align_phonemes(phonemes, durations, fps=10)
+    blendshapes = map_phonemes_to_blendshapes([p for _, p in frame_map])
+    assert blendshapes == ["closed", "open", "closed", "open"]
+


### PR DESCRIPTION
## Summary
- implement phoneme extraction using phonemizer
- map phonemes to facial blendshapes
- test phoneme to blendshape alignment

## Testing
- `pytest tests/test_lip_sync.py tests/test_phoneme_blendshape_alignment.py`

------
https://chatgpt.com/codex/tasks/task_e_68acca3e4c90832e90cfcce9fd78773c