### PR TITLE
Add OpenWebUI docker compose configuration

### DIFF
--- a/docker-compose.openwebui.yml
+++ b/docker-compose.openwebui.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  openwebui:
+    image: ghcr.io/open-webui/open-webui:latest
+    ports:
+      - "3000:8080"
+    environment:
+      FASTAPI_BASE_URL: ${FASTAPI_BASE_URL:-http://localhost:8000}
+    restart: unless-stopped

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,18 @@ This guide covers building versioned images and deploying them using Kubernetes 
    docker push registry.example.com/abzu:${APP_VERSION}
    ```
 
+## OpenWebUI
+
+1. Define the FastAPI endpoint that OpenWebUI should use:
+   ```bash
+   export FASTAPI_BASE_URL=http://localhost:8000
+   ```
+2. Launch the interface:
+   ```bash
+   docker compose -f docker-compose.openwebui.yml up
+   ```
+   The UI is available at http://localhost:3000.
+
 ## Kubernetes
 
 Reference manifests live in `deployment/kubernetes`. Apply them with:


### PR DESCRIPTION
## Summary
- add docker-compose.openwebui.yml for running OpenWebUI container with FASTAPI_BASE_URL env
- document OpenWebUI startup steps in deployment guide

## Testing
- `pre-commit run --files docker-compose.openwebui.yml docs/deployment.md`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68aee72a6d24832eaa7f378093a0adaf