### PR TITLE
Handle missing transformers in Bana

### DIFF
--- a/memory/narrative_engine.py
+++ b/memory/narrative_engine.py
@@ -2,12 +2,15 @@
 
 Provides interfaces for recording story events composed of an actor,
 action and symbolism.
+
+Also includes simple helper functions for logging generated stories in
+memory for later retrieval.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, List
 
 
 @dataclass
@@ -29,3 +32,26 @@ class NarrativeEngine:
     def stream(self) -> Iterable[StoryEvent]:
         """Iterate over stored story events."""
         raise NotImplementedError
+
+
+_STORY_LOG: List[str] = []
+
+
+def log_story(text: str) -> None:
+    """Append ``text`` to the in-memory story log."""
+
+    _STORY_LOG.append(text)
+
+
+def stream_stories() -> Iterable[str]:
+    """Yield recorded stories in insertion order."""
+
+    yield from list(_STORY_LOG)
+
+
+__all__ = [
+    "StoryEvent",
+    "NarrativeEngine",
+    "log_story",
+    "stream_stories",
+]

--- a/tests/agents/test_bana.py
+++ b/tests/agents/test_bana.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from agents.bana.bio_adaptive_narrator import generate_story
+
+
+@pytest.fixture
+def synthetic_ecg() -> np.ndarray:
+    """Return a 1-second synthetic ECG-like signal."""
+    t = np.linspace(0, 1, 1000, endpoint=False)
+    return np.sin(2 * np.pi * 1.0 * t)
+
+
+def test_generate_story_with_valid_signal(monkeypatch, synthetic_ecg):
+    """Story generation works with valid data and logs output."""
+
+    def fake_ecg(signal, sampling_rate, show):  # noqa: D401
+        assert sampling_rate == 1000.0
+        return {"heart_rate": np.array([72.0])}
+
+    monkeypatch.setattr(
+        "agents.bana.bio_adaptive_narrator.ecg", SimpleNamespace(ecg=fake_ecg)
+    )
+
+    class DummyGenerator:
+        def __call__(self, prompt, max_new_tokens, num_return_sequences):
+            return [{"generated_text": "Narrative"}]
+
+    monkeypatch.setattr(
+        "agents.bana.bio_adaptive_narrator.pipeline", lambda *a, **k: DummyGenerator()
+    )
+    logged: list[str] = []
+    monkeypatch.setattr(
+        "memory.narrative_engine.log_story", lambda text: logged.append(text)
+    )
+
+    story = generate_story(synthetic_ecg)
+    assert story == "Narrative"
+    assert logged == ["Narrative"]
+
+
+def test_invalid_sampling_rate(synthetic_ecg):
+    """Non-positive sampling rates raise an error."""
+
+    with pytest.raises(ValueError):
+        generate_story(synthetic_ecg, sampling_rate=0)
+
+
+def test_short_signal(monkeypatch):
+    """Signals shorter than one second are rejected."""
+
+    short_signal = np.zeros(100)
+    with pytest.raises(ValueError):
+        generate_story(short_signal, sampling_rate=1000.0)

--- a/tests/agents/test_bana_narrator.py
+++ b/tests/agents/test_bana_narrator.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from types import SimpleNamespace
 
 from agents.bana.bio_adaptive_narrator import generate_story
+from tests.agents.test_bana import synthetic_ecg
 
 
 class DummyGenerator:
@@ -15,21 +17,27 @@ class DummyGenerator:
         return [{"generated_text": "Once upon a time."}]
 
 
-def test_generate_story(monkeypatch):
+def test_generate_story(monkeypatch, synthetic_ecg):
     """generate_story returns narrative text using biosignal input."""
 
     def fake_ecg(signal, sampling_rate, show):  # noqa: D401
+        assert sampling_rate == 1000.0
         return {"heart_rate": np.array([80.0])}
 
     monkeypatch.setattr(
-        "agents.bana.bio_adaptive_narrator.ecg.ecg", fake_ecg
+        "agents.bana.bio_adaptive_narrator.ecg", SimpleNamespace(ecg=fake_ecg)
     )
     generator = DummyGenerator()
     monkeypatch.setattr(
         "agents.bana.bio_adaptive_narrator.pipeline", lambda *a, **k: generator
     )
+    logged: list[str] = []
+    monkeypatch.setattr(
+        "memory.narrative_engine.log_story", lambda text: logged.append(text)
+    )
 
-    story = generate_story([0.1, 0.2, 0.3])
+    story = generate_story(synthetic_ecg)
 
     assert story == "Once upon a time."
     assert "80.0 BPM" in generator.prompt
+    assert logged == ["Once upon a time."]


### PR DESCRIPTION
## Summary
- guard Bana's pipeline creation and biosppy import
- validate ECG sampling parameters and log stories
- add synthetic ECG fixtures and tests

## Testing
- `pytest tests/agents/test_bana.py tests/agents/test_bana_narrator.py --override-ini=addopts= -rs -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae2239ceac832e90747c3d86db77b9