### PR TITLE
Add snapshots, compaction and clustering to vector memory

### DIFF
--- a/CHANGELOG_vector_memory.md
+++ b/CHANGELOG_vector_memory.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### API Changes
 - Added `VersionInfo` dataclass and `__version__` constant for explicit semantic versioning.
+- Introduced automatic snapshots, on-disk compaction and `cluster_vectors` helper.
 
 ### Bug Fixes
 - None.


### PR DESCRIPTION
## Summary
- add periodic snapshots and SQLite vacuum-based compaction to vector memory
- expose FAISS/KMeans clustering helper for large embedding sets
- test snapshot persistence, decay removal and clustering

## Testing
- `pytest -q -c /dev/null` *(fails: No module named 'phonemizer')*
- `pytest tests/test_vector_memory.py -q -c /dev/null` *(passes: 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68accd7d2ac0832ea31292de62e2154d