### PR TITLE
Add persona loader and Nazarick messaging tests to allowlist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_pytest_runner.py"),
     str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
     str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
+    str(ROOT / "tests" / "test_persona_profiles_loader.py"),
+    str(ROOT / "tests" / "test_nazarick_messaging.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- allow `test_persona_profiles_loader.py` and `test_nazarick_messaging.py` to run in CI by whitelisting them in `ALLOWED_TESTS`

## Testing
- `pytest tests/test_persona_profiles_loader.py tests/test_nazarick_messaging.py -q` *(fails: file or directory not found: tests/test_persona_profiles_loader.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ab19390832e95ad54c8b73d3c61