### PR TITLE
Add rotating corpus memory logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 # Reusable anchors keep the workflow maintainable
 jobs:
@@ -57,3 +59,24 @@ jobs:
         run: pytest tests/test_interactions_jsonl_integrity.py
       - name: Profiling
         run: python -m cProfile -m task_profiling
+  corpus-memory-log-rotation:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *setup-python
+      - *install-deps
+      - name: Exercise corpus memory log rotation
+        run: |
+          python - <<'PY'
+          import os
+          os.environ['CORPUS_LOG_MAX_BYTES'] = '200'
+          import corpus_memory_logging as cml
+          log = cml.INTERACTIONS_FILE
+          log.parent.mkdir(parents=True, exist_ok=True)
+          if log.exists():
+              log.unlink()
+          for i in range(100):
+              cml.log_interaction(str(i), {}, {}, 'ok')
+          assert log.with_name(log.name + '.1').exists()
+          PY

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -4,6 +4,11 @@ The application writes JSON-formatted logs to `logs/INANNA_AI.log`. The file
 rotates when it reaches roughly 10 MB, keeping seven backups
 (`INANNA_AI.log.1`, `INANNA_AI.log.2`, ...).
 
+Interactions with the corpus memory are stored separately in
+`data/interactions.jsonl`. Entries are rotated when the log exceeds about 1 MB
+and up to five backups are retained (`interactions.jsonl.1`,
+`interactions.jsonl.2`, ...).
+
 ## Tailing logs
 
 ```bash
@@ -25,6 +30,31 @@ Several JSON fields are emitted by the system:
 - `ritual` from `invocation_engine.invoke_ritual`.
 - `path` and `method` for HTTP requests handled by the FastAPI middleware.
 - `duration` in seconds for any of the above operations.
+
+Corpus memory interaction records include:
+
+- `timestamp` – UTC time when the interaction was logged.
+- `input` – user input text.
+- `intent` – parsed intent dictionary.
+- `result` – resulting state or metadata.
+- `outcome` – textual summary of the result.
+- `emotion` – optional emotion detected or supplied.
+- `source_type`, `genre`, `instrument` – optional music metadata.
+- `feedback` and `rating` – optional evaluation details.
+
+## Inspecting interaction logs
+
+View recent corpus memory entries and pretty-print them with `jq`:
+
+```bash
+head -n 20 data/interactions.jsonl | jq .
+```
+
+Follow the file across rotations to watch interactions as they occur:
+
+```bash
+tail -F data/interactions.jsonl | jq '.input'
+```
 
 ## Timing metrics
 

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -18,6 +18,13 @@ handlers:
     encoding: utf-8
     maxBytes: 1048576
     backupCount: 5
+  interactions:
+    class: logging.handlers.RotatingFileHandler
+    formatter: json
+    filename: data/interactions.jsonl
+    encoding: utf-8
+    maxBytes: 1048576
+    backupCount: 5
 filters:
   emotion:
     '()': logging_filters.EmotionFilter
@@ -25,6 +32,10 @@ loggers:
   src.audio.play_ritual_music:
     level: INFO
     handlers: [file, audio]
+    propagate: false
+  corpus_memory_logging.file:
+    level: INFO
+    handlers: [interactions]
     propagate: false
 root:
   level: INFO


### PR DESCRIPTION
## Summary
- Rotate corpus memory interaction logs and expose handler in logging config
- Test corpus memory log integrity and rotation behavior
- Document corpus logging fields and add nightly CI rotation check

## Testing
- `pytest tests/test_corpus_memory_logging.py -q`
- `pytest tests/test_interactions_jsonl_integrity.py -q`
- `ruff check corpus_memory_logging.py tests/test_corpus_memory_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad357ca8e4832e8b5ceb53f6c1a36d