### PR TITLE
docs: add contributor resources links

### DIFF
--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -131,3 +131,9 @@ Robust health checks keep the system stable and observable.
 General guidance: stop the failed service, confirm dependencies, and restart
 following the startup order. For persistent issues, consult the
 [Recovery Playbook](recovery_playbook.md) to restore from snapshots.
+
+## Contributor Resources
+
+- [Developer Onboarding](developer_onboarding.md)
+- [Development Workflow](development_workflow.md)
+- [Coding Style](coding_style.md)


### PR DESCRIPTION
## Summary
- append a "Contributor Resources" section in system blueprint
- link to developer onboarding, development workflow, and coding style guides

## Testing
- `pre-commit run --files docs/system_blueprint.md`
- `pytest` *(fails: import mismatch and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3754cee4832eb929a616e588b032