### PR TITLE
Add benchmark suite and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: install-minimal install-audio install-vision install-full verify-deps test test-deterministic train-deterministic
+.PHONY: install-minimal install-audio install-vision install-full verify-deps test test-deterministic train-deterministic bench
 
 SEED ?= 0
 
@@ -27,4 +27,7 @@ test-deterministic:
 
 train-deterministic:
 >SEED=$(SEED) python auto_retrain.py --dry-run
+
+bench:
+>python benchmarks/run_benchmarks.py
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,12 @@
+# Benchmarks
+
+Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`.
+
+## Baseline metrics
+
+| Benchmark | Metric | Value |
+| --- | --- | --- |
+| Memory store insertion | adds/sec | 26,769.82 |
+| Memory store search | seconds | 0.0078 |
+| Chat gateway routing | messages/sec | 1,122,012.08 |
+| LLM throughput | tokens/sec | 4,077.48 |

--- a/benchmarks/chat_gateway_benchmark.py
+++ b/benchmarks/chat_gateway_benchmark.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Benchmark message routing through the chat gateway."""
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import types
+
+api_stub = types.ModuleType("api")
+api_stub.server = types.SimpleNamespace(
+    generate_video=lambda *args, **kwargs: None,
+    broadcast_avatar_update=lambda *args, **kwargs: None,
+    list_styles=lambda *args, **kwargs: None,
+)
+sys.modules["api"] = api_stub
+
+from communication.gateway import Gateway, ChannelMessage
+
+
+class DummyCore:
+    async def handle_message(self, message: ChannelMessage) -> None:
+        return None
+
+
+async def _bench(messages: int = 1000) -> dict[str, float]:
+    core = DummyCore()
+    gateway = Gateway(core)
+
+    start = time.perf_counter()
+    for _ in range(messages):
+        await gateway.handle_incoming("chat", "user", "hello")
+    duration = time.perf_counter() - start
+
+    metrics = {"messages_per_sec": round(messages / duration if duration else 0.0, 2)}
+    out_dir = Path("data/benchmarks")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "chat_gateway.json"
+    out_file.write_text(json.dumps(metrics))
+    return metrics
+
+
+def benchmark_chat_gateway(messages: int = 1000) -> dict[str, float]:
+    """Public wrapper that runs the asynchronous benchmark."""
+    return asyncio.run(_bench(messages))
+
+
+def main() -> None:
+    metrics = benchmark_chat_gateway()
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/llm_throughput_benchmark.py
+++ b/benchmarks/llm_throughput_benchmark.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Benchmark transformer throughput in tokens per second."""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+def benchmark_llm(
+    seq_len: int = 128, batch_size: int = 1, d_model: int = 64
+) -> dict[str, float]:
+    """Run a tiny transformer encoder once and measure tokens per second."""
+    layer = torch.nn.TransformerEncoderLayer(d_model=d_model, nhead=4)
+    model = torch.nn.TransformerEncoder(layer, num_layers=2)
+    tokens = torch.randn(seq_len, batch_size, d_model)
+
+    start = time.perf_counter()
+    with torch.no_grad():
+        model(tokens)
+    duration = time.perf_counter() - start
+
+    tokens_processed = seq_len * batch_size
+    metrics = {
+        "tokens_per_sec": round(tokens_processed / duration if duration else 0.0, 2)
+    }
+    out_dir = Path("data/benchmarks")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "llm_throughput.json"
+    out_file.write_text(json.dumps(metrics))
+    return metrics
+
+
+def main() -> None:
+    metrics = benchmark_llm()
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/memory_store_benchmark.py
+++ b/benchmarks/memory_store_benchmark.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Benchmark basic memory store operations."""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from memory_store import MemoryStore
+
+
+def benchmark_memory_store(entries: int = 1000, dim: int = 64) -> dict[str, float]:
+    """Insert ``entries`` vectors and measure add/search performance."""
+    store = MemoryStore(":memory:")
+    vectors = [[float(i % 10) for _ in range(dim)] for i in range(entries)]
+
+    start = time.perf_counter()
+    for i, vec in enumerate(vectors):
+        store.add(f"{i:032x}", vec, {})
+    add_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    store.search([0.0] * dim, k=5)
+    search_time = time.perf_counter() - start
+
+    metrics = {
+        "adds_per_sec": round(entries / add_time if add_time else 0.0, 2),
+        "search_time": round(search_time, 4),
+    }
+    out_dir = Path("data/benchmarks")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "memory_store.json"
+    out_file.write_text(json.dumps(metrics))
+    return metrics
+
+
+def main() -> None:
+    metrics = benchmark_memory_store()
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Run all benchmark scripts and report their metrics."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from chat_gateway_benchmark import benchmark_chat_gateway
+from llm_throughput_benchmark import benchmark_llm
+from memory_store_benchmark import benchmark_memory_store
+
+
+def main() -> None:
+    results = {
+        "memory_store": benchmark_memory_store(),
+        "chat_gateway": benchmark_chat_gateway(),
+        "llm_throughput": benchmark_llm(),
+    }
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts to benchmark memory store, chat gateway, and tiny transformer throughput
- record baseline metrics in `benchmarks/README.md`
- expose a `make bench` command to run the full suite

## Testing
- `pre-commit run --files Makefile benchmarks/memory_store_benchmark.py benchmarks/chat_gateway_benchmark.py benchmarks/llm_throughput_benchmark.py benchmarks/run_benchmarks.py benchmarks/README.md`
- `pytest benchmarks/train_infer.py -q -o addopts=''`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68af21a3743c832eb8b057d50a645748