### PR TITLE
Configure setup.cfg for packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,13 @@
+[metadata]
+name = spiral-os
+version = 0.1.0
+description = Spiral OS command line tools and agents
+
 [options]
-packages = find:
 package_dir =
     = src
+packages = find:
+include_package_data = True
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Summary
- add project metadata and package discovery to setup.cfg for proper packaging

## Testing
- `pre-commit run --files setup.cfg`
- `pip install -e .`
- `python -m cProfile -m task_profiling`


------
https://chatgpt.com/codex/tasks/task_e_68adb3675830832eb28840ad66346536