### PR TITLE
Add server smoke tests and voice model setup guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,24 @@ PY
           echo "CI checks failed. See the onboarding and architecture guides for help:" \
           && echo "https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_BASE_REF/docs/developer_onboarding.md" \
           && echo "https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_BASE_REF/docs/architecture.md"
+
+  server-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi httpx numpy pytest pytest-cov
+
+      - name: Run server smoke tests
+        env:
+          PYTHONPATH: .
+        run: pytest --noconftest --override-ini="addopts=" tests/test_server.py

--- a/docs/voice_setup.md
+++ b/docs/voice_setup.md
@@ -14,10 +14,16 @@ pip install piper-tts
 
 ## 2. Download a voice model
 
-Create a directory for model weights and fetch a voice file. The example below
-downloads an English voice for Piper and loads it once to populate the cache.
-Any ONNX voice from the Piper repository can be substituted for a different
-language or style:
+Create a directory for model weights and fetch a voice file. ABZU ships with a
+helper to download a few common voices:
+
+```bash
+python download_models.py piper-en-amy-medium
+```
+
+The example below downloads an English voice for Piper and loads it once to
+populate the cache. Any ONNX voice from the Piper repository can be substituted
+for a different language or style:
 
 ```bash
 mkdir -p voices
@@ -42,6 +48,11 @@ custom locations if the files live outside the repository.
 ## 5. Verify synthesis
 
 Start the CLI with `abzu start --speak` or launch the FastAPI server and
-confirm speech is produced. Once cached, the engine will reuse the downloaded
-weights on subsequent runs.
+confirm speech is produced. For a quick command-line check you can run:
+
+```bash
+python -m src.cli.voice "Hello world"
+```
+
+Once cached, the engine will reuse the downloaded weights on subsequent runs.
 


### PR DESCRIPTION
## Summary
- document voice model download and verification steps
- add FastAPI server smoke tests for health, GLM command, avatar frame and music endpoints
- introduce CI job to run server smoke tests

## Testing
- `pytest --noconftest --override-ini="addopts=" tests/test_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae00aa882c832e8b72403ebaa7b980