### PR TITLE
Add event infrastructure and processor

### DIFF
--- a/citadel/__init__.py
+++ b/citadel/__init__.py
@@ -1,0 +1,12 @@
+"""Event infrastructure for agents."""
+
+from .event_producer import Event, EventProducer, RedisEventProducer, KafkaEventProducer
+from .event_processor import create_app
+
+__all__ = [
+    "Event",
+    "EventProducer",
+    "RedisEventProducer",
+    "KafkaEventProducer",
+    "create_app",
+]

--- a/citadel/event_processor.py
+++ b/citadel/event_processor.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+"""FastAPI service that processes agent events."""
+
+import asyncio
+import contextlib
+import json
+from typing import Optional
+
+from fastapi import FastAPI
+
+from .event_producer import Event
+
+
+class TimescaleWriter:
+    """Persist events to TimescaleDB."""
+
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+        self._conn: Optional[object] = None
+
+    async def _connect(self) -> None:
+        import asyncpg  # type: ignore
+
+        self._conn = await asyncpg.connect(self.dsn)
+
+    async def write_event(self, event: Event) -> None:
+        if self._conn is None:
+            await self._connect()
+        await self._conn.execute(
+            """
+            INSERT INTO agent_events (agent_id, event_type, payload, ts)
+            VALUES ($1, $2, $3, $4)
+            """,
+            event.agent_id,
+            event.event_type,
+            json.dumps(event.payload),
+            event.timestamp,
+        )
+
+
+class Neo4jWriter:
+    """Persist relationships between agents in Neo4j."""
+
+    def __init__(self, uri: str, user: str, password: str) -> None:
+        self.uri = uri
+        self.user = user
+        self.password = password
+        self._driver: Optional[object] = None
+
+    async def _connect(self) -> None:
+        from neo4j import AsyncGraphDatabase  # type: ignore
+
+        self._driver = AsyncGraphDatabase.driver(self.uri, auth=(self.user, self.password))
+
+    async def write_event(self, event: Event) -> None:
+        if self._driver is None:
+            await self._connect()
+        async with self._driver.session() as session:  # type: ignore
+            await session.execute_write(
+                lambda tx: tx.run(
+                    """
+                    MERGE (a:Agent {id: $agent_id})
+                    CREATE (a)-[:EMITTED {type: $event_type, ts: $ts}]->(:Event {payload: $payload})
+                    """,
+                    agent_id=event.agent_id,
+                    event_type=event.event_type,
+                    ts=event.timestamp,
+                    payload=json.dumps(event.payload),
+                )
+            )
+
+
+async def process_event(event: Event, ts_writer: TimescaleWriter, neo_writer: Neo4jWriter) -> None:
+    """Write the event to all backends."""
+
+    await ts_writer.write_event(event)
+    await neo_writer.write_event(event)
+
+
+async def _redis_listener(channel: str, url: str, ts_writer: TimescaleWriter, neo_writer: Neo4jWriter) -> None:
+    import redis.asyncio as redis  # type: ignore
+
+    redis_client = redis.from_url(url)
+    pubsub = redis_client.pubsub()
+    await pubsub.subscribe(channel)
+    async for message in pubsub.listen():
+        if message["type"] != "message":
+            continue
+        event = Event.from_json(message["data"])
+        await process_event(event, ts_writer, neo_writer)
+
+
+async def _kafka_listener(topic: str, bootstrap_servers: str, ts_writer: TimescaleWriter, neo_writer: Neo4jWriter) -> None:
+    from aiokafka import AIOKafkaConsumer  # type: ignore
+
+    consumer = AIOKafkaConsumer(topic, bootstrap_servers=bootstrap_servers)
+    await consumer.start()
+    try:
+        async for msg in consumer:
+            event = Event.from_json(msg.value.decode("utf-8"))
+            await process_event(event, ts_writer, neo_writer)
+    finally:
+        await consumer.stop()
+
+
+def create_app(
+    *,
+    redis_channel: Optional[str] = None,
+    redis_url: str = "redis://localhost",
+    kafka_topic: Optional[str] = None,
+    kafka_servers: str = "localhost:9092",
+    timescale_dsn: str = "postgresql://localhost/spiral",
+    neo4j_uri: str = "bolt://localhost:7687",
+    neo4j_user: str = "neo4j",
+    neo4j_password: str = "neo4j",
+) -> FastAPI:
+    """Create the event processing application."""
+
+    app = FastAPI()
+    ts_writer = TimescaleWriter(timescale_dsn)
+    neo_writer = Neo4jWriter(neo4j_uri, neo4j_user, neo4j_password)
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        app.state.tasks = []
+        if redis_channel:
+            task = asyncio.create_task(
+                _redis_listener(redis_channel, redis_url, ts_writer, neo_writer)
+            )
+            app.state.tasks.append(task)
+        if kafka_topic:
+            task = asyncio.create_task(
+                _kafka_listener(kafka_topic, kafka_servers, ts_writer, neo_writer)
+            )
+            app.state.tasks.append(task)
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        for task in getattr(app.state, "tasks", []):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app

