### PR TITLE
chore: quiet test warnings

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,3 +25,9 @@ flowchart LR
 
 - During this test run, the CLI setup encountered dependency initialization issues, preventing the prompt from appearing.
 - `start_avatar_console.sh` reported a permission error for `start_crown_console.sh` and the WebRTC video stream did not start.
+
+## Common test failure modes
+
+- Missing pytest plugins such as `pytest-cov` will cause command-line options errors. Install required dev dependencies.
+- Duplicate or conflicting test module names can trigger collection errors like "import file mismatch". Remove `__pycache__` files or rename tests to be unique.
+- ImportError during test collection often indicates missing runtime dependencies or incorrect module paths. Verify imports such as `core.load_config` exist or adjust `PYTHONPATH`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 pythonpath = src
-addopts = --cov=src --cov=agents --cov-fail-under=0.5
+addopts = --cov=src --cov=agents --cov-fail-under=0.5 --log-cli-level=INFO
 filterwarnings =
     ignore:.*audioop.*:DeprecationWarning
     ignore:Couldn't find ffmpeg or avconv.*:RuntimeWarning
+    ignore:enable_nested_tensor is True, but self.use_nested_tensor is False.*:UserWarning


### PR DESCRIPTION
## Summary
- filter noisy nested tensor warning from torch
- show CLI logs during tests
- document common test failure modes

## Testing
- `pytest -vv --strict-markers`
- `pre-commit run --files pytest.ini docs/testing.md`

------
https://chatgpt.com/codex/tasks/task_e_68ae2b11f52c832ea886185e27ab5956