### PR TITLE
docs: add open web ui guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,50 @@ on:
   pull_request:
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
+  pytest:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            dev-requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+          pip install pytest pytest-cov
+      - name: Verify required pytest plugins
+        run: python - <<'PY'
+import importlib, sys
+sys.exit(0 if importlib.util.find_spec('pytest_cov') else 1)
+PY
+      - name: Run tests
+        run: pytest --cov
+
   ci:
     runs-on: ubuntu-latest
     env:
@@ -40,28 +84,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r dev-requirements.txt
           pip install -e .
-          pip install ruff black mypy pytest pytest-cov
-
-      - name: Verify required pytest plugins
-        run: python - <<'PY'
-import importlib, sys
-sys.exit(0 if importlib.util.find_spec('pytest_cov') else 1)
-PY
-
-      - name: Ruff
-        run: ruff check .
-
-      - name: Black
-        run: black --check --exclude tests .
+          pip install mypy
 
       - name: Mypy
         run: mypy
 
       - name: Validate templates and schemas
         run: python scripts/validate_configs.py
-
-      - name: Run tests
-        run: pytest --cov
 
       - name: Profiling
         run: python -m cProfile -m task_profiling

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ docker compose up server
 
 The service exposes `http://localhost:8000/health` for health checks.
 
+### Open Web UI quickstart
+Install the front end and connect it to the local server:
+
+```bash
+pip install open-webui
+FASTAPI_BASE_URL=http://localhost:8000 open-webui serve
+```
+
+The UI listens on `http://localhost:3000` by default.
+
 ## Health Scanner and CI
 Verify the stack with the health scanner:
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -115,6 +115,22 @@ Set the following variables in `secrets.env` or your shell:
 - `GITHUB_TOKEN`
 - model endpoint settings (e.g., `MODEL_ENDPOINT`)
 
+### Open Web UI Setup
+Launch the optional browser interface once the FastAPI backend is running:
+
+```bash
+pip install open-webui
+FASTAPI_BASE_URL=http://localhost:8000 open-webui serve
+```
+
+Or start it via Docker Compose:
+
+```bash
+docker compose -f docker-compose.openwebui.yml up
+```
+
+See [open_web_ui.md](open_web_ui.md) for architecture details.
+
 ### Core CI Commands
 Run these commands before committing changes:
 ```bash


### PR DESCRIPTION
## Summary
- document optional Open Web UI interface in onboarding guide
- show how to launch Open Web UI in project README
- expand CI with dedicated `pre-commit` and `pytest` jobs

## Testing
- `pre-commit run --files README.md docs/developer_onboarding.md .github/workflows/ci.yml`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68aef253081c832e8f1342a026dffd52