### PR TITLE
Add boot iteration metrics and retry backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ INANNA_AI/models/
 logs/*
 !logs/razar_state.json
 !logs/razar_remote_agents.json
+!logs/razar_boot_history.json
 
 # Ignore Blender files
 *.blend

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -35,6 +35,28 @@ RAZAR runs a perpetual ignition loop that:
    monitor the stack.  The loop never exits on its own—it continually
    verifies that previously healthy services stay responsive.
 
+### Iterative Boot Loop
+
+The loop now tracks launch metrics on every pass. Each component receives
+exponential backoff and retry attempts. After a configurable number of
+failures, stubborn modules are quarantined and skipped on future runs. Metrics
+and the best performing sequence are persisted to `logs/razar_boot_history.json`
+for later analysis.
+
+```mermaid
+flowchart TD
+    start((Start)) --> launch[Launch component]
+    launch --> check{Health check?}
+    check -- pass --> record[Record success]
+    record --> next{More components?}
+    next -- yes --> launch
+    next -- no --> persist[Persist metrics]
+    check -- fail --> retry[Backoff & retry]
+    retry --> check
+    retry -- exceeded --> quarantine[Quarantine]
+    quarantine --> record
+```
+
 ## Adaptive Startup Orchestrator
 
 The `razar/adaptive_orchestrator.py` helper experiments with different

--- a/logs/razar_boot_history.json
+++ b/logs/razar_boot_history.json
@@ -1,0 +1,5 @@
+{
+  "history": [],
+  "best_sequence": null,
+  "component_failures": {}
+}

--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -21,6 +21,64 @@ from .quarantine_manager import is_quarantined, quarantine_component
 
 LOGGER = logging.getLogger("razar.boot_orchestrator")
 
+LOGS_DIR = Path(__file__).resolve().parents[1] / "logs"
+HISTORY_FILE = LOGS_DIR / "razar_boot_history.json"
+
+
+def load_history() -> Dict[str, Any]:
+    """Return persisted boot history data."""
+
+    if HISTORY_FILE.exists():
+        try:
+            return json.loads(HISTORY_FILE.read_text())
+        except json.JSONDecodeError:  # pragma: no cover - corrupt file
+            LOGGER.warning("History file corrupt, starting fresh")
+    return {"history": [], "best_sequence": None, "component_failures": {}}
+
+
+def save_history(data: Dict[str, Any]) -> None:
+    """Persist ``data`` to the history file."""
+
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    HISTORY_FILE.write_text(json.dumps(data, indent=2))
+
+
+def finalize_metrics(
+    run_metrics: Dict[str, Any],
+    history: Dict[str, Any],
+    failure_counts: Dict[str, int],
+    start_time: float,
+) -> None:
+    """Compute run statistics and update ``history``."""
+
+    total = len(run_metrics["components"])
+    successes = sum(1 for c in run_metrics["components"] if c["success"])
+    run_metrics["success_rate"] = successes / total if total else 0.0
+    run_metrics["total_time"] = time.time() - start_time
+
+    history.setdefault("history", []).append(run_metrics)
+
+    best = history.get("best_sequence")
+    if (
+        not best
+        or run_metrics["success_rate"] > best.get("success_rate", 0)
+        or (
+            run_metrics["success_rate"] == best.get("success_rate", 0)
+            and run_metrics["total_time"] < best.get("total_time", float("inf"))
+        )
+    ):
+        history["best_sequence"] = {
+            "components": [
+                c["name"] for c in run_metrics["components"] if c["success"]
+            ],
+            "success_rate": run_metrics["success_rate"],
+            "total_time": run_metrics["total_time"],
+            "timestamp": run_metrics["timestamp"],
+        }
+
+    history["component_failures"] = failure_counts
+    save_history(history)
+
 
 def load_config(path: Path) -> List[Dict[str, Any]]:
     """Return ordered component definitions from ``path``.
@@ -58,6 +116,12 @@ def main() -> None:
     parser.add_argument(
         "--retries", type=int, default=3, help="Retries for failed launches"
     )
+    parser.add_argument(
+        "--failure-limit",
+        type=int,
+        default=3,
+        help="Quarantine component after N cumulative failures",
+    )
     args = parser.parse_args()
 
     log_file = Path(__file__).with_name("boot_orchestrator.log")
@@ -69,23 +133,49 @@ def main() -> None:
 
     components = load_config(args.config)
     processes: List[subprocess.Popen] = []
+
+    history = load_history()
+    failure_counts: Dict[str, int] = history.get("component_failures", {})
+    run_start = time.time()
+    run_metrics: Dict[str, Any] = {"timestamp": run_start, "components": []}
+
     try:
         for comp in components:
             name = comp.get("name", "")
             if is_quarantined(name):
                 LOGGER.info("Skipping quarantined component %s", name)
                 continue
+            if failure_counts.get(name, 0) >= args.failure_limit:
+                LOGGER.warning("Component %s exceeded failure limit; quarantining", name)
+                quarantine_component(comp, "Exceeded failure limit")
+                continue
+
+            attempts = 0
+            success = False
             for attempt in range(1, args.retries + 2):
+                attempts = attempt
                 try:
                     proc = launch_component(comp)
                     processes.append(proc)
+                    success = True
                     break
                 except Exception as exc:
                     LOGGER.error("Attempt %s failed for %s: %s", attempt, name, exc)
                     if attempt > args.retries:
+                        failure_counts[name] = failure_counts.get(name, 0) + 1
                         quarantine_component(comp, str(exc))
+                        run_metrics["components"].append(
+                            {"name": name, "attempts": attempts, "success": False}
+                        )
                         raise
-                    time.sleep(1)
+                    backoff = min(2 ** (attempt - 1), 60)
+                    time.sleep(backoff)
+
+            if success:
+                run_metrics["components"].append(
+                    {"name": name, "attempts": attempts, "success": True}
+                )
+
         LOGGER.info("All components launched")
         doc_sync.sync_docs()
         for proc in processes:
@@ -96,6 +186,8 @@ def main() -> None:
             proc.terminate()
             proc.wait()
         raise SystemExit(1)
+    finally:
+        finalize_metrics(run_metrics, history, failure_counts, run_start)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- track boot loop metrics and persist best sequences to logs/razar_boot_history.json
- add exponential backoff retries and quarantine on repeated failures
- document the iterative boot loop with diagram

## Testing
- `pytest -q` *(fails: import file mismatch and missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68af8d63573c832e95aebbdab1168583