### PR TITLE
docs: add Nazarick agents guide and README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ![Coverage](coverage.svg) ![CI](https://github.com/DINGIRABZU/ABZU/actions/workflows/ci.yml/badge.svg) ![CodeQL](https://github.com/DINGIRABZU/ABZU/actions/workflows/codeql.yml/badge.svg) ![Black](https://img.shields.io/badge/code%20style-black-000000.svg) ![isort](https://img.shields.io/badge/imports-isort-ef8336.svg)
 Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
+## Index
+- [Documentation Index](docs/index.md)
+- [Developer Onboarding](docs/developer_onboarding.md)
+- [Nazarick Agents](docs/nazarick_agents.md)
+
 ## Start Here
 Begin with the [CRYSTAL CODEX](CRYSTAL_CODEX.md) for mission, LWM architecture diagrams,
 chakra-to-module mappings, step-by-step setup guides, tutorials, dependency matrix,

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -1,0 +1,13 @@
+# Nazarick Agents
+
+This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Implementation stubs are linked for future development.
+
+| Agent | Role | Chakra | Memory Scope | External Libraries | Stub |
+| --- | --- | --- | --- | --- | --- |
+| Orchestration Master | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [orchestration_master.py](../orchestration_master.py) |
+| Prompt Orchestrator | Prompt routing and agent interface | Throat | Prompt/response JSON payloads | LLM APIs | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
+| QNL Engine | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |
+| Memory Scribe | Voice avatar configuration and memory storage | Heart | `voice_avatar_config.yaml`, embedding records | Vector database | [memory_scribe.py](../memory_scribe.py) |
+
+These agents draw from the chakra structure outlined in the [Developer Onboarding guide](developer_onboarding.md) and [Chakra Architecture](chakra_architecture.md).
+

--- a/memory_scribe.py
+++ b/memory_scribe.py
@@ -1,0 +1,14 @@
+"""Stub for the Memory Scribe agent.
+
+The Memory Scribe manages vector memory interactions within the Heart layer.
+"""
+
+from __future__ import annotations
+
+
+def store_embedding(text: str) -> None:
+    """Placeholder for recording an embedding."""
+    raise NotImplementedError("store_embedding is not implemented yet")
+
+
+__all__ = ["store_embedding"]

--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -1,0 +1,15 @@
+"""Stub for the Orchestration Master agent.
+
+The Orchestration Master coordinates high-level startup routines and inter-agent
+messaging across the Crown layer.
+"""
+
+from __future__ import annotations
+
+
+def boot_sequence() -> None:
+    """Placeholder for system boot logic."""
+    raise NotImplementedError("boot_sequence is not implemented yet")
+
+
+__all__ = ["boot_sequence"]


### PR DESCRIPTION
## Summary
- document Nazarick agents with roles, chakra alignment, memory scopes, and library dependencies
- add Orchestration Master and Memory Scribe stubs
- include quick navigation index in README

## Testing
- `pre-commit run --files README.md docs/nazarick_agents.md orchestration_master.py memory_scribe.py`
- `pytest --maxfail=1 -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68add863a5d4832eb11024cc3d18c807