### PR TITLE
Add schema validation for insight compiler

### DIFF
--- a/tests/test_logging_filters.py
+++ b/tests/test_logging_filters.py
@@ -42,3 +42,15 @@ def test_emotion_filter_handles_invalid_data(caplog):
     assert record.emotion is None
     assert record.resonance is None
     assert "returned invalid data" in caplog.text
+
+
+def test_filter_applies_metadata_via_logger(caplog):
+    """Ensure logger filters attach emotion metadata."""
+    logging_filters.set_emotion_provider(lambda: ("calm", 0.5))
+    logger = logging.getLogger("emotion-metadata")
+    logger.addFilter(logging_filters.EmotionFilter())
+    with caplog.at_level(logging.INFO):
+        logger.info("spell")
+    record = caplog.records[0]
+    assert record.emotion == "calm"
+    assert record.resonance == 0.5


### PR DESCRIPTION
## Summary
- ensure `insight_manifest.json` tracks semantic versions and checksums
- validate insight matrix and manifest against their JSON schemas
- test logging filters to confirm emotion metadata is applied

## Testing
- `pytest tests/test_insight_compiler.py::test_update_aggregates tests/test_insight_compiler.py::test_resonance_index_increases tests/test_insight_compiler.py::test_manifest_version_bumps tests/test_insight_compiler.py::test_manifest_history_records_updates tests/test_insight_compiler.py::test_connector_invoked tests/test_insight_compiler.py::test_logging_filter_integration tests/test_insight_compiler.py::test_broadcast_scores_handles_errors tests/test_insight_compiler.py::test_json_files_match_schema tests/test_insight_compiler.py::test_update_insights_validates_schema tests/test_logging_filters.py::test_emotion_filter_enriches_record tests/test_logging_filters.py::test_emotion_filter_handles_runtime_failure tests/test_logging_filters.py::test_emotion_filter_handles_invalid_data tests/test_logging_filters.py::test_filter_applies_metadata_via_logger -q -p no:cov -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68adbc480b60832e9a5ed84887f068ef