### PR TITLE
docs: describe Chat2DB interface and references

### DIFF
--- a/docs/chat2db.md
+++ b/docs/chat2db.md
@@ -39,3 +39,12 @@ interactions and fetch relevant context during dialogue.
 The interface is stateless; components import these helpers as needed. See the
 [system blueprint](system_blueprint.md#chat2db-interface) for how Chat2DB fits in
 the overall stack.
+
+## Agent Interactions
+Chat2DB sits between the chat gateway and memory utilities. Agents interact with it in several ways:
+
+- **Chat Gateway** logs each user and model utterance via `save_interaction` and retrieves recent history with `fetch_interactions`.
+- **Memory Scribe** persists transcripts and voice configurations, pushing embeddings through `insert_embeddings` for later recall.
+- **Prompt Orchestrator and development helpers** query `fetch_interactions` and `query_embeddings` to build context-aware prompts.
+
+Because the API exposes simple functions, agents import these helpers directly without maintaining additional state.

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -2,12 +2,14 @@
 
 This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Startup is coordinated by the external [RAZAR Agent](RAZAR_AGENT.md), which performs pre-creation checks, manages the isolated virtual environment, and handles restart logic before these internal services come online. See the [RAZAR Agent](RAZAR_AGENT.md) guide for its external role, objectives, and invariants.
 
+[Chat2DB](chat2db.md) bridges the SQLite log and vector store so agents can persist transcripts and retrieve relevant context.
+
 | Agent | Role | Chakra | Memory Scope | External Libraries | Stub |
 | --- | --- | --- | --- | --- | --- |
 | Orchestration Master | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [orchestration_master.py](../orchestration_master.py) |
-| Prompt Orchestrator | Prompt routing and agent interface | Throat | Prompt/response JSON payloads | LLM APIs | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
+| Prompt Orchestrator | Prompt routing, agent interface, context recall via [Chat2DB](chat2db.md) | Throat | Prompt/response JSON payloads | LLM APIs | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
 | QNL Engine | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |
-| Memory Scribe | Voice avatar configuration and memory storage | Heart | `voice_avatar_config.yaml`, embedding records | Vector database | [memory_scribe.py](../memory_scribe.py) |
+| Memory Scribe | Voice avatar configuration and memory storage via [Chat2DB](chat2db.md) | Heart | `voice_avatar_config.yaml`, embedding records | Vector database | [memory_scribe.py](../memory_scribe.py) |
 
 These agents draw from the chakra structure outlined in the [Developer Onboarding guide](developer_onboarding.md) and [Chakra Architecture](chakra_architecture.md).
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -175,7 +175,7 @@ demonstrate practical startup sequences. Core roles include:
 
 - **Orchestration Master** (Crown) – oversees launch control and high-level coordination. See
   [orchestration_master.py](../orchestration_master.py).
-- **Prompt Orchestrator** (Throat) – routes prompts and manages agent interfaces via
+- **Prompt Orchestrator** (Throat) – routes prompts, pulls recent context from [Chat2DB](chat2db.md), and manages agent interfaces via
   [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py).
 - **QNL Engine** (Third Eye) – performs insight and Quantum Narrative Language processing in
   [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py).
@@ -231,7 +231,7 @@ See [nazarick_agents.md](nazarick_agents.md) for the full roster and the
 index so agents can persist and retrieve context. It relies on
 [`INANNA_AI/db_storage.py`](../INANNA_AI/db_storage.py) and
 [`spiral_vector_db/`](../spiral_vector_db/) for storage and is documented in the
-[Memory Architecture](memory_architecture.md).
+[Memory Architecture](memory_architecture.md). Agents like the Memory Scribe and Prompt Orchestrator call this layer to save transcripts and fetch context before crafting responses.
 
 ## Essential Services
 ### RAZAR Startup Orchestrator


### PR DESCRIPTION
## Summary
- expand Chat2DB guide with architecture, usage examples, and agent interaction details
- link Chat2DB usage from system blueprint and Nazarick agent table

## Testing
- `pytest -q` *(fails: import mismatch and missing core module)*

------
https://chatgpt.com/codex/tasks/task_e_68af3d037ffc832ea75fb0a1c02b7c19