### PR TITLE
Integrate planning feedback into pytest runner

### DIFF
--- a/tests/agents/razar/test_pytest_runner.py
+++ b/tests/agents/razar/test_pytest_runner.py
@@ -1,0 +1,46 @@
+import json
+
+import pytest
+
+from agents.razar import pytest_runner as pr
+
+
+def test_run_pytest_logs_and_plans(monkeypatch, tmp_path):
+    log_path = tmp_path / "logs" / "pytest_priority.log"
+    map_path = tmp_path / "tests" / "priority_map.yaml"
+    state_path = tmp_path / "logs" / "pytest_state.json"
+    map_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    map_path.write_text("P1:\n  - tests/test_example.py\n", encoding="utf-8")
+
+    module_path = tmp_path / "example.py"
+    module_path.write_text("""def ok():\n    return True\n""", encoding="utf-8")
+
+    def fake_main(args):
+        return 1
+
+    monkeypatch.setattr(pr.pytest, "main", fake_main)
+    monkeypatch.setattr(pr, "_last_failed", lambda root: "tests/test_example.py::test_fail")
+    monkeypatch.setattr(pr, "_attempt_repair", lambda *a, **k: False)
+    monkeypatch.setattr(pr, "_guess_module_path", lambda root, node: (module_path, root / node.split("::")[0]))
+
+    called = {}
+
+    def fake_log_event(event, component, status, details=None):
+        called["log"] = (event, component, status, details)
+
+    def fake_plan():
+        called["plan"] = True
+        return {module_path.stem: {"steps": ["x"]}}
+
+    monkeypatch.setattr(pr.mission_logger, "log_event", fake_log_event)
+    monkeypatch.setattr(pr.planning_engine, "plan", fake_plan)
+
+    code = pr.run_pytest(["P1"], False, log_path, map_path, state_path)
+    assert code != 0
+    assert state_path.exists()
+    state = json.loads(state_path.read_text())
+    assert state["tier"] == "P1"
+    assert "tests/test_example.py" in state["nodeid"]
+    assert called["plan"] is True
+    assert called["log"][1] == module_path.stem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_runtime_manager.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_boot_sequence.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_module_builder.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_planning_engine.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_pytest_runner.py"),
     str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
     str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
 }


### PR DESCRIPTION
## Summary
- Persist last failing tier and test in `logs/pytest_state.json`
- Relay failing test context to `planning_engine` for targeted repairs
- Add unit test and whitelist entries for RAZAR pytest runner

## Testing
- `pytest tests/agents/razar/test_pytest_runner.py tests/agents/razar/test_planning_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68af8154b344832eae609cddbc4660d5