### PR TITLE
feat: centralize dev cycle orchestration

### DIFF
--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -1,10 +1,94 @@
-"""Stub for the Orchestration Master agent.
-
-The Orchestration Master coordinates high-level startup routines and inter-agent
-messaging across the Crown layer.
-"""
+"""High-level orchestrator selecting agents and wiring memory stores."""
 
 from __future__ import annotations
+
+import logging
+from pathlib import Path
+from queue import Queue
+from typing import Any, Dict, List
+
+from memory import spiral_cortex
+
+
+class AlbedoOrchestrator:
+    """Coordinate planner, coder and reviewer agents for an objective.
+
+    The orchestrator loads memory stores, selects the agent implementations and
+    schedules execution. Each invocation records a summary to
+    :mod:`memory.spiral_cortex` for later inspection.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo: str | Path | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        self.repo = Path(repo) if repo is not None else None
+        self.max_iterations = max_iterations
+
+    def start(self, objective: str) -> Dict[str, Any]:
+        """Run the development cycle for ``objective``.
+
+        Returns a dictionary with planning results, execution details and test
+        outcomes.
+        """
+
+        from tools import dev_orchestrator as _tools
+
+        queue: Queue[str] = Queue()
+
+        planner_glm = _tools._glm_from_env("PLANNER_MODEL")
+        coder_glm = _tools._glm_from_env("CODER_MODEL")
+        reviewer_glm = _tools._glm_from_env("REVIEWER_MODEL")
+
+        planner = _tools.Planner(
+            "planner", "Plan development tasks", planner_glm, objective, queue
+        )
+        coder = _tools.Coder(
+            "coder", "Write code", coder_glm, objective, queue
+        )
+        reviewer = _tools.Reviewer(
+            "reviewer", "Review code", reviewer_glm, objective, queue
+        )
+
+        logger = logging.getLogger(__name__)
+        plan_steps = planner.plan()
+        results: List[Dict[str, str]] = []
+        iterations = 0
+        while not queue.empty():
+            if self.max_iterations is not None and iterations >= self.max_iterations:
+                break
+            task = queue.get()
+            logger.info("Executing task %s", task)
+            code = coder.code(task)
+            review = reviewer.review(task, code)
+            results.append({"task": task, "code": code, "review": review})
+            iterations += 1
+
+        if not queue.empty():
+            logger.info(
+                "Max iterations reached with %s tasks remaining", queue.qsize()
+            )
+
+        test_result: Dict[str, Any] | None = None
+        if self.repo is not None:
+            test_result = _tools._run_tests(self.repo)
+            if test_result["returncode"] == 0:
+                _tools._commit(self.repo, f"Auto commit: {objective}")
+
+        spiral_cortex.log_insight(
+            objective,
+            [{"plan": plan_steps, "results": len(results)}],
+            sentiment=0.0,
+        )
+
+        return {
+            "objective": objective,
+            "plan": plan_steps,
+            "results": results,
+            "tests": test_result,
+        }
 
 
 def boot_sequence() -> None:
@@ -12,4 +96,4 @@ def boot_sequence() -> None:
     raise NotImplementedError("boot_sequence is not implemented yet")
 
 
-__all__ = ["boot_sequence"]
+__all__ = ["AlbedoOrchestrator", "boot_sequence"]


### PR DESCRIPTION
## Summary
- add `AlbedoOrchestrator` to drive planner/coder/reviewer agents and log to spiral cortex
- delegate dev cycle scheduling to `AlbedoOrchestrator`
- document guardian tier and narrative log flags and log every run to spiral cortex

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*
- `pytest tests/test_dev_orchestrator.py -q --override-ini addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68addd177664832e825710a18bbf9090