### PR TITLE
Add snapshot manifest logging and security canary

### DIFF
--- a/agents/victim/security_canary.py
+++ b/agents/victim/security_canary.py
@@ -1,5 +1,44 @@
-"""Responsibilities:
-- security alerts
-- intrusion detection
-- anomaly threshold tracking
+"""Security canary for intrusion monitoring.
+
+Provides a simple interface to react to breach indicators by
+persisting a memory snapshot and broadcasting an alert message.
 """
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from vector_memory import persist_snapshot
+
+logger = logging.getLogger(__name__)
+
+
+def broadcast_alert(message: str) -> None:
+    """Broadcast a security alert ``message`` via logging."""
+
+    logger.error("SECURITY ALERT: %s", message)
+
+
+def detect_breach(
+    breached: bool,
+    *,
+    snap_func: Callable[[], Path] | None = None,
+    alert: Callable[[str], None] | None = None,
+) -> bool:
+    """Trigger a snapshot and alert when a breach is detected.
+
+    Returns ``True`` if a breach was handled.
+    """
+
+    if not breached:
+        return False
+
+    snapper = snap_func or persist_snapshot
+    path = snapper()
+    (alert or broadcast_alert)(f"breach detected, snapshot stored at {path}")
+    return True
+
+
+__all__ = ["detect_breach", "broadcast_alert"]

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -1,19 +1,33 @@
 # Recovery Playbook
 
-This guide outlines steps to restore vector memory state from snapshots.
+This guide outlines how to restore **vector memory** from persisted snapshots
+and bring the narrative log back into alignment.
 
-1. **Locate snapshots**
-   - Snapshot files are listed in `snapshots/manifest.json` under the vector memory directory.
-   - Each entry records the absolute path of a persisted snapshot.
-2. **Select a snapshot**
-   - Choose the desired path from the manifest. The last entry is typically the most recent.
-3. **Restore**
-   - Use `vector_memory.restore(<path>)` to load a specific snapshot, or
-     call `vector_memory.restore_latest_snapshot()` to automatically load
-     the newest entry.
-4. **Verify**
-   - After restoration, run existing workflows or tests to ensure the
-     vector store has returned to the expected state.
+## Restoring a Snapshot
 
-This procedure provides a repeatable method for recovery using the
-snapshot manifest.
+1. Review `snapshots/manifest.json` to locate available snapshot paths.
+2. Load a specific snapshot:
+
+   ```python
+   from vector_memory import restore
+   restore("path/to/snapshot.sqlite")
+   ```
+
+   To load the most recent snapshot automatically:
+
+   ```python
+   from vector_memory import restore_latest_snapshot
+   restore_latest_snapshot()
+   ```
+
+## Narrative Resynchronization
+
+Every call to `vector_memory.snapshot()` records a narrative `sacrifice`
+entry in `data/narrative.log`. After restoring a snapshot:
+
+1. Inspect the log for the last sacrifice entry to confirm the restored path.
+2. Append new narrative events as activity resumes so the story timeline
+   stays continuous.
+
+This process ensures both data and narrative context are brought back
+together after a system recovery.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_vector_memory_extensions.py"),
     str(ROOT / "tests" / "test_cortex_memory.py"),
     str(ROOT / "tests" / "test_voice_cloner_cli.py"),
+    str(ROOT / "tests" / "test_security_canary.py"),
 }
 
 

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -66,6 +66,7 @@ def test_vector_memory_snapshot_restore(tmp_path, monkeypatch):
     monkeypatch.setattr(vector_memory, "_get_collection", lambda: col)
     monkeypatch.setattr(vector_memory, "_EMBED", lambda s: [1.0, 0.0])
     monkeypatch.setattr(vector_memory, "_DIR", tmp_path)
+    monkeypatch.setattr(vector_memory, "NARRATIVE_LOG", tmp_path / "narrative.log")
 
     vector_memory.add_vector("hello", {})
     snap = tmp_path / "vm.json"
@@ -73,7 +74,12 @@ def test_vector_memory_snapshot_restore(tmp_path, monkeypatch):
 
     manifest = tmp_path / "snapshots" / "manifest.json"
     assert manifest.exists()
-    assert str(snap) in json.loads(manifest.read_text())
+    assert json.loads(manifest.read_text()) == [str(snap)]
+
+    narr = tmp_path / "narrative.log"
+    log_entry = json.loads(narr.read_text().splitlines()[0])
+    assert log_entry["action"] == "sacrifice"
+    assert log_entry["symbolism"] == str(snap)
 
     col.data = {"ids": [], "embeddings": [], "metadatas": []}
     vector_memory.restore(snap)

--- a/tests/test_security_canary.py
+++ b/tests/test_security_canary.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from agents.victim import security_canary
+
+
+def test_canary_triggers_snapshot_and_alert(tmp_path):
+    snap_called = False
+
+    def fake_snap():
+        nonlocal snap_called
+        snap_called = True
+        return tmp_path / "snap.sqlite"
+
+    messages: list[str] = []
+
+    def fake_alert(msg: str) -> None:
+        messages.append(msg)
+
+    handled = security_canary.detect_breach(
+        True, snap_func=fake_snap, alert=fake_alert
+    )
+
+    assert handled is True
+    assert snap_called
+    assert messages and "snap.sqlite" in messages[0]


### PR DESCRIPTION
## Summary
- log snapshot paths and narrative "sacrifice" events
- add security canary to snapshot and alert on breaches
- document recovery and narrative resynchronization

## Testing
- `pytest tests/test_memory_snapshot.py::test_vector_memory_snapshot_restore tests/test_security_canary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade3e5e444832ea47f3515401c1995