### PR TITLE
Add RAZAR environment builder

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -18,3 +18,18 @@ Once the environment is cleared, RAZAR launches the system in order:
 RAZAR does not reside within the Nazarick agent hierarchy. Its sole mission is
 to ready the host and then hand off control to the internal agents once both
 Inanna and the CROWN model are running.
+
+## Recreating the Environment
+When the runtime becomes polluted or dependencies drift, rebuild the virtual
+environment before starting services:
+
+1. Define package lists for each component layer in `razar_env.yaml`.
+2. Execute the builder from the repository root:
+   ```bash
+   python -m razar.environment_builder --venv .razar_venv
+   ```
+   The script verifies the Python version, creates the virtual environment and
+   installs all layer packages.
+3. Re-run the RAZAR runtime manager to launch components.
+
+These steps guarantee a clean foundation for Inanna and CROWN.

--- a/razar/environment_builder.py
+++ b/razar/environment_builder.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Environment builder for RAZAR.
+
+This module verifies that a suitable Python interpreter is available,
+creates an isolated virtual environment and installs dependencies for
+each component layer defined in a configuration file.
+"""
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+import venv
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - handled in tests
+    raise RuntimeError("pyyaml is required to load environment configuration") from exc
+
+LOGGER = logging.getLogger("razar.environment_builder")
+
+
+def ensure_python(version: str) -> None:
+    """Ensure ``version`` of Python is available.
+
+    The builder relies on ``pyenv`` for installation if the requested version
+    does not match the current interpreter. If ``pyenv`` is not present an
+    informative error is raised.
+    """
+
+    current = f"{sys.version_info.major}.{sys.version_info.minor}"
+    if current.startswith(version):
+        LOGGER.info("Using system Python %s", current)
+        return
+
+    LOGGER.info("Installing Python %s via pyenv", version)
+    try:
+        subprocess.run(["pyenv", "install", "-s", version], check=True)
+    except Exception as exc:  # pragma: no cover - depends on host
+        raise RuntimeError(
+            f"Python {version} required but pyenv installation failed"
+        ) from exc
+
+
+def create_virtualenv(path: Path) -> None:
+    """Create a virtual environment at ``path`` if missing."""
+
+    if path.exists():
+        LOGGER.info("Using existing virtual environment at %s", path)
+        return
+
+    LOGGER.info("Creating virtual environment at %s", path)
+    builder = venv.EnvBuilder(with_pip=True)
+    builder.create(path)
+
+
+def _pip_executable(venv_path: Path) -> Path:
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    return venv_path / bin_dir / "pip"
+
+
+def install_packages(venv_path: Path, packages: list[str]) -> None:
+    """Install ``packages`` into the virtual environment located at ``venv_path``."""
+
+    if not packages:
+        return
+    pip = _pip_executable(venv_path)
+    cmd = [str(pip), "install", "--disable-pip-version-check", *packages]
+    LOGGER.info("Installing packages: %s", ", ".join(packages))
+    subprocess.run(cmd, check=True)
+
+
+def install_layers(config_path: Path, venv_path: Path) -> None:
+    """Install dependencies for each layer defined in ``config_path``."""
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    layers = data.get("layers", {})
+    for name, packages in layers.items():
+        LOGGER.info("\n--- Installing layer: %s ---", name)
+        install_packages(venv_path, list(packages or []))
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    parser = argparse.ArgumentParser(description="Build RAZAR environment")
+    default_cfg = Path(__file__).resolve().parent.parent / "razar_env.yaml"
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=default_cfg,
+        help="Path to razar_env.yaml",
+    )
+    parser.add_argument(
+        "--python",
+        default=f"{sys.version_info.major}.{sys.version_info.minor}",
+        help="Python version to ensure",
+    )
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        default=Path(".razar_venv"),
+        help="Location for virtual environment",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    ensure_python(str(args.python))
+    create_virtualenv(args.venv)
+    install_layers(args.config, args.venv)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/razar_env.yaml
+++ b/razar_env.yaml
@@ -1,0 +1,7 @@
+layers:
+  razar:
+    - pyyaml
+  inanna:
+    - requests
+  crown:
+    - numpy


### PR DESCRIPTION
## Summary
- add `razar.environment_builder` to set up Python and install layer dependencies
- provide `razar_env.yaml` defining packages for each component layer
- document virtual environment rebuild procedure in RAZAR agent guide

## Testing
- `pytest tests/agents/razar -q`
- `python -m razar.environment_builder --config razar_env.yaml --venv /tmp/razar_venv --python 3.12`


------
https://chatgpt.com/codex/tasks/task_e_68aec7c14e10832e89f8b2e287a6ef9e