### PR TITLE
feat: add socketio client and nlq api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ data/training/
 
 # Local virtual environment
 .venv/
+node_modules/
+floor_client/node_modules/
+floor_client/dist/
+floor_client/package-lock.json

--- a/communication/floor_channel_socket.py
+++ b/communication/floor_channel_socket.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Socket.IO server managing floor and channel rooms."""
+
+import socketio
+
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+
+socket_app = socketio.ASGIApp(sio)
+
+
+@sio.event
+async def connect(sid, environ):
+    """Handle client connection."""
+    # connection established; no-op
+    return None
+
+
+@sio.on("join")
+async def on_join(sid, data):
+    """Join a floor/channel room."""
+    floor = data.get("floor")
+    channel = data.get("channel")
+    if not floor or not channel:
+        return
+    room = f"{floor}:{channel}"
+    sio.enter_room(sid, room)
+    await sio.emit("joined", {"floor": floor, "channel": channel}, room=sid)
+
+
+@sio.on("message")
+async def on_message(sid, data):
+    """Broadcast ``message`` to all peers in the room."""
+    floor = data.get("floor")
+    channel = data.get("channel")
+    message = data.get("message")
+    if not (floor and channel and message):
+        return
+    room = f"{floor}:{channel}"
+    await sio.emit(
+        "message",
+        {"floor": floor, "channel": channel, "message": message},
+        room=room,
+    )
+
+
+__all__ = ["socket_app"]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -56,3 +56,7 @@ streamlit==1.48.1
     # via spiral-os (pyproject.toml)
 uvicorn==0.35.0
     # via spiral-os (pyproject.toml)
+python-socketio==5.13.0
+    # optional: websocket support
+vanna==0.7.9
+    # optional: NLQ queries

--- a/floor_client/index.html
+++ b/floor_client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Floor Channels</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/floor_client/package.json
+++ b/floor_client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "floor-client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "socket.io-client": "^4.7.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.0.0"
+  }
+}

--- a/floor_client/postcss.config.js
+++ b/floor_client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/floor_client/src/App.jsx
+++ b/floor_client/src/App.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+import Floor from './components/Floor.jsx';
+
+const floors = {
+  ground: ['alpha', 'beta'],
+  first: ['gamma', 'delta'],
+};
+
+const socket = io('http://localhost:8000/ws');
+
+export default function App() {
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    socket.on('message', (data) => {
+      setMessages((m) => [...m, data]);
+    });
+    return () => {
+      socket.off('message');
+    };
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      {Object.entries(floors).map(([floor, channels]) => (
+        <Floor key={floor} name={floor} channels={channels} socket={socket} />
+      ))}
+      <div className="mt-4">
+        {messages.map((m, idx) => (
+          <div key={idx}>{`${m.floor}/${m.channel}: ${m.message}`}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/floor_client/src/components/Channel.jsx
+++ b/floor_client/src/components/Channel.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+export default function Channel({ floor, name, socket }) {
+  const [input, setInput] = useState('');
+  const room = { floor, channel: name };
+
+  const send = () => {
+    if (input.trim()) {
+      socket.emit('message', { ...room, message: input });
+      setInput('');
+    }
+  };
+
+  return (
+    <div className="border rounded p-2 w-40">
+      <div className="font-semibold">{name}</div>
+      <input
+        className="border w-full p-1 mt-1"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="message"
+      />
+      <button
+        className="mt-1 bg-blue-500 text-white px-2 py-1 rounded"
+        onClick={send}
+      >
+        send
+      </button>
+    </div>
+  );
+}

--- a/floor_client/src/components/Floor.jsx
+++ b/floor_client/src/components/Floor.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Channel from './Channel.jsx';
+
+export default function Floor({ name, channels, socket }) {
+  return (
+    <div className="border rounded p-2">
+      <h2 className="font-bold mb-2">{name}</h2>
+      <div className="flex gap-2">
+        {channels.map((ch) => (
+          <Channel key={ch} floor={name} name={ch} socket={socket} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/floor_client/src/index.css
+++ b/floor_client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/floor_client/src/main.jsx
+++ b/floor_client/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/floor_client/tailwind.config.js
+++ b/floor_client/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/floor_client/vite.config.js
+++ b/floor_client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/nlq_api.py
+++ b/nlq_api.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""NLQ API powered by Vanna AI."""
+
+from pathlib import Path
+from fastapi import APIRouter
+
+from agents.vanna_data import query_db
+from core.utils.optional_deps import lazy_import
+
+router = APIRouter()
+vanna = lazy_import("vanna")
+
+
+def _train_vanna() -> None:
+    """Train Vanna on channel and log schemas if available."""
+    if getattr(vanna, "__stub__", False):
+        return
+    schemas_dir = Path("schemas")
+    for sql_file in schemas_dir.glob("*.sql"):
+        try:
+            vanna.train(ddl=sql_file.read_text())
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+_train_vanna()
+
+
+@router.post("/nlq")
+async def nlq_query(data: dict[str, str]) -> dict[str, object]:
+    """Execute a natural language query against the database."""
+    prompt = data.get("query", "")
+    rows = query_db(prompt) if prompt else []
+    return {"rows": rows}
+
+
+__all__ = ["router"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,7 @@ asyncpg==0.29.0
     # optional: event processing
 neo4j==5.23.1
     # optional: event processing
+python-socketio==5.13.0
+    # optional: websocket support
+vanna==0.7.9
+    # optional: NLQ queries

--- a/schemas/channel_schema.sql
+++ b/schemas/channel_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE channels (
+    id INTEGER PRIMARY KEY,
+    floor TEXT,
+    name TEXT
+);

--- a/schemas/log_schema.sql
+++ b/schemas/log_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE channel_logs (
+    id INTEGER PRIMARY KEY,
+    channel_id INTEGER,
+    message TEXT,
+    created_at TIMESTAMP
+);

--- a/server.py
+++ b/server.py
@@ -55,6 +55,8 @@ from connectors import webrtc_connector
 from core import feedback_logging, video_engine
 from crown_config import settings
 from glm_shell import send_command
+from communication.floor_channel_socket import socket_app
+from nlq_api import router as nlq_router
 
 logger = logging.getLogger(__name__)
 
@@ -157,8 +159,6 @@ def get_current_user(
     return token_info
 
 
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Manage startup and shutdown tasks for the FastAPI app.
@@ -175,8 +175,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(lifespan=lifespan)
 app.include_router(video_stream.router)
 app.include_router(webrtc_connector.router)
+app.include_router(nlq_router)
 
 Instrumentator().instrument(app).expose(app)
+app.mount("/ws", socket_app)
 
 
 @app.post("/token")


### PR DESCRIPTION
## Summary
- scaffold React/Tailwind client for floor and channel communication
- add Socket.IO server and mount into FastAPI app
- expose Vanna-powered NLQ endpoint trained on channel and log schemas

## Testing
- `npm run build`
- `pre-commit run --files server.py communication/floor_channel_socket.py nlq_api.py`
- `pytest tests/test_server.py::test_health_and_ready_return_200 -q --override-ini addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68af81487638832e9903b4b9c61a26a4