### PR TITLE
Include agents in test coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 pythonpath = src
-addopts = --cov=src --cov-fail-under=0.5
+addopts = --cov=src --cov=agents --cov-fail-under=0.5
 filterwarnings =
     ignore:.*audioop.*:DeprecationWarning
     ignore:Couldn't find ffmpeg or avconv.*:RuntimeWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "test_land_graph_geo_knowledge.py"),
     str(ROOT / "tests" / "test_orchestration_master.py"),
     str(ROOT / "tests" / "memory" / "test_vector_memory.py"),
+    str(ROOT / "tests" / "test_smoke_imports.py"),
 }
 
 

--- a/tests/test_smoke_imports.py
+++ b/tests/test_smoke_imports.py
@@ -1,0 +1,6 @@
+def test_import_src_and_agents():
+    import src
+    import agents
+    import src.core.config as core_config
+    import agents.victim.security_canary as canary
+    assert core_config is not None and canary is not None


### PR DESCRIPTION
## Summary
- include `agents` in pytest coverage configuration
- allow `test_smoke_imports.py` in test collection
- add smoke test that imports modules from `src` and `agents`

## Testing
- `pytest --cov=src --cov=agents tests/test_smoke_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae28242688832e97f55766d813344b