### PR TITLE
docs: add component priority registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ coverage report
 
 - Keep changes focused; submit separate PRs for unrelated fixes.
 - Ensure documentation is updated and tests pass.
+- Register new modules in [docs/component_priorities.yaml](docs/component_priorities.yaml) with a priority (P1–P5), criticality tag, and issue categories so RAZAR can orchestrate startup.
 - Record project-wide documentation or architectural changes in
   [docs/system_blueprint.md](docs/system_blueprint.md) by adding a new
   version entry; do not modify or remove prior content. After updates, run

--- a/docs/component_priorities.yaml
+++ b/docs/component_priorities.yaml
@@ -1,0 +1,39 @@
+memory_store:
+  priority: P1
+  criticality: core
+  issue_categories:
+    - config
+    - runtime
+chat_gateway:
+  priority: P2
+  criticality: core
+  issue_categories:
+    - runtime
+    - integration
+crown_llm:
+  priority: P2
+  criticality: core
+  issue_categories:
+    - config
+    - runtime
+vision_adapter:
+  priority: P2
+  criticality: optional
+  issue_categories:
+    - integration
+audio_device:
+  priority: P3
+  criticality: optional
+  issue_categories:
+    - runtime
+avatar:
+  priority: P4
+  criticality: optional
+  issue_categories:
+    - runtime
+    - integration
+video:
+  priority: P5
+  criticality: optional
+  issue_categories:
+    - integration

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -9,6 +9,10 @@ Thank you for considering a contribution!
 3. Ensure tests and linters pass locally.
 4. Open a pull request with a summary of your changes.
 
+## Component Registry
+
+Add new modules to [component_priorities.yaml](component_priorities.yaml) with a priority (P1–P5), criticality tag (core or optional), and relevant issue categories (config, runtime, integration). RAZAR uses this registry to schedule startup and classify errors.
+
 ## Code Quality
 
 - Follow the project's [coding style](coding_style.md).

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -29,6 +29,8 @@ CROWN LLM diagnostics, and shutdown–repair–restart handshake, and see
 When issues surface, consult the [Recovery Playbook](recovery_playbook.md)
 and [Monitoring Guide](monitoring.md).
 
+Component priorities, criticality tags, and issue categories are tracked in [component_priorities.yaml](component_priorities.yaml). RAZAR reads this registry to map the startup sequence, escalate failures by criticality, and label alerts as configuration, runtime, or integration issues.
+
 For deployment and reliability details, see:
 
 - [RAZAR Agent](RAZAR_AGENT.md) – external startup orchestrator with


### PR DESCRIPTION
## Summary
- document component priorities, criticality tags, and issue categories in a new YAML registry
- explain how RAZAR consumes the registry in system blueprint
- guide contributors on registering new components

## Testing
- `pre-commit run --files docs/component_priorities.yaml docs/system_blueprint.md docs/contribution_guide.md CONTRIBUTING.md`
- `pytest --maxfail=1 -q` *(fails: unrecognized arguments --cov=src --cov=agents --cov-fail-under=0.5)*

------
https://chatgpt.com/codex/tasks/task_e_68af51c415fc832e8d245438a58e7470