### PR TITLE
Add service health probes with Prometheus metrics

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -46,6 +46,37 @@ If RAZAR cannot restart components, rebuild the virtual environment and rerun
 the manager. Deleting the `.state` file next to the configuration forces a
 full restart cycle.
 
+## Health check metrics
+
+`agents/razar/health_checks.py` performs service probes with per-service latency
+thresholds. When the `prometheus_client` package is installed the script
+exposes metrics on port `9350`:
+
+```bash
+python -m agents.razar.health_checks --interval 30
+```
+
+Metrics exported:
+
+- `service_health_status` – `1` when healthy, `0` when a probe fails.
+- `service_health_latency_seconds` – latency for each probe.
+
+Add the endpoint to the Prometheus configuration:
+
+```yaml
+- job_name: 'razar-health'
+  static_configs:
+    - targets: ['razar-health:9350']
+```
+
+Start the bundled monitoring stack to explore dashboards in Grafana:
+
+```bash
+docker compose -f monitoring/docker-compose.yml up
+```
+
+Grafana listens on `http://localhost:3000` and Prometheus on `http://localhost:9090`.
+
 ## Timing metrics
 
 Latency histograms are exported via Prometheus:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -13,3 +13,6 @@ scrape_configs:
   - job_name: 'watchdog'
     static_configs:
       - targets: ['watchdog:9100']
+  - job_name: 'razar-health'
+    static_configs:
+      - targets: ['razar-health:9350']


### PR DESCRIPTION
## Summary
- expand RAZAR health checks with per-service latency thresholds and optional Prometheus metrics
- document how to run health probes and add Prometheus scrape config
- include razar health metrics job in monitoring Prometheus configuration

## Testing
- `pre-commit run --files agents/razar/health_checks.py monitoring/prometheus.yml docs/monitoring.md`
- `pytest` *(fails: ImportError while importing tests/test_voice_cloner_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af3b09a098832e98c20fa1d895f56d