### PR TITLE
Add log rotation test and document policy

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -109,6 +109,12 @@ records with tools like `jq` or `python -m json.tool`, and review quarantine
 and rotated files periodically. A nightly CI workflow invokes the logger and
 uploads rotated logs as build artifacts for auditing.
 
+Application logs defined in `logging_config.yaml` follow a similar policy.
+`INANNA_AI.log` rotates at 10 MB and keeps the seven most recent archives
+(`INANNA_AI.log.1` – `INANNA_AI.log.7`). Audio logs roll over at 1 MB with up to
+five backups. Each rotated file can be verified with standard checksum tools
+such as `sha256sum` to ensure integrity before archival.
+
 ## Script overview
 
 - **`INANNA_AI_AGENT/inanna_ai.py`** – Activation agent that loads source texts and can recite the INANNA birth chant or feed hex data into the QNL engine. Use `--list` to show available texts.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_interactions_jsonl.py"),
     str(ROOT / "tests" / "test_interactions_jsonl_integrity.py"),
     str(ROOT / "tests" / "test_corpus_memory_logging.py"),
+    str(ROOT / "tests" / "test_logging_config_rotation.py"),
     str(ROOT / "tests" / "test_music_generation.py"),
     str(ROOT / "tests" / "test_music_generation_emotion.py"),
     str(ROOT / "tests" / "test_music_generation_streaming.py"),

--- a/tests/test_logging_config_rotation.py
+++ b/tests/test_logging_config_rotation.py
@@ -1,0 +1,38 @@
+import hashlib
+import logging
+import logging.config
+from pathlib import Path
+
+import yaml
+
+
+def test_logging_rotation(tmp_path):
+    config_path = Path(__file__).resolve().parents[1] / "logging_config.yaml"
+    with config_path.open("r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+
+    log_file = tmp_path / "INANNA_AI.log"
+    config["handlers"]["file"]["filename"] = str(log_file)
+    config["handlers"]["file"]["maxBytes"] = 200
+    config["handlers"]["file"]["backupCount"] = 2
+    audio_file = tmp_path / "audio.log"
+    config["handlers"]["audio"]["filename"] = str(audio_file)
+    logging.config.dictConfig(config)
+
+    logger = logging.getLogger("rotation-test")
+    logger.info("A" * 120)
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    initial_data = log_file.read_bytes()
+    initial_checksum = hashlib.sha256(initial_data).hexdigest()
+
+    logger.info("B" * 120)
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    rolled_file = log_file.with_name("INANNA_AI.log.1")
+    assert rolled_file.exists()
+    assert rolled_file.stat().st_size <= 200
+    rolled_checksum = hashlib.sha256(rolled_file.read_bytes()).hexdigest()
+    assert rolled_checksum == initial_checksum


### PR DESCRIPTION
## Summary
- extend log configuration tests to verify rotation and checksum
- document log rotation policy for general and audio logs

## Testing
- `pre-commit run --files README_OPERATOR.md tests/conftest.py tests/test_logging_config_rotation.py`
- `pytest tests/test_logging_config_rotation.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ae03728828832e88ff869f8ad394ab