### PR TITLE
Enforce documentation updates in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure docs updated
+        run: |
+          git fetch origin $GITHUB_BASE_REF --depth=1
+          CODE_CHANGED=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD | grep -E '\.py$' | grep -v '^tests/' || true)
+          DOCS_CHANGED=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD | grep -E '^docs/.*\.md$' || true)
+          if [ -n "$CODE_CHANGED" ] && [ -z "$DOCS_CHANGED" ]; then
+            echo "Modules were modified without corresponding documentation updates:"
+            echo "$CODE_CHANGED"
+            exit 1
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -54,3 +67,10 @@ PY
           if grep -E "ERROR|MISSING" health.log; then
             exit 1
           fi
+
+      - name: Failure guidance
+        if: failure()
+        run: |
+          echo "CI checks failed. See the onboarding and architecture guides for help:" \
+          && echo "https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_BASE_REF/docs/developer_onboarding.md" \
+          && echo "https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_BASE_REF/docs/architecture.md"

--- a/docs/development_checklist.md
+++ b/docs/development_checklist.md
@@ -3,7 +3,7 @@
 Quick links: [Developer Onboarding](developer_onboarding.md) | [Developer Etiquette](developer_etiquette.md)
 
 ## Mandatory Steps for Any Code Change
-- Update related documentation and examples.
+- Update related documentation and examples. The CI workflow fails if Python modules are changed without matching updates in `docs/`.
 - Run `ruff` for linting.
 - Run `black` for formatting.
 - Run `mypy` for static type checks.


### PR DESCRIPTION
## Summary
- Fail CI when Python modules change without corresponding docs updates
- Guide contributors to onboarding and architecture docs on CI failure
- Document doc-check requirement in development checklist

## Testing
- `ruff check .` *(fails: line too long in tests)*
- `black --check --exclude tests .` *(fails: 8 files would be reformatted)*
- `mypy` *(fails: src/api/server.py incompatible types)*
- `pytest` *(fails: import errors in tests)*
- `python -m cProfile -m task_profiling`


------
https://chatgpt.com/codex/tasks/task_e_68add4de9928832e9376071b9cfb5dd8