### PR TITLE
docs: document razar startup and health checks

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -26,6 +26,26 @@ Several JSON fields are emitted by the system:
 - `path` and `method` for HTTP requests handled by the FastAPI middleware.
 - `duration` in seconds for any of the above operations.
 
+## RAZAR health
+
+Launch the RAZAR orchestrator before scraping metrics so it can supervise
+services and report status:
+
+```bash
+python -m agents.razar.runtime_manager config/razar_config.yaml
+```
+
+RAZAR provides a `/health` endpoint exposing an environment hash and heartbeat.
+Probe it directly or via Prometheus to verify the orchestrator is running:
+
+```bash
+curl http://localhost:9300/health
+```
+
+If RAZAR cannot restart components, rebuild the virtual environment and rerun
+the manager. Deleting the `.state` file next to the configuration forces a
+full restart cycle.
+
 ## Timing metrics
 
 Latency histograms are exported via Prometheus:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,5 +1,21 @@
 # Operations
 
+## RAZAR startup
+
+Launch the RAZAR runtime manager before any other component to prepare the
+environment and start services in priority order:
+
+```bash
+python -m agents.razar.runtime_manager config/razar_config.yaml
+```
+
+The orchestrator builds or validates the dedicated virtual environment and
+records the last successful component in a `.state` file. Monitor the
+`/health` endpoint to confirm the environment hash and heartbeat.
+
+If RAZAR cannot restart a component, rebuild the virtual environment and rerun
+the manager. Removing the `.state` file forces a full restart sequence.
+
 ## Dependency audits
 
 Use `tools/dependency_audit.py` to ensure installed packages match the pinned


### PR DESCRIPTION
## Summary
- add RAZAR startup instructions to operations guide
- describe RAZAR health endpoint, monitoring hooks, and recovery steps

## Testing
- `pre-commit run --files docs/operations.md docs/monitoring.md`

------
https://chatgpt.com/codex/tasks/task_e_68aebe4b95e0832e964d5b8ca399b23a