### PR TITLE
Add persona guide, demo, and config validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ PY
       - name: Mypy
         run: mypy
 
+      - name: Validate templates and schemas
+        run: python scripts/validate_configs.py
+
       - name: Run tests
         run: pytest --cov
 

--- a/docs/persona_api_guide.md
+++ b/docs/persona_api_guide.md
@@ -1,0 +1,67 @@
+# Persona API Guide
+
+This guide walks developers through the persona utilities that power Albedo
+interactions.  It shows how to update trust scores, compose messages and adjust
+configuration files.
+
+## Updating trust and state
+
+Use :func:`agents.albedo.trust.update_trust` to record the outcome of an
+interaction.  The function returns the updated trust magnitude along with the
+current alchemical state.
+
+```python
+from agents.albedo.trust import update_trust
+
+magnitude, state = update_trust("Ainz", "positive")
+print(magnitude, state)
+```
+
+Trust values start from the baselines defined in
+``memory/trust_registry.py`` and range from ``Magnitude.ZERO`` to
+``Magnitude.TEN``.  The associated state is computed with the
+:class:`albedo.state_machine.AlbedoStateMachine`.
+
+## Composing persona messages
+
+After updating trust you can build a reply using the messaging helpers.
+``compose_message_nazarick`` formats lines for allies while
+``compose_message_rival`` handles rivals:
+
+```python
+from agents.albedo.messaging import compose_message_nazarick
+from agents.albedo.trust import update_trust
+
+mag, state = update_trust("Ainz", "positive")
+print(compose_message_nazarick("Ainz", state, mag))
+```
+
+The helpers load templates from YAML files in ``agents/albedo``.  Modify the
+``nazarick_templates.yaml`` and ``rival_templates.yaml`` files to customise
+rank mappings and message text.
+
+## CLI demo
+
+A small demonstration utility is provided at
+``scripts/albedo_demo.py``.  It simulates a dialogue cycle by updating the
+trust score and emitting the corresponding message:
+
+```bash
+python scripts/albedo_demo.py Ainz positive
+python scripts/albedo_demo.py Shalltear negative --rival
+```
+
+## Configuration and logs
+
+Template files reside beside the messaging module and are reloaded at runtime.
+Dialogue interactions are appended to ``logs/albedo_interactions.jsonl``.  Delete
+this file to reset the in-memory trust tracker.
+
+Set the ``PYTHONPATH`` to the repository root when using the modules directly:
+
+```bash
+export PYTHONPATH=.
+```
+
+The persona APIs only depend on ``PyYAML`` and ``jsonschema`` which are included
+in the base development requirements.

--- a/scripts/albedo_demo.py
+++ b/scripts/albedo_demo.py
@@ -1,0 +1,35 @@
+"""Command line demo for Albedo persona interactions."""
+
+from __future__ import annotations
+
+import argparse
+
+from agents.albedo.messaging import compose_message_nazarick, compose_message_rival
+from agents.albedo.trust import update_trust
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate Albedo dialogue")
+    parser.add_argument("entity", help="Entity name to interact with")
+    parser.add_argument(
+        "outcome",
+        choices=["positive", "negative", "neutral", "success", "failure"],
+        help="Interaction outcome",
+    )
+    parser.add_argument(
+        "--rival",
+        action="store_true",
+        help="Treat entity as a rival instead of an ally",
+    )
+    args = parser.parse_args()
+
+    magnitude, state = update_trust(args.entity, args.outcome)
+    if args.rival:
+        message = compose_message_rival(args.entity, state, magnitude)
+    else:
+        message = compose_message_nazarick(args.entity, state, magnitude)
+    print(message)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    main()

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -1,0 +1,43 @@
+"""Validate YAML templates and JSON schema files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import validate
+
+SCHEMAS = [
+    ("insight_matrix.json", "insight_matrix.schema.json"),
+    ("insight_manifest.json", "insight_manifest.schema.json"),
+    ("intent_matrix.json", "intent_matrix.schema.json"),
+    ("mirror_thresholds.json", "mirror_thresholds.schema.json"),
+]
+
+
+def _validate_templates() -> None:
+    for name in [
+        "agents/albedo/nazarick_templates.yaml",
+        "agents/albedo/rival_templates.yaml",
+    ]:
+        path = Path(name)
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _validate_schemas() -> None:
+    for data_file, schema_file in SCHEMAS:
+        data_path = Path(data_file)
+        schema_path = Path("schemas") / schema_file
+        data = json.loads(data_path.read_text(encoding="utf-8"))
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        validate(data, schema)
+
+
+def main() -> None:
+    _validate_templates()
+    _validate_schemas()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document Albedo persona APIs and configuration guidance
- provide `albedo_demo.py` CLI to simulate dialogue interactions
- validate YAML templates and JSON schemas in CI

## Testing
- `ruff check scripts/albedo_demo.py scripts/validate_configs.py`
- `black --check scripts/albedo_demo.py scripts/validate_configs.py`
- `python scripts/validate_configs.py`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68ae1abd49ec832e95b8c42cbab9bc46