### PR TITLE
docs: expand RAZAR agent guide

### DIFF
--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -56,10 +56,11 @@ python docs/onboarding/wizard.py
 
 ## Getting Started with RAZAR
 
-See [RAZAR_AGENT.md](RAZAR_AGENT.md) for a detailed reference. As
-service 0, RAZAR’s mission is to verify dependencies, enforce component
-priorities, and log health to [Ignition.md](Ignition.md). For a local
-run:
+See [RAZAR_AGENT.md](RAZAR_AGENT.md) for a detailed reference on its
+perpetual ignition loop, CROWN diagnostic interface, and
+shutdown–repair–restart handshake. As service 0, RAZAR’s mission is to
+verify dependencies, enforce component priorities, and log health to
+[Ignition.md](Ignition.md). For a local run:
 
 1. **Build the RAZAR environment**
    ```bash

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -1,6 +1,6 @@
 # Nazarick Agents
 
-This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Startup is coordinated by the external [RAZAR Agent](RAZAR_AGENT.md), which performs pre-creation checks, manages the isolated virtual environment, and handles restart logic before these internal services come online. See the [RAZAR Agent](RAZAR_AGENT.md) guide for its external role, objectives, and invariants.
+This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Startup is coordinated by the external [RAZAR Agent](RAZAR_AGENT.md), which performs pre-creation checks, manages the isolated virtual environment, and cycles its perpetual ignition loop before these internal services come online. See the [RAZAR Agent](RAZAR_AGENT.md) guide for its CROWN diagnostics and shutdown–repair–restart handshake.
 
 [Chat2DB](chat2db.md) bridges the SQLite log and vector store so agents can persist transcripts and retrieve relevant context.
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -22,15 +22,17 @@ Start with these core references:
 
 RAZAR operates as service 0, validating the environment and enforcing the
 startup order. It rewrites [Ignition.md](Ignition.md) with status markers so
-operators can track health at a glance. Read the [RAZAR Agent](RAZAR_AGENT.md)
-guide for its mission and interfaces, and see
-[nazarick_agents.md](nazarick_agents.md) for the in‑world servant lineup. When
-issues surface, consult the [Recovery Playbook](recovery_playbook.md) and
-[Monitoring Guide](monitoring.md).
+operators can track health at a glance. Read the
+[RAZAR Agent](RAZAR_AGENT.md) guide for its perpetual ignition loop,
+CROWN LLM diagnostics, and shutdown–repair–restart handshake, and see
+[nazarick_agents.md](nazarick_agents.md) for the in‑world servant lineup.
+When issues surface, consult the [Recovery Playbook](recovery_playbook.md)
+and [Monitoring Guide](monitoring.md).
 
 For deployment and reliability details, see:
 
-- [RAZAR Agent](RAZAR_AGENT.md) – external startup orchestrator
+- [RAZAR Agent](RAZAR_AGENT.md) – external startup orchestrator with
+  a perpetual ignition loop and CROWN diagnostic interface
 - Runtime Manager (`agents/razar/runtime_manager.py`) – sequentially starts
   components, installs their dependencies from `razar_env.yaml`, quarantines
   failures and resumes from the last successful one stored in
@@ -282,12 +284,12 @@ index so agents can persist and retrieve context. It relies on
 
 ## Essential Services
 ### RAZAR Startup Orchestrator
-Prepares the runtime environment, fetches remote agents declared in `razar_config.yaml`, logs startup progress, triggers prioritized tests, and hosts the ZeroMQ recovery channel. See [RAZAR Agent](RAZAR_AGENT.md).
+Prepares the runtime environment, fetches remote agents declared in `razar_config.yaml`, logs startup progress, triggers prioritized tests, and hosts the ZeroMQ recovery channel. See [RAZAR Agent](RAZAR_AGENT.md) for its ignition loop and repair handshake.
 - **Layer:** External
 - **Priority:** 0
 - **Startup:** Runs first to build or validate the Python `venv` and broadcast lifecycle events on `messaging.lifecycle_bus`.
 - **Health Check:** Confirm the environment hash and orchestrator heartbeat.
-- **Verification:** Ensure Inanna AI and CROWN LLM report readiness; see [Final Verification Sequence](RAZAR_AGENT.md#final-verification-sequence).
+- **Verification:** Ensure Inanna AI and CROWN LLM report readiness; the shutdown–repair–restart handshake is detailed in [RAZAR Agent](RAZAR_AGENT.md).
 - **Recovery:** Rebuild the `venv` and restart RAZAR.
 
 ### Chat Gateway


### PR DESCRIPTION
## Summary
- add RAZAR Agent document outlining ignition loop, CROWN diagnostics, and shutdown–repair–restart handshake
- cross-link RAZAR guide from system blueprint, Nazarick agents roster, and developer onboarding

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/system_blueprint.md docs/nazarick_agents.md docs/developer_onboarding.md`
- `pytest --maxfail=1 -q` *(fails: import file mismatch in tests/test_vector_memory.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af5097405c832ead916c182b2e5cf7