### PR TITLE
feat: add razar boot orchestrator and docs

### DIFF
--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -1,63 +1,218 @@
-"""RAZAR boot orchestrator.
+"""Boot orchestrator for the RAZAR agent.
 
-Provides placeholders for the staged startup sequence described in
-``docs/system_blueprint.md``. Each hook will launch a component and wait for
-readiness before advancing to the next stage.
+The orchestrator derives the component startup order from
+``docs/system_blueprint.md`` and regenerates ``docs/Ignition.md`` with
+status markers. Components are launched sequentially and progress is
+persisted to ``logs/razar_state.json`` so subsequent runs can resume from
+the last successful component.
 """
 
 from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shlex
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+try:  # pragma: no cover - dependency is handled in tests
+    import yaml
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError("pyyaml is required for the boot orchestrator") from exc
+
+from . import health_checks
+from .ignition_builder import DEFAULT_STATUS, parse_system_blueprint
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BootOrchestrator:
     """Coordinate staged startup for core ABZU services."""
 
-    def start_memory_store(self) -> None:
-        """Start the memory store (stage 1)."""
-        # TODO: Implement Memory Store startup (priority 1)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+    def __init__(
+        self,
+        *,
+        blueprint: Path | None = None,
+        config: Path | None = None,
+        ignition: Path | None = None,
+        state: Path | None = None,
+    ) -> None:
+        root = Path(__file__).resolve().parents[2]
+        self.blueprint_path = blueprint or root / "docs" / "system_blueprint.md"
+        self.config_path = config or root / "config" / "razar_config.yaml"
+        self.ignition_path = ignition or root / "docs" / "Ignition.md"
+        self.state_path = state or root / "logs" / "razar_state.json"
 
-    def start_chat_gateway(self) -> None:
-        """Start the chat gateway (stage 2)."""
-        # TODO: Implement Chat Gateway startup (priority 2)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+        self.components = parse_system_blueprint(self.blueprint_path)
+        self.statuses: Dict[str, str] = {
+            str(comp["name"]): DEFAULT_STATUS for comp in self.components
+        }
 
-    def start_crown_llm(self) -> None:
-        """Start the CROWN LLM (stage 3)."""
-        # TODO: Implement CROWN LLM startup (priority 2)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def load_state(self) -> str:
+        if self.state_path.exists():
+            try:
+                data = json.loads(self.state_path.read_text(encoding="utf-8"))
+                return str(data.get("last_component", ""))
+            except json.JSONDecodeError:
+                return ""
+        return ""
 
-    def start_audio_device(self) -> None:
-        """Start the audio device (stage 4)."""
-        # TODO: Implement Audio Device startup (priority 3)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+    def save_state(self, name: str) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(
+            json.dumps({"last_component": name}), encoding="utf-8"
+        )
 
-    def start_avatar(self) -> None:
-        """Start the avatar service (stage 5)."""
-        # TODO: Implement Avatar startup (priority 4)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+    # ------------------------------------------------------------------
+    # Ignition file handling
+    # ------------------------------------------------------------------
+    def _render_ignition(self) -> str:
+        groups: Dict[int, List[Dict[str, object]]] = defaultdict(list)
+        for comp in self.components:
+            groups[int(comp["priority"])].append(comp)
 
-    def start_video(self) -> None:
-        """Start the video service (stage 6)."""
-        # TODO: Implement Video startup (priority 5)
-        #       See docs/system_blueprint.md
-        raise NotImplementedError
+        lines = [
+            "# Ignition",
+            "",
+            (
+                "RAZAR coordinates system boot and records runtime health. "
+                "Components are grouped by priority so operators can track "
+                "startup order and service status."
+            ),
+            "",
+        ]
 
-    def run(self) -> None:
+        for priority in sorted(groups):
+            lines.append(f"## Priority {priority}")
+            lines.append("| Order | Component | Health Check | Status |")
+            lines.append("| --- | --- | --- | --- |")
+            for comp in sorted(groups[priority], key=lambda c: c["order"]):
+                health_check = comp["health_check"] or "-"
+                status = self.statuses.get(str(comp["name"]), DEFAULT_STATUS)
+                lines.append(
+                    f"| {comp['order']} | {comp['name']} | {health_check} | {status} |"
+                )
+            lines.append("")
+
+        lines.extend(
+            [
+                "## Regeneration",
+                (
+                    "RAZAR monitors component events and rewrites this file whenever a "
+                    "priority or health state changes. Status markers update to:"
+                ),
+                "",
+                "- ✅ healthy",
+                "- ⚠️ starting or degraded",
+                "- ❌ offline",
+                "",
+                "This keeps the ignition sequence in version control so operators can "
+                "audit boot cycles.",
+                "",
+            ]
+        )
+
+        return "\n".join(lines)
+
+    def write_ignition(self) -> None:
+        self.ignition_path.write_text(self._render_ignition(), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Component launching
+    # ------------------------------------------------------------------
+    def _load_commands(self) -> Dict[str, str]:
+        if not self.config_path.exists():
+            return {}
+        data = yaml.safe_load(self.config_path.read_text(encoding="utf-8")) or {}
+        comps = data.get("components", [])
+        return {str(c.get("name")): str(c.get("command", "")) for c in comps}
+
+    def _launch(self, comp: Dict[str, object], commands: Dict[str, str]) -> None:
+        name = str(comp.get("name"))
+        cmd = commands.get(name) or f"echo launching {name}"
+        LOGGER.info("Starting component %s", name)
+        result = subprocess.run(
+            shlex.split(cmd) if isinstance(cmd, str) else cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if result.returncode != 0:
+            LOGGER.error("Component %s failed: %s", name, result.stdout)
+            self.statuses[name] = "❌"
+            self.write_ignition()
+            raise RuntimeError(f"{name} failed to start")
+
+        if not health_checks.run(name):
+            LOGGER.error("Health check failed for %s", name)
+            self.statuses[name] = "❌"
+            self.write_ignition()
+            raise RuntimeError(f"Health check failed for {name}")
+
+        self.statuses[name] = "✅"
+        self.save_state(name)
+        self.write_ignition()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> bool:
         """Execute the staged startup sequence."""
-        # TODO: Orchestrate component startups in the order defined above.
-        raise NotImplementedError
+
+        self.write_ignition()
+        commands = self._load_commands()
+        last = self.load_state()
+
+        start_index = 0
+        if last:
+            for idx, comp in enumerate(self.components):
+                if comp.get("name") == last:
+                    start_index = idx + 1
+                    break
+            if start_index:
+                LOGGER.info("Resuming after component %s", last)
+
+        for comp in self.components[start_index:]:
+            try:
+                self._launch(comp, commands)
+            except RuntimeError:
+                return False
+
+        LOGGER.info("Boot sequence complete")
+        return True
 
 
-def main() -> None:
-    """Run the boot orchestrator."""
-    orchestrator = BootOrchestrator()
-    orchestrator.run()
+def main() -> None:  # pragma: no cover - CLI helper
+    parser = argparse.ArgumentParser(description="Run the RAZAR boot orchestrator")
+    root = Path(__file__).resolve().parents[2]
+    parser.add_argument(
+        "--blueprint", type=Path, default=root / "docs" / "system_blueprint.md"
+    )
+    parser.add_argument(
+        "--config", type=Path, default=root / "config" / "razar_config.yaml"
+    )
+    parser.add_argument(
+        "--ignition", type=Path, default=root / "docs" / "Ignition.md"
+    )
+    parser.add_argument("--state", type=Path, default=root / "logs" / "razar_state.json")
+    args = parser.parse_args()
+
+    orchestrator = BootOrchestrator(
+        blueprint=args.blueprint,
+        config=args.config,
+        ignition=args.ignition,
+        state=args.state,
+    )
+    success = orchestrator.run()
+    raise SystemExit(0 if success else 1)
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI helper
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -7,6 +7,18 @@ startup progress. The agent forms a feedback loop with CROWN LLM to heal
 faulty modules and ensures the system can cycle back to a ready state
 without manual intervention.
 
+## Ignition Workflow
+
+`agents/razar/boot_orchestrator.py` drives the initial boot sequence. It
+parses `docs/system_blueprint.md` to derive component priorities and
+regenerates `docs/Ignition.md` with a status column. Each component is
+launched in priority order using commands from
+`config/razar_config.yaml`. After a component reports healthy via
+`agents/razar/health_checks.py` the marker flips to ✅ and progress is
+persisted to `logs/razar_state.json` so later runs resume from the last
+successful step. Failures are marked ❌ and halt the sequence. Invoke the
+workflow with `python -m agents.razar.boot_orchestrator`.
+
 ## Perpetual Ignition Loop
 
 RAZAR runs a perpetual ignition loop that:

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -22,8 +22,10 @@ Start with these core references:
 
 RAZAR operates as service 0, validating the environment and enforcing the
 startup order. It rewrites [Ignition.md](Ignition.md) with status markers so
-operators can track health at a glance. Read the
-[RAZAR Agent](RAZAR_AGENT.md) guide for its perpetual ignition loop,
+operators can track health at a glance. The
+[RAZAR Agent ignition workflow](RAZAR_AGENT.md#ignition-workflow) explains
+how priorities are derived and progress is persisted. The broader
+[RAZAR Agent](RAZAR_AGENT.md) guide covers its perpetual ignition loop,
 CROWN LLM diagnostics, and shutdown–repair–restart handshake, and see
 [nazarick_agents.md](nazarick_agents.md) for the in‑world servant lineup.
 When issues surface, consult the [Recovery Playbook](recovery_playbook.md)


### PR DESCRIPTION
## Summary
- implement boot orchestrator that parses system_blueprint, generates Ignition doc, launches components and persists state
- document ignition workflow and link from system blueprint

## Testing
- `pytest tests/agents/razar -q`

------
https://chatgpt.com/codex/tasks/task_e_68af61e117c8832eae0f4ece98bafc4c