### PR TITLE
feat: add crown link for razar

### DIFF
--- a/agents/razar/crown_link.py
+++ b/agents/razar/crown_link.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Communication link between the RAZAR agent and CROWN.
+
+This module implements a tiny WebSocket client used by the development
+``agents.razar`` toolkit to exchange diagnostic information with the CROWN
+stack.  RAZAR transmits a blueprint excerpt and failure log to CROWN, which in
+turn replies with code suggestions or architectural revisions.  Every request
+and response pair is recorded as a JSON line under
+``logs/razar_crown_dialogues.json`` for later inspection.
+"""
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import websockets
+except Exception:  # pragma: no cover - handled at runtime
+    websockets = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+LOG_PATH = Path("logs/razar_crown_dialogues.json")
+
+
+# ---------------------------------------------------------------------------
+# Message models
+# ---------------------------------------------------------------------------
+@dataclass
+class BlueprintReport:
+    """Payload sent from RAZAR describing a failure."""
+
+    blueprint_excerpt: str
+    failure_log: str
+
+
+# ---------------------------------------------------------------------------
+# WebSocket client
+# ---------------------------------------------------------------------------
+class CrownLink:
+    """Minimal WebSocket client for RAZAR ⇆ CROWN communication."""
+
+    def __init__(self, url: str) -> None:
+        if websockets is None:  # pragma: no cover - import guard
+            raise RuntimeError("websockets package is required to use CrownLink")
+        self.url = url
+        self._ws: websockets.client.WebSocketClientProtocol | None = None
+
+    async def __aenter__(self) -> "CrownLink":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.close()
+
+    async def connect(self) -> None:
+        """Establish the WebSocket connection."""
+
+        LOGGER.debug("Connecting to %s", self.url)
+        self._ws = await websockets.connect(self.url)
+
+    async def close(self) -> None:
+        """Close the WebSocket connection if open."""
+
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def _send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if self._ws is None:
+            await self.connect()
+        assert self._ws is not None  # for type checkers
+        await self._ws.send(json.dumps(payload))
+        reply = await self._ws.recv()
+        try:
+            data = json.loads(reply)
+        except json.JSONDecodeError:  # pragma: no cover - passthrough
+            data = {"raw": reply}
+        self._log_dialogue(payload, data)
+        return data
+
+    async def exchange(self, report: BlueprintReport) -> Dict[str, Any]:
+        """Send ``report`` to CROWN and return the decoded response."""
+
+        payload = {"type": "report", **asdict(report)}
+        return await self._send(payload)
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
+    def _log_dialogue(self, request: Dict[str, Any], response: Dict[str, Any]) -> None:
+        """Append the request/response pair to ``LOG_PATH``."""
+
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "request": request,
+            "response": response,
+        }
+        with LOG_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+
+__all__ = ["CrownLink", "BlueprintReport", "LOG_PATH"]

--- a/tests/agents/razar/test_crown_link.py
+++ b/tests/agents/razar/test_crown_link.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+from pathlib import Path
+
+import websockets
+
+from agents.razar import crown_link
+from agents.razar.crown_link import BlueprintReport, CrownLink
+
+
+async def _mock_handler(websocket):
+    msg = await websocket.recv()
+    data = json.loads(msg)
+    assert data["type"] == "report"
+    assert "blueprint_excerpt" in data
+    reply = {"suggestions": "use dataclasses", "revisions": "refactor"}
+    await websocket.send(json.dumps(reply))
+
+
+def test_exchange(tmp_path):
+    crown_link.LOG_PATH = tmp_path / "dialogues.json"
+
+    async def run():
+        server = await websockets.serve(_mock_handler, "127.0.0.1", 8765)
+        async with server:
+            async with CrownLink("ws://127.0.0.1:8765") as link:
+                resp = await link.exchange(BlueprintReport("bp", "log"))
+        return resp
+
+    resp = asyncio.run(run())
+    assert resp["suggestions"] == "use dataclasses"
+    assert crown_link.LOG_PATH.exists()
+    entry = json.loads(Path(crown_link.LOG_PATH).read_text().splitlines()[0])
+    assert entry["request"]["blueprint_excerpt"] == "bp"
+    assert entry["response"]["suggestions"] == "use dataclasses"


### PR DESCRIPTION
## Summary
- create WebSocket client to exchange RAZAR blueprint excerpts and failure logs with CROWN
- log each request/response pair to `logs/razar_crown_dialogues.json`
- add test scaffold for dialogue logging

## Testing
- `pytest tests/agents/razar/test_crown_link.py -q` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68af853e9614832ea00f94e669695a3a