### PR TITLE
Add resilient vector memory clustering

### DIFF
--- a/vector_memory.py
+++ b/vector_memory.py
@@ -486,6 +486,9 @@ def cluster_vectors(k: int = 5, limit: int = 1000) -> List[Dict[str, Any]]:
     if np is None or not ids:
         return []
     limit = min(limit, len(ids))
+    k = min(k, limit)
+    if k <= 0 or limit <= 0:
+        return []
     vectors: List[Any] = []
     for idx, id_ in enumerate(ids[:limit]):
         if hasattr(store, "index") and getattr(store, "index", None) is not None:


### PR DESCRIPTION
## Summary
- ensure vector_memory.cluster_vectors gracefully handles requests for more clusters than stored vectors
- test clustering with insufficient data
- exercise auto_retrain and learning_mutator against mocked insight/intent datasets

## Testing
- `pytest tests/test_auto_retrain.py tests/test_learning_mutator.py tests/test_vector_memory.py tests/test_vector_memory_extensions.py -q --override-ini addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68adbaed8984832e842371104f484cb8