### PR TITLE
docs: add RAZAR startup orchestrator entry

### DIFF
--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -4,7 +4,7 @@ This guide summarizes core agents within ABZU's Nazarick system. Each agent alig
 
 | Agent | Role | Chakra | Memory Scope | External Libraries | Stub |
 | --- | --- | --- | --- | --- | --- |
-| RAZAR Startup Orchestrator | Startup orchestration and venv supervision | Crown | `requirements.txt`, service registry | `venv`, `subprocess` | [RAZAR_AGENT.md](RAZAR_AGENT.md) |
+| RAZAR | Startup Orchestrator | Crown | `requirements.txt`, service registry | `venv`, `subprocess` | [RAZAR_AGENT.md](RAZAR_AGENT.md) |
 | Orchestration Master | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [orchestration_master.py](../orchestration_master.py) |
 | Prompt Orchestrator | Prompt routing and agent interface | Throat | Prompt/response JSON payloads | LLM APIs | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
 | QNL Engine | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |


### PR DESCRIPTION
## Summary
- list RAZAR as Startup Orchestrator in Nazarick agents table

## Testing
- `pre-commit run --files docs/nazarick_agents.md`

------
https://chatgpt.com/codex/tasks/task_e_68aec0577cac832e8e8ffd39ab24e78d