### PR TITLE
Add retro bootstrap utility and CLI command

### DIFF
--- a/agents/razar/retro_bootstrap.py
+++ b/agents/razar/retro_bootstrap.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Rebuild RAZAR modules from documentation references.
+
+This utility scans project documentation and the system blueprint for links to
+Python modules.  For every referenced module that appears in the planning
+specification produced by :mod:`agents.razar.planning_engine`, a fresh skeleton
+module is generated using :mod:`agents.razar.module_builder`.
+
+The generated modules are placed inside a new workspace directory so that the
+original repository remains untouched.  This is primarily intended for recovery
+or "from scratch" rebuild scenarios where a clean project tree must be
+reconstructed from the docs alone.
+"""
+
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Iterable, List
+
+from . import planning_engine, module_builder
+
+_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+\.py)\)")
+
+
+def _extract_module_names(text: str) -> List[str]:
+    """Return module names referenced by markdown links in ``text``."""
+
+    modules: List[str] = []
+    for match in _LINK_RE.finditer(text):
+        link = match.group(1).strip()
+        if link.startswith("../"):
+            link = link[3:]
+        link = link.lstrip("./")
+        modules.append(Path(link).stem)
+    return modules
+
+
+def _collect_modules(paths: Iterable[Path]) -> List[str]:
+    """Collect unique module names from a sequence of markdown ``paths``."""
+
+    found: List[str] = []
+    for p in paths:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        found.extend(_extract_module_names(text))
+    return sorted(set(found))
+
+
+def bootstrap_from_docs(
+    *,
+    docs_dir: Path | None = None,
+    blueprint: Path | None = None,
+    workspace: Path | None = None,
+) -> List[Path]:
+    """Regenerate modules referenced in project documentation.
+
+    Parameters
+    ----------
+    docs_dir:
+        Directory containing markdown documentation.  All ``*.md`` files within
+        this directory are scanned for links to Python modules.  Defaults to the
+        repository's ``docs`` directory.
+    blueprint:
+        Optional explicit path to ``system_blueprint.md``.  When provided and not
+        already inside ``docs_dir``, it is included in the scan.
+    workspace:
+        Target directory that will receive the reconstructed modules.  When not
+        specified, a temporary directory is created.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        Paths to the generated modules inside ``workspace``.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    docs_dir = docs_dir or repo_root / "docs"
+    blueprint = blueprint or docs_dir / "system_blueprint.md"
+    workspace = workspace or Path(tempfile.mkdtemp(prefix="razar_retro_"))
+
+    docs = list(docs_dir.glob("*.md"))
+    if blueprint not in docs:
+        docs.append(blueprint)
+
+    modules = _collect_modules(docs)
+    plan = planning_engine.plan()
+
+    generated: List[Path] = []
+    for name in modules:
+        spec = plan.get(name)
+        if spec is None:
+            continue
+        built = module_builder.build(name, plan=plan)
+        rel = Path(str(spec.get("component", "")))
+        target = workspace / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(built), target)
+        generated.append(target)
+    return generated
+
+
+__all__ = ["bootstrap_from_docs"]

--- a/razar/__main__.py
+++ b/razar/__main__.py
@@ -9,6 +9,7 @@ from agents.razar.ignition_builder import build_ignition
 from agents.razar.lifecycle_bus import LifecycleBus
 from agents.razar import mission_logger
 from agents.razar.blueprint_synthesizer import synthesize
+from agents.razar import retro_bootstrap
 
 
 def _cmd_status(args: argparse.Namespace) -> None:
@@ -59,6 +60,14 @@ def _cmd_map(_: argparse.Namespace) -> None:
         pass
 
 
+def _cmd_bootstrap(args: argparse.Namespace) -> None:
+    """Rebuild modules from documentation references."""
+
+    if args.from_docs:
+        for path in retro_bootstrap.bootstrap_from_docs():
+            print(path)
+
+
 def main() -> None:  # pragma: no cover - CLI entry point
     parser = argparse.ArgumentParser(description="RAZAR lifecycle utilities")
     parser.add_argument(
@@ -96,6 +105,10 @@ def main() -> None:  # pragma: no cover - CLI entry point
 
     p_map = sub.add_parser("map", help="Visualize component relationships")
     p_map.set_defaults(func=_cmd_map)
+
+    p_bootstrap = sub.add_parser("bootstrap", help="Rebuild modules")
+    p_bootstrap.add_argument("--from-docs", action="store_true", help="Reconstruct modules referenced in docs")
+    p_bootstrap.set_defaults(func=_cmd_bootstrap)
 
     args = parser.parse_args()
     if hasattr(args, "func"):


### PR DESCRIPTION
## Summary
- add retro_bootstrap module to rebuild RAZAR modules from documentation references
- expose `razar bootstrap --from-docs` CLI command to trigger the rebuild

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/agents/razar/test_planning_engine.py tests/agents/razar/test_module_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af8a990638832ea2285b63248f9183