### PR TITLE
feat(razar): log diagnostics and support reactivation

### DIFF
--- a/agents/razar/quarantine_manager.py
+++ b/agents/razar/quarantine_manager.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Re-export quarantine utilities for RAZAR agents.
+
+This thin wrapper exposes :mod:`razar.quarantine_manager` functionality within
+the ``agents.razar`` namespace so remote code agents can submit diagnostics and
+trigger component reactivation.
+"""
+
+from razar.quarantine_manager import (
+    is_quarantined,
+    quarantine_component,
+    record_diagnostics,
+    reactivate_component,
+    resolve_component,
+)
+
+__all__ = [
+    "is_quarantined",
+    "quarantine_component",
+    "record_diagnostics",
+    "reactivate_component",
+    "resolve_component",
+]
+

--- a/docs/quarantine_log.md
+++ b/docs/quarantine_log.md
@@ -1,6 +1,8 @@
 # Quarantine Log
 
 Failed components are moved to the `quarantine/` directory and recorded below.
+Remote agents may also submit diagnostic information for quarantined
+components; these entries appear in the log with an `diagnostic` action.
 
 ## Restoring components
 
@@ -8,6 +10,8 @@ To reinstate a component once it is fixed:
 
 1. Remove its JSON file from the `quarantine/` directory.
 2. Append a `resolved` entry in this log with any relevant notes.
+3. Invoke `reactivate_component` with `verified=True` to record a manual or
+   automated reactivation.
 
 | Timestamp (UTC) | Component | Action | Details |
 |-----------------|-----------|--------|---------|

--- a/razar/quarantine_manager.py
+++ b/razar/quarantine_manager.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 """Utilities for quarantining failing components.
 
 Components that fail during boot are moved to the top-level ``quarantine``
-folder and logged in ``docs/quarantine_log.md``.
+folder and logged in ``docs/quarantine_log.md``. Remote agents may submit
+additional diagnostic information which is recorded alongside quarantine
+events. Once a patch is verified, components can be reactivated either
+manually or automatically.
 """
 
 from datetime import datetime
@@ -45,13 +48,28 @@ def is_quarantined(name: str) -> bool:
     return (QUARANTINE_DIR / f"{name}.json").exists()
 
 
-def quarantine_component(component: Dict[str, Any], reason: str) -> None:
-    """Move ``component`` to quarantine and record ``reason``."""
+def quarantine_component(
+    component: Dict[str, Any], reason: str, diagnostics: Dict[str, Any] | None = None
+) -> None:
+    """Move ``component`` to quarantine and record ``reason``.
+
+    Parameters
+    ----------
+    component:
+        Component metadata.
+    reason:
+        Why the component was quarantined.
+    diagnostics:
+        Optional diagnostic information supplied by remote agents.
+    """
+
     _init_paths()
     name = component.get("name", "unknown")
     with (QUARANTINE_DIR / f"{name}.json").open("w") as fh:
         json.dump(component, fh, indent=2)
     _append_log(name, "quarantined", reason)
+    if diagnostics:
+        record_diagnostics(name, diagnostics)
 
 
 def resolve_component(name: str, note: str | None = None) -> None:
@@ -61,3 +79,50 @@ def resolve_component(name: str, note: str | None = None) -> None:
     if target.exists():
         target.unlink()
     _append_log(name, "resolved", note or "")
+
+
+def record_diagnostics(name: str, data: Dict[str, Any]) -> None:
+    """Append diagnostic ``data`` for ``name`` to the log.
+
+    ``data`` is serialized to JSON so it can be embedded in the Markdown log
+    table. Remote code agents may call this function directly to submit
+    information about a failure.
+    """
+
+    _init_paths()
+    serialized = json.dumps(data, sort_keys=True)
+    _append_log(name, "diagnostic", serialized)
+
+
+def reactivate_component(
+    name: str,
+    *,
+    verified: bool,
+    automated: bool = False,
+    note: str | None = None,
+) -> None:
+    """Reinstate ``name`` after a verified patch.
+
+    Parameters
+    ----------
+    name:
+        Component to reactivate.
+    verified:
+        ``True`` when a patch has been verified. ``False`` raises a
+        :class:`ValueError`.
+    automated:
+        Set to ``True`` if the reactivation was triggered automatically.
+    note:
+        Optional additional context to include in the log entry.
+    """
+
+    if not verified:
+        raise ValueError("Patch must be verified before reactivation")
+
+    _init_paths()
+    target = QUARANTINE_DIR / f"{name}.json"
+    if target.exists():
+        target.unlink()
+    mode = "auto" if automated else "manual"
+    detail = f"{mode}{': ' + note if note else ''}"
+    _append_log(name, "reactivated", detail)

--- a/tests/test_quarantine_manager.py
+++ b/tests/test_quarantine_manager.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import json
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import razar.quarantine_manager as qm
+
+
+def test_quarantine_records_diagnostics(tmp_path, monkeypatch):
+    quarantine_dir = tmp_path / "quarantine"
+    log_file = tmp_path / "log.md"
+    monkeypatch.setattr(qm, "QUARANTINE_DIR", quarantine_dir)
+    monkeypatch.setattr(qm, "LOG_FILE", log_file)
+
+    component = {"name": "alpha"}
+    diagnostics = {"error": "stack"}
+    qm.quarantine_component(component, "boom", diagnostics=diagnostics)
+
+    assert (quarantine_dir / "alpha.json").exists()
+    log_text = log_file.read_text(encoding="utf-8")
+    assert "quarantined" in log_text
+    assert json.dumps(diagnostics, sort_keys=True) in log_text
+
+
+def test_reactivate_requires_verification(tmp_path, monkeypatch):
+    quarantine_dir = tmp_path / "quarantine"
+    log_file = tmp_path / "log.md"
+    monkeypatch.setattr(qm, "QUARANTINE_DIR", quarantine_dir)
+    monkeypatch.setattr(qm, "LOG_FILE", log_file)
+
+    component = {"name": "beta"}
+    qm.quarantine_component(component, "fail")
+
+    with pytest.raises(ValueError):
+        qm.reactivate_component("beta", verified=False)
+
+    qm.reactivate_component("beta", verified=True, automated=True, note="patched")
+    assert not (quarantine_dir / "beta.json").exists()
+    lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert any("reactivated" in line and "auto" in line for line in lines)
+


### PR DESCRIPTION
## Summary
- allow quarantine manager to log diagnostics from remote agents
- support manual or automated reactivation after patch verification
- document diagnostic entries and reactivation workflow

## Testing
- `pytest --cov=src --cov=agents --cov=razar tests/test_quarantine_manager.py tests/test_corpus_logging.py tests/test_corpus_memory_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68aed4355d88832eaff2b6eeab9d8d42