### PR TITLE
Add insight manifest and schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Begin with the [CRYSTAL CODEX](CRYSTAL_CODEX.md) for mission, LWM architecture d
 chakra-to-module mappings, step-by-step setup guides, tutorials, dependency matrix,
 testing and style guidance. Then follow the [setup guide](docs/setup.md) to configure the
 environment. The [documentation index](docs/index.md) lists additional guides.
+See [docs/insight_system.md](docs/insight_system.md) for insight manifest usage and
+schema validation steps.
 New contributors should review the [developer onboarding guide](docs/developer_onboarding.md)
 for a structured walkthrough of the codebase. Current ratings, past scores and milestone validation
 results are tracked in [docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md).

--- a/docs/insight_system.md
+++ b/docs/insight_system.md
@@ -1,0 +1,25 @@
+# Insight System
+
+The insight system aggregates interaction logs into structured matrices used by
+reflection and adaptive learning components.
+
+## Manifest
+
+`insight_manifest.json` tracks the semantic versions and SHA-256 checksums for
+`insight_matrix.json`, `mirror_thresholds.json`, and `intent_matrix.json`.
+It records every update with a timestamp and version history so CI jobs can
+verify that the matrices match the expected state.
+
+## Validation
+
+Validate JSON structures against their schemas before committing changes:
+
+```bash
+python -m jsonschema ./schemas/insight_matrix.schema.json ./insight_matrix.json
+python -m jsonschema ./schemas/mirror_thresholds.schema.json ./mirror_thresholds.json
+python -m jsonschema ./schemas/intent_matrix.schema.json ./intent_matrix.json
+python -m jsonschema ./schemas/insight_manifest.schema.json ./insight_manifest.json
+```
+
+The test suite runs these checks automatically via
+`tests/test_insight_compiler.py`.

--- a/insight_manifest.json
+++ b/insight_manifest.json
@@ -1,9 +1,15 @@
 {
-  "_comment": "Tracks semantic versioning and integrity for matrices",
+  "_comment": "Tracks semantic versioning and integrity for matrices and thresholds",
   "version": "0.1.0",
   "updated": "",
+  "semantic_versions": {
+    "insight_matrix": "0.1.0",
+    "mirror_thresholds": "0.1.0",
+    "intent_matrix": "0.1.0"
+  },
   "checksums": {
     "insight_matrix": "480ff274fc4ed763c28dbfb1f4854097a07393d9cf64c54bfc353b77e71bb5ad",
+    "mirror_thresholds": "830e7e8f418bea804671121944da78df6af27cb9a77ef68fa9e3f743c535b0ef",
     "intent_matrix": "f629eec91306ea172e3ed9174e4cde8eadc8c68dc2c959aef0ab8ae9edf434d7"
   },
   "history": []

--- a/schemas/insight_manifest.schema.json
+++ b/schemas/insight_manifest.schema.json
@@ -9,6 +9,10 @@
       "type": "object",
       "additionalProperties": {"type": "string"}
     },
+    "semantic_versions": {
+      "type": "object",
+      "additionalProperties": {"type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$"}
+    },
     "history": {
       "type": "array",
       "items": {
@@ -20,6 +24,10 @@
           "checksums": {
             "type": "object",
             "additionalProperties": {"type": "string"}
+          },
+          "semantic_versions": {
+            "type": "object",
+            "additionalProperties": {"type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$"}
           }
         }
       }

--- a/schemas/mirror_thresholds.schema.json
+++ b/schemas/mirror_thresholds.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mirror Thresholds",
+  "type": "object",
+  "required": ["_comment", "default"],
+  "properties": {
+    "_comment": {"type": "string"},
+    "default": {"type": "number"}
+  },
+  "additionalProperties": {"type": "number"}
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,6 +8,7 @@ sentence-transformers  # required for semantic validator tests
 transformers>=4.38
 torch>=2.1
 pyopenssl
+jsonschema
 streamlit
 stable-baselines3
 python-json-logger


### PR DESCRIPTION
## Summary
- track mirror thresholds and per-file versions in `insight_manifest.json`
- validate insight JSON resources against schemas in tests
- document insight manifest and link guide from README

## Testing
- `pytest tests/test_insight_compiler.py::test_update_aggregates tests/test_insight_compiler.py::test_manifest_version_bumps tests/test_insight_compiler.py::test_manifest_history_records_updates tests/test_insight_compiler.py::test_json_files_match_schema -q`

------
https://chatgpt.com/codex/tasks/task_e_68aceda0c090832e87af5e6ad92e6ee4