### PR TITLE
docs: document doc indexer script

### DIFF
--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -417,3 +417,5 @@ deployments with user accounts and persistent chats.
 - [Developer Onboarding](developer_onboarding.md)
 - [Development Workflow](development_workflow.md)
 - [Coding Style](coding_style.md)
+- Index Markdown docs with `python tools/doc_indexer.py` to regenerate `docs/INDEX.md`; existing entries stay intact and new versions of generated files are appended.
+


### PR DESCRIPTION
## Summary
- mention `tools/doc_indexer.py` in system blueprint contributor resources and explain it regenerates `docs/INDEX.md`

## Testing
- `pytest -q` *(fails: import file mismatch and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68af0436c314832ea057305ecbefdc37