### PR TITLE
Track RAZAR runtime progress

### DIFF
--- a/agents/razar/checkpoint_manager.py
+++ b/agents/razar/checkpoint_manager.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 """Simple checkpoint manager for RAZAR components.
 
-The manager persists the name of the last successfully started component so the
-runtime manager can resume from that point after a failure. Checkpoints are
-stored as JSON files and can be cleared to restart from the beginning.
+The manager persists boot progress in ``logs/razar_state.json`` so the runtime
+manager can resume from the last successful component after a failure. Each
+successful component name is appended to a ``history`` list alongside the
+``last_component`` field.  Checkpoints can be cleared to restart from the
+beginning.
 """
 
 from pathlib import Path
@@ -26,10 +28,27 @@ def load_checkpoint(path: Path = DEFAULT_PATH) -> str:
 
 
 def save_checkpoint(name: str, path: Path = DEFAULT_PATH) -> None:
-    """Persist ``name`` as the last successful component."""
+    """Persist ``name`` as the last successful component.
+
+    The checkpoint file stores two fields:
+
+    - ``last_component`` – the most recently successful component.
+    - ``history`` – ordered list of all successful component names.
+    """
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"last_component": name}), encoding="utf-8")
+    history: list[str] = []
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            history = list(data.get("history", []))
+        except json.JSONDecodeError:  # pragma: no cover - corrupted state
+            history = []
+    history.append(name)
+    path.write_text(
+        json.dumps({"last_component": name, "history": history}),
+        encoding="utf-8",
+    )
 
 
 def clear_checkpoint(path: Path = DEFAULT_PATH) -> None:

--- a/agents/razar/ignition_builder.py
+++ b/agents/razar/ignition_builder.py
@@ -98,9 +98,9 @@ def build_ignition(system_blueprint: Path, output: Path) -> None:
         for comp in sorted(groups[priority], key=lambda c: c["order"]):
             health_check = comp["health_check"] or "-"
             lines.append(
-                f"| {comp['order']} | {comp['name']} | {health_check} | {DEFAULT_STATUS} |"
+                f"| {comp['order']} | {comp['name']} | {health_check} | "
+                f"{DEFAULT_STATUS} |",
             )
-        lines.append("")
 
     lines.extend(
         [

--- a/tests/agents/razar/test_checkpoint_manager.py
+++ b/tests/agents/razar/test_checkpoint_manager.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import json
+
 from agents.razar import checkpoint_manager as cm
 
 
@@ -6,6 +8,9 @@ def test_checkpoint_roundtrip(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     assert cm.load_checkpoint(path) == ""
     cm.save_checkpoint("alpha", path)
-    assert cm.load_checkpoint(path) == "alpha"
+    cm.save_checkpoint("beta", path)
+    assert cm.load_checkpoint(path) == "beta"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["history"] == ["alpha", "beta"]
     cm.clear_checkpoint(path)
     assert cm.load_checkpoint(path) == ""

--- a/tests/agents/razar/test_ignition_builder.py
+++ b/tests/agents/razar/test_ignition_builder.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -58,7 +59,33 @@ def test_cli_build_ignition(tmp_path: Path) -> None:
         "--output",
         str(output),
     ]
-    subprocess.run(cmd, check=True)
+    # Inject lightweight stubs for guardian and cocytus via ``sitecustomize`` so
+    # the CLI runs without heavy dependencies.
+    stubs = tmp_path / "stubs"
+    stubs.mkdir()
+    (stubs / "sitecustomize.py").write_text(
+        (
+            "import sys, types\n"
+            "guardian = types.ModuleType('agents.guardian')\n"
+            "def run_validated_task(*a, **k):\n"
+            "    t=k.get('task')\n"
+            "    return t(*a, **k) if callable(t) else None\n"
+            "guardian.run_validated_task = run_validated_task\n"
+            "sys.modules.setdefault('agents.guardian', guardian)\n"
+            "cocytus = types.ModuleType('agents.cocytus')\n"
+            "cocytus.__path__ = []\n"
+            "sys.modules.setdefault('agents.cocytus', cocytus)\n"
+            "pa = types.ModuleType('agents.cocytus.prompt_arbiter')\n"
+            "def arbitrate(*a, **k):\n"
+            "    return None\n"
+            "pa.arbitrate = arbitrate\n"
+            "sys.modules.setdefault('agents.cocytus.prompt_arbiter', pa)\n"
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(stubs) + os.pathsep + env.get("PYTHONPATH", "")
+    subprocess.run(cmd, check=True, env=env)
 
     content = output.read_text(encoding="utf-8")
     assert "| 0 | Gamma | - | ⚠️ |" in content

--- a/tests/agents/razar/test_runtime_manager.py
+++ b/tests/agents/razar/test_runtime_manager.py
@@ -16,6 +16,7 @@ def test_runtime_manager_resume(failing_runtime, caplog):
     assert not (tmp_path / "gamma.txt").exists()
     state = json.loads((tmp_path / "run.state").read_text(encoding="utf-8"))
     assert state["last_component"] == "alpha"
+    assert state["history"] == ["alpha"]
     assert (quarantine_dir / "beta.json").exists()
 
     # Second run – fix beta command, reactivate and ensure resume
@@ -28,6 +29,7 @@ def test_runtime_manager_resume(failing_runtime, caplog):
     assert (tmp_path / "gamma.txt").exists()
     state = json.loads((tmp_path / "run.state").read_text(encoding="utf-8"))
     assert state["last_component"] == "gamma"
+    assert state["history"] == ["alpha", "beta", "gamma"]
     assert any("Starting component beta" in r.message for r in caplog.records)
 
 
@@ -46,4 +48,7 @@ def test_runtime_manager_skips_quarantined(failing_runtime, caplog):
     assert (tmp_path / "gamma.txt").exists()
     state = json.loads((tmp_path / "run.state").read_text(encoding="utf-8"))
     assert state["last_component"] == "gamma"
-    assert any("Skipping quarantined component beta" in r.message for r in caplog.records)
+    assert state["history"] == ["alpha", "gamma"]
+    assert any(
+        "Skipping quarantined component beta" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Track component history in `razar_state.json` so the runtime manager can resume after failure.
- Stub guardian and cocytus modules in tests to isolate RAZAR runtime behaviour.
- Harden ignition builder CLI test with lightweight sitecustomize stubs.

## Testing
- `pytest --no-cov tests/agents/razar -q`
- `pre-commit run --files agents/razar/runtime_manager.py agents/razar/ignition_builder.py agents/razar/checkpoint_manager.py tests/agents/razar/test_checkpoint_manager.py tests/agents/razar/test_runtime_manager.py tests/agents/razar/conftest.py tests/agents/razar/test_ignition_builder.py docs/Ignition.md`


------
https://chatgpt.com/codex/tasks/task_e_68afa1bf8ff8832e9531d8c8c60bebaa