### PR TITLE
Invoke RAZAR before agents

### DIFF
--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -31,6 +31,13 @@ else
     exit 1
 fi
 
+# Start RAZAR runtime manager before launching servants; it orchestrates components by priority
+log "Starting RAZAR runtime manager"
+if ! python -m agents.razar.runtime_manager "${RAZAR_CONFIG:-config/razar_config.yaml}" >>"$LOG_FILE" 2>&1; then
+    log "RAZAR failed to start"
+    exit 1
+fi
+
 SERVANTS_FILE="${SERVANT_ENDPOINTS_FILE:-$ROOT/servant_endpoints.tmp}"
 : >"$SERVANTS_FILE"
 


### PR DESCRIPTION
## Summary
- Start RAZAR runtime manager before development agents run so downstream components launch in priority order
- Launch servants only after RAZAR orchestrates prerequisite components

## Testing
- `pre-commit run --files start_dev_agents.py launch_servants.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aec119a770832e847815d3635eeac5