### PR TITLE
docs: add RAZAR runbooks

### DIFF
--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -44,6 +44,28 @@ Run the interactive wizard to scaffold the environment and launch the CLI:
 python docs/onboarding/wizard.py
 ```
 
+## Getting Started with RAZAR
+
+RAZAR prepares a clean environment and boots components in sequence. For a
+local run:
+
+1. **Build the RAZAR environment**
+   ```bash
+   python -m razar.environment_builder --config razar_env.yaml
+   ```
+2. **Launch the runtime manager**
+   ```bash
+   python -m agents.razar.runtime_manager config/razar_config.yaml
+   ```
+
+### Troubleshooting RAZAR
+
+| Symptom | Resolution |
+| --- | --- |
+| Runtime stops on a component | Inspect `logs/razar.log` and `python -m razar.mission_logger summary` to find the failing step. Remove `config/razar_config.state` to force a full restart. |
+| Environment hash mismatch | Rebuild the virtual environment with `python -m razar.environment_builder --config razar_env.yaml`. |
+| Component fails repeatedly | Quarantine it with `razar.quarantine_manager.quarantine_component` and review the [RAZAR failure runbook](operations.md#razar-failure-runbook). |
+
 ## Repository Layout
 - `core/` – language processing and self-correction engines.
 - `INANNA_AI/` – model logic, memory systems, and ritual analysis modules.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,6 +27,38 @@ status for each component.
 If RAZAR cannot restart a component, rebuild the virtual environment and rerun
 the manager. Removing the `.state` file forces a full restart sequence.
 
+## RAZAR failure runbook
+
+1. **Summarize status**
+   ```bash
+   python -m razar.mission_logger summary
+   ```
+   Review `logs/razar.log` for the last successful component.
+2. **Reset state**
+   Remove `config/razar_config.state` to re-run the full sequence.
+3. **Rebuild environment**
+   ```bash
+   python -m razar.environment_builder --config razar_env.yaml
+   python -m agents.razar.runtime_manager config/razar_config.yaml
+   ```
+4. **Quarantine persistent failures**
+   ```python
+   from razar import quarantine_manager as qm
+   qm.quarantine_component({"name": "gateway"}, "health check failed")
+   ```
+
+## Quarantine management
+
+- Quarantined components are written to the `quarantine/` directory and logged
+  in [quarantine_log.md](quarantine_log.md).
+- To restore a component, remove its JSON file from `quarantine/` and record a
+  resolved entry:
+  ```python
+  from razar import quarantine_manager as qm
+  qm.resolve_component("gateway", note="reconfigured credentials")
+  ```
+  Append notes to `docs/quarantine_log.md` for auditability.
+
 ## Dependency audits
 
 Use `tools/dependency_audit.py` to ensure installed packages match the pinned

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -18,6 +18,8 @@ For deeper guidance on operations and reliability, refer to:
 - [Monitoring](monitoring.md)
 - [Testing](testing.md)
 - [Recovery Playbook](recovery_playbook.md)
+- [Getting Started with RAZAR](developer_onboarding.md#getting-started-with-razar)
+- [RAZAR Failure Runbook](operations.md#razar-failure-runbook)
 
 Before any chakra layer activates, the external [RAZAR Agent](RAZAR_AGENT.md)
 prepares a clean environment outside Nazarick and initiates the boot sequence.


### PR DESCRIPTION
## Summary
- document local RAZAR setup and troubleshooting in developer onboarding
- add failure runbook and quarantine management procedures to operations guide
- cross-link onboarding and runbooks from system blueprint

## Testing
- `pre-commit run --files docs/developer_onboarding.md docs/operations.md docs/system_blueprint.md`
- `pytest` *(fails: unrecognized arguments --cov=src --cov=agents --cov-fail-under=0.5)*

------
https://chatgpt.com/codex/tasks/task_e_68aecd48c5d4832ebbffafcdb21de84b