### PR TITLE
Add Nazarick message templates and composer

### DIFF
--- a/agents/albedo/__init__.py
+++ b/agents/albedo/__init__.py
@@ -1,0 +1,5 @@
+"""Albedo agent messaging utilities."""
+
+from .messaging import compose_message_nazarick
+
+__all__ = ["compose_message_nazarick"]

--- a/agents/albedo/messaging.py
+++ b/agents/albedo/messaging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Compose messages for Nazarick entities based on rank and trust."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+from albedo import State, Magnitude
+
+
+@lru_cache(maxsize=1)
+def _load_templates() -> Dict[str, Dict]:
+    """Load Nazarick messaging templates from YAML."""
+
+    path = Path(__file__).with_name("nazarick_templates.yaml")
+    data = yaml.safe_load(path.read_text())
+    return data
+
+
+def compose_message_nazarick(entity: str, state: State, magnitude: Magnitude) -> str:
+    """Return formatted message for ``entity`` given ``state`` and ``magnitude``.
+
+    Parameters
+    ----------
+    entity:
+        Name of the entity (case insensitive).
+    state:
+        Current alchemical :class:`~albedo.State`.
+    magnitude:
+        Trust level as :class:`~albedo.Magnitude`.
+    """
+
+    templates = _load_templates()
+    entity_key = entity.lower()
+    try:
+        rank = templates["entities"][entity_key]
+    except KeyError as exc:
+        raise KeyError(f"Unknown entity: {entity}") from exc
+
+    trust_templates: Dict[str, str] = templates["templates"][str(rank)]
+    trust_value = int(magnitude)
+    # Choose the highest defined trust level not exceeding the given magnitude
+    level = max(int(k) for k in trust_templates.keys() if int(k) <= trust_value)
+    template = trust_templates[str(level)]
+    return template.format(entity=entity, state=state.value, trust=trust_value)
+
+
+__all__ = ["compose_message_nazarick"]

--- a/agents/albedo/nazarick_templates.yaml
+++ b/agents/albedo/nazarick_templates.yaml
@@ -1,0 +1,24 @@
+# Mapping of entities to their rank and message templates by trust level.
+entities:
+  shalltear: 1
+  demiurge: 2
+  cocytus: 3
+  sebas: 4
+
+templates:
+  "1":
+    "0": "Rank 1 {entity}, your loyalty is questioned at trust {trust}. Maintain {state}."
+    "5": "Rank 1 {entity}, your performance is acceptable with trust {trust}. State {state} persists."
+    "10": "Rank 1 {entity}, supreme devotion acknowledged at trust {trust}. Achieve {state}."
+  "2":
+    "0": "Rank 2 {entity}, doubts arise at trust {trust}. {state} wavers."
+    "5": "Rank 2 {entity}, continue operations with trust {trust} and state {state}."
+    "10": "Rank 2 {entity}, exceptional service noted at trust {trust}. Proceed in {state}."
+  "3":
+    "0": "Rank 3 {entity}, trust {trust} is insufficient for {state}."
+    "5": "Rank 3 {entity}, trust {trust} maintains {state}."
+    "10": "Rank 3 {entity}, trust {trust} solidifies {state}."
+  "4":
+    "0": "Rank 4 {entity}, trust {trust} below expectations; {state} constrained."
+    "5": "Rank 4 {entity}, trust {trust} keeps {state} steady."
+    "10": "Rank 4 {entity}, trust {trust} empowers {state} fully."

--- a/tests/test_nazarick_messaging.py
+++ b/tests/test_nazarick_messaging.py
@@ -1,0 +1,22 @@
+from agents.albedo import compose_message_nazarick
+from albedo import State, Magnitude
+
+
+def test_demiurge_message_high_trust():
+    msg = compose_message_nazarick("Demiurge", State.CITRINITAS, Magnitude.EIGHT)
+    expected = "Rank 2 Demiurge, continue operations with trust 8 and state citrinitas."
+    assert msg == expected
+
+
+def test_shalltear_message_low_trust():
+    msg = compose_message_nazarick("Shalltear", State.NIGREDO, Magnitude.ZERO)
+    expected = (
+        "Rank 1 Shalltear, your loyalty is questioned at trust 0. Maintain nigredo."
+    )
+    assert msg == expected
+
+
+def test_cocytus_message_mid_trust():
+    msg = compose_message_nazarick("Cocytus", State.ALBEDO, Magnitude.FIVE)
+    expected = "Rank 3 Cocytus, trust 5 maintains albedo."
+    assert msg == expected


### PR DESCRIPTION
## Summary
- add templated rank/trust messaging for Nazarick entities
- implement `compose_message_nazarick` to format messages using YAML templates
- cover Demiurge, Shalltear, and Cocytus dialogues with unit tests

## Testing
- `pre-commit run --files agents/albedo/__init__.py agents/albedo/messaging.py agents/albedo/nazarick_templates.yaml tests/test_nazarick_messaging.py`
- `PYTHONPATH=src pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68ae1156a474832e99406a13ec3cb2cd