### PR TITLE
Add Nazarick persona profiles and loader

### DIFF
--- a/agents/nazarick/__init__.py
+++ b/agents/nazarick/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Loader utilities for Nazarick persona profiles."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+
+
+@lru_cache(maxsize=1)
+def load_persona_profiles() -> Dict[str, Dict[str, Any]]:
+    """Return mapping of agent IDs to persona profile data.
+
+    Profiles are defined in ``persona_profiles.yaml`` with fields:
+    ``agent_id``, ``floor``, ``channel``, ``voice_style`` and
+    ``chakra_alignment``.
+    """
+
+    path = Path(__file__).with_name("persona_profiles.yaml")
+    data = yaml.safe_load(path.read_text())
+    return {item["agent_id"]: item for item in data}
+
+
+__all__ = ["load_persona_profiles"]
+

--- a/agents/nazarick/persona_profiles.yaml
+++ b/agents/nazarick/persona_profiles.yaml
@@ -1,0 +1,21 @@
+# Nazarick persona profiles mapping agent identifiers to metadata.
+# Fields: agent_id, floor, channel, voice_style, chakra_alignment.
+
+- agent_id: demiurge
+  floor: 7
+  channel: "Lava Pits"
+  voice_style: strategic
+  chakra_alignment: crown
+
+- agent_id: shalltear
+  floor: "1-3"
+  channel: "Catacombs"
+  voice_style: dramatic
+  chakra_alignment: root
+
+- agent_id: cocytus
+  floor: 5
+  channel: "Glacier Prison"
+  voice_style: stoic
+  chakra_alignment: throat
+

--- a/tests/test_persona_profiles_loader.py
+++ b/tests/test_persona_profiles_loader.py
@@ -1,0 +1,9 @@
+"""Tests for Nazarick persona profile loader."""
+
+from agents.nazarick import load_persona_profiles
+
+
+def test_load_persona_profiles_returns_expected_entries():
+    profiles = load_persona_profiles()
+    assert profiles["demiurge"]["floor"] == 7
+    assert profiles["shalltear"]["channel"] == "Catacombs"


### PR DESCRIPTION
## Summary
- add `agents/nazarick/persona_profiles.yaml` mapping agent profiles to floor, channel, voice style and chakra
- provide `load_persona_profiles` utility to read profiles
- add basic test for loader

## Testing
- `pip install pytest-cov`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `pytest tests/test_persona_profiles_loader.py tests/test_nazarick_messaging.py -q` *(skipped by conftest)*
- `python - <<'PY'\nfrom agents.nazarick import load_persona_profiles\nprint(load_persona_profiles()["demiurge"])\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68af88445fc4832ebb231fa744825be6