### PR TITLE
Add ritual demo and developer onboarding updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,4 +83,4 @@ None at the moment.
 
 ## Developer Docs
 
-New contributors should start with the [developer onboarding guide](docs/developer_onboarding.md) for setup steps, chakra overview, CLI usage and troubleshooting tips. Chakra module versions live in [docs/chakra_versions.json](docs/chakra_versions.json) and are paired with the verses in [docs/chakra_koan_system.md](docs/chakra_koan_system.md).
+New contributors should start with the [developer onboarding guide](docs/developer_onboarding.md) for setup steps, chakra overview, CLI usage and troubleshooting tips. A minimal emotion→music→insight example lives in [examples/ritual_demo.py](examples/ritual_demo.py). Chakra module versions live in [docs/chakra_versions.json](docs/chakra_versions.json) and are paired with the verses in [docs/chakra_koan_system.md](docs/chakra_koan_system.md).

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ See [docs/insight_system.md](docs/insight_system.md) for insight manifest usage 
 schema validation steps.
 Vital workflows and recovery procedures live in [docs/essential_services.md](docs/essential_services.md).
 New contributors should review the [developer onboarding guide](docs/developer_onboarding.md)
-for a structured walkthrough of the codebase. Current ratings, past scores and milestone validation
-results are tracked in [docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md).
+for a structured walkthrough of the codebase. A minimal emotion→music→insight example
+is available in [examples/ritual_demo.py](examples/ritual_demo.py). Current ratings,
+past scores and milestone validation results are tracked in
+[docs/QUALITY_EVALUATION.md](docs/QUALITY_EVALUATION.md).
 For the project's guiding vision and mission, see
 [docs/VISION.md](docs/VISION.md) and [docs/MISSION.md](docs/MISSION.md).
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -145,6 +145,12 @@ See [testing.md](testing.md) for detailed instructions.
    ```bash
    pytest --maxfail=1 -q
    ```
+4. **Ritual demo** – link emotion, music and insight:
+   ```bash
+   python examples/ritual_demo.py
+   ```
+   The script sets an emotion, composes a short ritual track and logs an
+   insight entry to `data/spiral_cortex_memory.jsonl`.
 
 ## Setup Scripts
 - `scripts/check_requirements.sh` – loads `secrets.env`, ensures required commands are present, and verifies essential environment variables.

--- a/examples/ritual_demo.py
+++ b/examples/ritual_demo.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Demonstration script for emotion setting, music playback, and insight logging.
+"""Minimal emotion→music→insight demonstration.
 
-The script performs three actions:
-
-1. Sets the current emotion via :mod:`emotional_state`.
-2. Plays a sample tone bundled under ``examples/assets``.
-3. Logs a dummy insight to the spiral cortex memory.
+1. Records an emotion via :mod:`emotional_state`.
+2. Attempts to compose ritual music with :mod:`audio.play_ritual_music` and
+   falls back to a bundled tone if the module is unavailable.
+3. Logs the result to the spiral cortex memory.
 """
 from __future__ import annotations
 
-from pathlib import Path
 import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:  # Optional dependency
+    from audio.play_ritual_music import compose_ritual_music
+except Exception:  # pragma: no cover - graceful fallback
+    compose_ritual_music = None  # type: ignore
 
 from emotional_state import set_last_emotion
 from memory import spiral_cortex
@@ -21,8 +30,8 @@ TONE_FILE = ASSET_DIR / "ritual_tone.wav"
 
 def play_audio(path: Path) -> None:
     """Play ``path`` using :mod:`simpleaudio` if available."""
-    try:
-        import simpleaudio as sa  # type: ignore
+    try:  # pragma: no cover - optional dependency
+        import simpleaudio as sa
 
         wave_obj = sa.WaveObject.from_wave_file(str(path))
         play_obj = wave_obj.play()
@@ -33,20 +42,28 @@ def play_audio(path: Path) -> None:
 
 def main() -> None:
     """Run the ritual demo."""
-    # 1. Set the active emotion
-    set_last_emotion("joy")
+    emotion = "joy"
 
-    # 2. Play the ritual tone
-    play_audio(TONE_FILE)
+    # 1. Record the active emotion
+    set_last_emotion(emotion)
 
-    # 3. Log an insight
-    spiral_cortex.log_insight(
-        "ritual demo",
-        [{"text": "played ritual tone"}],
-        sentiment=0.5,
-    )
+    if compose_ritual_music:
+        # 2a. Generate music tied to the emotion
+        track = compose_ritual_music(emotion, ritual="\u2609")
+        snippet = {"text": f"generated {emotion} ritual", "path": str(track.path)}
+    else:
+        # 2b. Fallback playback of bundled tone
+        play_audio(TONE_FILE)
+        track = None
+        snippet = {"text": "played ritual tone"}
 
-    print("Ritual demo complete.")
+    # 3. Log an insight referencing the produced track or tone
+    spiral_cortex.log_insight("ritual demo", [snippet], sentiment=0.5)
+
+    if track:
+        print(f"Ritual demo complete; audio at {track.path}")
+    else:
+        print("Ritual demo complete; audio backend unavailable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend onboarding guide with ritual demo and troubleshooting
- add emotion→music→insight ritual demo script
- reference guide and demo from root docs

## Testing
- `pre-commit run --files AGENTS.md README.md docs/developer_onboarding.md examples/ritual_demo.py`
- `pytest --maxfail=1 -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68adc3c8fa34832ea03727954ceca1c5