### PR TITLE
docs: add vision adapter service

### DIFF
--- a/config/razar_config.yaml
+++ b/config/razar_config.yaml
@@ -9,6 +9,11 @@ components:
   - name: crown_llm
     priority: 2
     command: "echo 'starting crown_llm'"
+  - name: vision_adapter
+    priority: 2
+    command: "echo 'starting vision_adapter'"
+    stop: "echo 'stopping vision_adapter'"
+    quarantine_on_fail: true
   - name: audio_device
     priority: 3
     command: "echo 'starting audio_device'"

--- a/docs/Ignition.md
+++ b/docs/Ignition.md
@@ -17,21 +17,22 @@ RAZAR coordinates system boot and records runtime health. Components are grouped
 | --- | --- | --- | --- |
 | 2 | Chat Gateway | Probe `/chat/health` and watch latency. | ⚠️ |
 | 3 | CROWN LLM | Send a dummy prompt and inspect response time. | ⚠️ |
+| 4 | Vision Adapter (YOLOE) | Verify prediction FPS meets target. | ⚠️ |
 
 ## Priority 3
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 4 | Audio Device | Run an audio loopback test. | ⚠️ |
+| 5 | Audio Device | Run an audio loopback test. | ⚠️ |
 
 ## Priority 4
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 5 | Avatar | Verify avatar frame rendering. | ⚠️ |
+| 6 | Avatar | Verify avatar frame rendering. | ⚠️ |
 
 ## Priority 5
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 6 | Video | Probe the video stream endpoint. | ⚠️ |
+| 7 | Video | Probe the video stream endpoint. | ⚠️ |
 
 ## Regeneration
 RAZAR monitors component events and rewrites this file whenever a priority or health state changes. Status markers update to:

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -30,3 +30,13 @@ layers:
 ```
 
 Add or modify packages as required by updating this file and re-running the builder.
+
+## Health Checks
+
+RAZAR probes each component through `agents/razar/health_checks.py` after a
+startup command succeeds.  Service‑specific functions can examine logs or
+metrics and return `True` when the component is healthy.  For the Vision
+Adapter (YOLOE), a check might confirm that prediction FPS stays above a target
+threshold.  Failed checks automatically quarantine the component via
+`quarantine_manager.py`, preventing unstable services from continuing in the
+boot sequence.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -324,6 +324,14 @@ See [nazarick_agents.md](nazarick_agents.md) for the full roster and the
 - **Health Check:** Send a dummy prompt and inspect response time.
 - **Recovery:** Reload weights with `crown_model_launcher.sh` or switch to a fallback model.
 
+### Vision Adapter (YOLOE)
+- **Layer:** Third Eye
+- **Priority:** 2
+- **Purpose:** Detect objects with YOLOE and stream bounding boxes to the Large World Model for the 2D→3D pipeline.
+- **Startup:** Launch once core messaging services are online.
+- **Health Check:** Verify prediction FPS meets the expected threshold.
+- **Recovery:** Reload YOLOE weights or restart the adapter.
+
 ## Non‑Essential Services
 ### Audio Device
 - **Priority:** 3
@@ -357,9 +365,10 @@ recommended for both local runs and production deployments described in
 1. Memory Store (Heart, priority 1)
 2. Chat Gateway (Throat, priority 2)
 3. CROWN LLM (Crown, priority 2)
-4. Audio Device (priority 3)
-5. Avatar (priority 4)
-6. Video (priority 5)
+4. Vision Adapter (Third Eye, priority 2)
+5. Audio Device (priority 3)
+6. Avatar (priority 4)
+7. Video (priority 5)
 
 Each step should report readiness before continuing. After the final service
 comes online, run the smoke tests in [testing.md](testing.md) to confirm the


### PR DESCRIPTION
## Summary
- document new Vision Adapter (YOLOE) as a Priority-2 service in the system blueprint and ignition sequence
- allow RAZAR to manage the Vision Adapter via updated razar_config
- describe RAZAR health checks and Vision Adapter FPS verification

## Testing
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68af2bbc35fc832e8efac21f6fdd3341