### PR TITLE
ci: cache models and document workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
             pyproject.toml
             requirements.txt
             dev-requirements.txt
+      - name: Cache model downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface
+            INANNA_AI/models
+          key: ${{ runner.os }}-models-${{ hashFiles('download_models.py') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -53,6 +53,20 @@ ruff check .
 Fix any reported issues before pushing to ensure the CI pipeline remains
 green.
 
+## Continuous Integration
+
+Pull requests trigger the workflow defined in
+`.github/workflows/ci.yml`. It runs `pre-commit` and the full pytest suite
+to keep the codebase healthy. Model downloads are cached between runs so
+tests execute quickly without repeatedly fetching weights.
+
+To reproduce the checks locally before pushing changes:
+
+```bash
+pre-commit run --all-files
+pytest
+```
+
 ## Ignition Chain
 
 Component priorities drive startup order. When introducing or modifying a


### PR DESCRIPTION
## Summary
- cache Hugging Face and local model folders in CI to speed up test job
- document how the CI pipeline runs lint and tests with cached model downloads

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/development_workflow.md`
- `PYTHONPATH=src pytest` *(fails: ImportError: cannot import name 'load_config' from 'core', ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_68af0e092a38832e8d763e5c6162760a