### PR TITLE
docs: add voice model install guide and endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,19 @@ orchestrator works with several engines:
   PY
   ```
 
+- **Piper**
+
+  ```bash
+  pip install piper-tts
+  mkdir -p voices
+  curl -L -o voices/en_US-amy-medium.onnx \
+    https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US-amy-medium.onnx
+  python - <<'PY'
+  from piper import PiperVoice
+  PiperVoice.load("voices/en_US-amy-medium.onnx")
+  PY
+  ```
+
 Each example caches the model files in the backend's default location so later
 runs avoid network access.
 


### PR DESCRIPTION
## Summary
- document installing Piper TTS voice models
- test FastAPI health and GLM command routes

## Testing
- `pre-commit run --files README.md tests/test_server_endpoints.py`
- `pytest tests/test_server_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_68acdaa6ed94832eb8919e26e6d1789e