### PR TITLE
Add corpus log rotation checks and nightly archive

### DIFF
--- a/.github/workflows/nightly_logger.yml
+++ b/.github/workflows/nightly_logger.yml
@@ -1,0 +1,37 @@
+name: Nightly Logger
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  log:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Invoke logger
+        run: |
+          python - <<'PY'
+import json
+import corpus_memory_logging as cml
+cml.MAX_LOG_SIZE = 1
+cml.INTERACTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+# pre-populate to force rotation
+cml.INTERACTIONS_FILE.write_text(json.dumps({'pre': 1}) + '\n', encoding='utf-8')
+cml.log_interaction('nightly run', {'emotion': 'none'}, {'emotion': 'none'}, 'ok')
+PY
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus-logs
+          path: data/*.jsonl*
+          if-no-files-found: ignore

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -97,6 +97,18 @@ fixes:
 python tools/preflight.py --report
 ```
 
+## Log inspection and rotation
+
+Interaction records are appended as JSON lines to `data/interactions.jsonl`.
+The watchdog quarantines malformed entries in
+`data/interactions.quarantine.jsonl` while keeping the primary log clean.
+Logs rotate automatically once the file reaches roughly 1 MB
+(`MAX_LOG_SIZE`). The current log is renamed with a timestamp suffix such as
+`interactions-20250101_000000.jsonl` and a fresh file is started. Inspect
+records with tools like `jq` or `python -m json.tool`, and review quarantine
+and rotated files periodically. A nightly CI workflow invokes the logger and
+uploads rotated logs as build artifacts for auditing.
+
 ## Script overview
 
 - **`INANNA_AI_AGENT/inanna_ai.py`** – Activation agent that loads source texts and can recite the INANNA birth chant or feed hex data into the QNL engine. Use `--list` to show available texts.


### PR DESCRIPTION
## Summary
- test corpus log rotation preserves JSONL and truncates active file
- schedule nightly logger run and archive rotated JSONL logs
- document interaction log inspection and rotation policy

## Testing
- `python -m pytest tests/test_corpus_memory_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adbddce054832e9297e5bfb0b018d3