### PR TITLE
feat: add concurrent tag search for cortex

### DIFF
--- a/docs/memory_cortex.md
+++ b/docs/memory_cortex.md
@@ -1,0 +1,41 @@
+# Cortex Memory Search
+
+The `memory.cortex` module stores spiral decisions as JSON lines under
+`data/cortex_memory_spiral.jsonl`. Each entry may contain a list of semantic
+`tags` which are indexed for fast lookup. A companion full‑text index tokenizes
+these tags allowing substring queries.
+
+## Recording
+
+```python
+from memory import cortex
+
+cortex.record_spiral(node, {"action": "run", "tags": ["fast runner"]})
+```
+
+## Querying
+
+Use exact tag matching:
+
+```python
+cortex.query_spirals(tags=["fast runner"])
+```
+
+Full‑text search splits tags into tokens so the above entry is also retrieved
+with:
+
+```python
+cortex.query_spirals(text="runner")
+```
+
+Multiple queries can be issued concurrently with `query_spirals_concurrent`:
+
+```python
+queries = [{"tags": ["fast"]}, {"text": "runner"}]
+results = cortex.query_spirals_concurrent(queries)
+```
+
+Each element in `results` corresponds to the associated query dict.
+
+The tag index is persisted to `data/cortex_memory_index.json` and is rebuilt
+whenever entries are pruned.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_music_generation_streaming.py"),
     str(ROOT / "tests" / "test_music_backends_missing.py"),
     str(ROOT / "tests" / "test_vector_memory_extensions.py"),
+    str(ROOT / "tests" / "test_cortex_memory.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- extend cortex memory with persistent full-text tag index
- add concurrent query helper and thread-safe pruning
- document cortex search usage

## Testing
- `pytest tests/test_cortex_memory.py -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68accb66b090832eb350e5f42ad18ddd