### PR TITLE
Add Nazarick ethics manifesto

### DIFF
--- a/agents/nazarick/ethics_manifesto.py
+++ b/agents/nazarick/ethics_manifesto.py
@@ -22,8 +22,8 @@ class Law:
 @dataclass(frozen=True)
 class EthosClause:
     """A guiding ethos clause."""
-
-    key: str
+    # Use ``name`` for consistency with :class:`Law`.
+    name: str
     description: str
 
 


### PR DESCRIPTION
## Summary
- define dataclasses for Nazarick's seven laws and ethos clauses
- provide Manifesto utilities to fetch a law and validate actions
- verify manifesto behaviour with unit tests

## Testing
- `pytest tests/agents/nazarick/test_ethics_manifesto.py -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68af9c5077c8832e94f321946ae8f13e