### PR TITLE
Align core packaging and document locked dependency workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN python -m pip install --no-cache-dir --require-hashes -r requirements.lock
 
 COPY . .
 
-RUN python -m pip install --no-cache-dir --no-deps .
+# Install the project in editable mode so local modules resolve
+RUN python -m pip install --no-cache-dir --no-deps -e .
 
 RUN useradd --create-home --shell /bin/bash inanna && \
     chown -R inanna:inanna /app

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ These packages provide the compilers and headers required to build wheels for
 the local platform. See [docs/setup.md](docs/setup.md) for additional system
 packages.
 
+## Environment Setup
+
+Dependencies are locked with [pip-tools](https://github.com/jazzband/pip-tools).
+Regenerate the lock file whenever `requirements.txt` or
+`dev-requirements.txt` change:
+
+```bash
+pip-compile --allow-unsafe --generate-hashes \
+  --output-file=requirements.lock dev-requirements.txt requirements.txt
+```
+
+Install the pinned dependencies and the project in editable mode so
+`task_profiling.py` can import the `core` package:
+
+```bash
+pip install -r requirements.lock
+pip install -e .
+```
+
+### Docker image
+
+The provided `Dockerfile` installs from `requirements.lock` and performs an
+editable install of the project. Build the image with:
+
+```bash
+docker build -t abzu .
+```
+
 ## Docker Compose
 Launch the simple FastAPI server with:
 

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -1,0 +1,30 @@
+# Environment Setup
+
+## Dependency locking
+
+Regenerate `requirements.lock` when `requirements.txt` or `dev-requirements.txt`
+change:
+
+```bash
+pip-compile --allow-unsafe --generate-hashes \
+  --output-file=requirements.lock dev-requirements.txt requirements.txt
+```
+
+## Local installation
+
+Install the pinned dependencies and register the project in editable mode so
+tools such as `task_profiling.py` resolve the `core` package:
+
+```bash
+pip install -r requirements.lock
+pip install -e .
+```
+
+## Docker image
+
+The Dockerfile uses `requirements.lock` and installs the project in editable
+mode. Build the container with:
+
+```bash
+docker build -t abzu .
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {file = "LICENSE_CRYSTAL.md"}
 # exposed individually through extras below.
 dependencies = [
     "numpy==1.26.4",
-    "scipy==1.11.4",
+    "scipy==1.13.1",
     "pandas==2.2.3",
     "requests==2.32.4",
     "python-json-logger==3.3.0",
@@ -59,7 +59,7 @@ mlflow = ["mlflow==3.2.0"]
 langchain = ["langchain==0.3.27"]
 aiortc = ["aiortc==1.13.0"]
 pyautogui = ["pyautogui==0.9.54"]
-opencv = ["opencv-python==4.12.0.88"]
+opencv = ["opencv-python==4.10.0.84"]
 pytesseract = ["pytesseract==0.3.13"]
 selenium = ["selenium==4.35.0"]
 fastapi = ["fastapi==0.116.1"]
@@ -77,7 +77,7 @@ shap = ["shap==0.45.0"]
 # including testing and formatting tools
 dev = [
     "numpy==1.26.4",
-    "scipy==1.11.4",
+    "scipy==1.13.1",
     "soundfile==0.13.1",
     "librosa==0.11.0",
     "pydub==0.25.1",


### PR DESCRIPTION
## Summary
- align SciPy and OpenCV pins in pyproject with requirements
- install project in editable mode in the Docker image
- document locked dependency workflow and environment setup

## Testing
- ⚠️ `pip-compile --allow-unsafe --generate-hashes --output-file=requirements.lock dev-requirements.txt requirements.txt` (aborted, existing lock file retained)
- ✅ `pre-commit run --files Dockerfile README.md pyproject.toml docs/environment_setup.md`


------
https://chatgpt.com/codex/tasks/task_e_68ace56be570832e99b02aeba78989dd