### PR TITLE
Add Nazarick TrustMatrix with SQLite persistence

### DIFF
--- a/agents/nazarick/trust_matrix.py
+++ b/agents/nazarick/trust_matrix.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+"""Trust classification and protocol lookup for Nazarick entities.
+
+The :class:`TrustMatrix` records trust scores in a tiny SQLite database and
+provides utilities to classify entities and determine the protocol to use for
+interactions. Entity types and rank mappings mirror the Nazarick manifesto.
+"""
+
+from enum import Enum
+from pathlib import Path
+import sqlite3
+from typing import Dict, Optional, Tuple
+
+
+class EntityType(str, Enum):
+    """Supported entity categories."""
+
+    NAZARICK = "nazarick"
+    RIVAL = "rival"
+    OUTSIDER = "outsider"
+
+
+# Known Nazarick allies and their ranks
+NAZARICK_RANKS: Dict[str, int] = {
+    "shalltear": 1,
+    "demiurge": 2,
+    "cocytus": 3,
+    "sebas": 4,
+}
+
+# Known rivals and their levels
+RIVAL_RANKS: Dict[str, int] = {
+    "clementine": 1,
+    "slane": 2,
+    "empire": 3,
+    "kingdom": 4,
+}
+
+DEFAULT_TRUST = 5
+"""Starting trust for entities without a recorded history."""
+
+
+class TrustMatrix:
+    """Track and evaluate trust for Nazarick interactions."""
+
+    def __init__(self, db_path: Optional[Path | str] = None) -> None:
+        self.db_path = Path(db_path) if db_path is not None else Path("memory") / "trust.db"
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.db_path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS trust (name TEXT PRIMARY KEY, score INTEGER)"
+        )
+
+    # ------------------------------------------------------------------
+    # Classification
+    # ------------------------------------------------------------------
+    def classify(self, name: str) -> Tuple[EntityType, Optional[int]]:
+        """Return entity category and rank if known."""
+
+        key = name.lower()
+        if key in NAZARICK_RANKS:
+            return EntityType.NAZARICK, NAZARICK_RANKS[key]
+        if key in RIVAL_RANKS:
+            return EntityType.RIVAL, RIVAL_RANKS[key]
+        return EntityType.OUTSIDER, None
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def get_trust(self, name: str) -> int:
+        """Fetch trust score for ``name`` inserting baseline if absent."""
+
+        key = name.lower()
+        cur = self._conn.execute("SELECT score FROM trust WHERE name=?", (key,))
+        row = cur.fetchone()
+        if row is None:
+            self.set_trust(key, DEFAULT_TRUST)
+            return DEFAULT_TRUST
+        return int(row[0])
+
+    def set_trust(self, name: str, score: int) -> None:
+        """Persist ``score`` for ``name``."""
+
+        key = name.lower()
+        self._conn.execute(
+            "INSERT OR REPLACE INTO trust(name, score) VALUES(?, ?)", (key, int(score))
+        )
+        self._conn.commit()
+
+    def delete(self, name: str) -> None:
+        """Remove ``name`` from the trust store."""
+
+        key = name.lower()
+        self._conn.execute("DELETE FROM trust WHERE name=?", (key,))
+        self._conn.commit()
+
+    def all(self) -> Dict[str, int]:
+        """Return mapping of all stored trust scores."""
+
+        cur = self._conn.execute("SELECT name, score FROM trust")
+        return {row[0]: int(row[1]) for row in cur.fetchall()}
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+    def lookup_protocol(self, name: str) -> str:
+        """Return the communication protocol for ``name``.
+
+        Protocol names are derived from entity type, rank and trust score:
+
+        - Nazarick allies use ``nazarick_rank{rank}_<low|mid|high>`` tiers.
+        - Rivals use ``rival_level{rank}_<wrath|teaching>`` depending on trust.
+        - Outsiders default to ``outsider_standard``.
+        """
+
+        etype, rank = self.classify(name)
+        trust = self.get_trust(name)
+        if etype is EntityType.NAZARICK:
+            tier = "low"
+            if trust >= 8:
+                tier = "high"
+            elif trust >= 5:
+                tier = "mid"
+            return f"nazarick_rank{rank}_{tier}"
+        if etype is EntityType.RIVAL:
+            intent = "teaching" if trust >= 5 else "wrath"
+            return f"rival_level{rank}_{intent}"
+        return "outsider_standard"
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+
+        self._conn.close()
+
+
+__all__ = [
+    "EntityType",
+    "NAZARICK_RANKS",
+    "RIVAL_RANKS",
+    "DEFAULT_TRUST",
+    "TrustMatrix",
+]

--- a/tests/agents/nazarick/test_trust_matrix.py
+++ b/tests/agents/nazarick/test_trust_matrix.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from agents.nazarick.trust_matrix import EntityType, TrustMatrix
+
+
+def test_classify_entities(tmp_path):
+    db = tmp_path / 'trust.db'
+    tm = TrustMatrix(db)
+
+    etype, rank = tm.classify('Shalltear')
+    assert etype is EntityType.NAZARICK
+    assert rank == 1
+
+    etype, rank = tm.classify('Empire')
+    assert etype is EntityType.RIVAL
+    assert rank == 3
+
+    etype, rank = tm.classify('Bob')
+    assert etype is EntityType.OUTSIDER
+    assert rank is None
+
+
+def test_protocol_lookup(tmp_path):
+    db = tmp_path / 'trust.db'
+    tm = TrustMatrix(db)
+
+    tm.set_trust('Demiurge', 9)
+    assert tm.lookup_protocol('Demiurge') == 'nazarick_rank2_high'
+
+    tm.set_trust('Slane', 2)
+    assert tm.lookup_protocol('Slane') == 'rival_level2_wrath'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_persona_profiles_loader.py"),
     str(ROOT / "tests" / "test_nazarick_messaging.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_ethics_manifesto.py"),
+    str(ROOT / "tests" / "agents" / "nazarick" / "test_trust_matrix.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- implement TrustMatrix for classifying entities, storing trust scores in SQLite, and resolving communication protocols
- add tests covering entity classification and protocol lookup

## Testing
- `pytest tests/agents/nazarick/test_trust_matrix.py tests/agents/nazarick/test_ethics_manifesto.py tests/test_nazarick_messaging.py tests/test_trust_registry.py tests/test_albedo_trust.py tests/test_albedo_state_machine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af98852ec4832eb1643c63f784879c