### PR TITLE
Add ethics and trust checks to agent tasks

### DIFF
--- a/agents/albedo/__init__.py
+++ b/agents/albedo/__init__.py
@@ -1,8 +1,25 @@
 """Albedo agent messaging utilities and vision hooks."""
 
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
 from .messaging import compose_message_nazarick, compose_message_rival
 from .trust import update_trust
 from .vision import consume_detections, current_avatar
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "albedo"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
 
 __all__ = [
     "compose_message_nazarick",
@@ -10,4 +27,5 @@ __all__ = [
     "update_trust",
     "consume_detections",
     "current_avatar",
+    "execute_task",
 ]

--- a/agents/asian_gen/__init__.py
+++ b/agents/asian_gen/__init__.py
@@ -1,5 +1,22 @@
 """Asian language creative agents."""
 
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
 from .creative_engine import CreativeEngine
 
-__all__ = ["CreativeEngine"]
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "asian_gen"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["CreativeEngine", "execute_task"]

--- a/agents/bana/__init__.py
+++ b/agents/bana/__init__.py
@@ -2,6 +2,23 @@
 
 from __future__ import annotations
 
-__all__ = ["generate_story"]
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
 
 from .bio_adaptive_narrator import generate_story
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "bana"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["generate_story", "execute_task"]

--- a/agents/cocytus/__init__.py
+++ b/agents/cocytus/__init__.py
@@ -1,1 +1,20 @@
 """Cocytus agent modules."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "cocytus"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/cocytus/prompt_arbiter.py
+++ b/agents/cocytus/prompt_arbiter.py
@@ -1,5 +1,26 @@
-"""Responsibilities:
+"""Cocytus prompt arbitration utilities.
+
+Responsibilities:
 - logical sanitization
 - legal parsing
 - audit model bias
 """
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..event_bus import emit_event
+
+
+def arbitrate(actor: str, action: str, entity_eval: Dict[str, Any]) -> None:
+    """Escalate a non-compliant action for Cocytus arbitration."""
+
+    emit_event(
+        "cocytus",
+        "arbitration",
+        {"actor": actor, "action": action, "entity": entity_eval},
+    )
+
+
+__all__ = ["arbitrate"]

--- a/agents/demiurge/__init__.py
+++ b/agents/demiurge/__init__.py
@@ -1,1 +1,20 @@
 """Demiurge agent modules."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "demiurge"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/guardian.py
+++ b/agents/guardian.py
@@ -1,0 +1,41 @@
+"""Shared utilities for guardian agents."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .event_bus import emit_event
+from .cocytus.prompt_arbiter import arbitrate
+
+
+def run_validated_task(
+    manifesto: Any,
+    trust_matrix: Any,
+    actor: str,
+    action: str,
+    entity: str,
+    task: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Execute ``task`` only if ethics validation passes.
+
+    Validation and entity evaluation results are emitted to the global event
+    bus. When the action violates the ethics manifesto the request is escalated
+    to Cocytus for arbitration and ``None`` is returned.
+    """
+
+    ethics_result = manifesto.validate_action(actor, action)
+    emit_event(actor, "validate_action", ethics_result)
+
+    entity_result = trust_matrix.evaluate_entity(entity)
+    emit_event(actor, "evaluate_entity", entity_result)
+
+    if not ethics_result.get("compliant", False):
+        arbitrate(actor, action, entity_result)
+        return None
+
+    return task(*args, **kwargs)
+
+
+__all__ = ["run_validated_task"]

--- a/agents/pandora/__init__.py
+++ b/agents/pandora/__init__.py
@@ -1,1 +1,20 @@
 """Pandora persona agents."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "pandora"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/pleiades/__init__.py
+++ b/agents/pleiades/__init__.py
@@ -1,1 +1,20 @@
 """Pleiades utility modules."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "pleiades"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/razar/__init__.py
+++ b/agents/razar/__init__.py
@@ -1,5 +1,9 @@
 """RAZAR agents."""
 
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
 from .remote_loader import (
     load_remote_agent,
     load_remote_agent_from_git,
@@ -7,9 +11,23 @@ from .remote_loader import (
 )
 from .lifecycle_bus import LifecycleBus
 
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "razar"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
 __all__ = [
     "load_remote_agent",
     "load_remote_agent_from_git",
     "load_remote_gpt_agent",
     "LifecycleBus",
+    "execute_task",
 ]

--- a/agents/sebas/__init__.py
+++ b/agents/sebas/__init__.py
@@ -1,1 +1,20 @@
 """Sebas compassion agents."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "sebas"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/shalltear/__init__.py
+++ b/agents/shalltear/__init__.py
@@ -1,1 +1,20 @@
 """Shalltear agent modules."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "shalltear"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]

--- a/agents/victim/__init__.py
+++ b/agents/victim/__init__.py
@@ -1,1 +1,20 @@
 """Victim security agents."""
+
+from agents.nazarick.ethics_manifesto import Manifesto
+from agents.nazarick.trust_matrix import TrustMatrix
+from ..guardian import run_validated_task
+
+_manifesto = Manifesto()
+_trust_matrix = TrustMatrix()
+_AGENT = "victim"
+
+
+def execute_task(action: str, entity: str, task, *args, **kwargs):
+    """Run ``task`` after ethics and trust checks."""
+
+    return run_validated_task(
+        _manifesto, _trust_matrix, _AGENT, action, entity, task, *args, **kwargs
+    )
+
+
+__all__ = ["execute_task"]


### PR DESCRIPTION
## Summary
- add shared `run_validated_task` helper that logs ethics validation and trust evaluation
- integrate manifesto and trust matrix imports into each agent and expose `execute_task`
- escalate non-compliant actions to Cocytus via new arbitration helper

## Testing
- `pre-commit run --files agents/nazarick/trust_matrix.py agents/guardian.py agents/cocytus/prompt_arbiter.py agents/albedo/__init__.py agents/bana/__init__.py agents/demiurge/__init__.py agents/cocytus/__init__.py agents/pandora/__init__.py agents/pleiades/__init__.py agents/sebas/__init__.py agents/shalltear/__init__.py agents/asian_gen/__init__.py agents/razar/__init__.py agents/victim/__init__.py`
- `pytest tests/agents/nazarick/test_ethics_manifesto.py`

------
https://chatgpt.com/codex/tasks/task_e_68af99b2ece0832e8692de7f6450f5db