### PR TITLE
Add RAZAR boot orchestrator placeholder

### DIFF
--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -1,0 +1,63 @@
+"""RAZAR boot orchestrator.
+
+Provides placeholders for the staged startup sequence described in
+``docs/system_blueprint.md``. Each hook will launch a component and wait for
+readiness before advancing to the next stage.
+"""
+
+from __future__ import annotations
+
+
+class BootOrchestrator:
+    """Coordinate staged startup for core ABZU services."""
+
+    def start_memory_store(self) -> None:
+        """Start the memory store (stage 1)."""
+        # TODO: Implement Memory Store startup (priority 1)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def start_chat_gateway(self) -> None:
+        """Start the chat gateway (stage 2)."""
+        # TODO: Implement Chat Gateway startup (priority 2)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def start_crown_llm(self) -> None:
+        """Start the CROWN LLM (stage 3)."""
+        # TODO: Implement CROWN LLM startup (priority 2)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def start_audio_device(self) -> None:
+        """Start the audio device (stage 4)."""
+        # TODO: Implement Audio Device startup (priority 3)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def start_avatar(self) -> None:
+        """Start the avatar service (stage 5)."""
+        # TODO: Implement Avatar startup (priority 4)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def start_video(self) -> None:
+        """Start the video service (stage 6)."""
+        # TODO: Implement Video startup (priority 5)
+        #       See docs/system_blueprint.md
+        raise NotImplementedError
+
+    def run(self) -> None:
+        """Execute the staged startup sequence."""
+        # TODO: Orchestrate component startups in the order defined above.
+        raise NotImplementedError
+
+
+def main() -> None:
+    """Run the boot orchestrator."""
+    orchestrator = BootOrchestrator()
+    orchestrator.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()


### PR DESCRIPTION
## Summary
- scaffold `BootOrchestrator` for staged startup of core services
- add TODO hooks for Memory Store, Chat Gateway, CROWN LLM, Audio Device, Avatar, and Video
- provide CLI entry point for future script execution

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py`
- `mypy agents/razar/boot_orchestrator.py`
- `pytest` *(fails: import file mismatch and missing core import)*


------
https://chatgpt.com/codex/tasks/task_e_68af08372c10832ebd588d91f77c0bec