### PR TITLE
Add RAZAR module repair utility and docs

### DIFF
--- a/agents/razar/code_repair.py
+++ b/agents/razar/code_repair.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Automated module repair using LLM patch suggestions.
+
+This helper collects context around failing modules, requests patch suggestions
+from the CROWN LLM (or alternate models) and evaluates the patches inside a
+sandbox.  When the patched module passes its tests the change is reintroduced
+and the component is reactivated.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from INANNA_AI.glm_integration import GLMIntegration
+
+from . import quarantine_manager
+
+logger = logging.getLogger(__name__)
+
+# Determine repository root relative to this file
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _gather_context(module_path: Path, error: str) -> str:
+    """Return a textual context block for ``module_path`` and ``error``."""
+    source = module_path.read_text(encoding="utf-8")
+    return f"""Repair the following module.\n\nError:\n{error}\n\nCode:\n{source}\n"""
+
+
+def _request_patch(context: str, models: Sequence[GLMIntegration]) -> str:
+    """Return patch text by querying ``models`` in order."""
+    for model in models:
+        suggestion = model.complete(context)
+        if suggestion and "unavailable" not in suggestion.lower():
+            return suggestion
+    return ""
+
+
+def _run_tests(test_paths: Iterable[Path], env: dict[str, str]) -> bool:
+    """Execute ``pytest`` for ``test_paths`` with ``env``."""
+    cmd = ["pytest", *map(str, test_paths)]
+    result = subprocess.run(cmd, cwd=str(PROJECT_ROOT), env=env, text=True)
+    if result.returncode != 0:
+        logger.error("Tests failed with code %s", result.returncode)
+        return False
+    return True
+
+
+def _apply_patch(
+    module_path: Path, patch_text: str, test_paths: Sequence[Path]
+) -> bool:
+    """Apply ``patch_text`` in a sandbox and run tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sandbox_root = Path(tmpdir)
+        rel = module_path.relative_to(PROJECT_ROOT)
+        target = sandbox_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(patch_text, encoding="utf-8")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(sandbox_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+        if not _run_tests(test_paths, env):
+            return False
+
+        shutil.copy2(target, module_path)
+    quarantine_manager.reactivate_component(
+        module_path.stem, verified=True, automated=True
+    )
+    return True
+
+
+def repair_module(
+    module_path: Path,
+    tests: Sequence[Path],
+    error: str,
+    *,
+    models: Sequence[GLMIntegration] | None = None,
+) -> bool:
+    """Attempt to repair ``module_path`` using ``tests`` and ``error`` context.
+
+    Parameters
+    ----------
+    module_path:
+        Path to the failing module.
+    tests:
+        Test file paths verifying the module's behaviour.
+    error:
+        Error message from the failing test run.
+    models:
+        Optional ordered list of models to query for patch suggestions.  When
+        omitted, a single default :class:`GLMIntegration` is used.
+    """
+
+    if models is None:
+        models = [GLMIntegration()]
+
+    context = _gather_context(module_path, error)
+    patch = _request_patch(context, models)
+    if not patch:
+        logger.error("No patch suggestion received")
+        return False
+    return _apply_patch(module_path, patch, tests)
+
+
+__all__ = ["repair_module"]

--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -40,3 +40,9 @@ The Crown router looks up previous expression decisions in `vector_memory`. When
 ## Session Logger
 
 Running the console interface now writes audio clips under `logs/audio/` and avatar frames to `logs/video/`. These helpers live in `tools/session_logger.py` and make it easier to review how voice modulation and streaming evolve across sessions.
+
+## Automated Module Repair
+
+The Crown stack can defer failing components to the RAZAR agent for automatic
+patching. See [RAZAR Agent](RAZAR_AGENT.md) for details on the repair workflow
+that queries an LLM for fixes and reintroduces modules after successful tests.

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -97,3 +97,21 @@ python agents/razar/pytest_runner.py --resume
 
 Output from each invocation is written to `logs/pytest_priority.log` for
 inspection by other RAZAR components.
+
+## Automated Code Repair
+
+`agents/razar/code_repair.py` automates patching of failing modules. The helper
+collects the failing source and error message, queries the CROWN LLM (or fallback
+models) for a patch suggestion and evaluates the result in a sandbox:
+
+1. **Context gathering** – read the module source and failing test output.
+2. **Patch request** – submit the context to `GLMIntegration` or alternate
+   models for a code fix.
+3. **Sandbox tests** – write the patched module to a temporary directory and
+   execute the module's test files with `pytest` using that sandbox on the
+   `PYTHONPATH`.
+4. **Reactivation** – if tests succeed, copy the patched file back to the
+   repository and reintroduce the module via `quarantine_manager.reactivate_component`.
+
+This workflow allows RAZAR to iteratively heal quarantined components without
+manually editing the repository.


### PR DESCRIPTION
## Summary
- add `agents/razar/code_repair.py` to request LLM patches, test in sandbox, and reactivate modules
- document repair workflow in `docs/RAZAR_AGENT.md`
- cross-link repair docs from `docs/CROWN_OVERVIEW.md`

## Testing
- `pre-commit run --files agents/razar/code_repair.py docs/RAZAR_AGENT.md docs/CROWN_OVERVIEW.md`
- `pytest tests/agents/razar/test_runtime_manager.py tests/agents/razar/test_boot_sequence.py tests/agents/razar/test_ignition_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68af44619fdc832e8f38deef49ecca0a