### PR TITLE
feat: add hash index and process-safe cortex

### DIFF
--- a/docs/memory_layer.md
+++ b/docs/memory_layer.md
@@ -1,0 +1,39 @@
+# Memory Layer
+
+The `memory.cortex` module stores spiral decisions and maintains an index for
+fast retrieval. Each entry is appended to `data/cortex_memory_spiral.jsonl` and
+metadata is written to `data/cortex_memory_index.json`.
+
+## Hash-based tag lookups
+
+Tags are recorded in plain text and by a deterministic SHA256 hash. Use
+`hash_tag` to compute the hash and query the index without revealing the
+original tag:
+
+```python
+from memory import cortex
+
+h = cortex.hash_tag("quick")
+ids = cortex.search_index(tag_hashes=[h])
+entries = cortex.query_spirals(tag_hashes=[h])
+```
+
+## Concurrency
+
+Reads and writes are protected by a reader/writer lock combined with a file
+lock. Multiple threads or processes can safely interact with the memory files
+without corrupting the index.
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from memory import cortex
+
+node = ...  # object implementing the SpiralNode protocol
+
+def writer(i):
+    cortex.record_spiral(node, {"num": i, "tags": [f"t{i}"]})
+
+with ThreadPoolExecutor(max_workers=4) as ex:
+    for i in range(10):
+        ex.submit(writer, i)
+```


### PR DESCRIPTION
## Summary
- expand cortex memory with SHA256 tag hashes and file-based locks
- cover concurrent thread and process access in tests
- document hash lookups and concurrency in memory layer guide

## Testing
- `pytest tests/test_cortex_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae07d58300832e84115bd5d5a1a9ca