### PR TITLE
Add RAZAR runtime manager with resume capability

### DIFF
--- a/agents/razar/runtime_manager.py
+++ b/agents/razar/runtime_manager.py
@@ -1,0 +1,140 @@
+"""RAZAR runtime manager.
+
+This module ensures a Python virtual environment exists and uses it to
+sequentially start system components based on their priority. Progress is
+logged and the last successfully started component is cached so the manager can
+resume from that point after a failure.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List
+import venv
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependencies handled by tests
+    raise RuntimeError("pyyaml is required to load razar configuration") from exc
+
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeManager:
+    """Start components defined in a configuration file."""
+
+    def __init__(
+        self,
+        config_path: Path,
+        *,
+        state_path: Path | None = None,
+        venv_path: Path | None = None,
+    ) -> None:
+        self.config_path = config_path
+        self.state_path = state_path or config_path.with_suffix(".state")
+        self.venv_path = venv_path or config_path.parent / ".razar_venv"
+    # ------------------------------------------------------------------
+    # Virtual environment handling
+    # ------------------------------------------------------------------
+    def ensure_venv(self) -> None:
+        """Create a virtual environment if missing."""
+
+        if not self.venv_path.exists():
+            logger.info("Creating virtual environment at %s", self.venv_path)
+            builder = venv.EnvBuilder(with_pip=False)
+            builder.create(self.venv_path)
+        else:
+            logger.info("Using existing virtual environment at %s", self.venv_path)
+
+    # ------------------------------------------------------------------
+    # State persistence helpers
+    # ------------------------------------------------------------------
+    def load_state(self) -> str:
+        """Return the name of the last successful component."""
+
+        if self.state_path.exists():
+            return self.state_path.read_text(encoding="utf-8").strip()
+        return ""
+
+    def save_state(self, name: str) -> None:
+        self.state_path.write_text(name, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Component execution
+    # ------------------------------------------------------------------
+    def _env(self) -> Dict[str, str]:
+        env = os.environ.copy()
+        bin_dir = "Scripts" if os.name == "nt" else "bin"
+        env["VIRTUAL_ENV"] = str(self.venv_path)
+        env["PATH"] = str(self.venv_path / bin_dir) + os.pathsep + env.get("PATH", "")
+        return env
+
+    def _load_components(self) -> List[Dict[str, object]]:
+        data = yaml.safe_load(self.config_path.read_text(encoding="utf-8"))
+        components = data.get("components", []) if isinstance(data, dict) else []
+        return sorted(components, key=lambda c: int(c.get("priority", 0)))
+
+    def _starting_index(self, components: Iterable[Dict[str, object]]) -> int:
+        last = self.load_state()
+        if not last:
+            return 0
+        for idx, comp in enumerate(components):
+            if comp.get("name") == last:
+                return idx + 1
+        return 0
+
+    def run(self) -> bool:
+        """Run components in order. Returns ``True`` if all succeed."""
+
+        self.ensure_venv()
+        components = self._load_components()
+        start = self._starting_index(components)
+        env = self._env()
+
+        for comp in components[start:]:
+            name = comp.get("name", "<unknown>")
+            command = comp.get("command", "")
+            logger.info("Starting component %s", name)
+            result = subprocess.run(
+                command,
+                shell=True,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(self.config_path.parent),
+            )
+            if result.returncode == 0:
+                logger.info("Component %s started successfully", name)
+                self.save_state(str(name))
+                continue
+
+            logger.error(
+                "Component %s failed with code %s\n%s",
+                name,
+                result.returncode,
+                result.stdout,
+            )
+            return False
+
+        return True
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run components via RAZAR")
+    parser.add_argument("config", type=Path, help="Path to razar_config.yaml")
+    args = parser.parse_args()
+
+    manager = RuntimeManager(args.config)
+    success = manager.run()
+    raise SystemExit(0 if success else 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/config/razar_config.yaml
+++ b/config/razar_config.yaml
@@ -1,0 +1,4 @@
+components:
+  - name: example
+    priority: 1
+    command: "echo 'RAZAR component running'"

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -1,26 +1,33 @@
-# RAZAR Agent
+# RAZAR Runtime Manager
 
-RAZAR serves as the startup orchestrator for Nazarick, acting as "service 0". It prepares the runtime before any other agent activates.
+`RuntimeManager` coordinates the startup of RAZAR components. It ensures a
+Python virtual environment exists, launches components in order of their
+priority and records the last successful component so a failed run can resume
+from that point.
 
-## Component Priority
+## Configuration
 
-RAZAR ranks downstream components on a 1‑5 scale:
+Components and their priorities are defined in a YAML file. An example lives at
+`config/razar_config.yaml`:
 
-1. **Critical** – mandatory for boot.
-2. **Required** – core functionality.
-3. **Important** – enhances core but can start later.
-4. **Optional** – noncritical utilities.
-5. **Experimental** – development or diagnostic helpers.
+```yaml
+components:
+  - name: example
+    priority: 1
+    command: "echo 'RAZAR component running'"
+```
 
-This classification guides launch order and restart policy.
+Each entry lists a component name, numeric priority (lower values start first)
+and the shell command used to launch it.
 
-## Virtual Environment Management and Restart Logic
+## Usage
 
-RAZAR ensures a clean Python virtual environment:
+Run the manager by pointing it at the configuration file:
 
-- creates or updates the `venv` at startup,
-- verifies required packages against `requirements.txt`,
-- injects paths into `PYTHONPATH` for launched services.
+```bash
+python -m agents.razar.runtime_manager config/razar_config.yaml
+```
 
-If a component exits or the environment hash changes, RAZAR restarts the affected process. Repeated failures trigger a full environment rebuild and orchestrator restart.
-
+On failure, the manager writes the last successful component to a `.state` file
+next to the configuration. Re‑running the command starts from the component
+following that entry.

--- a/tests/agents/razar/test_runtime_manager.py
+++ b/tests/agents/razar/test_runtime_manager.py
@@ -1,0 +1,59 @@
+import logging
+
+import yaml
+
+from agents.razar.runtime_manager import RuntimeManager
+
+
+def _touch_cmd(filename: str) -> str:
+    return f"python -c \"import pathlib; pathlib.Path('{filename}').touch()\""
+
+
+def _write_exec_cmd(filename: str) -> str:
+    return (
+        "python -c \"import pathlib,sys; "
+        f"pathlib.Path('{filename}').write_text(sys.executable)\""
+    )
+
+
+def test_runtime_manager_resume(tmp_path, caplog):
+    config_path = tmp_path / "razar_config.yaml"
+    state_path = tmp_path / "run.state"
+    venv_path = tmp_path / "venv"
+
+    config = {
+        "components": [
+            {"name": "beta", "priority": 2, "command": _touch_cmd("beta.txt")},
+            {"name": "alpha", "priority": 1, "command": _write_exec_cmd("alpha.txt")},
+            {"name": "gamma", "priority": 3, "command": _touch_cmd("gamma.txt")},
+        ]
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    manager = RuntimeManager(config_path, state_path=state_path, venv_path=venv_path)
+
+    # First run – alpha succeeds, beta fails, gamma skipped
+    config["components"][0]["command"] = "python -c 'import sys; sys.exit(1)'"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        success = manager.run()
+    assert not success
+    assert (tmp_path / "alpha.txt").exists()
+    assert not (tmp_path / "beta.txt").exists()
+    assert not (tmp_path / "gamma.txt").exists()
+    assert state_path.read_text(encoding="utf-8") == "alpha"
+    exec_path = (tmp_path / "alpha.txt").read_text(encoding="utf-8")
+    assert str(venv_path) in exec_path
+
+    # Second run – fix beta command and ensure resume
+    config["components"][0]["command"] = _touch_cmd("beta.txt")
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        success = manager.run()
+    assert success
+    assert (tmp_path / "beta.txt").exists()
+    assert (tmp_path / "gamma.txt").exists()
+    assert state_path.read_text(encoding="utf-8") == "gamma"
+    assert any("Starting component beta" in r.message for r in caplog.records)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "memory" / "test_vector_memory.py"),
     str(ROOT / "tests" / "test_smoke_imports.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_ignition_builder.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_runtime_manager.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- add `RuntimeManager` to orchestrate component startup in a dedicated virtual env and resume after failures
- provide sample `razar_config.yaml` and documentation
- test resume behaviour

## Testing
- `python -m pytest tests/agents/razar/test_runtime_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae7c0bf73c832e802d865c35199276