### PR TITLE
chore: document lockfile workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pinned dependencies from the lock file
+# Install pinned dependencies from the lock file for reproducible builds
 COPY requirements.lock ./
 RUN python -m pip install --no-cache-dir --require-hashes -r requirements.lock
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ pip-compile --allow-unsafe --generate-hashes \
   --output-file=requirements.lock dev-requirements.txt requirements.txt
 ```
 
+Key scientific packages like `numpy`, `scipy` and `opencv-python` are pinned in
+both requirement files. Regenerating the lock file captures these exact versions
+to ensure reproducible builds.
+
 Install the pinned dependencies and the project in editable mode so
 `task_profiling.py` can import the `core` package:
 
@@ -77,6 +81,7 @@ python scripts/vast_check.py http://localhost:8000
 Run the continuous integration checks locally:
 
 ```bash
+python -c "import scipy.sparse"  # ensure SciPy is available
 pre-commit run --all-files
 pytest --maxfail=1 -q
 ```


### PR DESCRIPTION
## Summary
- document pinning of numpy/scipy/opencv and highlight requirements.lock
- note SciPy import check in CI instructions for reproducible builds

## Testing
- `python -c "import scipy.sparse"`
- `pre-commit run --files README.md Dockerfile`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68adb0f2f324832e83641ff47629681a