### PR TITLE
Implement NumPy fallback for ritual music and cache emotion map

### DIFF
--- a/docs/testing_music_pipeline.md
+++ b/docs/testing_music_pipeline.md
@@ -1,0 +1,12 @@
+# Testing Music Pipeline
+
+To run the unit tests for the ritual music pipeline:
+
+```bash
+pytest tests/test_play_ritual_music.py::test_synthesize_melody_with_sf
+pytest tests/test_play_ritual_music.py::test_synthesize_melody_without_sf
+pytest tests/test_play_ritual_music.py::test_archetype_mix_soundfile_present
+pytest tests/test_play_ritual_music.py::test_archetype_mix_fallback
+```
+
+These cover both scenarios where the `soundfile` library is available and where the NumPy fallback is used.

--- a/emotion_music_map.yaml
+++ b/emotion_music_map.yaml
@@ -1,4 +1,11 @@
+# Mapping from emotions to musical parameters.
+# Loaded once via ``load_emotion_music_map`` which caches the parsed YAML
+# to avoid repeated disk reads. When the ``soundfile`` library is missing,
+# ``play_ritual_music.py`` falls back to a NumPy synthesizer using these
+# values so playback still succeeds.
+
 joy:
+
   tempo: 140
   scale: C_major
   rhythm: syncopated

--- a/src/audio/emotion_params.py
+++ b/src/audio/emotion_params.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Tuple
+from functools import lru_cache
 
 from INANNA_AI import emotion_analysis, sonic_emotion_mapper
 from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import (
@@ -15,6 +16,13 @@ from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import (
 EMOTION_MAP = Path(__file__).resolve().parent / "emotion_music_map.yaml"
 
 
+@lru_cache(maxsize=None)
+def _load_map() -> dict:
+    """Load and cache the emotion music mapping from YAML."""
+
+    return load_emotion_music_map(EMOTION_MAP)
+
+
 def resolve(emotion: str, archetype: str | None = None) -> Tuple[float, List[str], str, str]:
     """Return tempo, melody, wave type and resolved archetype."""
 
@@ -24,7 +32,7 @@ def resolve(emotion: str, archetype: str | None = None) -> Tuple[float, List[str
         except Exception:  # pragma: no cover
             archetype = "Everyman"
 
-    mapping = load_emotion_music_map(EMOTION_MAP)
+    mapping = _load_map()
     params = sonic_emotion_mapper.map_emotion_to_sound(emotion, archetype)
 
     tempo, _scale, melody, _rhythm = select_music_params(


### PR DESCRIPTION
## Summary
- handle lack of `soundfile` by synthesizing tones with NumPy
- cache emotion music mapping and note-to-frequency lookups using `lru_cache`
- add tests and documentation for both soundfile and fallback paths

## Testing
- `pytest tests/test_play_ritual_music.py::test_synthesize_melody_with_sf -q`
- `pytest tests/test_play_ritual_music.py::test_synthesize_melody_without_sf -q`
- `pytest tests/test_play_ritual_music.py::test_archetype_mix_soundfile_present -q`
- `pytest tests/test_play_ritual_music.py::test_archetype_mix_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace8c1f41c832e97a4e94db8716e5c