### PR TITLE
Add health checks and retry logic to boot orchestrator

### DIFF
--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -31,3 +31,28 @@ entry in `data/narrative.log`. After restoring a snapshot:
 
 This process ensures both data and narrative context are brought back
 together after a system recovery.
+
+## Component Recovery
+
+When a component fails during boot:
+
+1. Review `razar/boot_orchestrator.log` for error details.
+2. Run the component's health check manually to validate the fix:
+
+   ```python
+   from razar.health_checks import run
+   run("basic_service")
+   ```
+
+3. Once the check passes, restart the boot sequence. If failures persist,
+   quarantine the component and investigate configuration or environment
+   issues before reattempting.
+
+## Escalation Paths
+
+- **First failure** – developer on duty addresses the issue and restores the
+  service.
+- **Repeated failures** – notify the operations channel and create an
+  incident ticket.
+- **Prolonged outage** – escalate to the infrastructure lead for broader
+  coordination and resolution.

--- a/razar/health_checks.py
+++ b/razar/health_checks.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Health check routines for Razar boot components."""
+
+import logging
+import urllib.request
+from pathlib import Path
+from typing import Callable, Dict
+
+LOGGER = logging.getLogger("razar.health_checks")
+
+
+def ping_endpoint(url: str, timeout: int = 5) -> bool:
+    """Return ``True`` if ``url`` responds within ``timeout`` seconds."""
+    try:
+        with urllib.request.urlopen(
+            url, timeout=timeout
+        ) as resp:  # nosec B310 - trusted endpoints
+            return 200 <= resp.status < 300
+    except Exception as exc:  # pragma: no cover - network dependent
+        LOGGER.error("Ping failed for %s: %s", url, exc)
+        return False
+
+
+def verify_log(path: Path, phrase: str) -> bool:
+    """Return ``True`` if ``phrase`` is found in ``path``."""
+    try:
+        data = Path(path).read_text()
+    except OSError as exc:  # pragma: no cover - filesystem dependent
+        LOGGER.error("Could not read log %s: %s", path, exc)
+        return False
+    return phrase in data
+
+
+def check_basic_service() -> bool:
+    """Example check for ``basic_service``."""
+    return ping_endpoint("http://localhost:8000/healthz")
+
+
+def check_complex_service() -> bool:
+    """Example check for ``complex_service``."""
+    return verify_log(Path("/var/log/complex_service.log"), "started")
+
+
+CHECKS: Dict[str, Callable[[], bool]] = {
+    "basic_service": check_basic_service,
+    "complex_service": check_complex_service,
+}
+
+
+def run(name: str) -> bool:
+    """Run health check for ``name`` and return ``True`` on success."""
+    func = CHECKS.get(name)
+    if not func:
+        LOGGER.info("No health check defined for %s", name)
+        return True
+    return func()


### PR DESCRIPTION
## Summary
- add reusable health check routines for Razar components
- invoke health checks with configurable retries in boot orchestrator
- document recovery actions and escalation paths

## Testing
- `pre-commit run --files razar/health_checks.py razar/boot_orchestrator.py docs/recovery_playbook.md`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68aec8cd43e0832eb6373e2e7d6dfe94