### PR TITLE
Add boot sequence and memory store tests

### DIFF
--- a/.github/workflows/pytest-minimal.yml
+++ b/.github/workflows/pytest-minimal.yml
@@ -1,0 +1,19 @@
+name: pytest-minimal
+
+on:
+  pull_request:
+
+jobs:
+  minimal:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install pytest numpy
+      - name: Run tests
+        run: pytest tests/agents/razar/test_boot_sequence.py tests/memory

--- a/tests/agents/razar/test_boot_sequence.py
+++ b/tests/agents/razar/test_boot_sequence.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from razar import boot_orchestrator as bo
+
+
+def test_boot_sequence_order_and_failure(tmp_path: Path, monkeypatch) -> None:
+    config = {
+        "components": [
+            {"name": "alpha", "command": ["alpha"]},
+            {"name": "beta", "command": ["beta"]},
+            {"name": "gamma", "command": ["gamma"]},
+        ]
+    }
+    cfg = tmp_path / "boot.json"
+    cfg.write_text(json.dumps(config), encoding="utf-8")
+
+    events: list[str] = []
+
+    def fake_run(name: str) -> bool:
+        events.append(f"health:{name}")
+        return name != "beta"
+
+    monkeypatch.setattr(bo.health_checks, "run", fake_run)
+
+    class DummyProc:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            events.append(f"launch:{name}")
+
+        def wait(self) -> None:
+            events.append(f"wait:{self.name}")
+
+        def terminate(self) -> None:
+            events.append(f"terminate:{self.name}")
+
+    def fake_popen(cmd: list[str]):
+        return DummyProc(cmd[0])
+
+    monkeypatch.setattr(bo.subprocess, "Popen", fake_popen)
+
+    components = bo.load_config(cfg)
+    with pytest.raises(RuntimeError):
+        for comp in components:
+            bo.launch_component(comp)
+
+    assert events == [
+        "launch:alpha",
+        "health:alpha",
+        "launch:beta",
+        "health:beta",
+        "terminate:beta",
+        "wait:beta",
+    ]
+    assert all(not e.startswith("launch:gamma") for e in events)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_smoke_imports.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_ignition_builder.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_runtime_manager.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_boot_sequence.py"),
+    str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
 }
 
 

--- a/tests/memory/test_sharded_memory_store.py
+++ b/tests/memory/test_sharded_memory_store.py
@@ -1,0 +1,57 @@
+import types
+
+import numpy as np
+
+import memory_store as ms
+
+
+def _patch_faiss(monkeypatch):
+    class IndexFlatL2:
+        def __init__(self, dim: int) -> None:
+            self.vectors: list[np.ndarray] = []
+
+        def add(self, arr: np.ndarray) -> None:
+            for row in arr:
+                self.vectors.append(np.asarray(row, dtype="float32"))
+
+        def search(self, vec: np.ndarray, k: int):
+            if not self.vectors:
+                return np.empty((1, k)), np.full((1, k), -1)
+            arr = np.stack(self.vectors)
+            dists = np.sum((arr - vec) ** 2, axis=1)
+            idxs = np.argsort(dists)[:k]
+            return dists[idxs][None, :], idxs[None, :]
+
+        def reconstruct(self, idx: int) -> np.ndarray:
+            return self.vectors[idx]
+
+    dummy = types.SimpleNamespace(IndexFlatL2=IndexFlatL2)
+    monkeypatch.setattr(ms, "faiss", dummy)
+    monkeypatch.setattr(ms, "np", np)
+
+
+def test_sharded_store_add_and_search(tmp_path, monkeypatch):
+    _patch_faiss(monkeypatch)
+    store = ms.ShardedMemoryStore(tmp_path / "base", shards=2)
+    v1 = np.array([1.0, 0.0], dtype="float32")
+    v2 = np.array([0.0, 1.0], dtype="float32")
+    store.add("0", v1, {"n": "zero"})
+    store.add("1", v2, {"n": "one"})
+    assert set(store.ids) == {"0", "1"}
+    ids1 = [r[0] for r in store.search(v1, 2)]
+    ids2 = [r[0] for r in store.search(v2, 2)]
+    assert "0" in ids1
+    assert "1" in ids2
+
+
+def test_sharded_store_snapshot_restore(tmp_path, monkeypatch):
+    _patch_faiss(monkeypatch)
+    base = tmp_path / "base"
+    store = ms.ShardedMemoryStore(base, shards=2)
+    vec = np.array([1.0, 0.0], dtype="float32")
+    store.add("0", vec, {})
+    snap = tmp_path / "snap"
+    store.snapshot(snap)
+    restored = ms.ShardedMemoryStore(tmp_path / "restored", shards=2)
+    restored.restore(snap)
+    assert restored.search(vec, 1)[0][0] == "0"


### PR DESCRIPTION
## Summary
- add boot sequence test to verify component ordering and failure handling
- test sharded memory store add/search and snapshot restore
- run minimal pytest subset in CI

## Testing
- `pre-commit run --files tests/agents/razar/test_boot_sequence.py tests/memory/test_sharded_memory_store.py .github/workflows/pytest-minimal.yml tests/conftest.py`
- `pytest --cov=src --cov=agents --cov-fail-under=0 tests/agents/razar/test_boot_sequence.py tests/memory/test_sharded_memory_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68af0ab761b8832e85912842807d7228