### PR TITLE
Add narrative stream subcommand to RAZAR CLI

### DIFF
--- a/agents/razar/cli.py
+++ b/agents/razar/cli.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Command line utilities for RAZAR agents."""
+
+import argparse
+import time
+from pathlib import Path
+from typing import Iterator
+
+from memory import narrative_engine
+
+ROOT = Path(__file__).resolve().parents[2]
+LOG_PATH = ROOT / "logs" / "nazarick_story.log"
+
+
+def _tail_log(path: Path) -> Iterator[str]:
+    """Yield appended lines from ``path``."""
+
+    with path.open("r", encoding="utf-8") as fh:
+        fh.seek(0, 2)
+        while True:
+            line = fh.readline()
+            if not line:
+                time.sleep(0.5)
+                continue
+            yield line.rstrip("\n")
+
+
+def _cmd_narrative(_: argparse.Namespace) -> None:
+    """Print narratives from the log file or memory."""
+
+    try:
+        if LOG_PATH.exists():
+            for line in _tail_log(LOG_PATH):
+                print(line)
+        else:
+            for story in narrative_engine.stream_stories():
+                print(story)
+    except KeyboardInterrupt:  # pragma: no cover - user abort
+        pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the top level argument parser."""
+
+    parser = argparse.ArgumentParser(prog="razar", description="RAZAR utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    narr_p = sub.add_parser("narrative", help="Stream narrative stories")
+    narr_p.set_defaults(func=_cmd_narrative)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``razar`` CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = args.func
+    func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -7,6 +7,16 @@ startup progress. The agent forms a feedback loop with CROWN LLM to heal
 faulty modules and ensures the system can cycle back to a ready state
 without manual intervention.
 
+## Narrative Stream Utility
+
+Use `razar narrative` to watch the evolving story log. The command tails
+`logs/nazarick_story.log` and falls back to in-memory stories from
+`memory.narrative_engine.stream_stories` when the log is missing.
+
+```bash
+razar narrative
+```
+
 ## Ignition Workflow
 
 `agents/razar/boot_orchestrator.py` drives the initial boot sequence. It


### PR DESCRIPTION
## Summary
- add `razar narrative` CLI that tails story log or streams from memory
- document narrative stream utility in RAZAR agent docs

## Testing
- `pytest -q` *(fails: import file mismatch for quarantine_manager and vector_memory; ImportError for load_config in test_voice_cloner_cli)*


------
https://chatgpt.com/codex/tasks/task_e_68af8df634e8832e8e232e39f09f888d