--- a/citadel/event_producer.py
+++ b/citadel/event_producer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Interfaces for emitting agent events to message brokers."""
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Event:
+    """Representation of an agent event."""
+
+    agent_id: str
+    event_type: str
+    payload: dict
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+    def to_json(self) -> str:
+        """Serialise the event to a JSON string."""
+
+        return json.dumps(asdict(self), default=str)
+
+    @classmethod
+    def from_json(cls, data: str) -> Event:
+        """Deserialise an event from a JSON string."""
+
+        raw = json.loads(data)
+        raw["timestamp"] = datetime.fromisoformat(raw["timestamp"])
+        return cls(**raw)
+
+
+class EventProducer:
+    """Interface for event producers."""
+
+    async def emit(self, event: Event) -> None:
+        """Emit an event to the underlying broker."""
+
+        raise NotImplementedError
+
+
+class RedisEventProducer(EventProducer):
+    """Publish events to a Redis channel."""
+
+    def __init__(self, channel: str, url: str = "redis://localhost") -> None:
+        self.channel = channel
+        self.url = url
+        self._redis: Optional[object] = None
+
+    async def _connect(self) -> None:
+        import redis.asyncio as redis  # type: ignore
+
+        self._redis = redis.from_url(self.url)
+
+    async def emit(self, event: Event) -> None:  # noqa: D401 - See base class
+        if self._redis is None:
+            await self._connect()
+        await self._redis.publish(self.channel, event.to_json())
+
+
+class KafkaEventProducer(EventProducer):
+    """Publish events to a Kafka topic."""
+
+    def __init__(self, topic: str, bootstrap_servers: str = "localhost:9092") -> None:
+        self.topic = topic
+        self.bootstrap_servers = bootstrap_servers
+        self._producer: Optional[object] = None
+
+    async def _connect(self) -> None:
+        from aiokafka import AIOKafkaProducer  # type: ignore
+
+        self._producer = AIOKafkaProducer(bootstrap_servers=self.bootstrap_servers)
+        await self._producer.start()
+
+    async def emit(self, event: Event) -> None:  # noqa: D401 - See base class
+        if self._producer is None:
+            await self._connect()
+        await self._producer.send_and_wait(self.topic, event.to_json().encode("utf-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,13 @@ ultralytics = ["ultralytics==8.3.179"]
 optuna = ["optuna==3.6.1"]
 shap = ["shap==0.45.0"]
 
+citadel = [
+    "redis==5.0.3",
+    "aiokafka==0.10.0",
+    "asyncpg==0.29.0",
+    "neo4j==5.23.1",
+]
+
 # Development extras mirror dev-requirements.txt
 # including testing and formatting tools
 dev = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,13 @@ soundfile==0.13.1
     # optional: audio processing features
 phonemizer==3.3.0
     # for phoneme extraction
+fastapi==0.116.1
+    # via citadel event processor
+redis==5.0.3
+    # optional: event processing
+aiokafka==0.10.0
+    # optional: event processing
+asyncpg==0.29.0
+    # optional: event processing
+neo4j==5.23.1
+    # optional: event processing

--- a/tests/test_citadel_event_producer.py
+++ b/tests/test_citadel_event_producer.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from citadel.event_producer import Event, EventProducer
+
+
+class MockProducer(EventProducer):
+    def __init__(self) -> None:
+        self.events = []
+
+    async def emit(self, event: Event) -> None:
+        self.events.append(event)
+
+
+def test_event_serialisation_round_trip() -> None:
+    event = Event(agent_id="a1", event_type="test", payload={"x": 1})
+    restored = Event.from_json(event.to_json())
+    assert restored == event
+
+
+def test_mock_producer_emits_event() -> None:
+    producer = MockProducer()
+    event = Event(agent_id="a1", event_type="ping", payload={})
+    asyncio.run(producer.emit(event))
+    assert producer.events == [event]


### PR DESCRIPTION
## Summary
- add citadel package with event producer interface and Redis/Kafka producers
- implement FastAPI event processor writing to TimescaleDB and Neo4j
- document optional dependencies for citadel

## Testing
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68af7f436310832eb2cf9684532713eb