### PR TITLE
feat: add prioritized pytest runner

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -68,6 +68,15 @@ context to the LLM, receives a patch suggestion, and validates the result
 in a sandbox.  Successful patches are committed back to the repository
 and the component is marked ready for reactivation.
 
+## Prioritized Pytest Runner
+
+`agents/razar/pytest_runner.py` drives tiered test execution.  Test files are
+grouped into priorities in `tests/priority_map.yaml` and executed sequentially
+with the `pytest-order` plug‑in.  Output from each tier is appended to
+`logs/pytest_priority.log`.  When a test fails, the runner invokes the code
+repair workflow to solicit a patch, applies it in a temporary workspace, and
+reruns the affected tests before resuming the remaining tiers.
+
 ## Remote Agent Registration
 
 External helper agents can be loaded at runtime via

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,7 +11,9 @@ flowchart LR
 ### Prioritized test tiers
 
 Execute tests in priority order using the RAZAR runner. The mapping of test
-files to tiers lives in `tests/priority_map.yaml`.
+files to tiers lives in `tests/priority_map.yaml`.  Each tier is executed
+sequentially with the `pytest-order` plug‑in so critical smoke tests fail fast.
+Output from every run appends to `logs/pytest_priority.log`.
 
 Run all tiers:
 
@@ -19,11 +21,21 @@ Run all tiers:
 python agents/razar/pytest_runner.py
 ```
 
+Run a specific tier:
+
+```bash
+python agents/razar/pytest_runner.py --priority P1
+```
+
 Resume from the last failing tier:
 
 ```bash
 python agents/razar/pytest_runner.py --resume
 ```
+
+If a tier fails, the runner invokes the remote code repair agent.  The failing
+module is patched in a temporary workspace and its tests rerun.  Successful
+patches are applied to the repository automatically.
 
 ### CLI console interface
 

--- a/tests/priority_map.yaml
+++ b/tests/priority_map.yaml
@@ -1,3 +1,5 @@
+# Map test modules to priority tiers for the RAZAR pytest runner.
+# Higher tiers run first to catch critical failures quickly.
 P1:
   - tests/test_smoke_imports.py
   - tests/test_core_scipy_smoke.py


### PR DESCRIPTION
## Summary
- map smoke tests into P1–P5 tiers
- add pytest runner that executes tiers, resumes, and attempts automated repair
- document prioritized testing workflow and RAZAR involvement

## Testing
- `pre-commit run --files tests/priority_map.yaml agents/razar/pytest_runner.py docs/testing.md docs/RAZAR_AGENT.md`
- `python agents/razar/pytest_runner.py --priority P1`


------
https://chatgpt.com/codex/tasks/task_e_68af6639d578832eb8a5ac2b5da5e7ed