### PR TITLE
Expose VoiceCloner via CLI and API with MOS metric

### DIFF
--- a/docs/voice_cloner.md
+++ b/docs/voice_cloner.md
@@ -1,0 +1,29 @@
+# Voice Cloner
+
+The `VoiceCloner` utility records a short sample of a speaker and synthesises
+new speech in the captured voice. It exposes both a command line interface and
+REST endpoints.
+
+## CLI usage
+
+Record a sample and synthesise a phrase:
+
+```bash
+python -m src.cli.voice_clone capture sample.wav --speaker alice
+python -m src.cli.voice_clone synthesize "Hello" out.wav --sample sample.wav --speaker alice
+```
+
+The synthesis command logs a crude Mean Opinion Score (MOS) estimate indicating
+quality on a scale from 1 to 5. When optional dependencies are missing, silent
+audio is generated and the MOS defaults to 1.
+
+## REST API
+
+The FastAPI server exposes matching endpoints:
+
+- `POST /voice/capture` – store a voice sample.
+- `POST /voice/synthesize` – generate speech and return the MOS metric.
+
+These endpoints accept JSON bodies containing `speaker`, `text` and file paths.
+When audio backends are unavailable the server falls back to silent audio
+production and reports a low MOS score.

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -88,7 +88,7 @@ async def capture_voice(data: dict[str, object]) -> dict[str, str]:
 
 
 @app.post("/voice/synthesize")  # type: ignore[misc]
-async def synthesize_voice(data: dict[str, object]) -> dict[str, str]:
+async def synthesize_voice(data: dict[str, object]) -> dict[str, object]:
     """Generate speech for ``text`` with a cloned voice."""
 
     text = str(data.get("text", ""))
@@ -96,10 +96,12 @@ async def synthesize_voice(data: dict[str, object]) -> dict[str, str]:
     speaker = str(data.get("speaker", "user"))
     emotion = str(data.get("emotion", "neutral"))
     try:
-        voice_cloner.synthesize(text, out_path, speaker=speaker, emotion=emotion)
+        _, mos = voice_cloner.synthesize(
+            text, out_path, speaker=speaker, emotion=emotion
+        )
     except RuntimeError as exc:
         return {"error": str(exc)}
-    return {"audio": str(out_path), "speaker": speaker, "emotion": emotion}
+    return {"audio": str(out_path), "speaker": speaker, "emotion": emotion, "mos": mos}
 
 
 __all__ = [

--- a/src/cli/voice_clone.py
+++ b/src/cli/voice_clone.py
@@ -52,16 +52,16 @@ def main(argv: list[str] | None = None) -> None:
     elif args.cmd == "synthesize":
         cloner.samples[args.speaker] = Path(args.sample)
         try:
-            cloner.synthesize(
+            _, mos = cloner.synthesize(
                 args.text,
                 Path(args.out),
                 speaker=args.speaker,
                 emotion=args.emotion,
             )
+            logger.info("Synthesis MOS=%.2f", mos)
         except RuntimeError as exc:  # pragma: no cover - missing deps
             logger.error("%s", exc)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_music_backends_missing.py"),
     str(ROOT / "tests" / "test_vector_memory_extensions.py"),
     str(ROOT / "tests" / "test_cortex_memory.py"),
+    str(ROOT / "tests" / "test_voice_cloner_cli.py"),
 }
 
 

--- a/tests/test_voice_cloner_cli.py
+++ b/tests/test_voice_cloner_cli.py
@@ -44,27 +44,33 @@ ev.TTS = _DummyTTS
 sys.modules.setdefault("emotivoice", ev)
 
 
-sf = types.SimpleNamespace(write=lambda p, d, sr, subtype=None: Path(p).write_bytes(b""))
+sf = types.SimpleNamespace(
+    write=lambda p, d, sr, subtype=None: Path(p).write_bytes(b""),
+    read=lambda p, dtype="float32": (np.zeros(1, dtype=np.float32), 22_050),
+)
 sys.modules.setdefault("soundfile", sf)
 
 
 from src.cli.voice_clone import main as cli_main
 from src.api.server import app
+from src.audio.voice_cloner import VoiceCloner
 
 
 def test_cli_capture_and_synthesize(tmp_path):
     sample = tmp_path / "sample.wav"
     out = tmp_path / "out.wav"
-    cli_main([
-        "capture",
-        str(sample),
-        "--speaker",
-        "alice",
-        "--seconds",
-        "0.1",
-        "--sr",
-        "8000",
-    ])
+    cli_main(
+        [
+            "capture",
+            str(sample),
+            "--speaker",
+            "alice",
+            "--seconds",
+            "0.1",
+            "--sr",
+            "8000",
+        ]
+    )
     cli_main(
         [
             "synthesize",
@@ -94,7 +100,14 @@ def test_api_capture_and_synthesize(tmp_path):
         "/voice/synthesize",
         json={"text": "ok", "speaker": "bob", "emotion": "sad", "out": str(out)},
     )
-    assert r.status_code == 200
+    assert r.status_code == 200 and "mos" in r.json()
     assert out.exists()
 
 
+def test_voice_cloner_smoke(tmp_path):
+    cloner = VoiceCloner()
+    sample = tmp_path / "s.wav"
+    out = tmp_path / "o.wav"
+    cloner.capture_sample(sample, seconds=0.1, sr=8000, speaker="carol")
+    _, mos = cloner.synthesize("hi", out, speaker="carol")
+    assert out.exists() and 1.0 <= mos <= 5.0


### PR DESCRIPTION
## Summary
- add MOS quality estimation and silence fallbacks to VoiceCloner
- expose MOS in CLI and REST API
- document VoiceCloner usage

## Testing
- `pre-commit run --files src/audio/voice_cloner.py src/cli/voice_clone.py src/api/server.py tests/test_voice_cloner_cli.py tests/conftest.py docs/voice_cloner.md`
- `pytest tests/test_voice_cloner_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68accfb7cf08832e96e9849cea4c5670