### PR TITLE
docs: document RAZAR startup orchestrator

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -1,0 +1,26 @@
+# RAZAR Agent
+
+RAZAR serves as the startup orchestrator for Nazarick, acting as "service 0". It prepares the runtime before any other agent activates.
+
+## Component Priority
+
+RAZAR ranks downstream components on a 1‑5 scale:
+
+1. **Critical** – mandatory for boot.
+2. **Required** – core functionality.
+3. **Important** – enhances core but can start later.
+4. **Optional** – noncritical utilities.
+5. **Experimental** – development or diagnostic helpers.
+
+This classification guides launch order and restart policy.
+
+## Virtual Environment Management and Restart Logic
+
+RAZAR ensures a clean Python virtual environment:
+
+- creates or updates the `venv` at startup,
+- verifies required packages against `requirements.txt`,
+- injects paths into `PYTHONPATH` for launched services.
+
+If a component exits or the environment hash changes, RAZAR restarts the affected process. Repeated failures trigger a full environment rebuild and orchestrator restart.
+

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -4,6 +4,7 @@ This guide summarizes core agents within ABZU's Nazarick system. Each agent alig
 
 | Agent | Role | Chakra | Memory Scope | External Libraries | Stub |
 | --- | --- | --- | --- | --- | --- |
+| RAZAR Startup Orchestrator | Startup orchestration and venv supervision | Crown | `requirements.txt`, service registry | `venv`, `subprocess` | [RAZAR_AGENT.md](RAZAR_AGENT.md) |
 | Orchestration Master | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [orchestration_master.py](../orchestration_master.py) |
 | Prompt Orchestrator | Prompt routing and agent interface | Throat | Prompt/response JSON payloads | LLM APIs | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
 | QNL Engine | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |


### PR DESCRIPTION
## Summary
- document RAZAR startup orchestrator as service 0 with priority scheme and restart logic
- reference RAZAR agent from Nazarick agents overview

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/nazarick_agents.md`

------
https://chatgpt.com/codex/tasks/task_e_68ae776039f8832e891f84c6fd6f4f4a