### PR TITLE
Handle missing sentencepiece gracefully

### DIFF
--- a/agents/asian_gen/creative_engine.py
+++ b/agents/asian_gen/creative_engine.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import Optional
 import tempfile
 
-import sentencepiece as spm
+try:  # pragma: no cover - optional dependency
+    import sentencepiece as spm
+except Exception:  # pragma: no cover
+    spm = None
 
 try:  # pragma: no cover - optional dependency
     from transformers import AutoTokenizer, pipeline
@@ -46,6 +49,8 @@ class CreativeEngine:
             except Exception:
                 pass
         if self.spm_path:
+            if spm is None:
+                raise RuntimeError("sentencepiece not installed")
             sp = spm.SentencePieceProcessor()
             sp.load(self.spm_path)
             return sp

--- a/tests/agents/test_asian_gen.py
+++ b/tests/agents/test_asian_gen.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from agents.asian_gen.creative_engine import CreativeEngine
 
 
@@ -43,3 +45,11 @@ def test_sentencepiece_fallback(monkeypatch):
 
     output = engine.generate("hello", locale="ja")
     assert isinstance(output, str) and output
+
+
+def test_sentencepiece_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr("agents.asian_gen.creative_engine.spm", None)
+    monkeypatch.setattr("agents.asian_gen.creative_engine.AutoTokenizer", None)
+    engine = CreativeEngine(spm_path=str(tmp_path / "spm.model"))
+    with pytest.raises(RuntimeError, match="sentencepiece not installed"):
+        engine._load_tokenizer()


### PR DESCRIPTION
## Summary
- guard `sentencepiece` import and raise clear error if absent
- test CreativeEngine's behavior when `sentencepiece` isn't installed

## Testing
- `pre-commit run --files agents/asian_gen/creative_engine.py tests/agents/test_asian_gen.py`
- `pytest tests/agents/test_asian_gen.py::test_sentencepiece_missing -vv -o addopts=''` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68ae27124cd8832eafab5688706486fd