### PR TITLE
Add land graph geo knowledge module with JSONL import/export

### DIFF
--- a/agents/land_graph/__init__.py
+++ b/agents/land_graph/__init__.py
@@ -1,0 +1,8 @@
+"""Land graph utilities.
+
+Refer to docs/nazarick_agents.md for an overview of Nazarick agents.
+"""
+
+from .geo_knowledge import GeoKnowledge
+
+__all__ = ["GeoKnowledge"]

--- a/agents/land_graph/geo_knowledge.py
+++ b/agents/land_graph/geo_knowledge.py
@@ -1,0 +1,91 @@
+"""Geo-referenced land graph utilities.
+
+This module stores a lightweight knowledge graph using ``networkx`` with
+optional ``geopandas`` support. Nodes typically represent sites with
+longitude/latitude coordinates; edges represent paths between sites.
+
+The `docs/nazarick_agents.md` guide provides broader architectural context.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Tuple
+
+import networkx as nx
+
+try:  # ``geopandas`` is optional
+    import geopandas as gpd
+    from shapely.geometry import Point
+except Exception:  # pragma: no cover - optional dependency
+    gpd = None
+    Point = None
+
+
+class GeoKnowledge:
+    """Graph wrapper with optional GeoPandas support."""
+
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def add_site(self, node_id: str, *, lon: float, lat: float, **attrs: float) -> None:
+        """Add a site node to the graph."""
+        data = {"lon": float(lon), "lat": float(lat), **attrs}
+        self.graph.add_node(node_id, **data)
+
+    def add_path(self, a: str, b: str, **attrs: float) -> None:
+        """Add an edge between two sites."""
+        self.graph.add_edge(a, b, **attrs)
+
+    def to_jsonl(self, path: str) -> None:
+        """Export nodes and edges to a JSONL file."""
+        with open(path, "w", encoding="utf-8") as fh:
+            for node, data in self.graph.nodes(data=True):
+                entry = {"type": "node", "id": node, **data}
+                fh.write(json.dumps(entry) + "\n")
+            for a, b, data in self.graph.edges(data=True):
+                entry = {"type": "edge", "source": a, "target": b, **data}
+                fh.write(json.dumps(entry) + "\n")
+
+    @classmethod
+    def from_jsonl(cls, path: str) -> "GeoKnowledge":
+        """Reconstruct a graph from a JSONL file."""
+        gk = cls()
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                item = json.loads(line)
+                kind = item.pop("type", None)
+                if kind == "node":
+                    node_id = item.pop("id")
+                    gk.graph.add_node(node_id, **item)
+                elif kind == "edge":
+                    src = item.pop("source")
+                    dst = item.pop("target")
+                    gk.graph.add_edge(src, dst, **item)
+        return gk
+
+    def nearest_ritual_site(self, lon: float, lat: float) -> Tuple[str, Dict]:
+        """Return the ritual site closest to the provided coordinates."""
+        ritual_nodes = [
+            (n, d)
+            for n, d in self.graph.nodes(data=True)
+            if d.get("category") == "ritual_site"
+        ]
+        if not ritual_nodes:
+            raise ValueError("No ritual sites found")
+
+        def dist(data: Dict) -> float:
+            return (lon - data["lon"]) ** 2 + (lat - data["lat"]) ** 2
+
+        node, data = min(ritual_nodes, key=lambda nd: dist(nd[1]))
+        return node, data
+
+    def to_geodataframe(self):
+        """Return a GeoDataFrame of nodes if GeoPandas is installed."""
+        if gpd is None or Point is None:
+            raise ImportError("geopandas is not installed")
+        records = []
+        for node, data in self.graph.nodes(data=True):
+            record = {**data, "id": node, "geometry": Point(data["lon"], data["lat"])}
+            records.append(record)
+        return gpd.GeoDataFrame(records, geometry="geometry")

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -27,4 +27,5 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 | Pleiades Signal Router Utility | Cross-agent signal routing, fallback relay strategies | [agents/pleiades/signal_router.py](../agents/pleiades/signal_router.py) |
 | Bana Bio-Adaptive Narrator | Biosignal-driven narrative generation | [agents/bana/bio_adaptive_narrator.py](../agents/bana/bio_adaptive_narrator.py) |
 | Asian Gen Creative Engine | Multilingual generation with locale codes, offline SentencePiece fallbacks | [agents/asian_gen/creative_engine.py](../agents/asian_gen/creative_engine.py) |
+| Land Graph Geo Knowledge | Landscape graph, ritual site queries | [agents/land_graph/geo_knowledge.py](../agents/land_graph/geo_knowledge.py) |
 

--- a/tests/agents/test_land_graph_geo_knowledge.py
+++ b/tests/agents/test_land_graph_geo_knowledge.py
@@ -1,0 +1,26 @@
+from agents.land_graph.geo_knowledge import GeoKnowledge
+
+
+def build_sample_graph():
+    gk = GeoKnowledge()
+    gk.add_site("ritual", lon=0.0, lat=0.0, category="ritual_site")
+    gk.add_site("village", lon=1.0, lat=1.0, category="village")
+    gk.add_path("ritual", "village", distance=1.5)
+    return gk
+
+
+def test_jsonl_roundtrip(tmp_path):
+    gk = build_sample_graph()
+    path = tmp_path / "graph.jsonl"
+    gk.to_jsonl(path)
+
+    loaded = GeoKnowledge.from_jsonl(path)
+    assert set(loaded.graph.nodes) == {"ritual", "village"}
+    assert loaded.graph.edges["ritual", "village"]["distance"] == 1.5
+
+
+def test_nearest_ritual_site():
+    gk = build_sample_graph()
+    node, data = gk.nearest_ritual_site(lon=0.2, lat=0.1)
+    assert node == "ritual"
+    assert data["category"] == "ritual_site"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_cortex_memory.py"),
     str(ROOT / "tests" / "test_voice_cloner_cli.py"),
     str(ROOT / "tests" / "test_security_canary.py"),
+    str(ROOT / "tests" / "agents" / "test_land_graph_geo_knowledge.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- add `GeoKnowledge` graph storing nodes and edges with optional GeoPandas layers
- support JSONL import/export and nearest ritual site lookup
- document land graph agent in Nazarick agents guide and test graph integrity

## Testing
- `pre-commit run --files agents/land_graph/__init__.py agents/land_graph/geo_knowledge.py tests/agents/test_land_graph_geo_knowledge.py tests/conftest.py docs/nazarick_agents.md`
- `pytest tests/agents/test_land_graph_geo_knowledge.py --cov=agents.land_graph --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68adec7a9c7c832ea90afc96705af8a3