### PR TITLE
Add command dispatch microservice with event mirroring

### DIFF
--- a/communication/__init__.py
+++ b/communication/__init__.py
@@ -1,3 +1,7 @@
-"""Package initialization."""
+"""Communication utilities and microservices."""
 
 from __future__ import annotations
+
+from .command_dispatch import app as command_dispatch_app, register_agent
+
+__all__ = ["command_dispatch_app", "register_agent"]

--- a/communication/command_dispatch.py
+++ b/communication/command_dispatch.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Command dispatch microservice with event mirroring.
+
+Operator directives are validated and routed to registered agents. Commands sent
+through critical channels are mirrored to an immutable storage directory. The
+service exposes an endpoint to verify mirrored events.
+"""
+
+import json
+import uuid
+from pathlib import Path
+from typing import Callable, Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+
+# Channels requiring event mirroring
+CRITICAL_CHANNELS = {"ops", "safety"}
+
+# Storage location for mirrored events
+STORAGE_DIR = Path("event_mirror")
+
+Handler = Callable[[str], None]
+
+_dispatch_registry: Dict[str, Handler] = {}
+app = FastAPI(title="Command Dispatch Service")
+
+
+class Directive(BaseModel):
+    """Instruction from an operator targeting an agent."""
+
+    operator: str = Field(min_length=1)
+    agent: str = Field(min_length=1)
+    channel: str = Field(min_length=1)
+    command: str = Field(min_length=1)
+
+
+def register_agent(name: str, handler: Handler) -> None:
+    """Register ``handler`` for ``name``."""
+
+    _dispatch_registry[name] = handler
+
+
+def _mirror_event(event_id: str, directive: Directive) -> None:
+    """Write ``directive`` to a read-only file under its channel."""
+
+    channel_dir = STORAGE_DIR / directive.channel
+    channel_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "event_id": event_id,
+        "operator": directive.operator,
+        "agent": directive.agent,
+        "channel": directive.channel,
+        "command": directive.command,
+    }
+    dest = channel_dir / f"{event_id}.json"
+    dest.write_text(json.dumps(record))
+    dest.chmod(0o444)
+
+
+@app.post("/dispatch")
+async def dispatch_directive(directive: Directive) -> dict[str, str]:
+    """Validate ``directive`` and route it to its agent."""
+
+    handler = _dispatch_registry.get(directive.agent)
+    if handler is None:
+        raise HTTPException(status_code=404, detail="unknown agent")
+    handler(directive.command)
+    event_id = uuid.uuid4().hex
+    if directive.channel in CRITICAL_CHANNELS:
+        _mirror_event(event_id, directive)
+    return {"event_id": event_id}
+
+
+@app.get("/verify/{event_id}")
+async def verify_event(event_id: str) -> dict:
+    """Return mirrored event ``event_id`` if available."""
+
+    for path in STORAGE_DIR.rglob(f"{event_id}.json"):
+        return json.loads(path.read_text())
+    raise HTTPException(status_code=404, detail="event not found")
+
+
+__all__ = ["app", "register_agent", "CRITICAL_CHANNELS"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_module_builder.py"),
     str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
     str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
+    str(ROOT / "tests" / "test_command_dispatch.py"),
 }
 
 

--- a/tests/test_command_dispatch.py
+++ b/tests/test_command_dispatch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from communication import command_dispatch
+
+
+def test_dispatch_and_verify(tmp_path, monkeypatch):
+    module = importlib.reload(command_dispatch)
+
+    calls: list[str] = []
+
+    def handler(cmd: str) -> None:
+        calls.append(cmd)
+
+    module.register_agent("alpha", handler)
+    monkeypatch.setattr(module, "STORAGE_DIR", Path(tmp_path))
+
+    client = TestClient(module.app)
+
+    # Non-critical channel should not mirror events
+    resp = client.post(
+        "/dispatch",
+        json={
+            "operator": "op",
+            "agent": "alpha",
+            "channel": "general",
+            "command": "ping",
+        },
+    )
+    assert resp.status_code == 200
+    assert calls == ["ping"]
+    assert not list(Path(tmp_path).rglob("*.json"))
+
+    critical = next(iter(module.CRITICAL_CHANNELS))
+    resp = client.post(
+        "/dispatch",
+        json={
+            "operator": "op",
+            "agent": "alpha",
+            "channel": critical,
+            "command": "pong",
+        },
+    )
+    assert resp.status_code == 200
+    event_id = resp.json()["event_id"]
+    mirrored = Path(tmp_path) / critical / f"{event_id}.json"
+    assert mirrored.exists()
+    assert mirrored.stat().st_mode & 0o222 == 0  # read-only
+
+    verify = client.get(f"/verify/{event_id}")
+    assert verify.status_code == 200
+    assert verify.json()["command"] == "pong"


### PR DESCRIPTION
## Summary
- add FastAPI microservice that validates operator directives and dispatches to registered agents
- mirror critical channel events to read-only storage and expose verification endpoint
- exercise dispatch service with tests and enable test execution in harness

## Testing
- `pytest --no-cov tests/test_command_dispatch.py`

------
https://chatgpt.com/codex/tasks/task_e_68af832274f8832eb10bdbcc7cb4585b