### PR TITLE
Add vector memory snapshot persistence and rollback tests

### DIFF
--- a/CHANGELOG_vector_memory.md
+++ b/CHANGELOG_vector_memory.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### API Changes
 - Added `VersionInfo` dataclass and `__version__` constant for explicit semantic versioning.
 - Introduced automatic snapshots, on-disk compaction and `cluster_vectors` helper.
+- Added `persist_snapshot` and `restore_latest_snapshot` helpers for manual snapshot persistence.
 
 ### Bug Fixes
 - None.

--- a/README.md
+++ b/README.md
@@ -196,9 +196,11 @@ For an overview of available agents and defensive modules, see
 ## Architect and Developer Guidance
 - [docs/developer_manual.md](docs/developer_manual.md) – repository layout, crown orchestration and sandbox workflow.
 - [docs/memory_architecture.md](docs/memory_architecture.md) – memory layers and their interaction.
+- [docs/vector_memory.md](docs/vector_memory.md) – vector store clustering and snapshot persistence.
 - [docs/roadmap.md](docs/roadmap.md) – completed milestones and future work.
 - [docs/architecture_overview.md](docs/architecture_overview.md) – request flow diagram.
 - [docs/project_overview.md](docs/project_overview.md) – chakra oriented context.
+- [docs/learning_pipeline.md](docs/learning_pipeline.md) – auto retrain and mutation cycle with rollback tests.
 
 For a short deployment overview covering Vast.ai and local Docker Compose, see [docs/deployment_overview.md](docs/deployment_overview.md). Detailed Vast.ai instructions live in [docs/VAST_DEPLOYMENT.md](docs/VAST_DEPLOYMENT.md).
 

--- a/docs/learning_pipeline.md
+++ b/docs/learning_pipeline.md
@@ -1,0 +1,19 @@
+# Learning Pipeline
+
+The learning pipeline pairs two utilities:
+
+* `learning_mutator.py` proposes mutations for poorly performing intents.
+* `auto_retrain.py` assembles feedback and retrains the model when the system is
+  idle.
+
+Both scripts rely on mocked training data in the test suite and ensure failure
+paths roll back cleanly. The following tests exercise these flows:
+
+* `tests/test_learning_mutator.py` – verifies existing mutation files are
+  preserved when suggestion generation fails.
+* `tests/test_auto_retrain.py` – ensures failed fine‑tune attempts log an error
+  and trigger any available rollback hooks.
+
+The pipeline can optionally use `vector_memory.persist_snapshot` and
+`vector_memory.restore_latest_snapshot` to safeguard the embedding store before
+training.

--- a/docs/vector_memory.md
+++ b/docs/vector_memory.md
@@ -1,0 +1,27 @@
+# Vector Memory
+
+The `vector_memory` module provides a lightweight FAISS/SQLite backed store for
+text embeddings. Entries are logged, decayed over time and can be searched or
+clustered to discover emerging themes.
+
+## Snapshot persistence
+
+Every write increments an operation counter. When the counter reaches the
+configured `snapshot_interval`, the store writes a snapshot to
+`settings.vector_db_path/snapshots`. Snapshots can also be managed manually:
+
+```python
+from vector_memory import persist_snapshot, restore_latest_snapshot
+
+path = persist_snapshot()           # write a timestamped snapshot
+restore_latest_snapshot()           # restore most recent snapshot
+```
+
+These helpers simplify rollbacks in higher level pipelines such as auto
+retraining.
+
+## Clustering
+
+`cluster_vectors(k)` groups stored embeddings into `k` clusters using FAISS when
+available, falling back to scikit-learn's `KMeans`. Each cluster summary contains
+the cluster index and number of members.

--- a/tests/test_learning_mutator.py
+++ b/tests/test_learning_mutator.py
@@ -44,6 +44,21 @@ def test_main_returns_suggestions_without_run(monkeypatch):
     assert out == ["x"]
 
 
+def test_main_preserves_file_on_exception(tmp_path, monkeypatch):
+    mfile = tmp_path / "mutations.txt"
+    mfile.write_text("old", encoding="utf-8")
+    monkeypatch.setattr(lm, "MUTATION_FILE", mfile)
+    monkeypatch.setattr(lm, "load_insights", lambda path=None: {})
+
+    def boom(_data):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(lm, "propose_mutations", boom)
+    with pytest.raises(RuntimeError):
+        lm.main(["--run"])
+    assert mfile.read_text(encoding="utf-8") == "old"
+
+
 def test_main_rolls_back_on_write_error(tmp_path, monkeypatch):
     mfile = tmp_path / "mutations.txt"
     mfile.write_text("old", encoding="utf-8")


### PR DESCRIPTION
## Summary
- document and expose snapshot helpers for vector_memory
- test auto_retrain and learning_mutator rollback paths with mock data
- add learning pipeline docs and reference persistence features

## Testing
- `pytest tests/test_auto_retrain.py tests/test_learning_mutator.py tests/test_vector_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68aceb9c9994832e9c18738ea5237fe1