### PR TITLE
Add checkpoint and quarantine metadata handling

### DIFF
--- a/agents/razar/checkpoint_manager.py
+++ b/agents/razar/checkpoint_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Simple checkpoint manager for RAZAR components.
+
+The manager persists the name of the last successfully started component so the
+runtime manager can resume from that point after a failure. Checkpoints are
+stored as JSON files and can be cleared to restart from the beginning.
+"""
+
+from pathlib import Path
+import json
+
+DEFAULT_PATH = Path("logs/razar_state.json")
+
+
+def load_checkpoint(path: Path = DEFAULT_PATH) -> str:
+    """Return the name of the last successful component if available."""
+
+    if not path.exists():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return ""
+    return str(data.get("last_component", ""))
+
+
+def save_checkpoint(name: str, path: Path = DEFAULT_PATH) -> None:
+    """Persist ``name`` as the last successful component."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"last_component": name}), encoding="utf-8")
+
+
+def clear_checkpoint(path: Path = DEFAULT_PATH) -> None:
+    """Remove the checkpoint file if it exists."""
+
+    if path.exists():
+        path.unlink()

--- a/tests/agents/razar/test_checkpoint_manager.py
+++ b/tests/agents/razar/test_checkpoint_manager.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from agents.razar import checkpoint_manager as cm
+
+
+def test_checkpoint_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    assert cm.load_checkpoint(path) == ""
+    cm.save_checkpoint("alpha", path)
+    assert cm.load_checkpoint(path) == "alpha"
+    cm.clear_checkpoint(path)
+    assert cm.load_checkpoint(path) == ""

--- a/tests/agents/razar/test_quarantine_manager.py
+++ b/tests/agents/razar/test_quarantine_manager.py
@@ -1,0 +1,20 @@
+import json
+from agents.razar import quarantine_manager as qm
+
+
+def test_quarantine_metadata(tmp_path, monkeypatch):
+    quarantine_dir = tmp_path / "quarantine"
+    log_file = tmp_path / "log.md"
+    monkeypatch.setattr(qm, "QUARANTINE_DIR", quarantine_dir)
+    monkeypatch.setattr(qm, "LOG_FILE", log_file)
+
+    component = {"name": "alpha"}
+    qm.quarantine_component(component, "boom")
+    data = json.loads((quarantine_dir / "alpha.json").read_text(encoding="utf-8"))
+    assert data["reason"] == "boom"
+    assert data["attempts"] == 1
+    assert data["patches_applied"] == []
+
+    qm.record_patch("alpha", "fix1")
+    data = json.loads((quarantine_dir / "alpha.json").read_text(encoding="utf-8"))
+    assert data["patches_applied"] == ["fix1"]

--- a/tests/agents/razar/test_runtime_manager.py
+++ b/tests/agents/razar/test_runtime_manager.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from agents.razar import quarantine_manager as qm
+
 
 def test_runtime_manager_resume(failing_runtime, caplog):
     manager, fix_beta, tmp_path, quarantine_dir = failing_runtime
@@ -16,8 +18,9 @@ def test_runtime_manager_resume(failing_runtime, caplog):
     assert state["last_component"] == "alpha"
     assert (quarantine_dir / "beta.json").exists()
 
-    # Second run – fix beta command and ensure resume
+    # Second run – fix beta command, reactivate and ensure resume
     fix_beta()
+    qm.reactivate_component("beta", verified=True)
     with caplog.at_level(logging.INFO):
         success = manager.run()
     assert success
@@ -26,3 +29,21 @@ def test_runtime_manager_resume(failing_runtime, caplog):
     state = json.loads((tmp_path / "run.state").read_text(encoding="utf-8"))
     assert state["last_component"] == "gamma"
     assert any("Starting component beta" in r.message for r in caplog.records)
+
+
+def test_runtime_manager_skips_quarantined(failing_runtime, caplog):
+    manager, fix_beta, tmp_path, quarantine_dir = failing_runtime
+
+    # First run – beta fails and is quarantined
+    manager.run()
+
+    # Second run without reactivation should skip beta
+    fix_beta()
+    with caplog.at_level(logging.INFO):
+        success = manager.run()
+    assert success
+    assert not (tmp_path / "beta.txt").exists()
+    assert (tmp_path / "gamma.txt").exists()
+    state = json.loads((tmp_path / "run.state").read_text(encoding="utf-8"))
+    assert state["last_component"] == "gamma"
+    assert any("Skipping quarantined component beta" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add checkpoint manager to persist RAZAR runtime progress
- extend quarantine manager with reason, attempt tracking, and patches
- skip quarantined modules and resume from checkpoints in runtime manager
- add tests for new managers and runtime behaviour

## Testing
- `pytest tests/agents/razar/test_runtime_manager.py tests/agents/razar/test_quarantine_manager.py tests/agents/razar/test_checkpoint_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8366cc70832ea0e2fc9c46329a98