### PR TITLE
feat(razar): generate ignition status from blueprint

### DIFF
--- a/agents/razar/ignition_builder.py
+++ b/agents/razar/ignition_builder.py
@@ -1,0 +1,121 @@
+"""Generate Ignition.md from system_blueprint.md."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+
+def parse_system_blueprint(path: Path) -> List[Dict[str, object]]:
+    """Extract component data from ``system_blueprint.md``.
+
+    Returns a list of dictionaries containing the component order,
+    name, priority and health check command (if available).
+    """
+
+    text = path.read_text(encoding="utf-8")
+
+    # Collect component metadata from their sections
+    heading_re = re.compile(r"^###\s+(.*)$", re.MULTILINE)
+    headings = list(heading_re.finditer(text))
+    meta: Dict[str, Dict[str, object]] = {}
+    for idx, match in enumerate(headings):
+        name = match.group(1).strip()
+        start = match.end()
+        end = headings[idx + 1].start() if idx + 1 < len(headings) else len(text)
+        section = text[start:end]
+        prio_match = re.search(r"-\s*\*\*Priority:\*\*\s*(\d+)", section)
+        hc_match = re.search(r"-\s*\*\*Health Check:\*\*\s*(.+)", section)
+        if prio_match:
+            meta[name] = {
+                "priority": int(prio_match.group(1)),
+                "health_check": hc_match.group(1).strip() if hc_match else "",
+            }
+
+    # Parse the staged startup order for component ordering
+    order_re = re.compile(
+        r"^(\d+)\.\s+(.*?)\s*\(.*?priority\s+(\d+)\)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    components: List[Dict[str, object]] = []
+    for match in order_re.finditer(text):
+        order = int(match.group(1))
+        name = match.group(2).strip()
+        priority = int(match.group(3))
+        health_check = ""
+        for meta_name, data in meta.items():
+            if name.lower().startswith(
+                meta_name.lower()
+            ) or meta_name.lower().startswith(name.lower()):
+                health_check = data["health_check"]
+                break
+        components.append(
+            {
+                "order": order,
+                "name": name,
+                "priority": priority,
+                "health_check": health_check,
+            }
+        )
+
+    return components
+
+
+def build_ignition(system_blueprint: Path, output: Path) -> None:
+    """Build the Ignition markdown file."""
+
+    components = parse_system_blueprint(system_blueprint)
+    groups: Dict[int, List[Dict[str, object]]] = defaultdict(list)
+    for comp in components:
+        groups[int(comp["priority"])].append(comp)
+
+    lines = [
+        "# Ignition",
+        "",
+        (
+            "RAZAR coordinates system boot and records runtime health. "
+            "Components are grouped by priority so operators can track "
+            "startup order and service status."
+        ),
+        "",
+    ]
+
+    for priority in sorted(groups):
+        lines.append(f"## Priority {priority}")
+        lines.append("| Order | Component | Health Check | Status |")
+        lines.append("| --- | --- | --- | --- |")
+        for comp in sorted(groups[priority], key=lambda c: c["order"]):
+            health_check = comp["health_check"] or "-"
+            lines.append(f"| {comp['order']} | {comp['name']} | {health_check} | ⚠️ |")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Regeneration",
+            (
+                "RAZAR monitors component events and rewrites this file whenever a "
+                "priority or health state changes. Status markers update to:"
+            ),
+            "",
+            "- ✅ healthy",
+            "- ⚠️ starting or degraded",
+            "- ❌ offline",
+            "",
+            "This keeps the ignition sequence in version control so operators can "
+            "audit boot cycles.",
+            "",
+        ]
+    )
+
+    output.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[2]
+    build_ignition(root / "docs" / "system_blueprint.md", root / "docs" / "Ignition.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/Ignition.md
+++ b/docs/Ignition.md
@@ -2,36 +2,36 @@
 
 RAZAR coordinates system boot and records runtime health. Components are grouped by priority so operators can track startup order and service status.
 
-## Priority 0 – Orchestrator
+## Priority 0
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 0 | RAZAR Startup Orchestrator | `razar --status` | ⚠️ |
+| 0 | RAZAR Startup Orchestrator | Confirm the environment hash and orchestrator heartbeat. | ⚠️ |
 
-## Priority 1 – Persistence
+## Priority 1
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 1 | Memory Store | `curl http://memory/ready` | ⚠️ |
+| 1 | Memory Store | - | ⚠️ |
 
-## Priority 2 – Gateways
+## Priority 2
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 2 | Chat Gateway | `curl http://chat/health` | ⚠️ |
-| 3 | CROWN LLM | dummy prompt round‑trip | ⚠️ |
+| 2 | Chat Gateway | Probe `/chat/health` and watch latency. | ⚠️ |
+| 3 | CROWN LLM | Send a dummy prompt and inspect response time. | ⚠️ |
 
-## Priority 3 – Audio
+## Priority 3
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 4 | Audio Device | loopback test | ⚠️ |
+| 4 | Audio Device | Run an audio loopback test. | ⚠️ |
 
-## Priority 4 – Avatar
+## Priority 4
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 5 | Avatar | frame render ping | ⚠️ |
+| 5 | Avatar | Verify avatar frame rendering. | ⚠️ |
 
-## Priority 5 – Video
+## Priority 5
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 6 | Video | stream probe | ⚠️ |
+| 6 | Video | Probe the video stream endpoint. | ⚠️ |
 
 ## Regeneration
 RAZAR monitors component events and rewrites this file whenever a priority or health state changes. Status markers update to:
@@ -41,4 +41,3 @@ RAZAR monitors component events and rewrites this file whenever a priority or he
 - ❌ offline
 
 This keeps the ignition sequence in version control so operators can audit boot cycles.
-

--- a/tests/agents/razar/test_ignition_builder.py
+++ b/tests/agents/razar/test_ignition_builder.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from agents.razar.ignition_builder import build_ignition
+
+
+def test_build_ignition(tmp_path: Path) -> None:
+    blueprint = tmp_path / "system_blueprint.md"
+    blueprint.write_text(
+        """
+### Alpha
+- **Priority:** 1
+- **Health Check:** check alpha
+
+### Beta
+- **Priority:** 2
+- **Health Check:** check beta
+
+## Staged Startup Order
+0. Alpha (priority 1)
+1. Beta (priority 2)
+        """,
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "Ignition.md"
+    build_ignition(blueprint, output)
+
+    content = output.read_text(encoding="utf-8")
+    assert "## Priority 1" in content
+    assert "## Priority 2" in content
+    assert "| 0 | Alpha | check alpha | ⚠️ |" in content
+    assert "| 1 | Beta | check beta | ⚠️ |" in content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_orchestration_master.py"),
     str(ROOT / "tests" / "memory" / "test_vector_memory.py"),
     str(ROOT / "tests" / "test_smoke_imports.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_ignition_builder.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- add ignition_builder to parse system_blueprint.md and write docs/Ignition.md
- expose command line entry to regenerate ignition status
- test ignition_builder and allow test in suite

## Testing
- `pre-commit run --files agents/razar/ignition_builder.py tests/agents/razar/test_ignition_builder.py tests/conftest.py`
- `pytest tests/agents/razar/test_ignition_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae7ae39860832ea0b8942893862b3e