### PR TITLE
Add RAZAR checkpoint recovery and auto‑resume

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -33,9 +33,19 @@ reuse the quickest sequence.
 
 ### CLI Options
 
-- `--strategy` – choose `priority` (default) to start components in declared
+- `--strategy` – choose `priority` \(default\) to start components in declared
   order or `random` to explore shuffled sequences.
 - `--resume` – reuse the best sequence from previous history entries.
+
+### Checkpoint recovery
+
+The adaptive orchestrator persists its progress to `logs/razar_checkpoint.json`.
+If RAZAR restarts, the orchestrator loads this checkpoint and continues from the
+last successful component automatically. Operators can override this behaviour:
+
+- `razar resume` – force continuation from the saved checkpoint.
+- `razar rollback` – delete the checkpoint and rerun the full sequence.
+
 
 ## CROWN LLM Diagnostics and Patching
 

--- a/razar/checkpoint_manager.py
+++ b/razar/checkpoint_manager.py
@@ -1,0 +1,54 @@
+"""Checkpoint utilities for the adaptive orchestrator.
+
+The checkpoint stores the component sequence, per-component states and the
+index of the next component to start. It allows the orchestrator to resume a
+partially completed run after a crash or manual interruption.
+"""
+
+from pathlib import Path
+import json
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKPOINT_PATH = ROOT / "logs" / "razar_checkpoint.json"
+
+
+def load_checkpoint(path: Path = CHECKPOINT_PATH) -> Dict[str, Any] | None:
+    """Return checkpoint data if available.
+
+    The checkpoint file contains a ``sequence`` list of component names,
+    ``last_success`` index and a mapping of component ``states``.
+    ``None`` is returned when the checkpoint does not exist or is invalid.
+    """
+
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def save_checkpoint(sequence: List[str], last_success: int, path: Path = CHECKPOINT_PATH) -> None:
+    """Persist ``sequence`` and ``last_success`` to ``path``.
+
+    ``last_success`` denotes the index of the next component to start. All
+    components with an index lower than this value are marked ``started`` in the
+    checkpoint ``states`` dictionary; the remaining components are marked
+    ``pending``.
+    """
+
+    states = {
+        name: ("started" if idx < last_success else "pending")
+        for idx, name in enumerate(sequence)
+    }
+    data = {"sequence": sequence, "last_success": last_success, "states": states}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def clear_checkpoint(path: Path = CHECKPOINT_PATH) -> None:
+    """Remove the checkpoint file if it exists."""
+
+    if path.exists():
+        path.unlink()


### PR DESCRIPTION
## Summary
- add `checkpoint_manager` module to persist component states and last completed step
- teach adaptive orchestrator to load checkpoints, persist progress, and resume automatically
- document restart behaviour and manual `razar resume` / `razar rollback` overrides

## Testing
- `pip install pytest-cov`
- `pytest razar -q` *(fails: Coverage failure: total of 0 is less than fail-under=0)*

------
https://chatgpt.com/codex/tasks/task_e_68af5adf3738832ea8d3420d9d747e96