### PR TITLE
Enable numpy audio fallback and cache ritual profile loads

### DIFF
--- a/docs/testing_music_pipeline.md
+++ b/docs/testing_music_pipeline.md
@@ -7,6 +7,8 @@ pytest tests/test_play_ritual_music.py::test_synthesize_melody_with_sf
 pytest tests/test_play_ritual_music.py::test_synthesize_melody_without_sf
 pytest tests/test_play_ritual_music.py::test_archetype_mix_soundfile_present
 pytest tests/test_play_ritual_music.py::test_archetype_mix_fallback
+pytest tests/test_audio_backends.py::test_get_backend_noop
+pytest tests/test_play_ritual_music.py::test_ritual_profile_cached
 ```
 
-These cover both scenarios where the `soundfile` library is available and where the NumPy fallback is used.
+These cover scenarios where the `soundfile` library is available and where the NumPy fallback and caching mechanisms are used.

--- a/src/audio/backends.py
+++ b/src/audio/backends.py
@@ -84,4 +84,5 @@ def get_backend():
     logger.warning(
         "soundfile and simpleaudio libraries not installed; audio playback disabled"
     )
+    logger.info("Selected NoOpBackend")
     return NoOpBackend()

--- a/src/audio/stego.py
+++ b/src/audio/stego.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from functools import lru_cache
 
 import numpy as np
 
@@ -12,6 +13,7 @@ from MUSIC_FOUNDATION.synthetic_stego_engine import encode_phrase
 RITUAL_PROFILE = Path(__file__).resolve().parent / "ritual_profile.json"
 
 
+@lru_cache(maxsize=None)
 def load_ritual_profile(path: Path = RITUAL_PROFILE) -> dict:
     """Return ritual mappings loaded from ``path`` if available."""
     if path.exists():

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -19,14 +19,16 @@ import audio.backends as backends
 import audio.play_ritual_music as prm
 
 
-def test_get_backend_simpleaudio(monkeypatch):
+def test_get_backend_simpleaudio(monkeypatch, caplog):
     """SimpleAudioBackend is selected when soundfile is missing."""
     monkeypatch.setattr(backends, "sf", None)
     monkeypatch.setattr(backends, "sa", object())
 
-    backend = backends.get_backend()
+    with caplog.at_level("INFO"):
+        backend = backends.get_backend()
 
     assert isinstance(backend, backends.SimpleAudioBackend)
+    assert "Selected SimpleAudioBackend" in caplog.text
 
 
 def test_get_backend_noop(monkeypatch, caplog):
@@ -34,11 +36,12 @@ def test_get_backend_noop(monkeypatch, caplog):
     monkeypatch.setattr(backends, "sf", None)
     monkeypatch.setattr(backends, "sa", None)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("INFO"):
         backend = backends.get_backend()
 
     assert isinstance(backend, backends.NoOpBackend)
-    assert "No audio playback backend" in caplog.text
+    assert "Selected NoOpBackend" in caplog.text
+    assert "soundfile and simpleaudio libraries not installed" in caplog.text
 
 
 def test_archetype_mix_logs_when_soundfile_missing(monkeypatch, caplog):

--- a/tests/test_play_ritual_music.py
+++ b/tests/test_play_ritual_music.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
+import json
 
 import numpy as np
 import logging
@@ -248,6 +249,28 @@ def test_emotion_map_cached(tmp_path, monkeypatch):
     prm.map_emotion.cache_clear()
     prm.compose_ritual_music("joy", "\u2609", output_dir=tmp_path)
     prm.compose_ritual_music("joy", "\u2609", output_dir=tmp_path)
+
+    assert calls["count"] == 1
+
+
+def test_ritual_profile_cached(tmp_path, monkeypatch):
+    """Repeated calls to load_ritual_profile should hit cache."""
+
+    data = {"ritual": {"joy": ["secret"]}}
+    path = tmp_path / "profile.json"
+    path.write_text(json.dumps(data))
+
+    calls = {"count": 0}
+
+    def fake_json_load(fh):
+        calls["count"] += 1
+        return data
+
+    monkeypatch.setattr(prm.stego.json, "load", fake_json_load)
+    prm.stego.load_ritual_profile.cache_clear()
+
+    prm.stego.load_ritual_profile(path)
+    prm.stego.load_ritual_profile(path)
 
     assert calls["count"] == 1
 


### PR DESCRIPTION
## Summary
- log audio backend selection and support NoOp fallback
- cache ritual profile JSON loading with `lru_cache`
- add tests for backend selection and profile caching
- document music pipeline tests including backend and caching scenarios

## Testing
- `pytest tests/test_audio_backends.py::test_get_backend_simpleaudio tests/test_audio_backends.py::test_get_backend_noop tests/test_audio_backends.py::test_archetype_mix_logs_when_soundfile_missing tests/test_play_ritual_music.py::test_ritual_profile_cached tests/test_play_ritual_music.py::test_emotion_map_cached tests/test_play_ritual_music.py::test_playback_logs_output_path -q`

------
https://chatgpt.com/codex/tasks/task_e_68adb85bec80832eab109a1b0390aa24