### PR TITLE
Verify Inanna and Crown readiness with restart safeguards

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -33,3 +33,13 @@ environment before starting services:
 3. Re-run the RAZAR runtime manager to launch components.
 
 These steps guarantee a clean foundation for Inanna and CROWN.
+
+## Final Verification Sequence
+Before yielding control, RAZAR confirms that the core services report readiness:
+
+1. Query `http://localhost:8000/ready` and expect `{"status": "ready"}` from Inanna AI.
+2. Query `http://localhost:8001/ready` and expect `{"status": "ready"}` from CROWN LLM.
+3. If either check fails, RAZAR invokes the corresponding restart script (`run_inanna.sh` or `crown_model_launcher.sh`) and repeats the probe once.
+4. Persistent failures mark the mission incomplete and halt the startup sequence.
+
+These verifications ensure both agents are prepared before internal orchestration begins.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -205,6 +205,7 @@ See [nazarick_agents.md](nazarick_agents.md) for the full roster and the
 - **Purpose:** Prepare the runtime environment and supervise service launches before any other component starts. See [RAZAR Agent](RAZAR_AGENT.md).
 - **Startup:** Runs first to build or validate the Python `venv`.
 - **Health Check:** Confirm the environment hash and orchestrator heartbeat.
+- **Verification:** Ensure Inanna AI and CROWN LLM report readiness; see [Final Verification Sequence](RAZAR_AGENT.md#final-verification-sequence).
 - **Recovery:** Rebuild the `venv` and restart RAZAR.
 
 ### Chat Gateway

--- a/razar/health_checks.py
+++ b/razar/health_checks.py
@@ -1,13 +1,31 @@
-from __future__ import annotations
-
 """Health check routines for Razar boot components."""
 
+from __future__ import annotations
+
+import json
 import logging
+import subprocess
 import urllib.request
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
 LOGGER = logging.getLogger("razar.health_checks")
+
+
+def ready_signal(url: str, timeout: int = 5) -> bool:
+    """Return ``True`` if ``url`` reports a ready status."""
+    try:
+        with urllib.request.urlopen(
+            url, timeout=timeout
+        ) as resp:  # nosec B310 - trusted endpoints
+            if not 200 <= resp.status < 300:
+                return False
+            data = resp.read()
+        payload = json.loads(data)
+    except Exception as exc:  # pragma: no cover - network dependent
+        LOGGER.error("Ready check failed for %s: %s", url, exc)
+        return False
+    return payload.get("status") == "ready"
 
 
 def ping_endpoint(url: str, timeout: int = 5) -> bool:
@@ -42,16 +60,50 @@ def check_complex_service() -> bool:
     return verify_log(Path("/var/log/complex_service.log"), "started")
 
 
+def check_inanna_ready() -> bool:
+    """Confirm Inanna AI reports readiness."""
+    return ready_signal("http://localhost:8000/ready")
+
+
+def check_crown_ready() -> bool:
+    """Confirm CROWN LLM reports readiness."""
+    return ready_signal("http://localhost:8001/ready")
+
+
 CHECKS: Dict[str, Callable[[], bool]] = {
     "basic_service": check_basic_service,
     "complex_service": check_complex_service,
+    "inanna_ai": check_inanna_ready,
+    "crown_llm": check_crown_ready,
+}
+
+
+RESTART_COMMANDS: Dict[str, List[str]] = {
+    "inanna_ai": ["bash", "run_inanna.sh"],
+    "crown_llm": ["bash", "crown_model_launcher.sh"],
 }
 
 
 def run(name: str) -> bool:
-    """Run health check for ``name`` and return ``True`` on success."""
+    """Run health check for ``name`` and return ``True`` on success.
+
+    If the initial check fails and a restart command is registered, attempt to
+    restart the component once before reporting failure.
+    """
+
     func = CHECKS.get(name)
     if not func:
         LOGGER.info("No health check defined for %s", name)
         return True
+    if func():
+        return True
+    LOGGER.warning("Health check failed for %s", name)
+    cmd = RESTART_COMMANDS.get(name)
+    if not cmd:
+        return False
+    try:
+        subprocess.run(cmd, check=True)
+    except Exception as exc:  # pragma: no cover - system dependent
+        LOGGER.error("Restart command failed for %s: %s", name, exc)
+        return False
     return func()

--- a/tests/test_razar_health_checks.py
+++ b/tests/test_razar_health_checks.py
@@ -1,0 +1,57 @@
+from unittest import mock
+
+
+from razar import health_checks as hc
+
+
+def _fake_ready_response(status="ready"):
+    class FakeResp:
+        def __init__(self, status_code=200, payload=None):
+            self.status = status_code
+            self._payload = payload or {"status": status}
+
+        def read(self):
+            import json
+
+            return json.dumps(self._payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    return FakeResp()
+
+
+def test_ready_signal_parses_status(monkeypatch):
+    def fake_urlopen(url, timeout=5):
+        assert url.endswith("/ready")
+        return _fake_ready_response("ready")
+
+    monkeypatch.setattr(hc.urllib.request, "urlopen", fake_urlopen)
+    assert hc.check_inanna_ready()
+    assert hc.check_crown_ready()
+
+    def fake_urlopen_bad(url, timeout=5):
+        return _fake_ready_response("waiting")
+
+    monkeypatch.setattr(hc.urllib.request, "urlopen", fake_urlopen_bad)
+    assert not hc.check_inanna_ready()
+
+
+def test_run_attempts_restart(monkeypatch):
+    calls = {"count": 0}
+
+    def check():
+        calls["count"] += 1
+        return calls["count"] > 1
+
+    monkeypatch.setitem(hc.CHECKS, "demo", check)
+    monkeypatch.setitem(hc.RESTART_COMMANDS, "demo", ["bash", "-c", "true"])
+
+    run_mock = mock.Mock()
+    monkeypatch.setattr(hc.subprocess, "run", run_mock)
+
+    assert hc.run("demo") is True
+    run_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- verify Inanna AI and CROWN LLM `/ready` endpoints and add restart hooks
- document RAZAR final verification sequence and link from system blueprint
- add tests covering readiness parsing and restart attempts

## Testing
- `pre-commit run --files razar/health_checks.py docs/RAZAR_AGENT.md docs/system_blueprint.md tests/test_razar_health_checks.py`
- `pytest tests/test_razar_health_checks.py -o "addopts=--cov=razar.health_checks --cov-fail-under=0.5"`
- `pytest` *(fails: ImportError in tests/test_vector_memory.py, tests/test_voice_cloner_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aecc0a98e0832ead90f9f481e668bf