### PR TITLE
Log vector memory snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added chakra status table in `docs/chakra_status.md` outlining capabilities,
   limitations and planned evolutions for each layer.
 - Linked release notes to `docs/chakra_versions.json` and `CHANGELOG.md`.
+- Added recovery playbook documenting snapshot restoration steps.
 
 ### Quality
 
 - Verified repository passes `ruff` and `black` checks.
+
+### Vector Memory
+
+- `snapshot` logs paths to `snapshots/manifest.json` for recovery tracking.
 
 ### Chakra Versions
 
@@ -26,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Record each chakra version bump in this changelog.
 - Bumped `root` and `crown` chakras to `1.0.1`.
 - Bumped `sacral` chakra to `1.0.1`.
+- Bumped `heart` chakra to `1.0.1`.
 
 ### Insight Matrix
 

--- a/CHANGELOG_vector_memory.md
+++ b/CHANGELOG_vector_memory.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VersionInfo` dataclass and `__version__` constant for explicit semantic versioning.
 - Introduced automatic snapshots, on-disk compaction and `cluster_vectors` helper.
 - Added `persist_snapshot` and `restore_latest_snapshot` helpers for manual snapshot persistence.
+- `snapshot` now records snapshot paths in `snapshots/manifest.json`.
 
 ### Bug Fixes
 - None.

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -12,7 +12,7 @@
     "koan": "chakra_koan_system.md#solar"
   },
   "heart": {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "koan": "chakra_koan_system.md#heart"
   },
   "throat": {

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -1,0 +1,19 @@
+# Recovery Playbook
+
+This guide outlines steps to restore vector memory state from snapshots.
+
+1. **Locate snapshots**
+   - Snapshot files are listed in `snapshots/manifest.json` under the vector memory directory.
+   - Each entry records the absolute path of a persisted snapshot.
+2. **Select a snapshot**
+   - Choose the desired path from the manifest. The last entry is typically the most recent.
+3. **Restore**
+   - Use `vector_memory.restore(<path>)` to load a specific snapshot, or
+     call `vector_memory.restore_latest_snapshot()` to automatically load
+     the newest entry.
+4. **Verify**
+   - After restoration, run existing workflows or tests to ensure the
+     vector store has returned to the expected state.
+
+This procedure provides a repeatable method for recovery using the
+snapshot manifest.


### PR DESCRIPTION
## Summary
- Record vector memory snapshot paths in `snapshots/manifest.json`
- Document snapshot restoration workflow in `docs/recovery_playbook.md`
- Track heart chakra version bump in `docs/chakra_versions.json` and `CHANGELOG.md`

## Testing
- `ruff check vector_memory.py tests/test_memory_snapshot.py`
- `black --check vector_memory.py tests/test_memory_snapshot.py`
- `pytest tests/test_memory_snapshot.py::test_vector_memory_snapshot_restore -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9a1e7b0c832ead1403befda9652e