### PR TITLE
Add Asian Gen creative engine with fallback tokenizers

### DIFF
--- a/agents/asian_gen/__init__.py
+++ b/agents/asian_gen/__init__.py
@@ -1,0 +1,5 @@
+"""Asian language creative agents."""
+
+from .creative_engine import CreativeEngine
+
+__all__ = ["CreativeEngine"]

--- a/agents/asian_gen/creative_engine.py
+++ b/agents/asian_gen/creative_engine.py
@@ -1,0 +1,81 @@
+"""Creative engine for Asian language text generation.
+
+This module tries to load a multilingual Hugging Face model to generate text for
+specific locale codes. When the transformers tokenizer or model is not
+available, it falls back to a local SentencePiece tokenizer so that basic
+operations still function offline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import sentencepiece as spm
+
+try:  # pragma: no cover - optional dependency
+    from transformers import AutoTokenizer, pipeline
+except Exception:  # pragma: no cover
+    AutoTokenizer = None  # type: ignore
+    pipeline = None  # type: ignore
+
+
+@dataclass
+class CreativeEngine:
+    """Generate short creative text for a given locale."""
+
+    model_name: str = "facebook/mbart-large-50-many-to-many-mmt"
+    spm_path: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.tokenizer = self._load_tokenizer()
+        self.generator = self._build_generator()
+
+    def _load_tokenizer(self):
+        if AutoTokenizer is not None:
+            try:
+                return AutoTokenizer.from_pretrained(
+                    self.model_name, local_files_only=True
+                )
+            except Exception:
+                pass
+        if self.spm_path:
+            sp = spm.SentencePieceProcessor()
+            sp.load(self.spm_path)
+            return sp
+        raise RuntimeError("No tokenizer available")
+
+    def _build_generator(self):
+        if pipeline is None:
+            return None
+        try:
+            return pipeline(
+                "text-generation",
+                model=self.model_name,
+                tokenizer=self.tokenizer,
+                device=-1,
+                model_kwargs={"local_files_only": True},
+            )
+        except Exception:
+            return None
+
+    def generate(self, prompt: str, locale: str) -> str:
+        """Generate text conditioned on locale."""
+
+        if self.generator is not None:
+            kwargs = {}
+            if hasattr(self.tokenizer, "lang_code_to_id"):
+                lang_id = self.tokenizer.lang_code_to_id.get(locale)
+                if lang_id is not None:
+                    kwargs["forced_bos_token_id"] = lang_id
+            result = self.generator(
+                prompt, max_new_tokens=20, num_return_sequences=1, **kwargs
+            )
+            if isinstance(result, list) and result:
+                return result[0].get("generated_text", "")
+            return ""
+
+        if isinstance(self.tokenizer, spm.SentencePieceProcessor):
+            tokens = self.tokenizer.encode(prompt, out_type=str)
+            return " ".join(tokens)
+        return prompt

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -26,4 +26,5 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 | Pleiades Star Map Utility | Celestial navigation utilities, cosmic alignment calculations | [agents/pleiades/star_map.py](../agents/pleiades/star_map.py) |
 | Pleiades Signal Router Utility | Cross-agent signal routing, fallback relay strategies | [agents/pleiades/signal_router.py](../agents/pleiades/signal_router.py) |
 | Bana Bio-Adaptive Narrator | Biosignal-driven narrative generation | [agents/bana/bio_adaptive_narrator.py](../agents/bana/bio_adaptive_narrator.py) |
+| Asian Gen Creative Engine | Multilingual generation with locale codes, offline SentencePiece fallbacks | [agents/asian_gen/creative_engine.py](../agents/asian_gen/creative_engine.py) |
 

--- a/tests/agents/test_asian_gen.py
+++ b/tests/agents/test_asian_gen.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import sentencepiece as spm
+
+from agents.asian_gen.creative_engine import CreativeEngine
+
+
+def _build_sp_model(tmp_path: Path) -> Path:
+    text_file = tmp_path / "text.txt"
+    text_file.write_text("hello world\nこんにちは 世界\n")
+    spm.SentencePieceTrainer.train(
+        input=str(text_file), model_prefix=str(tmp_path / "m"), vocab_size=32
+    )
+    return tmp_path / "m.model"
+
+
+def test_locale_routed_generation(monkeypatch):
+    class DummyTokenizer:
+        lang_code_to_id = {"ja": 7}
+
+    class DummyAutoTokenizer:
+        @staticmethod
+        def from_pretrained(model_name, local_files_only=True):
+            return DummyTokenizer()
+
+    class DummyPipe:
+        def __call__(
+            self,
+            prompt,
+            max_new_tokens,
+            num_return_sequences,
+            forced_bos_token_id=None,
+        ):
+            assert forced_bos_token_id == 7
+            return [{"generated_text": "response"}]
+
+    monkeypatch.setattr(
+        "agents.asian_gen.creative_engine.AutoTokenizer", DummyAutoTokenizer
+    )
+    monkeypatch.setattr(
+        "agents.asian_gen.creative_engine.pipeline", lambda *a, **k: DummyPipe()
+    )
+
+    engine = CreativeEngine()
+    text = engine.generate("hello", locale="ja")
+    assert text == "response"
+
+
+def test_sentencepiece_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr("agents.asian_gen.creative_engine.AutoTokenizer", None)
+    monkeypatch.setattr("agents.asian_gen.creative_engine.pipeline", None)
+
+    model_path = _build_sp_model(tmp_path)
+    engine = CreativeEngine(spm_path=str(model_path))
+
+    output = engine.generate("hello", locale="ja")
+    assert isinstance(output, str) and output


### PR DESCRIPTION
## Summary
- add Asian Gen creative engine that loads multilingual Hugging Face models and supports locale codes
- fallback to SentencePiece tokenizer when transformers resources are unavailable
- document agent in Nazarick guide and add smoke tests for locale routing and offline operation

## Testing
- `pre-commit run --files tests/agents/test_asian_gen.py agents/asian_gen/__init__.py agents/asian_gen/creative_engine.py docs/nazarick_agents.md`
- `pytest tests/agents/test_asian_gen.py -q --cov=agents`

------
https://chatgpt.com/codex/tasks/task_e_68adea87b38c832e9f3b8bd6c022702f