### PR TITLE
Add agent stubs and registry entries

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Core agent packages for ABZU."""

--- a/agents/cocytus/__init__.py
+++ b/agents/cocytus/__init__.py
@@ -1,0 +1,1 @@
+"""Cocytus agent modules."""

--- a/agents/cocytus/prompt_arbiter.py
+++ b/agents/cocytus/prompt_arbiter.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- logical sanitization
+- legal parsing
+- audit model bias
+"""

--- a/agents/demiurge/__init__.py
+++ b/agents/demiurge/__init__.py
@@ -1,0 +1,1 @@
+"""Demiurge agent modules."""

--- a/agents/demiurge/strategic_simulator.py
+++ b/agents/demiurge/strategic_simulator.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- long-term planning
+- failure forecasting
+- scenario stress-testing
+"""

--- a/agents/ecosystem/__init__.py
+++ b/agents/ecosystem/__init__.py
@@ -1,0 +1,1 @@
+"""Ecosystem monitoring agents."""

--- a/agents/ecosystem/aura_capture.py
+++ b/agents/ecosystem/aura_capture.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- data harvesting
+- environmental telemetry
+- sensor health checks
+"""

--- a/agents/ecosystem/mare_gardener.py
+++ b/agents/ecosystem/mare_gardener.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- infrastructure metrics
+- performance trend analysis
+- capacity planning advisories
+"""

--- a/agents/pandora/__init__.py
+++ b/agents/pandora/__init__.py
@@ -1,0 +1,1 @@
+"""Pandora persona agents."""

--- a/agents/pandora/persona_emulator.py
+++ b/agents/pandora/persona_emulator.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- persona emulation
+- scenario roleplay
+- identity consistency checks
+"""

--- a/agents/pleiades/__init__.py
+++ b/agents/pleiades/__init__.py
@@ -1,0 +1,1 @@
+"""Pleiades utility modules."""

--- a/agents/pleiades/signal_router.py
+++ b/agents/pleiades/signal_router.py
@@ -1,0 +1,4 @@
+"""Responsibilities:
+- cross-agent signal routing
+- fallback relay strategies
+"""

--- a/agents/pleiades/star_map.py
+++ b/agents/pleiades/star_map.py
@@ -1,0 +1,4 @@
+"""Responsibilities:
+- celestial navigation utilities
+- cosmic alignment calculations
+"""

--- a/agents/sebas/__init__.py
+++ b/agents/sebas/__init__.py
@@ -1,0 +1,1 @@
+"""Sebas compassion agents."""

--- a/agents/sebas/compassion_module.py
+++ b/agents/sebas/compassion_module.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- empathy modeling
+- emotional safety buffer
+- conflict signal resolution
+"""

--- a/agents/shalltear/__init__.py
+++ b/agents/shalltear/__init__.py
@@ -1,0 +1,1 @@
+"""Shalltear agent modules."""

--- a/agents/shalltear/fast_inference_agent.py
+++ b/agents/shalltear/fast_inference_agent.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- burst compute
+- load shedding
+- monitor API quotas
+"""

--- a/agents/victim/__init__.py
+++ b/agents/victim/__init__.py
@@ -1,0 +1,1 @@
+"""Victim security agents."""

--- a/agents/victim/security_canary.py
+++ b/agents/victim/security_canary.py
@@ -1,0 +1,5 @@
+"""Responsibilities:
+- security alerts
+- intrusion detection
+- anomaly threshold tracking
+"""

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -11,3 +11,18 @@ This guide summarizes core agents within ABZU's Nazarick system. Each agent alig
 
 These agents draw from the chakra structure outlined in the [Developer Onboarding guide](developer_onboarding.md) and [Chakra Architecture](chakra_architecture.md).
 
+## Additional Agents
+
+| Agent | Responsibilities | Path |
+| --- | --- | --- |
+| Demiurge Strategic Simulator | Long-term planning, failure forecasting, scenario stress-testing | [agents/demiurge/strategic_simulator.py](../agents/demiurge/strategic_simulator.py) |
+| Shalltear Fast Inference Agent | Burst compute, load shedding, monitors API quotas | [agents/shalltear/fast_inference_agent.py](../agents/shalltear/fast_inference_agent.py) |
+| Cocytus Prompt Arbiter | Logical sanitization, legal parsing, audits model bias | [agents/cocytus/prompt_arbiter.py](../agents/cocytus/prompt_arbiter.py) |
+| Ecosystem Aura Capture | Data harvesting, environmental telemetry, sensor health checks | [agents/ecosystem/aura_capture.py](../agents/ecosystem/aura_capture.py) |
+| Ecosystem Mare Gardener | Infrastructure metrics, performance trend analysis, capacity planning advisories | [agents/ecosystem/mare_gardener.py](../agents/ecosystem/mare_gardener.py) |
+| Sebas Compassion Module | Empathy modeling, emotional safety buffer, conflict signal resolution | [agents/sebas/compassion_module.py](../agents/sebas/compassion_module.py) |
+| Victim Security Canary | Security alerts, intrusion detection, anomaly threshold tracking | [agents/victim/security_canary.py](../agents/victim/security_canary.py) |
+| Pandora Persona Emulator | Persona emulation, scenario roleplay, identity consistency checks | [agents/pandora/persona_emulator.py](../agents/pandora/persona_emulator.py) |
+| Pleiades Star Map Utility | Celestial navigation utilities, cosmic alignment calculations | [agents/pleiades/star_map.py](../agents/pleiades/star_map.py) |
+| Pleiades Signal Router Utility | Cross-agent signal routing, fallback relay strategies | [agents/pleiades/signal_router.py](../agents/pleiades/signal_router.py) |
+

--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -10,6 +10,18 @@ from typing import Any, Dict, List
 from memory import spiral_cortex
 
 
+AGENT_LOOKUP: Dict[str, str] = {
+    "strategic_simulator": "agents.demiurge.strategic_simulator",
+    "fast_inference_agent": "agents.shalltear.fast_inference_agent",
+    "prompt_arbiter": "agents.cocytus.prompt_arbiter",
+    "aura_capture": "agents.ecosystem.aura_capture",
+    "mare_gardener": "agents.ecosystem.mare_gardener",
+    "compassion_module": "agents.sebas.compassion_module",
+    "security_canary": "agents.victim.security_canary",
+    "persona_emulator": "agents.pandora.persona_emulator",
+}
+
+
 class AlbedoOrchestrator:
     """Coordinate planner, coder and reviewer agents for an objective.
 
@@ -96,4 +108,4 @@ def boot_sequence() -> None:
     raise NotImplementedError("boot_sequence is not implemented yet")
 
 
-__all__ = ["AlbedoOrchestrator", "boot_sequence"]
+__all__ = ["AlbedoOrchestrator", "boot_sequence", "AGENT_LOOKUP"]


### PR DESCRIPTION
## Summary
- stub out new agent modules and utilities under `agents/` with responsibilities docstrings
- register agents in `AGENT_LOOKUP` inside `orchestration_master.py`
- document new agents and duties in `docs/nazarick_agents.md`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68addf6e9e90832e9d1d524f906b8c05