### PR TITLE
Add corpus log watchdog and audio/voice fallback tests

### DIFF
--- a/corpus_memory_logging.py
+++ b/corpus_memory_logging.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Append and read JSONL interaction records for corpus memory usage."""
+
+from __future__ import annotations
 
 import json
 import logging
@@ -9,7 +9,57 @@ from pathlib import Path
 from typing import Any, List
 
 INTERACTIONS_FILE = Path("data/interactions.jsonl")
+"""Primary JSONL log file for interaction records."""
+
+QUARANTINE_FILE = INTERACTIONS_FILE.with_suffix(".quarantine.jsonl")
+"""Location for quarantined malformed records."""
+
+MAX_LOG_SIZE = 1_000_000
+"""Maximum size in bytes before the log file is rotated."""
+
 logger = logging.getLogger(__name__)
+
+
+def _rotate_if_needed() -> None:
+    """Rotate the interactions log when it grows beyond ``MAX_LOG_SIZE``."""
+
+    if (
+        INTERACTIONS_FILE.exists()
+        and INTERACTIONS_FILE.stat().st_size >= MAX_LOG_SIZE
+    ):
+        ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        rotated = INTERACTIONS_FILE.with_name(
+            f"{INTERACTIONS_FILE.stem}-{ts}{INTERACTIONS_FILE.suffix}"
+        )
+        INTERACTIONS_FILE.rename(rotated)
+        logger.info("rotated interaction log to %s", rotated)
+
+
+def watchdog() -> None:
+    """Quarantine malformed JSONL entries and keep the log clean."""
+
+    if not INTERACTIONS_FILE.exists():
+        return
+
+    valid: list[str] = []
+    bad: list[str] = []
+    with INTERACTIONS_FILE.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                json.loads(line)
+                valid.append(line)
+            except Exception:
+                bad.append(line)
+
+    if bad:
+        QUARANTINE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with QUARANTINE_FILE.open("a", encoding="utf-8") as qh:
+            qh.writelines(bad)
+        with INTERACTIONS_FILE.open("w", encoding="utf-8") as fh:
+            fh.writelines(valid)
+        logger.error(
+            "quarantined %d malformed entries", len(bad), extra={"event": "corpus_watchdog"}
+        )
 
 
 def log_interaction(
@@ -51,7 +101,9 @@ def log_interaction(
         entry["feedback"] = feedback
     if rating is not None:
         entry["rating"] = rating
+
     INTERACTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_if_needed()
     with INTERACTIONS_FILE.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, ensure_ascii=False))
         fh.write("\n")
@@ -60,16 +112,15 @@ def log_interaction(
 
 def load_interactions(limit: int | None = None) -> List[dict[str, Any]]:
     """Return recorded interactions ordered from oldest to newest."""
+
+    watchdog()
     if not INTERACTIONS_FILE.exists():
         return []
+
     entries: List[dict[str, Any]] = []
     with INTERACTIONS_FILE.open("r", encoding="utf-8") as fh:
         for line in fh:
-            try:
-                entries.append(json.loads(line))
-            except Exception as exc:
-                logger.error("invalid json line in %s: %s", INTERACTIONS_FILE, exc)
-                continue
+            entries.append(json.loads(line))
     if limit is not None:
         entries = entries[-limit:]
     return entries
@@ -83,6 +134,7 @@ def log_ritual_result(name: str, steps: List[str]) -> None:
         "steps": steps,
     }
     INTERACTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_if_needed()
     with INTERACTIONS_FILE.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, ensure_ascii=False))
         fh.write("\n")
@@ -93,5 +145,7 @@ __all__ = [
     "log_interaction",
     "load_interactions",
     "log_ritual_result",
+    "watchdog",
     "INTERACTIONS_FILE",
+    "QUARANTINE_FILE",
 ]

--- a/tests/test_corpus_logging.py
+++ b/tests/test_corpus_logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import corpus_memory_logging as cml
+
+
+def test_log_writes_jsonl(tmp_path, monkeypatch):
+    log_path = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", log_path)
+    monkeypatch.setattr(cml, "QUARANTINE_FILE", log_path.with_suffix(".quarantine.jsonl"))
+    cml.log_interaction("hi", {"intent": "greet"}, {}, "ok")
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["input"] == "hi" and entry["intent"]["intent"] == "greet"
+
+
+def test_log_rotation(tmp_path, monkeypatch):
+    log_path = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", log_path)
+    monkeypatch.setattr(cml, "QUARANTINE_FILE", log_path.with_suffix(".quarantine.jsonl"))
+    monkeypatch.setattr(cml, "MAX_LOG_SIZE", 150)
+
+    cml.log_interaction("a" * 40, {"intent": "x"}, {}, "ok")
+    cml.log_interaction("b" * 40, {"intent": "x"}, {}, "ok")
+
+    rotated = list(tmp_path.glob("interactions-*.jsonl"))
+    assert rotated and log_path.exists()
+    # rotated file should contain first entry
+    first = json.loads(rotated[0].read_text(encoding="utf-8").splitlines()[0])
+    assert first["input"].startswith("a")
+    # current log should contain second entry
+    second = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+    assert second["input"].startswith("b")

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -158,6 +158,18 @@ def test_archetype_mix_soundfile_present(monkeypatch):
     assert mix.shape[0] == 10
 
 
+def test_archetype_mix_unknown_archetype(monkeypatch):
+    """Unknown archetypes should fall back to synthesized tones."""
+
+    monkeypatch.setattr(prm.backends, "sf", object())
+    prm._get_archetype_mix.cache_clear()
+
+    mix = prm._get_archetype_mix("mystic", sample_rate=8000)
+
+    assert mix.size > 0
+    assert np.any(mix)
+
+
 def test_encode_phrase_increases_size(tmp_path, monkeypatch):
     """Embedding a phrase should grow the output file size."""
 

--- a/tests/test_voice_cloner_cli.py
+++ b/tests/test_voice_cloner_cli.py
@@ -104,6 +104,20 @@ def test_api_capture_and_synthesize(tmp_path):
     assert out.exists()
 
 
+def test_api_synthesize_missing_voice(tmp_path):
+    """Synthesis should return an error when speaker model is absent."""
+
+    client = TestClient(app)
+    out = tmp_path / "out.wav"
+    r = client.post(
+        "/voice/synthesize",
+        json={"text": "hi", "speaker": "ghost", "out": str(out)},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "error" in data and "ghost" in data["error"]
+
+
 def test_voice_cloner_smoke(tmp_path):
     cloner = VoiceCloner()
     sample = tmp_path / "s.wav"


### PR DESCRIPTION
## Summary
- add log rotation and malformed-entry quarantine to corpus memory logging
- test JSONL logging and rotation in new corpus logging tests
- test synthetic archetype mix fallback and missing voice samples

## Testing
- `pytest tests/test_play_ritual_music.py::test_archetype_mix_unknown_archetype -q`
- `pytest tests/test_voice_cloner_cli.py::test_api_synthesize_missing_voice -q`
- `pytest tests/test_corpus_memory_logging.py tests/test_corpus_logging.py -q`
- `pytest tests/test_server.py::test_music_endpoint_success tests/test_server.py::test_music_endpoint_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad95cb22e8832ebddc565d83e2be7d