### PR TITLE
Add YOLOE adapter with LargeWorldModel integration

### DIFF
--- a/docs/vision_system.md
+++ b/docs/vision_system.md
@@ -1,0 +1,25 @@
+# Vision System
+
+The vision module provides real‑time object detection using a YOLOE adapter. It
+forwards bounding boxes to the `LargeWorldModel` for downstream processing.
+
+## Usage
+
+```python
+from pathlib import Path
+import numpy as np
+from vision.yoloe_adapter import YOLOEAdapter
+from src.lwm.large_world_model import LargeWorldModel
+
+# Load model and connect to LargeWorldModel
+lwm = LargeWorldModel()
+adapter = YOLOEAdapter(model_path=Path("yoloe.pt"), lwm=lwm)
+
+# Run detection on a frame
+frame = np.load("tests/vision/data/sample_frame.npy")
+adapter.detect(frame, frame_id=0)
+print(lwm.get_detections())
+```
+
+Provide a path to YOLOE weights when available. The adapter falls back to a
+simple bounding box heuristic if the model cannot be loaded.

--- a/src/lwm/large_world_model.py
+++ b/src/lwm/large_world_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Dict, List, Tuple
 
 
 class LargeWorldModel:
@@ -16,6 +16,7 @@ class LargeWorldModel:
 
     def __init__(self) -> None:
         self._scene: dict[str, Any] | None = None
+        self._detections: Dict[int, List[Tuple[int, int, int, int]]] = {}
 
     def from_frames(self, frames: Iterable[Path]) -> dict[str, Any]:
         """Generate a 3D scene representation from ``frames``.
@@ -42,3 +43,17 @@ class LargeWorldModel:
     def inspect_scene(self) -> dict[str, Any]:
         """Return the last generated scene."""
         return self._scene or {}
+
+    # ------------------------------------------------------------------
+    # Detection handling
+    def ingest_detections(
+        self, frame_index: int, boxes: List[Tuple[int, int, int, int]]
+    ) -> None:
+        """Store detection ``boxes`` for ``frame_index``."""
+
+        self._detections[frame_index] = boxes
+
+    def get_detections(self) -> Dict[int, List[Tuple[int, int, int, int]]]:
+        """Return stored detections keyed by frame index."""
+
+        return self._detections

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_runtime_manager.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_boot_sequence.py"),
     str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
+    str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
 }
 
 

--- a/tests/vision/test_yoloe_adapter.py
+++ b/tests/vision/test_yoloe_adapter.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vision.yoloe_adapter import YOLOEAdapter
+from src.lwm.large_world_model import LargeWorldModel
+
+
+def generate_sample() -> "np.ndarray":
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    frame[8:24, 10:22] = 255  # simple non-zero region
+    return frame
+
+
+def test_adapter_emits_detections_to_lwm() -> None:
+    frame = generate_sample()
+    lwm = LargeWorldModel()
+    adapter = YOLOEAdapter(lwm=lwm)
+    detections = adapter.detect(frame, frame_id=0)
+    assert detections, "No detections returned"
+    stored = lwm.get_detections()
+    assert 0 in stored
+    assert stored[0][0] == detections[0].box

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,0 +1,1 @@
+"""Vision utilities and adapters."""

--- a/vision/yoloe_adapter.py
+++ b/vision/yoloe_adapter.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""YOLOE wrapper emitting detections to the LargeWorldModel."""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from ultralytics import YOLO  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    YOLO = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Detection:
+    """Single detection result."""
+
+    label: str
+    confidence: float
+    box: Tuple[int, int, int, int]
+
+
+class YOLOEAdapter:
+    """Run YOLOE detection and forward boxes to ``LargeWorldModel``."""
+
+    def __init__(
+        self,
+        model_path: str | Path | None = None,
+        lwm: "LargeWorldModel" | None = None,
+    ) -> None:
+        self.lwm = lwm
+        self.model = None
+        if YOLO is not None:
+            weights = str(model_path) if model_path else "yoloe.pt"
+            try:  # pragma: no cover - optional dependency
+                self.model = YOLO(weights)
+            except Exception as exc:  # pragma: no cover - optional dependency
+                logger.warning("Could not load YOLOE model: %s", exc)
+
+    def detect(
+        self, frame: "np.ndarray", frame_id: int | None = None
+    ) -> List[Detection]:
+        """Return detections for ``frame`` and emit boxes to ``LargeWorldModel``."""
+
+        boxes: List[Detection] = []
+        if self.model is not None:  # pragma: no branch - requires model
+            results = self.model(frame)
+            names = getattr(
+                self.model,
+                "names",
+                getattr(self.model, "model", None) and self.model.model.names,
+            )
+            for r in results:
+                for b in r.boxes:
+                    cls_name = names[int(b.cls)] if names else str(int(b.cls))
+                    conf = float(b.conf)
+                    x1, y1, x2, y2 = b.xyxy[0].tolist()
+                    boxes.append(
+                        Detection(
+                            cls_name, conf, (int(x1), int(y1), int(x2), int(y2))
+                        )
+                    )
+        elif np is not None:
+            ys, xs = np.where(frame.sum(axis=-1) > 0)
+            if ys.size and xs.size:
+                x1, x2 = xs.min(), xs.max()
+                y1, y2 = ys.min(), ys.max()
+                boxes.append(Detection("object", 1.0, (x1, y1, x2, y2)))
+        if frame_id is not None and self.lwm is not None:
+            self.lwm.ingest_detections(frame_id, [d.box for d in boxes])
+        return boxes
+
+    def process_stream(self, frames: Iterable["np.ndarray"]) -> Iterable[List[Detection]]:
+        """Yield detections for each frame in ``frames``."""
+
+        for idx, frame in enumerate(frames):
+            yield self.detect(frame, frame_id=idx)
+
+
+__all__ = ["YOLOEAdapter", "Detection"]


### PR DESCRIPTION
## Summary
- add YOLOEAdapter for real-time detection and LWM emission
- extend LargeWorldModel to store detections
- document vision system and provide integration test
- replace binary test frame with generated sample

## Testing
- `pytest tests/vision/test_yoloe_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af26862b44832ea2e26efe3f713f09