### PR TITLE
docs: add ignition startup reference

### DIFF
--- a/docs/Ignition.md
+++ b/docs/Ignition.md
@@ -1,0 +1,44 @@
+# Ignition
+
+RAZAR coordinates system boot and records runtime health. Components are grouped by priority so operators can track startup order and service status.
+
+## Priority 0 – Orchestrator
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 0 | RAZAR Startup Orchestrator | `razar --status` | ⚠️ |
+
+## Priority 1 – Persistence
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 1 | Memory Store | `curl http://memory/ready` | ⚠️ |
+
+## Priority 2 – Gateways
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 2 | Chat Gateway | `curl http://chat/health` | ⚠️ |
+| 3 | CROWN LLM | dummy prompt round‑trip | ⚠️ |
+
+## Priority 3 – Audio
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 4 | Audio Device | loopback test | ⚠️ |
+
+## Priority 4 – Avatar
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 5 | Avatar | frame render ping | ⚠️ |
+
+## Priority 5 – Video
+| Order | Component | Health Check | Status |
+| --- | --- | --- | --- |
+| 6 | Video | stream probe | ⚠️ |
+
+## Regeneration
+RAZAR monitors component events and rewrites this file whenever a priority or health state changes. Status markers update to:
+
+- ✅ healthy
+- ⚠️ starting or degraded
+- ❌ offline
+
+This keeps the ignition sequence in version control so operators can audit boot cycles.
+

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -14,6 +14,7 @@ For high-level orientation, consult:
 For deeper guidance on operations and reliability, refer to:
 
 - [Deployment Guide](deployment.md)
+- [Ignition Sequence](Ignition.md)
 - [Monitoring](monitoring.md)
 - [Testing](testing.md)
 - [Recovery Playbook](recovery_playbook.md)


### PR DESCRIPTION
## Summary
- document ignition sequence with component priorities, health checks and status markers
- link ignition reference from system blueprint

## Testing
- `pre-commit run --files docs/Ignition.md docs/system_blueprint.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae790f97c8832e8bb5d13ae0314c71