### PR TITLE
Add prioritized pytest runner

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -57,3 +57,30 @@ python agents/razar/runtime_manager.py config/razar_config.yaml
 Each component entry in the configuration specifies a `command` and `priority`.
 After every successful start the manager records the component name in
 `logs/razar_state.json`, allowing subsequent runs to skip completed steps.
+
+## Prioritized Test Execution
+
+Tests can be executed in priority tiers using `agents/razar/pytest_runner.py`.
+The mapping of test files to tiers is stored in `tests/priority_map.yaml` with
+levels `P1` through `P5`.
+
+Run all tests in order of priority:
+
+```bash
+python agents/razar/pytest_runner.py
+```
+
+Execute only selected tiers (for example P1 and P2):
+
+```bash
+python agents/razar/pytest_runner.py --priority P1 P2
+```
+
+Resume from the last failing test session:
+
+```bash
+python agents/razar/pytest_runner.py --resume
+```
+
+Output from each invocation is written to `logs/pytest_priority.log` for
+inspection by other RAZAR components.

--- a/tests/priority_map.yaml
+++ b/tests/priority_map.yaml
@@ -1,0 +1,16 @@
+P1:
+  - tests/test_smoke_imports.py
+  - tests/test_core_scipy_smoke.py
+P2:
+  - tests/test_server.py
+  - tests/test_api_endpoints.py
+P3:
+  - tests/test_memory_store.py
+  - tests/memory/test_vector_memory.py
+P4:
+  - tests/test_music_generation.py
+  - tests/test_voice_avatar_pipeline.py
+P5:
+  - tests/test_video_stream.py
+  - tests/test_voice_cloner_cli.py
+


### PR DESCRIPTION
## Summary
- introduce tests/priority_map.yaml to define P1–P5 tiers
- implement agents/razar/pytest_runner.py to execute tests by priority with optional resume
- document prioritized test execution in docs/RAZAR_AGENT.md

## Testing
- `python agents/razar/pytest_runner.py --priority P1`


------
https://chatgpt.com/codex/tasks/task_e_68af395ed9a4832eb4095f947d2be418