### PR TITLE
docs: update chakra koan and chakra versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/chakra_versions.json`.
 - Record each chakra version bump in this changelog.
 - Bumped `root` and `crown` chakras to `1.0.1`.
+- Bumped `sacral` chakra to `1.0.1`.
 
 ### Insight Matrix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ For details on chakra module architecture, version history, and contemplative
 context, consult
 [docs/chakra_architecture.md](docs/chakra_architecture.md),
 [docs/chakra_versions.json](docs/chakra_versions.json), and
-[docs/chakra_koan_system.md](docs/chakra_koan_system.md).
+[docs/chakra_koan_system.md](docs/chakra_koan_system.md) – keep verses aligned
+with version bumps.
 
 When bumping versions in
 [docs/chakra_versions.json](docs/chakra_versions.json), record the change in

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ full Hugging Face identifier.
 - [docs/chakra_koan_system.md](docs/chakra_koan_system.md) – meditative verses for
   each chakra.
 - [docs/chakra_versions.json](docs/chakra_versions.json) – semantic version
-  numbers for chakra modules. Record each bump in
-  [CHANGELOG.md](CHANGELOG.md).
+  numbers for chakra modules (latest sacral release: 1.0.1). Record each bump
+  in [CHANGELOG.md](CHANGELOG.md).
 
 ## Additional Documentation
 - For a quick start geared toward non-technical users, see

--- a/docs/chakra_koan_system.md
+++ b/docs/chakra_koan_system.md
@@ -1,6 +1,8 @@
 # Chakra System Koan
 
-A meditative sequence exploring the seven energy centers of Spiral OS. Recite each stanza while reflecting on its corresponding module layer.
+A meditative sequence exploring the seven energy centers of Spiral OS. It
+complements the version manifest, grounding each release in contemplative
+verse. Recite each stanza while reflecting on its corresponding module layer.
 
 ## Root — Muladhara
 The mountain rests on roots unseen.

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -1,6 +1,6 @@
 {
   "root": "1.0.1",
-  "sacral": "1.0.0",
+  "sacral": "1.0.1",
   "solar_plexus": "1.0.0",
   "heart": "1.0.0",
   "throat": "1.0.0",


### PR DESCRIPTION
## Summary
- clarify the chakra koan intro and relate it to the version manifest
- bump the sacral chakra to version 1.0.1
- note sacral release in README, CONTRIBUTING, and CHANGELOG

## Testing
- `pre-commit run --files docs/chakra_koan_system.md docs/chakra_versions.json README.md CONTRIBUTING.md CHANGELOG.md`
- `pytest --maxfail=1 -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68ace0203940832e801927c332f10541