### PR TITLE
docs: document operations and contributor references

### DIFF
--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -328,21 +328,17 @@ General guidance: stop the failed service, confirm dependencies, and restart
 following the startup order. For persistent issues, consult the
 [Recovery Playbook](recovery_playbook.md) to restore from snapshots.
 
-## Operational Guides
+## Operations & Monitoring
 
 These guides support the startup order, health check practices, and recovery
-procedures outlined above:
+procedures outlined above. RAZAR’s logs (`logs/razar.log`) feed into the
+monitoring pipeline to surface orchestration events and anomalies.
 
 - [Operations Guide](operations.md)
 - [Monitoring Guide](monitoring.md)
 - [Deployment Guide](deployment.md)
 - [Testing Guide](testing.md)
-
-## Contributor Resources
-
-- [Developer Onboarding](developer_onboarding.md)
-- [Development Workflow](development_workflow.md)
-- [Coding Style](coding_style.md)
+- [Recovery Playbook](recovery_playbook.md)
 
 ## LLM Console Alternatives
 
@@ -385,3 +381,9 @@ Each project can replace or augment the bundled `web_console/` depending on the
 desired trade‑off between simplicity and features. Chainlit pairs well with the
 existing Python services for rapid prototypes, while OpenWebUI targets full
 deployments with user accounts and persistent chats.
+
+## Contributor Resources
+
+- [Developer Onboarding](developer_onboarding.md)
+- [Development Workflow](development_workflow.md)
+- [Coding Style](coding_style.md)


### PR DESCRIPTION
## Summary
- add operations & monitoring section with links to operations, monitoring, deployment, testing, and recovery playbook
- highlight how RAZAR logs feed into the monitoring pipeline
- append contributor resources referencing onboarding, workflow, and coding style

## Testing
- `pytest -q` *(fails: import file mismatch and missing `load_config` during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd896d74832eab04435ebd7ac9de