### PR TITLE
Add logging and tests for creative engine

### DIFF
--- a/agents/asian_gen/creative_engine.py
+++ b/agents/asian_gen/creative_engine.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 import tempfile
+import logging
+import os
 
 try:  # pragma: no cover - optional dependency
     import sentencepiece as spm
@@ -24,6 +26,9 @@ except Exception:  # pragma: no cover
     AutoTokenizer = None  # type: ignore
     pipeline = None  # type: ignore
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
 
 @dataclass
 class CreativeEngine:
@@ -31,8 +36,15 @@ class CreativeEngine:
 
     model_name: str = "facebook/mbart-large-50-many-to-many-mmt"
     spm_path: Optional[str] = None
+    log_level: Optional[Union[int, str]] = None
 
     def __post_init__(self) -> None:
+        level: Union[int, str, None] = (
+            self.log_level or os.getenv("CREATIVE_ENGINE_LOG_LEVEL")
+        )
+        if isinstance(level, str):
+            level = getattr(logging, level.upper(), logging.INFO)
+        logger.setLevel(level if isinstance(level, int) else logging.INFO)
         try:
             self.tokenizer = self._load_tokenizer()
         except RuntimeError:
@@ -43,17 +55,21 @@ class CreativeEngine:
     def _load_tokenizer(self):
         if AutoTokenizer is not None:
             try:
-                return AutoTokenizer.from_pretrained(
+                tokenizer = AutoTokenizer.from_pretrained(
                     self.model_name, local_files_only=True
                 )
+                logger.info("Loaded AutoTokenizer")
+                return tokenizer
             except Exception:
-                pass
+                logger.info("AutoTokenizer unavailable; falling back")
         if self.spm_path:
             if spm is None:
                 raise RuntimeError("sentencepiece not installed")
             sp = spm.SentencePieceProcessor()
             sp.load(self.spm_path)
+            logger.info("Using SentencePiece fallback")
             return sp
+        logger.error("No tokenizer available")
         raise RuntimeError("No tokenizer available")
 
     def _ensure_sentencepiece_model(self) -> str:
@@ -74,16 +90,20 @@ class CreativeEngine:
 
     def _build_generator(self):
         if pipeline is None:
+            logger.info("Transformers pipeline not available")
             return None
         try:
-            return pipeline(
+            gen = pipeline(
                 "text-generation",
                 model=self.model_name,
                 tokenizer=self.tokenizer,
                 device=-1,
                 model_kwargs={"local_files_only": True},
             )
+            logger.info("Built transformers generator")
+            return gen
         except Exception:
+            logger.warning("Failed to initialize transformers generator")
             return None
 
     def generate(self, prompt: str, locale: str) -> str:

--- a/tests/agents/test_asian_gen.py
+++ b/tests/agents/test_asian_gen.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import pytest
+from pathlib import Path
 
 from agents.asian_gen.creative_engine import CreativeEngine
 
 
-def test_locale_routed_generation(monkeypatch):
+def test_locale_routed_generation(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
     class DummyTokenizer:
         lang_code_to_id = {"ja": 7}
 
@@ -35,21 +38,42 @@ def test_locale_routed_generation(monkeypatch):
     engine = CreativeEngine()
     text = engine.generate("hello", locale="ja")
     assert text == "response"
+    assert "Loaded AutoTokenizer" in caplog.text
+    assert "Built transformers generator" in caplog.text
 
 
-def test_sentencepiece_fallback(monkeypatch):
+def test_sentencepiece_fallback(monkeypatch, caplog, tmp_path):
     monkeypatch.setattr("agents.asian_gen.creative_engine.AutoTokenizer", None)
     monkeypatch.setattr("agents.asian_gen.creative_engine.pipeline", None)
+
+    class DummySP:
+        class SentencePieceProcessor:
+            def load(self, path):
+                pass
+
+            def encode(self, text, out_type=str):
+                return ["tok"]
+
+        class SentencePieceTrainer:
+            @staticmethod
+            def train(input, model_prefix, **kwargs):
+                Path(model_prefix + ".model").touch()
+
+    monkeypatch.setattr("agents.asian_gen.creative_engine.spm", DummySP)
+    caplog.set_level(logging.INFO)
 
     engine = CreativeEngine()
 
     output = engine.generate("hello", locale="ja")
     assert isinstance(output, str) and output
+    assert "Using SentencePiece fallback" in caplog.text
+    assert "Transformers pipeline not available" in caplog.text
 
 
 def test_sentencepiece_missing(monkeypatch, tmp_path):
     monkeypatch.setattr("agents.asian_gen.creative_engine.spm", None)
     monkeypatch.setattr("agents.asian_gen.creative_engine.AutoTokenizer", None)
-    engine = CreativeEngine(spm_path=str(tmp_path / "spm.model"))
+    engine = CreativeEngine.__new__(CreativeEngine)
+    engine.spm_path = str(tmp_path / "spm.model")
     with pytest.raises(RuntimeError, match="sentencepiece not installed"):
         engine._load_tokenizer()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_voice_cloner_cli.py"),
     str(ROOT / "tests" / "test_security_canary.py"),
     str(ROOT / "tests" / "agents" / "test_land_graph_geo_knowledge.py"),
+    str(ROOT / "tests" / "agents" / "test_asian_gen.py"),
     str(ROOT / "tests" / "test_orchestration_master.py"),
     str(ROOT / "tests" / "memory" / "test_vector_memory.py"),
     str(ROOT / "tests" / "test_smoke_imports.py"),


### PR DESCRIPTION
## Summary
- add module-level logger and configurable log level for CreativeEngine
- log tokenizer/generator branch decisions
- cover logging branches with caplog tests

## Testing
- `pytest tests/agents/test_asian_gen.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae299df9cc832e873272949ef1646a