### PR TITLE
Add RAZAR ethics and trust CLI commands

### DIFF
--- a/agents/razar/blueprint_synthesizer.py
+++ b/agents/razar/blueprint_synthesizer.py
@@ -83,6 +83,7 @@ def synthesize(output: Path | None = None) -> nx.DiGraph:
     docs = [
         root / "docs" / "system_blueprint.md",
         root / "docs" / "component_index.md",
+        root / "docs" / "nazarick_manifesto.md",
     ]
     graph = build_graph(docs)
     if output is None:

--- a/agents/razar/cli.py
+++ b/agents/razar/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Iterator
 
 from memory import narrative_engine
+from agents.nazarick.ethics_manifesto import LAWS
+from agents.nazarick.trust_matrix import TrustMatrix
 
 ROOT = Path(__file__).resolve().parents[2]
 LOG_PATH = ROOT / "logs" / "nazarick_story.log"
@@ -40,6 +42,24 @@ def _cmd_narrative(_: argparse.Namespace) -> None:
         pass
 
 
+def _cmd_ethics(_: argparse.Namespace) -> None:
+    """Print the Nazarick manifesto laws."""
+
+    for idx, law in enumerate(LAWS, 1):
+        print(f"{idx}. {law.name}: {law.description}")
+
+
+def _cmd_trust(args: argparse.Namespace) -> None:
+    """Display trust score and protocol for ``args.entity``."""
+
+    matrix = TrustMatrix()
+    try:
+        info = matrix.evaluate_entity(args.entity)
+    finally:
+        matrix.close()
+    print(f"Trust: {info['trust']}")
+    print(f"Protocol: {info['protocol']}")
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the top level argument parser."""
 
@@ -48,6 +68,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     narr_p = sub.add_parser("narrative", help="Stream narrative stories")
     narr_p.set_defaults(func=_cmd_narrative)
+
+    ethics_p = sub.add_parser("ethics", help="Show manifesto laws")
+    ethics_p.set_defaults(func=_cmd_ethics)
+
+    trust_p = sub.add_parser("trust", help="Evaluate entity trust")
+    trust_p.add_argument("entity", help="Entity name")
+    trust_p.set_defaults(func=_cmd_trust)
 
     return parser
 

--- a/docs/nazarick_manifesto.md
+++ b/docs/nazarick_manifesto.md
@@ -1,0 +1,11 @@
+# Nazarick Manifesto
+
+The Nazarick agents abide by the following laws:
+
+1. **Nonaggression** – Refrain from unprovoked violence
+2. **Consent** – Seek consent in all dealings
+3. **Honesty** – Uphold truth and transparency
+4. **Stewardship** – Protect resources and the environment
+5. **Justice** – Act with fairness and equity
+6. **Compassion** – Show empathy toward others
+7. **Wisdom** – Pursue knowledge responsibly

--- a/tests/agents/test_razar_blueprint_synthesizer.py
+++ b/tests/agents/test_razar_blueprint_synthesizer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "razar_blueprint_synthesizer",
+    Path(__file__).resolve().parents[2] / "agents" / "razar" / "blueprint_synthesizer.py",
+)
+blueprint = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(blueprint)
+synthesize = blueprint.synthesize
+
+
+def test_synthesize_includes_manifesto(tmp_path):
+    output = tmp_path / "graph.json"
+    graph = synthesize(output)
+    root = Path(__file__).resolve().parents[2]
+    manifesto = (root / "docs" / "nazarick_manifesto.md").resolve()
+    assert str(manifesto) in graph.nodes
+    assert output.exists()

--- a/tests/agents/test_razar_cli.py
+++ b/tests/agents/test_razar_cli.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from agents.nazarick.ethics_manifesto import LAWS
+
+spec = importlib.util.spec_from_file_location(
+    "razar_cli", Path(__file__).resolve().parents[2] / "agents" / "razar" / "cli.py"
+)
+cli = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(cli)
+
+
+def test_ethics_lists_manifesto_laws(capsys):
+    cli.main(["ethics"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == len(LAWS)
+    assert out[0].startswith("1. " + LAWS[0].name)
+
+
+def test_trust_outputs_score_and_protocol(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    cli.main(["trust", "shalltear"])
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "Trust: 5" in out_lines[0]
+    assert out_lines[1].startswith("Protocol: nazarick_rank1_")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_nazarick_messaging.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_ethics_manifesto.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_trust_matrix.py"),
+    str(ROOT / "tests" / "agents" / "test_razar_cli.py"),
+    str(ROOT / "tests" / "agents" / "test_razar_blueprint_synthesizer.py"),
 }
 
 


### PR DESCRIPTION
## Summary
- extend `razar` CLI with `ethics` and `trust` subcommands
- include `docs/nazarick_manifesto.md` in blueprint graph
- document manifesto laws and test new commands

## Testing
- `pytest tests/agents/test_razar_cli.py tests/agents/test_razar_blueprint_synthesizer.py tests/agents/nazarick/test_ethics_manifesto.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af9c106338832e838476934f198d86