### PR TITLE
Add Vanna-powered data agent

### DIFF
--- a/agents/vanna_data.py
+++ b/agents/vanna_data.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Vanna-powered data lookup agent.
+
+Responsibilities:
+- translate natural language prompts into SQL via vanna
+- execute generated SQL queries
+- store raw results in mental memory and narrative summaries in narrative memory
+"""
+
+from dataclasses import asdict
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+from uuid import uuid4
+
+from core.utils.optional_deps import lazy_import
+from memory.mental import record_task_flow
+from memory.narrative_engine import NarrativeEngine, StoryEvent
+
+vanna = lazy_import("vanna")
+logger = logging.getLogger(__name__)
+
+
+class _FileNarrativeEngine(NarrativeEngine):
+    """Persist narrative events to ``data/narrative.log``."""
+
+    def __init__(self, path: Path = Path("data/narrative.log")) -> None:
+        self.path = path
+
+    def record(self, event: StoryEvent) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(event)) + "\n")
+
+    def stream(self) -> Iterable[StoryEvent]:
+        if not self.path.exists():
+            return []
+        with open(self.path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                data = json.loads(line)
+                yield StoryEvent(**data)
+
+
+_narrative_engine = _FileNarrativeEngine()
+
+
+def query_db(prompt: str) -> List[Dict[str, Any]]:
+    """Query the configured database using a natural language ``prompt``.
+
+    Returns a list of result rows as dictionaries. Requires the optional
+    ``vanna`` dependency to be installed and configured with a database
+    connection.
+    """
+
+    if getattr(vanna, "__stub__", False):  # pragma: no cover - optional dep
+        raise RuntimeError("vanna library is not installed")
+
+    sql, df, *_ = vanna.ask(prompt)  # type: ignore[attr-defined]
+    rows = df.to_dict("records") if df is not None else []
+
+    task_id = str(uuid4())
+    context = {"prompt": prompt, "sql": sql, "rows": rows}
+    try:
+        record_task_flow(task_id, context)
+    except Exception:  # pragma: no cover - best effort
+        logger.debug("mental memory recording failed", exc_info=True)
+
+    summary = f"{prompt} -> {len(rows)} rows"
+    event = StoryEvent(actor="vanna_data", action=summary, symbolism=sql)
+    try:
+        _narrative_engine.record(event)
+    except Exception:  # pragma: no cover - best effort
+        logger.debug("narrative memory recording failed", exc_info=True)
+
+    return rows
+
+
+__all__ = ["query_db"]

--- a/docs/vanna_usage.md
+++ b/docs/vanna_usage.md
@@ -1,0 +1,20 @@
+# Vanna Data Agent Usage
+
+The `vanna_data` agent translates natural language prompts into SQL queries using the [Vanna](https://github.com/vanna-ai/vanna) library. Query results are stored in mental memory while narrative summaries are appended to `data/narrative.log`.
+
+## Basic Example
+
+```python
+import vanna
+from agents.vanna_data import query_db
+
+# Configure Vanna with your API key, model, and database connection
+vanna.set_api_key("YOUR_API_KEY")
+vanna.set_model("your-model")
+vanna.connect_to_sqlite("my.db")
+
+rows = query_db("How many users signed up last week?")
+print(rows)
+```
+
+The call stores the raw rows in Neo4j-backed mental memory and records a summary event in narrative memory for later storytelling.

--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -19,6 +19,7 @@ AGENT_LOOKUP: Dict[str, str] = {
     "compassion_module": "agents.sebas.compassion_module",
     "security_canary": "agents.victim.security_canary",
     "persona_emulator": "agents.pandora.persona_emulator",
+    "vanna_data": "agents.vanna_data",
 }
 
 
@@ -57,9 +58,7 @@ class AlbedoOrchestrator:
         planner = _tools.Planner(
             "planner", "Plan development tasks", planner_glm, objective, queue
         )
-        coder = _tools.Coder(
-            "coder", "Write code", coder_glm, objective, queue
-        )
+        coder = _tools.Coder("coder", "Write code", coder_glm, objective, queue)
         reviewer = _tools.Reviewer(
             "reviewer", "Review code", reviewer_glm, objective, queue
         )
@@ -79,9 +78,7 @@ class AlbedoOrchestrator:
             iterations += 1
 
         if not queue.empty():
-            logger.info(
-                "Max iterations reached with %s tasks remaining", queue.qsize()
-            )
+            logger.info("Max iterations reached with %s tasks remaining", queue.qsize())
 
         test_result: Dict[str, Any] | None = None
         if self.repo is not None:


### PR DESCRIPTION
## Summary
- implement `query_db` agent using Vanna to convert prompts into SQL and log results to mental and narrative memory
- register `vanna_data` in `AGENT_LOOKUP` for delegation
- document usage of the Vanna data agent

## Testing
- `pre-commit run --files agents/vanna_data.py orchestration_master.py docs/vanna_usage.md`
- `pytest` *(fails: 101 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ade20341f0832e80dcea65474e4d92