### PR TITLE
Add RAZAR lifecycle bus with Redis and CLI tools

### DIFF
--- a/agents/razar/__init__.py
+++ b/agents/razar/__init__.py
@@ -1,5 +1,6 @@
 """RAZAR agents."""
 
 from .remote_loader import load_remote_agent
+from .lifecycle_bus import LifecycleBus
 
-__all__ = ["load_remote_agent"]
+__all__ = ["load_remote_agent", "LifecycleBus"]

--- a/agents/razar/lifecycle_bus.py
+++ b/agents/razar/lifecycle_bus.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Lifecycle message bus for RAZAR components.
+
+This module uses Redis pub/sub channels to broadcast component status updates
+and listen for issue reports.  It exposes a small API used by operational
+scripts and command line utilities.
+"""
+
+from dataclasses import dataclass
+import json
+from typing import Dict, Iterator
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore
+
+STATUS_KEY = "razar:status"
+STATUS_CHANNEL = "razar:status"
+ISSUE_CHANNEL = "razar:issues"
+CONTROL_CHANNEL = "razar:control"
+
+
+@dataclass
+class Issue:
+    """Represents an issue reported by a component."""
+
+    component: str
+    issue: str
+
+
+class LifecycleBus:
+    """Redis-backed lifecycle bus.
+
+    Parameters
+    ----------
+    url:
+        Redis connection URL. Defaults to ``redis://localhost:6379/0``.
+    """
+
+    def __init__(self, url: str = "redis://localhost:6379/0") -> None:
+        if redis is None:  # pragma: no cover - defensive
+            raise RuntimeError("redis package is required for LifecycleBus")
+        self.url = url
+        self._client = redis.Redis.from_url(url)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # Status helpers
+    def publish_status(self, component: str, status: str) -> None:
+        """Broadcast ``status`` for ``component`` and store it in Redis."""
+        payload = {"component": component, "status": status}
+        data = json.dumps(payload)
+        self._client.hset(STATUS_KEY, component, status)
+        self._client.publish(STATUS_CHANNEL, data)
+
+    def get_statuses(self) -> Dict[str, str]:
+        """Return a mapping of component names to their last known status."""
+        raw = self._client.hgetall(STATUS_KEY)
+        return {k.decode(): v.decode() for k, v in raw.items()}
+
+    # ------------------------------------------------------------------
+    # Control helpers
+    def send_control(self, component: str, action: str) -> None:
+        """Publish a control message for ``component`` with ``action``."""
+        payload = {"component": component, "action": action}
+        self._client.publish(CONTROL_CHANNEL, json.dumps(payload))
+
+    # ------------------------------------------------------------------
+    # Issue helpers
+    def report_issue(self, component: str, issue: str) -> None:
+        """Publish an issue notification for ``component``."""
+        payload = {"component": component, "issue": issue}
+        self._client.publish(ISSUE_CHANNEL, json.dumps(payload))
+
+    def listen_for_issues(self) -> Iterator[Issue]:
+        """Yield :class:`Issue` objects as they are reported.
+
+        This is a blocking generator which listens on the ``ISSUE_CHANNEL``
+        and yields issues as they arrive.
+        """
+        pubsub = self._client.pubsub()
+        pubsub.subscribe(ISSUE_CHANNEL)
+        for message in pubsub.listen():
+            if message.get("type") != "message":
+                continue
+            try:
+                data = json.loads(message["data"])
+                yield Issue(
+                    component=data.get("component", ""),
+                    issue=data.get("issue", ""),
+                )
+            except json.JSONDecodeError:  # pragma: no cover - ignore bad msgs
+                continue

--- a/razar/__main__.py
+++ b/razar/__main__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Command line utilities for operating the RAZAR lifecycle bus."""
+
+import argparse
+
+from agents.razar.lifecycle_bus import LifecycleBus
+
+
+def _cmd_status(args: argparse.Namespace) -> None:
+    bus = LifecycleBus(url=args.url)
+    statuses = bus.get_statuses()
+    if args.component:
+        status = statuses.get(args.component, "unknown")
+        print(f"{args.component}: {status}")
+    else:
+        for comp, status in sorted(statuses.items()):
+            print(f"{comp}: {status}")
+
+
+def _cmd_stop(args: argparse.Namespace) -> None:
+    bus = LifecycleBus(url=args.url)
+    bus.send_control(args.component, "stop")
+    print(f"Stop signal sent to {args.component}")
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    parser = argparse.ArgumentParser(description="RAZAR lifecycle utilities")
+    parser.add_argument(
+        "--url",
+        default="redis://localhost:6379/0",
+        help="Redis connection URL",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_status = sub.add_parser("status", help="Show component status")
+    p_status.add_argument("component", nargs="?", help="Component to query")
+    p_status.set_defaults(func=_cmd_status)
+
+    p_stop = sub.add_parser("stop", help="Request a component to stop")
+    p_stop.add_argument("component", help="Component name")
+    p_stop.set_defaults(func=_cmd_stop)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:  # pragma: no cover - show help when no subcommand
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - module CLI
+    main()


### PR DESCRIPTION
## Summary
- add `LifecycleBus` for Redis-based status and issue messaging
- expose lifecycle bus utilities via `python -m razar` CLI

## Testing
- `pytest` *(fails: ImportError cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68aed83cd6a4832e9a17161ce6043df7