### PR TITLE
Add Wish Box charter document

### DIFF
--- a/docs/WISH_BOX_CHARTER.md
+++ b/docs/WISH_BOX_CHARTER.md
@@ -1,0 +1,35 @@
+# Wish Box Charter
+
+## Mission and Vision
+- Provide a communal space where participants can submit, refine, and realize their "wishes" for new capabilities.
+- Encourage transparent collaboration so ideas evolve from simple requests into shared artifacts.
+
+## Key Features
+- Simple wish submission pipeline with tagging and prioritization.
+- Traceable history from proposal to implementation.
+- Modular architecture so components can be swapped or reimplemented independently.
+
+## User Roles
+- **Dreamers** propose wishes and describe desired outcomes.
+- **Builders** evaluate, prototype, and merge accepted wishes.
+- **Stewards** maintain infrastructure, triage issues, and document progress.
+
+## Success Metrics
+- Ratio of implemented wishes to total submissions.
+- User satisfaction surveys and qualitative feedback.
+- Mean time to evaluate and either accept or archive a wish.
+
+## Recovery Instructions
+- Restore the most recent stable backup of the wish database.
+- Rebuild the service container and replay pending submissions from logs.
+- Notify affected users and document the incident in the recovery ledger.
+
+## Future Milestones
+- Integrate automated prioritization based on community voting.
+- Expose an API for external tools to submit or query wishes.
+- Launch a plugin system that lets different domains attach custom wish handlers.
+
+## Reimplementation Strategy
+- Each module publishes a minimal interface contract and acceptance tests.
+- Teams may reimplement modules in any language or framework as long as the contract and tests are honored.
+- Prefer stateless designs and clear configuration boundaries to ease portability across stacks.


### PR DESCRIPTION
## Summary
- introduce Wish Box charter outlining mission, vision, user roles, and success metrics
- document recovery steps, upcoming milestones, and module reimplementation strategy

## Testing
- `pytest tests/test_smoke_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68af01dd7278832e8d56d48f9ceffad8