### PR TITLE
feat: add optional agent orchestration

### DIFF
--- a/pipeline/agents.yaml
+++ b/pipeline/agents.yaml
@@ -1,0 +1,6 @@
+bana:
+  enabled: false
+asiangen:
+  enabled: false
+landgraph:
+  enabled: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_voice_cloner_cli.py"),
     str(ROOT / "tests" / "test_security_canary.py"),
     str(ROOT / "tests" / "agents" / "test_land_graph_geo_knowledge.py"),
+    str(ROOT / "tests" / "test_orchestration_master.py"),
 }
 
 

--- a/tests/test_orchestration_master.py
+++ b/tests/test_orchestration_master.py
@@ -1,0 +1,37 @@
+"""Tests for orchestration master optional agents."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import orchestration_master as om
+from src.core.utils.seed import seed_all
+
+
+def test_launch_agents_missing_optional(tmp_path):
+    cfg = tmp_path / "agents.yaml"
+    cfg.write_text(
+        """
+        bana:
+          enabled: true
+        asiangen:
+          enabled: true
+        landgraph:
+          enabled: true
+        """
+    )
+
+    called = {}
+    bana_mod = types.ModuleType("agents.bana")
+    bana_mod.launch = lambda: called.setdefault("bana", True)
+    sys.modules["agents.bana"] = bana_mod
+
+    seed_all(1)
+    launched = om.launch_agents_from_config(cfg)
+    assert launched == {"bana": True}
+    assert called.get("bana") is True


### PR DESCRIPTION
## Summary
- load Bana, AsianGen, and LandGraph agents only when enabled in config
- add pipeline config stubs to toggle optional agents
- ensure orchestration gracefully skips missing optional libraries

## Testing
- `pre-commit run --files orchestration_master.py tests/test_orchestration_master.py tests/conftest.py`
- `pytest tests/test_orchestration_master.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adf26416ac832eaa0f1c61236e1219