### PR TITLE
Add entity-aware enlightened prompt composer

### DIFF
--- a/INANNA_AI/personality_layers/albedo/enlightened_prompt.py
+++ b/INANNA_AI/personality_layers/albedo/enlightened_prompt.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Helpers to compose prompts for Albedo's enlightened responses."""
+
+from typing import Callable, Dict
+
+from .alchemical_persona import AlchemicalPersona, State
+
+# Human readable fragments describing each state. All phases of the
+# alchemical cycle must be represented here so callers can format
+# prompts without conditional checks.
+STATE_DESCRIPTIONS: Dict[str, str] = {
+    "nigredo": "desc_nigredo",
+    "albedo": "desc_albedo",
+    "rubedo": "desc_rubedo",
+    "citrinitas": "desc_citrinitas",
+}
+
+
+def _compose_deity(state: State, text: str) -> str:
+    """Return prompt line for deity entities."""
+    desc = STATE_DESCRIPTIONS[state.value]
+    return f"DEITY-{state.value}-{desc}:{text}"
+
+
+def _compose_person(state: State, text: str) -> str:
+    """Return prompt line for person entities."""
+    desc = STATE_DESCRIPTIONS[state.value]
+    return f"PERSON-{state.value}-{desc}:{text}"
+
+
+def _compose_object(state: State, text: str) -> str:
+    """Return prompt line for object entities."""
+    desc = STATE_DESCRIPTIONS[state.value]
+    return f"OBJECT-{state.value}-{desc}:{text}"
+
+
+_COMPOSERS: Dict[str, Callable[[State, str], str]] = {
+    "deity": _compose_deity,
+    "person": _compose_person,
+    "object": _compose_object,
+}
+
+
+def _build_enlightened_prompt(persona: AlchemicalPersona, text: str) -> str:
+    """Return a composed prompt based on ``persona``'s entity detection."""
+    entity, _ = persona.detect_state_trigger(text)
+    composer = _COMPOSERS.get(entity, _compose_object)
+    return composer(persona.state, text)
+
+
+__all__ = ["_build_enlightened_prompt", "STATE_DESCRIPTIONS"]

--- a/INANNA_AI/personality_layers/albedo/state_contexts.py
+++ b/INANNA_AI/personality_layers/albedo/state_contexts.py
@@ -6,6 +6,7 @@ CONTEXTS = {
     "nigredo": "[Nigredo] ({entity}) {text} {triggers} {qcontext}",
     "albedo": "[Albedo] ({entity}) {text} {triggers} {qcontext}",
     "rubedo": "[Rubedo] ({entity}) {text} {triggers} {qcontext}",
+    "citrinitas": "[Citrinitas] ({entity}) {text} {triggers} {qcontext}",
 }
 
 __all__ = ["CONTEXTS"]

--- a/tests/test_enlightened_prompt.py
+++ b/tests/test_enlightened_prompt.py
@@ -1,0 +1,45 @@
+"""Tests for enlightened prompt builder."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy optional dependencies before importing the module under test
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+qlm_mod = types.ModuleType("MUSIC_FOUNDATION.qnl_utils")
+setattr(qlm_mod, "quantum_embed", lambda t: np.array([0.0]))
+sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qlm_mod)
+sys.modules.setdefault("SPIRAL_OS", types.ModuleType("SPIRAL_OS"))
+sys.modules.setdefault("SPIRAL_OS.qnl_engine", types.ModuleType("qnl_engine"))
+
+from INANNA_AI.personality_layers.albedo.alchemical_persona import AlchemicalPersona, State
+from INANNA_AI.personality_layers.albedo.enlightened_prompt import _build_enlightened_prompt
+
+
+def test_deity_prompt_selection() -> None:
+    persona = AlchemicalPersona()
+    persona.state = State.NIGREDO
+    out = _build_enlightened_prompt(persona, "the god speaks")
+    assert out == "DEITY-nigredo-desc_nigredo:the god speaks"
+
+
+def test_person_prompt_selection() -> None:
+    persona = AlchemicalPersona()
+    persona.state = State.ALBEDO
+    out = _build_enlightened_prompt(persona, "Alice smiles")
+    assert out == "PERSON-albedo-desc_albedo:Alice smiles"
+
+
+def test_object_prompt_selection() -> None:
+    persona = AlchemicalPersona()
+    persona.state = State.CITRINITAS
+    out = _build_enlightened_prompt(persona, "a stone rests")
+    assert out == "OBJECT-citrinitas-desc_citrinitas:a stone rests"


### PR DESCRIPTION
## Summary
- extend albedo state templates with Citrinitas phase
- add prompt composer that selects persona functions by entity/state
- cover deity, person, and object cases with regression tests

## Testing
- `pytest tests/test_enlightened_prompt.py tests/test_alchemical_persona.py tests/test_albedo_personality.py tests/test_rival_messaging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae16a6a8c8832e9020d84873851bdc