### PR TITLE
docs: expand documentation update guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,10 @@ coverage report
 
 - Keep changes focused; submit separate PRs for unrelated fixes.
 - Ensure documentation is updated and tests pass.
+- Record project-wide documentation or architectural changes in
+  [docs/system_blueprint.md](docs/system_blueprint.md) by adding a new
+  version entry; do not modify or remove prior content. After updates, run
+  `python tools/doc_indexer.py` to refresh `docs/INDEX.md`.
 - Lint Markdown files with `markdownlint` and verify links using `markdown-link-check`.
 - Request review from a maintainer and address feedback promptly.
 


### PR DESCRIPTION
## Summary
- note to document project-wide or architectural changes in docs/system_blueprint.md with additive entries
- reference doc index generator to refresh docs/INDEX.md

## Testing
- `pre-commit run --files CONTRIBUTING.md`
- `pytest -q` *(fails: import file mismatch, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68af05abed28832e8d18e497eea17eee