### PR TITLE
feat: add indexed memory search and resilient store

### DIFF
--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -1,41 +1,27 @@
 # Memory Architecture
 
-The cortex memory stores a chronological log of spiral decisions in a JSONL
-file located at `data/cortex_memory_spiral.jsonl`. Each entry captures the
-serialized state of the node, the decision payload, and a UTC timestamp.
+This project blends several complementary memory systems to capture context and
+long‑term knowledge.
 
-## Indexing
+## Cortex memory
 
-Entries may provide a list of semantic `tags` in the decision payload. These
-are tracked in an inverted index (`data/cortex_memory_index.json`) mapping each
-tag to the identifiers of entries containing it. The index accelerates
-retrieval for tag-based queries and is updated atomically when new spirals are
-recorded.
+`memory/cortex.py` persists application state as JSON lines while maintaining an
+inverted index for semantic tags and a full‑text index for tag tokens. Reader
+and writer locks guard the log and index so multiple threads can record and
+query safely. Helper utilities allow concurrent queries and pruning of old
+entries.
 
-## Concurrency
+## Vector memory store
 
-Read and write access to the memory and index files is synchronized with a
-lightweight reader/writer lock. Recording a spiral acquires the write lock
-while queries take the read lock, allowing concurrent reads but exclusive
-writes.
+`memory_store.py` combines SQLite persistence with an in‑memory similarity index
+using FAISS. When optional dependencies such as `faiss` or `numpy` are missing
+it transparently falls back to a pure Python implementation. The database schema
+is automatically migrated to include new columns, preserving compatibility with
+older snapshots.
 
-## Schema Evolution
+## Other memories
 
-Entries are stored as standalone JSON objects.  New fields can therefore be
-introduced to the decision payload over time without requiring a migration of
-existing records.  Older entries simply omit the additional keys and continue
-to be readable.  Rebuilding the index via maintenance utilities such as
-`prune_spirals` recreates the inverted and full‑text structures in the latest
-format, keeping the log forwards compatible.
-
-## Utilities
-
-The `memory.cortex` module exposes helpers to manage the log:
-
-- `prune_spirals(keep)` – retain only the most recent `keep` entries.
-- `export_spirals(path, tags=None, filter=None)` – export matching entries to a
-  JSON file.
-- `query_spirals(filter=None, tags=None)` – retrieve entries filtered by
-  decision fields or semantic tags.
-
-A small CLI wrapper `memory.cortex_cli` provides access to these functions.
+Specialised modules like `vector_memory.py` and `spiral_memory.py` provide
+additional stores for short text snippets and ritual state. Together these
+components form a layered architecture where symbolic records, vectors and
+higher order reasoning coexist.


### PR DESCRIPTION
## Summary
- add `search_index` to cortex memory for quick tag/text lookups
- make memory store fallback when faiss/numpy missing and migrate schemas
- document project memory architecture

## Testing
- `pytest tests/test_cortex_memory.py tests/test_memory_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68adac0c5e4c832ead1b28555ee8ae08