### PR TITLE
Add mission event logger and timeline CLI

### DIFF
--- a/agents/razar/mission_logger.py
+++ b/agents/razar/mission_logger.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 This module records lifecycle events for RAZAR components in a JSON lines log
 stored at ``logs/razar.log``. Each entry captures:
 
-- ``event`` – type of event such as ``launch`` or ``health_check``
+- ``event`` – type of event such as ``start`` or ``health``
 - ``component`` – component name
 - ``status`` – outcome or note for the event
 - ``timestamp`` – ISO-8601 time in UTC
 - ``details`` – optional free-form text
 
-Utility helpers are provided for the common events of component launches,
-health checks, quarantines and recovery actions. The log can be summarised to
-find the last successful component or rendered as a chronological timeline for
+Utility helpers are provided for the common events of component starts, health
+results, quarantines and applied patches. The log can be summarised to find the
+last successful component or rendered as a chronological timeline for
 debugging.
 """
 
@@ -80,18 +80,18 @@ def log_event(
         fh.write(json.dumps(record) + "\n")
 
 
-def log_launch(component: str, status: str, details: str | None = None) -> None:
-    """Record a component launch event."""
+def log_start(component: str, status: str, details: str | None = None) -> None:
+    """Record that a component has started."""
 
-    log_event("launch", component, status, details)
+    log_event("start", component, status, details)
 
 
-def log_health_check(
+def log_health(
     component: str, status: str, details: str | None = None
 ) -> None:
-    """Record a health check event."""
+    """Record a health result for a component."""
 
-    log_event("health_check", component, status, details)
+    log_event("health", component, status, details)
 
 
 def log_quarantine(component: str, reason: str, details: str | None = None) -> None:
@@ -100,10 +100,21 @@ def log_quarantine(component: str, reason: str, details: str | None = None) -> N
     log_event("quarantine", component, reason, details)
 
 
-def log_recovery(component: str, action: str, details: str | None = None) -> None:
-    """Record that recovery actions were taken for a component."""
+def log_patch(component: str, patch: str, details: str | None = None) -> None:
+    """Record that a patch has been applied to a component."""
 
-    log_event("recovery", component, action, details)
+    log_event("patch", component, patch, details)
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility aliases
+# ---------------------------------------------------------------------------
+
+# Older helpers used different terminology. Keep them as thin wrappers so
+# existing scripts continue to work.
+log_launch = log_start
+log_health_check = log_health
+log_recovery = log_patch
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +210,7 @@ def main() -> None:  # pragma: no cover - CLI helper
     p_log.add_argument(
         "--event",
         default="info",
-        help="Event type such as launch, health_check, quarantine, recovery",
+        help="Event type such as start, health, quarantine or patch",
     )
     p_log.add_argument("--details", help="Optional additional information")
     p_log.set_defaults(func=_cmd_log)

--- a/docs/logging_guidelines.md
+++ b/docs/logging_guidelines.md
@@ -3,7 +3,7 @@
 The mission logger records component activity in `logs/razar.log` using one JSON
 object per line. Each entry contains:
 
-- `event` – type of action (`launch`, `health_check`, `quarantine`, `recovery`)
+- `event` – type of action (`start`, `health`, `quarantine`, `patch`)
 - `component` – name of the component
 - `status` – outcome or note for the event
 - `timestamp` – UTC time the event occurred
@@ -15,8 +15,9 @@ Use `agents.razar.mission_logger` or the command line interface to append
 entries:
 
 ```bash
-python -m razar.mission_logger log gateway success --event launch
-python -m razar.mission_logger log gateway fail --event health_check --details "timeout"
+python -m razar.mission_logger log gateway success --event start
+python -m razar.mission_logger log gateway fail --event health --details "timeout"
+python -m razar.mission_logger log gateway patched --event patch --details "1.2.3"
 ```
 
 ## Inspecting the timeline

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -46,6 +46,16 @@ If RAZAR cannot restart components, rebuild the virtual environment and rerun
 the manager. Deleting the `.state` file next to the configuration forces a
 full restart cycle.
 
+## Boot history
+
+Component activity is written to `logs/razar.log` in JSON lines. Refer to the
+[logging guidelines](logging_guidelines.md) for event types and usage. To
+reconstruct the boot history and identify failures chronologically, run:
+
+```bash
+python -m razar timeline
+```
+
 ## Status dashboard
 
 Use the status dashboard for a quick snapshot of the current boot attempt and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,11 +16,12 @@ environment hash and heartbeat. Failed components are automatically moved to
 `quarantine/`, classified by `razar.issue_analyzer`, and logged in
 `docs/quarantine_log.md` with their issue type and suggested fix.
 
-Use ``razar.mission_logger`` to record progress as components start (see
+Use ``razar.mission_logger`` to record progress as components start, report
+health results, enter quarantine and receive patches (see
 [logging guidelines](logging_guidelines.md) for event types and examples):
 
 ```bash
-python -m razar.mission_logger log gateway success
+python -m razar.mission_logger log gateway success --event start
 python -m razar.mission_logger summary
 ```
 

--- a/razar/__main__.py
+++ b/razar/__main__.py
@@ -32,7 +32,7 @@ def _cmd_build_ignition(args: argparse.Namespace) -> None:
 
 
 def _cmd_timeline(_: argparse.Namespace) -> None:
-    """Print the chronological mission log."""
+    """Print the chronological boot history from the mission log."""
 
     for entry in mission_logger.timeline():
         details = f" - {entry['details']}" if entry.get("details") else ""

--- a/tests/test_mission_logger.py
+++ b/tests/test_mission_logger.py
@@ -4,22 +4,22 @@ from razar import mission_logger
 
 def test_log_and_timeline(tmp_path):
     mission_logger.LOG_PATH = tmp_path / "logs" / "razar.log"
-    mission_logger.log_launch("alpha", "success")
-    mission_logger.log_health_check("beta", "fail")
+    mission_logger.log_start("alpha", "success")
+    mission_logger.log_health("beta", "fail")
     mission_logger.log_quarantine("beta", "isolated")
-    mission_logger.log_recovery("beta", "restart")
+    mission_logger.log_patch("beta", "restart")
 
     assert mission_logger.LOG_PATH.exists()
     data = [json.loads(l) for l in mission_logger.LOG_PATH.read_text().splitlines()]
-    assert data[0]["event"] == "launch"
+    assert data[0]["event"] == "start"
 
     timeline = mission_logger.timeline()
-    assert [e["event"] for e in timeline] == ["launch", "health_check", "quarantine", "recovery"]
+    assert [e["event"] for e in timeline] == ["start", "health", "quarantine", "patch"]
 
-    summary = mission_logger.summarize(event_filter="launch")
+    summary = mission_logger.summarize(event_filter="start")
     assert summary["last_success"] == "alpha"
     assert summary["pending"] == []
 
-    mission_logger.log_launch("gamma", "pending")
-    summary = mission_logger.summarize(event_filter="launch")
+    mission_logger.log_start("gamma", "pending")
+    summary = mission_logger.summarize(event_filter="start")
     assert summary["pending"] == ["gamma"]


### PR DESCRIPTION
## Summary
- Record mission events (start, health, quarantine, patch) in structured JSON lines
- Provide `razar timeline` CLI command to replay boot history
- Link logging guidance from monitoring and operations docs

## Testing
- `pytest tests/test_mission_logger.py -q` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d400664832e9cbeab0670219467