### PR TITLE
feat: expand doc sync and document regeneration

### DIFF
--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -35,6 +35,20 @@ python -m razar.module_sandbox path/to/module --patch change.diff
 
 The helper clones selected components into a temp directory, applies patches or scaffolds, runs `pytest` on the touched modules and copies the results back only when tests pass.
 
+## Documentation Regeneration
+
+Regenerate docs after a successful patch to keep status tables current:
+
+```bash
+python -m razar.doc_sync
+```
+
+This command rebuilds `Ignition.md`, refreshes `system_blueprint.md` and rewrites the component inventory under `docs`.
+For a standalone inventory update, run:
+
+```bash
+python scripts/component_inventory.py
+```
 
 ## Testing
 

--- a/logs/razar_mission.log
+++ b/logs/razar_mission.log
@@ -1,1 +1,2 @@
 2025-08-27T22:40:07Z Established automated doc synchronization for repairs and scaffolds.
+2025-08-28T00:03:12Z Expanded doc_sync to regenerate blueprint, ignition, and component docs.


### PR DESCRIPTION
## Summary
- regenerate component inventories as part of doc sync
- document doc regeneration workflow
- log doc sync expansion

## Testing
- `ruff check razar/doc_sync.py`
- `pytest --override-ini="addopts=" razar`
- `python -m razar.doc_sync` *(fails: ImportError: cannot import name 'run_validated_task')*

------
https://chatgpt.com/codex/tasks/task_e_68af9c4357d0832e85384f5813bf8512