### PR TITLE
Add tests for vector memory snapshots and clustering

### DIFF
--- a/docs/memory_layer.md
+++ b/docs/memory_layer.md
@@ -37,3 +37,27 @@ with ThreadPoolExecutor(max_workers=4) as ex:
     for i in range(10):
         ex.submit(writer, i)
 ```
+
+## Snapshot restoration
+
+Vector embeddings can be backed up and recovered using helper functions from
+`vector_memory`. Writing a snapshot saves the current collection under the
+configured database directory:
+
+```python
+from vector_memory import persist_snapshot, restore_latest_snapshot
+
+snap = persist_snapshot()  # writes to <db_path>/snapshots
+```
+
+If the main database files are lost, the most recent snapshot can be restored
+before continuing operations:
+
+```python
+restored = restore_latest_snapshot()
+assert restored, "no snapshot found"
+```
+
+The `snapshots/manifest.json` file tracks available snapshots and is updated
+whenever a new one is persisted.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_security_canary.py"),
     str(ROOT / "tests" / "agents" / "test_land_graph_geo_knowledge.py"),
     str(ROOT / "tests" / "test_orchestration_master.py"),
+    str(ROOT / "tests" / "memory" / "test_vector_memory.py"),
 }
 
 

--- a/tests/memory/test_vector_memory.py
+++ b/tests/memory/test_vector_memory.py
@@ -1,0 +1,75 @@
+"""Verify snapshot persistence and clustering for vector memory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import numpy as np
+import vector_memory
+
+
+def _embed(text: str) -> list[float]:
+    """Deterministic embedder based on text length."""
+    return [float(len(text))]
+
+
+def _cluster_embed(text: str) -> np.ndarray:
+    """Simple 2D embeddings to produce two distinct clusters."""
+    if text.startswith("a"):
+        return np.array([1.0, 0.0], dtype=float)
+    return np.array([0.0, 1.0], dtype=float)
+
+
+@pytest.fixture(autouse=True)
+def reset_distance(monkeypatch) -> None:
+    """Ensure distance cache is clear for each test."""
+    monkeypatch.setattr(vector_memory, "_DIST", None)
+
+
+def test_persist_and_restore_snapshot(tmp_path: Path) -> None:
+    """Persist a snapshot and restore it from the latest file."""
+    dbdir = tmp_path / "vm"
+    vector_memory.configure(db_path=dbdir, embedder=_embed, snapshot_interval=1)
+    vector_memory.add_vector("hello", {})
+
+    snap_path = vector_memory.persist_snapshot()
+    assert snap_path.exists()
+
+    manifest = dbdir / "snapshots" / "manifest.json"
+    entries = json.loads(manifest.read_text(encoding="utf-8"))
+    assert str(snap_path) in entries
+
+    for f in dbdir.glob("*.sqlite"):
+        f.unlink()
+
+    vector_memory.configure(db_path=dbdir, embedder=_embed, snapshot_interval=1)
+    assert vector_memory.restore_latest_snapshot() is True
+
+    items = vector_memory.query_vectors(limit=10)
+    assert any(i["text"] == "hello" for i in items)
+
+
+def test_cluster_vectors_and_manifest(tmp_path: Path) -> None:
+    """Cluster stored vectors and persist cluster manifest."""
+    if getattr(vector_memory, "faiss", None) is None and getattr(
+        vector_memory, "KMeans", None
+    ) is None:
+        pytest.skip("no clustering backend available")
+
+    dbdir = tmp_path / "cluster"
+    vector_memory.configure(db_path=dbdir, embedder=_cluster_embed, snapshot_interval=100)
+    for t in ["a1", "a2", "b1", "b2"]:
+        vector_memory.add_vector(t, {})
+
+    clusters = vector_memory.cluster_vectors(k=2, limit=10)
+    counts = sorted(c["count"] for c in clusters)
+    assert counts == [2, 2]
+
+    cluster_path = vector_memory.persist_clusters(k=2, limit=10)
+    assert cluster_path.exists()
+    manifest = dbdir / "snapshots" / "clusters_manifest.json"
+    manifest_entries = json.loads(manifest.read_text(encoding="utf-8"))
+    assert str(cluster_path) in manifest_entries


### PR DESCRIPTION
## Summary
- cover vector memory snapshot persistence and restoration
- exercise clustering logic and manifest creation
- document snapshot restoration flow

## Testing
- `pytest tests/memory/test_vector_memory.py -q --cov=vector_memory --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ee3ed88832e992259b1379b89a7