### PR TITLE
Add mission timeline CLI and documentation

### DIFF
--- a/agents/razar/cli.py
+++ b/agents/razar/cli.py
@@ -10,6 +10,7 @@ from typing import Iterator
 from memory import narrative_engine
 from agents.nazarick.ethics_manifesto import LAWS
 from agents.nazarick.trust_matrix import TrustMatrix
+from agents.razar import mission_logger
 
 ROOT = Path(__file__).resolve().parents[2]
 LOG_PATH = ROOT / "logs" / "nazarick_story.log"
@@ -60,6 +61,16 @@ def _cmd_trust(args: argparse.Namespace) -> None:
     print(f"Trust: {info['trust']}")
     print(f"Protocol: {info['protocol']}")
 
+
+def _cmd_timeline(_: argparse.Namespace) -> None:
+    """Print the boot timeline from the mission log."""
+
+    for entry in mission_logger.timeline():
+        details = f" - {entry['details']}" if entry.get("details") else ""
+        print(
+            f"{entry['timestamp']} {entry['event']} {entry['component']}: {entry['status']}{details}"
+        )
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the top level argument parser."""
 
@@ -75,6 +86,9 @@ def build_parser() -> argparse.ArgumentParser:
     trust_p = sub.add_parser("trust", help="Evaluate entity trust")
     trust_p.add_argument("entity", help="Entity name")
     trust_p.set_defaults(func=_cmd_trust)
+
+    timeline_p = sub.add_parser("timeline", help="Show boot history")
+    timeline_p.set_defaults(func=_cmd_timeline)
 
     return parser
 

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -19,6 +19,13 @@ Component priorities are read from `docs/system_blueprint.md` and `config/razar_
 
 Successful components are marked ✅ and persisted to `logs/razar_state.json` so later runs resume from the last healthy step.
 
+## Mission Logging
+
+RAZAR records each component start, health result, quarantine event and applied
+patch through `agents.razar.mission_logger`. Entries are written as JSON lines
+to `logs/razar.log`. Operators can run `razar timeline` to reconstruct the boot
+history or `python -m razar.mission_logger summary` to list pending steps.
+
 ## Crown Handshake
 
 Before the boot cycle, RAZAR sends a `mission_brief` to the CROWN LLM via `agents/razar/crown_handshake.py`. CROWN replies with available capabilities and readiness confirmation. During startup and after a failure, RAZAR contacts the relevant servant models and the CROWN LLM through `agents/razar/crown_link.py` to request patches or acknowledge health.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,10 +25,10 @@ python -m razar.mission_logger log gateway success --event start
 python -m razar.mission_logger summary
 ```
 
-Entries are stored in ``logs/razar.log``. The ``summary`` command prints the
-last successful component and lists pending tasks based on the most recent
-status for each component. For a full chronological view, run ``razar
-timeline`` to reconstruct the mission sequence.
+Entries are stored as JSON lines in ``logs/razar.log``. The ``summary``
+command prints the last successful component and lists pending tasks based on
+the most recent status for each component. The ``razar timeline`` CLI parses
+these entries to reconstruct the mission sequence.
 
 For a real-time snapshot of boot progress and component priorities, launch the
 status dashboard:

--- a/tests/agents/test_razar_cli.py
+++ b/tests/agents/test_razar_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from agents.nazarick.ethics_manifesto import LAWS
+from razar import mission_logger
 
 spec = importlib.util.spec_from_file_location(
     "razar_cli", Path(__file__).resolve().parents[2] / "agents" / "razar" / "cli.py"
@@ -28,3 +29,13 @@ def test_trust_outputs_score_and_protocol(monkeypatch, tmp_path, capsys):
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert "Trust: 5" in out_lines[0]
     assert out_lines[1].startswith("Protocol: nazarick_rank1_")
+
+
+def test_timeline_displays_boot_history(tmp_path, capsys):
+    mission_logger.LOG_PATH = tmp_path / "logs" / "razar.log"
+    mission_logger.log_start("alpha", "success")
+
+    cli.main(["timeline"])
+    out = capsys.readouterr().out.strip()
+    assert "alpha" in out
+    assert "start" in out


### PR DESCRIPTION
## Summary
- add `timeline` subcommand to `razar` CLI for boot history reconstruction
- document mission logging and timeline usage in operations and RAZAR agent guides
- test CLI timeline output

## Testing
- `pytest tests/agents/test_razar_cli.py tests/agents/razar/test_pytest_runner.py tests/test_mission_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afdfde9998832eac836ba7cd807827