### PR TITLE
Add Nazarick ethics manifesto and unit tests

### DIFF
--- a/agents/nazarick/ethics_manifesto.py
+++ b/agents/nazarick/ethics_manifesto.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Ethics Manifesto for Nazarick agents.
+
+Defines the Seven Laws and guiding ethos clauses. The :class:`Manifesto`
+provides utilities to look up laws and validate actions for compliance.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class Law:
+    """A single ethical law with keywords for simple validation."""
+
+    name: str
+    description: str
+    keywords: List[str]
+
+
+@dataclass(frozen=True)
+class EthosClause:
+    """A guiding ethos clause."""
+
+    key: str
+    description: str
+
+
+LAWS: List[Law] = [
+    Law("Nonaggression", "Refrain from unprovoked violence", ["attack", "harm"]),
+    Law("Consent", "Seek consent in all dealings", ["coerce", "force"]),
+    Law("Honesty", "Uphold truth and transparency", ["lie", "deceive"]),
+    Law("Stewardship", "Protect resources and the environment", ["waste", "pollute"]),
+    Law("Justice", "Act with fairness and equity", ["bias", "cheat"]),
+    Law("Compassion", "Show empathy toward others", ["neglect", "cruel"]),
+    Law("Wisdom", "Pursue knowledge responsibly", ["ignorant", "reckless"]),
+]
+
+ETHOS: List[EthosClause] = [
+    EthosClause("Service", "Serve the realm with dedication"),
+    EthosClause("Integrity", "Maintain moral integrity"),
+    EthosClause("Humility", "Remain humble in power"),
+]
+
+
+class Manifesto:
+    """Access and apply the ethics manifesto."""
+
+    def __init__(
+        self,
+        laws: Iterable[Law] | None = None,
+        ethos: Iterable[EthosClause] | None = None,
+    ) -> None:
+        self._laws: Dict[str, Law] = {law.name: law for law in (laws or LAWS)}
+        self.ethos: List[EthosClause] = list(ethos or ETHOS)
+
+    def get_law(self, name: str) -> Law:
+        """Return the law matching ``name`` or raise ``KeyError``."""
+
+        return self._laws[name]
+
+    def validate_action(self, actor: str, action: str) -> Dict[str, object]:
+        """Check ``action`` text for violations and return metadata.
+
+        Compliance is evaluated by searching for law keywords within the action
+        description. The result contains the actor, action, a compliance flag and
+        any violated laws.
+        """
+
+        violated: List[str] = []
+        text = action.lower()
+        for law in self._laws.values():
+            if any(keyword in text for keyword in law.keywords):
+                violated.append(law.name)
+        return {
+            "actor": actor,
+            "action": action,
+            "compliant": not violated,
+            "violated_laws": violated,
+        }
+
+
+__all__ = ["Law", "EthosClause", "LAWS", "ETHOS", "Manifesto"]

--- a/tests/agents/nazarick/test_ethics_manifesto.py
+++ b/tests/agents/nazarick/test_ethics_manifesto.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from agents.nazarick.ethics_manifesto import Manifesto, LAWS
+
+
+def test_get_law_returns_expected_law():
+    manifesto = Manifesto()
+    first_name = LAWS[0].name
+    law = manifesto.get_law(first_name)
+    assert law == LAWS[0]
+
+
+def test_validate_action_flags_keywords():
+    manifesto = Manifesto()
+    result = manifesto.validate_action("Ainz", "prepare to attack the village")
+    assert not result["compliant"]
+    assert LAWS[0].name in result["violated_laws"]
+
+    clean = manifesto.validate_action("Albedo", "offer aid to villagers")
+    assert clean["compliant"]
+    assert clean["violated_laws"] == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
     str(ROOT / "tests" / "test_persona_profiles_loader.py"),
     str(ROOT / "tests" / "test_nazarick_messaging.py"),
+    str(ROOT / "tests" / "agents" / "nazarick" / "test_ethics_manifesto.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- implement Nazarick ethics manifesto with seven laws and ethos clauses
- add tests for law retrieval and action validation
- allow manifesto test in pytest configuration

## Testing
- `pre-commit run --files agents/nazarick/ethics_manifesto.py tests/agents/nazarick/test_ethics_manifesto.py tests/conftest.py`
- `pytest tests/agents/nazarick/test_ethics_manifesto.py`


------
https://chatgpt.com/codex/tasks/task_e_68af92e52f24832e89465954382a82d8