### PR TITLE
feat: add remote agent loader and crown link

### DIFF
--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -56,7 +56,9 @@ implemented in `razar/crown_link.py`. Two JSON message types are exchanged:
 - **Repair requests** – `{"type": "repair", "stack_trace": "...", "config_summary": "..."}`
 
 The Crown side replies with patch instructions which RAZAR uses to heal faulty
-modules before reintroducing them into the boot cycle.
+modules before reintroducing them into the boot cycle. See the
+[RAZAR Agent](RAZAR_AGENT.md#crown-link-protocol) document for detailed schema
+descriptions.
 
 ## Mission Brief Handshake
 

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -23,6 +23,31 @@ Successful components are marked ✅ and persisted to `logs/razar_state.json` so
 
 Before the boot cycle, RAZAR sends a `mission_brief` to the CROWN LLM via `agents/razar/crown_handshake.py`. CROWN replies with available capabilities and readiness confirmation. During startup and after a failure, RAZAR contacts the relevant servant models and the CROWN LLM through `agents/razar/crown_link.py` to request patches or acknowledge health.
 
+## Remote Agent Loader
+
+External helpers can be fetched at runtime through
+`agents/razar/remote_loader.py`.  A remote agent must provide two functions:
+
+- `configure() -> dict` returns runtime options or parameters.
+- `patch(context=None)` optionally accepts a context string and returns repair
+  suggestions or diff content.
+
+Agents served over HTTP expose matching `/configure` and `/patch` endpoints.
+All interactions are written to `logs/razar_remote_agents.json`.
+
+## Crown Link Protocol
+
+Status and repair messages flow between RAZAR and CROWN over a small WebSocket
+client implemented in `agents/razar/crown_link.py`.
+
+- **Status update**
+  `{"type": "status", "component": "state_engine", "result": "ok", "log_snippet": "..."}`
+- **Failure report**
+  `{"type": "report", "blueprint_excerpt": "...", "failure_log": "..."}`
+
+Every request/response pair is appended to
+`logs/razar_crown_dialogues.json` for later inspection.
+
 ## Further Reading
 
 - [Nazarick Agents](nazarick_agents.md)

--- a/tests/agents/razar/test_crown_link.py
+++ b/tests/agents/razar/test_crown_link.py
@@ -5,26 +5,30 @@ from pathlib import Path
 import websockets
 
 from agents.razar import crown_link
-from agents.razar.crown_link import BlueprintReport, CrownLink
+from agents.razar.crown_link import BlueprintReport, CrownLink, StatusUpdate
 
 
 async def _mock_handler(websocket):
     msg = await websocket.recv()
     data = json.loads(msg)
-    assert data["type"] == "report"
-    assert "blueprint_excerpt" in data
-    reply = {"suggestions": "use dataclasses", "revisions": "refactor"}
+    if data["type"] == "status":
+        assert "component" in data
+        reply = {"ack": data["component"]}
+    else:
+        assert data["type"] == "report"
+        assert "blueprint_excerpt" in data
+        reply = {"suggestions": "use dataclasses", "revisions": "refactor"}
     await websocket.send(json.dumps(reply))
 
 
-def test_exchange(tmp_path):
+def test_send_report_and_log(tmp_path):
     crown_link.LOG_PATH = tmp_path / "dialogues.json"
 
     async def run():
         server = await websockets.serve(_mock_handler, "127.0.0.1", 8765)
         async with server:
             async with CrownLink("ws://127.0.0.1:8765") as link:
-                resp = await link.exchange(BlueprintReport("bp", "log"))
+                resp = await link.send_report(BlueprintReport("bp", "log"))
         return resp
 
     resp = asyncio.run(run())
@@ -33,3 +37,17 @@ def test_exchange(tmp_path):
     entry = json.loads(Path(crown_link.LOG_PATH).read_text().splitlines()[0])
     assert entry["request"]["blueprint_excerpt"] == "bp"
     assert entry["response"]["suggestions"] == "use dataclasses"
+
+
+def test_send_status(tmp_path):
+    crown_link.LOG_PATH = tmp_path / "dialogues.json"
+
+    async def run():
+        server = await websockets.serve(_mock_handler, "127.0.0.1", 8765)
+        async with server:
+            async with CrownLink("ws://127.0.0.1:8765") as link:
+                resp = await link.send_status(StatusUpdate("engine", "ok"))
+        return resp
+
+    resp = asyncio.run(run())
+    assert resp["ack"] == "engine"


### PR DESCRIPTION
## Summary
- add remote loader utilities to fetch external agents and log configure/patch interactions
- build CrownLink WebSocket client with status and report messages logged for auditing
- document remote loader endpoints and Crown link schemas, cross-linked from CROWN overview

## Testing
- `pre-commit run --files agents/razar/remote_loader.py agents/razar/crown_link.py tests/agents/razar/test_crown_link.py docs/RAZAR_AGENT.md docs/CROWN_OVERVIEW.md`
- `pytest --no-cov tests/agents/razar/test_crown_link.py tests/agents/razar/test_module_builder.py` *(skipped crown link tests: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68afd9af0c64832e86fbdb756e6cd690