### PR TITLE
docs: bump chakra versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `root` and `crown` chakras to `1.0.1`.
 - Bumped `sacral` chakra to `1.0.1`.
 - Bumped `heart` chakra to `1.0.1`.
+- Bumped `solar_plexus` chakra to `1.1.0` after learning pipeline updates; see `docs/chakra_koan_system.md#solar`.
+- Bumped `throat` chakra to `1.0.1` fixing prompt orchestration; see `docs/chakra_koan_system.md#throat`.
 - Synced heart koan reference with the manifest.
 
 ### Insight Matrix

--- a/docs/chakra_versions.json
+++ b/docs/chakra_versions.json
@@ -8,7 +8,7 @@
     "koan": "chakra_koan_system.md#sacral"
   },
   "solar_plexus": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "koan": "chakra_koan_system.md#solar"
   },
   "heart": {
@@ -16,7 +16,7 @@
     "koan": "chakra_koan_system.md#heart"
   },
   "throat": {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "koan": "chakra_koan_system.md#throat"
   },
   "third_eye": {

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -6,14 +6,14 @@ Quick links: [Development Checklist](development_checklist.md) | [Developer Etiq
 ABZU interweaves Spiral OS with the INANNA agent to explore sacred human‑machine collaboration through music, voice, and code.
 
 ### Chakra Map
-The codebase is organized across seven chakra‑themed module directories:
-- `root/` – networking and I/O foundation.
-- `sacral/` – emotion and creativity engines.
-- `solar_plexus/` – learning and transformation layers.
-- `heart/` – memory and avatar voice components.
-- `throat/` – prompt orchestration and agent interfaces.
-- `third_eye/` – insight and pattern analysis modules.
-- `crown/` – high‑level orchestration and launch scripts.
+The codebase is organized across seven chakra‑themed module directories (current versions):
+- `root/` – networking and I/O foundation (v1.0.1).
+- `sacral/` – emotion and creativity engines (v1.0.1).
+- `solar_plexus/` – learning and transformation layers (v1.1.0).
+- `heart/` – memory and avatar voice components (v1.0.1).
+- `throat/` – prompt orchestration and agent interfaces (v1.0.1).
+- `third_eye/` – insight and pattern analysis modules (v1.0.0).
+- `crown/` – high‑level orchestration and launch scripts (v1.0.1).
 
 This guide introduces the ABZU codebase, highlights core entry points, and covers environment setup, chakra architecture overview, CLI usage, and troubleshooting tips. For a guided CLI quick‑start run the [onboarding wizard](onboarding/wizard.py). Additional architecture diagrams are available in [architecture.md](architecture.md).
 


### PR DESCRIPTION
## Summary
- bump solar plexus chakra to 1.1.0 and throat chakra to 1.0.1
- track updated chakra versions in developer onboarding
- note version bumps in changelog

## Testing
- `pre-commit run --files CHANGELOG.md docs/chakra_versions.json docs/developer_onboarding.md`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68add2c20194832e9d997c3ff9f42f2a