### PR TITLE
docs: add Bana, AsianGen, LandGraph agent details

### DIFF
--- a/docs/chakra_architecture.md
+++ b/docs/chakra_architecture.md
@@ -12,6 +12,11 @@ This document summarizes the major modules aligned with each chakra layer, their
 | Third Eye | `insight_compiler.py`, `SPIRAL_OS/qnl_engine.py`, `seven_dimensional_music.py` | Insight and QNL processing | Experimental | QNL engine emits occasional warnings |
 | Crown | `init_crown_agent.py`, `start_spiral_os.py`, `crown_model_launcher.sh` | High-level orchestration | Alpha | Startup scripts assume local model availability |
 
+Additional Nazarick agents expand these layers:
+[Bana Bio-Adaptive Narrator](nazarick_agents.md#bana-bio-adaptive-narrator) (Heart),
+[AsianGen Creative Engine](nazarick_agents.md#asiangen-creative-engine) (Throat), and
+[LandGraph Geo Knowledge](nazarick_agents.md#landgraph-geo-knowledge) (Root).
+
 ## Service and Schema Mapping
 
 | Chakra | Modules | Third-party Services | Data Schemas |

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -118,6 +118,11 @@ the full table.
 | Third Eye | Insight and QNL processing | `insight_compiler.py`, `SPIRAL_OS/qnl_engine.py` |
 | Crown | High‑level orchestration | `init_crown_agent.py`, `start_spiral_os.py`, `crown_model_launcher.sh` |
 
+Specialized Nazarick agents extend these layers, including
+[Bana Bio-Adaptive Narrator](nazarick_agents.md#bana-bio-adaptive-narrator) (Heart),
+[AsianGen Creative Engine](nazarick_agents.md#asiangen-creative-engine) (Throat), and
+[LandGraph Geo Knowledge](nazarick_agents.md#landgraph-geo-knowledge) (Root).
+
 ### Chakra Interactions
 
 ```mermaid

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -29,3 +29,50 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 | Asian Gen Creative Engine | Multilingual generation with locale codes, offline SentencePiece fallbacks | [agents/asian_gen/creative_engine.py](../agents/asian_gen/creative_engine.py) |
 | Land Graph Geo Knowledge | Landscape graph, ritual site queries | [agents/land_graph/geo_knowledge.py](../agents/land_graph/geo_knowledge.py) |
 
+## Bana Bio-Adaptive Narrator
+
+- **Role:** Biosignal-driven narrative generation.
+- **Chakra:** Heart
+- **Dependencies:** `biosppy`, `transformers`, `numpy`
+- **Quick start:**
+
+  ```python
+  from agents.bana.bio_adaptive_narrator import generate_story
+
+  story = generate_story([0.0, 0.1, 0.2])
+  print(story)
+  ```
+
+## AsianGen Creative Engine
+
+- **Role:** Multilingual text generation with locale codes and offline fallbacks.
+- **Chakra:** Throat
+- **Dependencies:** `transformers`, `sentencepiece`
+- **Quick start:**
+
+  ```python
+  from agents.asian_gen.creative_engine import CreativeEngine
+
+  engine = CreativeEngine()
+  text = engine.generate("hello", locale="ja_JP")
+  print(text)
+  ```
+
+## LandGraph Geo Knowledge
+
+- **Role:** Landscape graph utilities and ritual site queries.
+- **Chakra:** Root
+- **Dependencies:** `networkx`, `geopandas` *(optional)*
+- **Quick start:**
+
+  ```python
+  from agents.land_graph.geo_knowledge import GeoKnowledge
+
+  gk = GeoKnowledge()
+  gk.add_site("home", lon=0.0, lat=0.0, category="ritual_site")
+  gk.add_site("mountain", lon=1.0, lat=1.0)
+  gk.add_path("home", "mountain")
+  node, data = gk.nearest_ritual_site(lon=0.2, lat=0.1)
+  print(node, data)
+  ```
+


### PR DESCRIPTION
## Summary
- document Bana, AsianGen, LandGraph agents with roles, chakra mappings, dependencies, and quick-start examples
- link these agents from developer onboarding and chakra architecture docs

## Testing
- `pre-commit run --files docs/nazarick_agents.md docs/developer_onboarding.md docs/chakra_architecture.md`
- `pytest -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68adef329d30832eb07474ea001f3811