### PR TITLE
Add service probes and quarantine handling for RAZAR runtime

### DIFF
--- a/agents/razar/health_checks.py
+++ b/agents/razar/health_checks.py
@@ -115,17 +115,36 @@ def check_crown_ready() -> bool:
     return ready_signal(f"http://localhost:{port}/ready")
 
 
+def check_memory_store_ready() -> bool:
+    """Ping the memory store service."""
+
+    port = os.getenv("MEMORY_STORE_PORT", "8900")
+    return ping_endpoint(f"http://localhost:{port}/health")
+
+
+def check_chat_gateway_ready() -> bool:
+    """Confirm chat gateway reports readiness."""
+
+    port = os.getenv("CHAT_GATEWAY_PORT", "8800")
+    return ready_signal(f"http://localhost:{port}/ready")
+
+
 CHECKS: Dict[str, Callable[[], bool]] = {
     "basic_service": check_basic_service,
     "complex_service": check_complex_service,
     "inanna_ai": check_inanna_ready,
     "crown_llm": check_crown_ready,
+    "memory_store": check_memory_store_ready,
+    "chat_gateway": check_chat_gateway_ready,
 }
 
 
 RESTART_COMMANDS: Dict[str, List[str]] = {
     "inanna_ai": ["bash", "run_inanna.sh"],
     "crown_llm": ["bash", "crown_model_launcher.sh"],
+    # Additional restart helpers for common services
+    "memory_store": ["bash", "start_memory_store.sh"],
+    "chat_gateway": ["bash", "start_chat_gateway.sh"],
 }
 
 
@@ -135,6 +154,8 @@ THRESHOLDS: Dict[str, float] = {
     "complex_service": 0.5,
     "inanna_ai": 1.0,
     "crown_llm": 1.0,
+    "memory_store": 0.5,
+    "chat_gateway": 0.5,
 }
 
 

--- a/agents/razar/quarantine_manager.py
+++ b/agents/razar/quarantine_manager.py
@@ -113,7 +113,14 @@ def quarantine_module(path: str | Path, reason: str) -> Path:
         raise FileNotFoundError(src)
     target = QUARANTINE_DIR / src.name
     shutil.move(str(src), target)
-    _append_log(src.name, "quarantined", reason)
+    metadata = {
+        "name": src.name,
+        "original_path": str(src),
+        "reason": reason,
+        "quarantined_at": datetime.utcnow().isoformat(),
+    }
+    _write_metadata(src.name, metadata)
+    _append_log(src.name, "quarantined", f"{reason}; moved from {src}")
     emit_event(
         "razar",
         "module_quarantined",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -56,6 +56,15 @@ reconstruct the boot history and identify failures chronologically, run:
 python -m razar timeline
 ```
 
+## Quarantine log
+
+Components that repeatedly fail their health checks are quarantined by the
+runtime manager. The affected module is moved under the repository-level
+`quarantine/` directory and an entry is appended to
+`docs/quarantine_log.md` with the failure reason and timestamp. Remove the
+corresponding JSON file and add a `resolved` line to the log once the component
+has been fixed.
+
 ## Status dashboard
 
 Use the status dashboard for a quick snapshot of the current boot attempt and

--- a/tests/agents/razar/test_quarantine_manager.py
+++ b/tests/agents/razar/test_quarantine_manager.py
@@ -18,3 +18,20 @@ def test_quarantine_metadata(tmp_path, monkeypatch):
     qm.record_patch("alpha", "fix1")
     data = json.loads((quarantine_dir / "alpha.json").read_text(encoding="utf-8"))
     assert data["patches_applied"] == ["fix1"]
+
+
+def test_quarantine_module_moves_and_logs(tmp_path, monkeypatch):
+    quarantine_dir = tmp_path / "quarantine"
+    log_file = tmp_path / "log.md"
+    monkeypatch.setattr(qm, "QUARANTINE_DIR", quarantine_dir)
+    monkeypatch.setattr(qm, "LOG_FILE", log_file)
+
+    src = tmp_path / "mod.py"
+    src.write_text("print('x')", encoding="utf-8")
+    qm.quarantine_module(src, "failure")
+    assert not src.exists()
+    moved = quarantine_dir / "mod.py"
+    assert moved.exists()
+    meta = json.loads((quarantine_dir / "mod.py.json").read_text(encoding="utf-8"))
+    assert meta["reason"] == "failure"
+    assert "mod.py" in log_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add memory store and chat gateway health probes with restart commands and latency thresholds
- move failing modules into `quarantine/` and record metadata
- quarantine components and modules on runtime health check failures
- document how to monitor the quarantine log

## Testing
- `pytest --no-cov tests/test_razar_health_checks.py tests/agents/razar/test_quarantine_manager.py tests/agents/razar/test_runtime_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68afdc79a908832eaa67ea154805f000