### PR TITLE
Persist trust scores with optional decay

### DIFF
--- a/agents/albedo/trust.py
+++ b/agents/albedo/trust.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+from datetime import datetime, timedelta
 from typing import Dict, Tuple, Union
 
 from albedo import Magnitude, State
@@ -17,8 +18,48 @@ from memory.trust_registry import (
 TRUST_SCORES: Dict[str, int] = {}
 """In-memory tracker of current trust scores per entity."""
 
+LAST_INTERACTION: Dict[str, datetime] = {}
+"""Last interaction timestamp for each entity."""
+
 LOG_FILE = Path("logs/albedo_interactions.jsonl")
 """Location for dialogue interaction records."""
+
+TRUST_FILE = Path("logs/trust_scores.json")
+"""Persistence file for trust scores and timestamps."""
+
+
+def _now() -> datetime:
+    """Return current UTC time.
+
+    Wrapped for easier testing.
+    """
+    return datetime.utcnow()
+
+
+def _load_scores() -> None:
+    """Populate :data:`TRUST_SCORES` and :data:`LAST_INTERACTION` from disk."""
+    if not TRUST_FILE.exists():
+        return
+    try:
+        data = json.loads(TRUST_FILE.read_text())
+    except json.JSONDecodeError:
+        return
+    for key, info in data.items():
+        try:
+            TRUST_SCORES[key] = int(info["trust"])
+            LAST_INTERACTION[key] = datetime.fromisoformat(info["last"])
+        except (KeyError, ValueError):
+            continue
+
+
+def _save_scores() -> None:
+    """Write current trust state to :data:`TRUST_FILE`."""
+    TRUST_FILE.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        key: {"trust": score, "last": LAST_INTERACTION[key].isoformat()}
+        for key, score in TRUST_SCORES.items()
+    }
+    TRUST_FILE.write_text(json.dumps(data, indent=2))
 
 
 def _category_and_baseline(entity: str) -> Tuple[EntityCategory, int]:
@@ -31,7 +72,9 @@ def _category_and_baseline(entity: str) -> Tuple[EntityCategory, int]:
     return EntityCategory.NEUTRAL, DEFAULT_OUTSIDER_TRUST
 
 
-def update_trust(entity: str, outcome: Union[str, bool]) -> Tuple[Magnitude, State]:
+def update_trust(
+    entity: str, outcome: Union[str, bool], decay_seconds: float | None = None
+) -> Tuple[Magnitude, State]:
     """Adjust trust for ``entity`` based on interaction ``outcome``.
 
     Parameters
@@ -49,6 +92,10 @@ def update_trust(entity: str, outcome: Union[str, bool]) -> Tuple[Magnitude, Sta
     """
     key = entity.lower()
     category, baseline = _category_and_baseline(entity)
+
+    if decay_seconds is not None:
+        _apply_decay(key, baseline, decay_seconds)
+
     trust = TRUST_SCORES.get(key, baseline)
 
     is_positive = outcome in (True, "positive", "success")
@@ -63,10 +110,12 @@ def update_trust(entity: str, outcome: Union[str, bool]) -> Tuple[Magnitude, Sta
         outcome_str = "neutral"
 
     TRUST_SCORES[key] = trust
+    LAST_INTERACTION[key] = _now()
     magnitude = Magnitude(trust)
     state_machine = AlbedoStateMachine()
     state = state_machine.transition(magnitude, category)
     _log_interaction(entity, outcome_str, magnitude, state)
+    _save_scores()
     return magnitude, state
 
 
@@ -85,4 +134,27 @@ def _log_interaction(
         fh.write(json.dumps(entry) + "\n")
 
 
-__all__ = ["update_trust", "TRUST_SCORES", "LOG_FILE"]
+def _apply_decay(key: str, baseline: int, decay_seconds: float) -> None:
+    """Reduce trust toward ``baseline`` based on elapsed time."""
+    last = LAST_INTERACTION.get(key)
+    if not last:
+        return
+    now = _now()
+    elapsed = (now - last).total_seconds()
+    steps = int(elapsed // decay_seconds)
+    if steps <= 0:
+        return
+    trust = TRUST_SCORES.get(key, baseline)
+    if trust > baseline:
+        trust = max(baseline, trust - steps)
+    elif trust < baseline:
+        trust = min(baseline, trust + steps)
+    TRUST_SCORES[key] = trust
+    LAST_INTERACTION[key] = last + timedelta(seconds=steps * decay_seconds)
+    _save_scores()
+
+
+_load_scores()
+
+
+__all__ = ["update_trust", "TRUST_SCORES", "LOG_FILE", "TRUST_FILE"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_music_generation_streaming.py"),
     str(ROOT / "tests" / "test_music_backends_missing.py"),
     str(ROOT / "tests" / "test_albedo_state_machine.py"),
+    str(ROOT / "tests" / "test_albedo_trust.py"),
     str(ROOT / "tests" / "test_vector_memory_extensions.py"),
     str(ROOT / "tests" / "test_cortex_memory.py"),
     str(ROOT / "tests" / "test_voice_cloner_cli.py"),


### PR DESCRIPTION
## Summary
- persist Albedo trust scores to disk with timestamps
- allow optional trust decay based on inactivity
- add tests for trust persistence and decay and enable running them

## Testing
- `pytest tests/test_albedo_trust.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae20969e58832eaa9ed7dbc4a7fb46