### PR TITLE
Add schema validation for matrix files and regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ For the project's guiding vision and mission, see
 
 For an end-to-end request pipeline and chakra status summary, see [docs/data_flow.md](docs/data_flow.md) and [docs/chakra_overview.md](docs/chakra_overview.md).
 
+## JSON Schema Validation
+
+Core configuration files ship with JSON Schemas under the `schemas/` directory.
+Validate them to ensure local edits remain well formed:
+
+```bash
+python scripts/validate_schemas.py
+# or individually
+python -m jsonschema schemas/insight_matrix.schema.json insight_matrix.json
+python -m jsonschema schemas/mirror_thresholds.schema.json mirror_thresholds.json
+python -m jsonschema schemas/intent_matrix.schema.json intent_matrix.json
+```
+
 ## Build Tools
 Some dependencies compile native extensions such as SciPy. Install the system
 toolchain before creating the virtual environment:

--- a/insight_compiler.py
+++ b/insight_compiler.py
@@ -11,21 +11,32 @@ from typing import Any, Dict, List
 import jsonschema
 import requests
 
+SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
+
+
+def _load_json(path: Path, schema_file: Path) -> Dict[str, Any]:
+    """Return parsed JSON from ``path`` validated against ``schema_file``."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        schema = json.loads(schema_file.read_text(encoding="utf-8"))
+        jsonschema.validate(data, schema)
+        return data
+    except Exception:  # pragma: no cover - optional files
+        return {}
+
+
 INSIGHT_FILE = Path(__file__).resolve().parent / "insight_matrix.json"
 INSIGHT_MANIFEST_FILE = Path(__file__).resolve().parent / "insight_manifest.json"
-SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
 INSIGHT_SCHEMA_FILE = SCHEMAS_DIR / "insight_matrix.schema.json"
 MANIFEST_SCHEMA_FILE = SCHEMAS_DIR / "insight_manifest.schema.json"
+INTENT_SCHEMA_FILE = SCHEMAS_DIR / "intent_matrix.schema.json"
+MIRROR_SCHEMA_FILE = SCHEMAS_DIR / "mirror_thresholds.schema.json"
 
 # Map ritual glyphs to intents
 _INTENT_FILE = Path(__file__).resolve().parent / "intent_matrix.json"
 _MIRROR_FILE = Path(__file__).resolve().parent / "mirror_thresholds.json"
-try:
-    _INTENT_MAP: Dict[str, Dict[str, Any]] = json.loads(
-        _INTENT_FILE.read_text(encoding="utf-8")
-    )
-except Exception:  # pragma: no cover - file may be missing
-    _INTENT_MAP = {}
+_INTENT_MAP: Dict[str, Dict[str, Any]] = _load_json(_INTENT_FILE, INTENT_SCHEMA_FILE)
+_MIRROR_THRESHOLDS: Dict[str, Any] = _load_json(_MIRROR_FILE, MIRROR_SCHEMA_FILE)
 
 _GLYPHS: Dict[str, set[str]] = {}
 for _name, _info in _INTENT_MAP.items():

--- a/tests/fixtures/insight_compiler/v1.json
+++ b/tests/fixtures/insight_compiler/v1.json
@@ -1,0 +1,27 @@
+{
+  "open portal": {
+    "counts": {
+      "total": 1,
+      "success": 1,
+      "tones": {
+        "joy": {
+          "total": 1,
+          "success": 1
+        }
+      },
+      "emotions": {
+        "joy": {
+          "total": 1,
+          "success": 1
+        }
+      },
+      "responded_with": {
+        "text": 1
+      }
+    },
+    "resonance_index": {},
+    "best_tone": "joy",
+    "action_success_rate": 1.0,
+    "last_updated": "2024-01-01T00:00:00"
+  }
+}

--- a/tests/fixtures/insight_compiler/v2.json
+++ b/tests/fixtures/insight_compiler/v2.json
@@ -1,0 +1,32 @@
+{
+  "open portal": {
+    "counts": {
+      "total": 2,
+      "success": 1,
+      "tones": {
+        "joy": {
+          "total": 2,
+          "success": 1
+        }
+      },
+      "emotions": {
+        "joy": {
+          "total": 1,
+          "success": 1
+        },
+        "sad": {
+          "total": 1,
+          "success": 0
+        }
+      },
+      "responded_with": {
+        "text": 1,
+        "voice": 1
+      }
+    },
+    "resonance_index": {},
+    "best_tone": "joy",
+    "action_success_rate": 0.5,
+    "last_updated": "2024-01-01T00:00:00"
+  }
+}


### PR DESCRIPTION
## Summary
- validate insight, intent, and mirror matrices against their JSON Schemas
- add versioned fixtures and regression test for insight_compiler
- document schema validation commands in README

## Testing
- `pytest tests/test_insight_compiler.py::test_update_insights_regression tests/test_insight_compiler.py::test_json_files_match_schema tests/test_schema_validation.py::test_insight_json_files_validate --override-ini="addopts=" -q`
- `python scripts/validate_schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68adfccbad5c832eabce8ea15c980ac5