### PR TITLE
feat: reconstruct modules from docs

### DIFF
--- a/agents/razar/cli.py
+++ b/agents/razar/cli.py
@@ -10,7 +10,7 @@ from typing import Iterator
 from memory import narrative_engine
 from agents.nazarick.ethics_manifesto import LAWS
 from agents.nazarick.trust_matrix import TrustMatrix
-from agents.razar import mission_logger
+from agents.razar import mission_logger, retro_bootstrap
 
 ROOT = Path(__file__).resolve().parents[2]
 LOG_PATH = ROOT / "logs" / "nazarick_story.log"
@@ -71,6 +71,14 @@ def _cmd_timeline(_: argparse.Namespace) -> None:
             f"{entry['timestamp']} {entry['event']} {entry['component']}: {entry['status']}{details}"
         )
 
+
+def _cmd_bootstrap(args: argparse.Namespace) -> None:
+    """Rebuild modules based on documentation references."""
+
+    if args.from_docs:
+        for path in retro_bootstrap.bootstrap_from_docs():
+            print(path)
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the top level argument parser."""
 
@@ -89,6 +97,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     timeline_p = sub.add_parser("timeline", help="Show boot history")
     timeline_p.set_defaults(func=_cmd_timeline)
+
+    bootstrap_p = sub.add_parser("bootstrap", help="Rebuild modules")
+    bootstrap_p.add_argument(
+        "--from-docs",
+        action="store_true",
+        help="Reconstruct modules referenced in docs",
+    )
+    bootstrap_p.set_defaults(func=_cmd_bootstrap)
 
     return parser
 

--- a/agents/razar/retro_bootstrap.py
+++ b/agents/razar/retro_bootstrap.py
@@ -24,6 +24,18 @@ from . import planning_engine, module_builder
 _LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+\.py)\)")
 
 
+def _ensure_packages(base: Path, module_path: Path) -> None:
+    """Create ``__init__`` files for ``module_path`` relative to ``base``."""
+
+    current = module_path.parent
+    while True:
+        init_file = current / "__init__.py"
+        init_file.touch(exist_ok=True)
+        if current == base:
+            break
+        current = current.parent
+
+
 def _extract_module_names(text: str) -> List[str]:
     """Return module names referenced by markdown links in ``text``."""
 
@@ -98,6 +110,7 @@ def bootstrap_from_docs(
         rel = Path(str(spec.get("component", "")))
         target = workspace / rel
         target.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_packages(workspace, target)
         shutil.move(str(built), target)
         generated.append(target)
     return generated

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -55,6 +55,25 @@ client implemented in `agents/razar/crown_link.py`.
 Every request/response pair is appended to
 `logs/razar_crown_dialogues.json` for later inspection.
 
+## Emergency Reconstruction
+
+RAZAR can reconstruct a minimal project skeleton when the repository is
+unavailable. The command
+
+```bash
+razar bootstrap --from-docs
+```
+
+scans the documentation for links to Python modules and regenerates those
+modules in a fresh workspace. Paths to the rebuilt files are printed for
+inspection.
+
+### Limitations
+
+- Only modules referenced in Markdown links are recreated.
+- The workspace does not include dependencies, data files or configuration.
+- Generated modules are skeletal and require manual review before use.
+
 ## Further Reading
 
 - [Nazarick Agents](nazarick_agents.md)

--- a/tests/agents/test_razar_cli.py
+++ b/tests/agents/test_razar_cli.py
@@ -1,17 +1,39 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
 from agents.nazarick.ethics_manifesto import LAWS
-from razar import mission_logger
+
+base = Path(__file__).resolve().parents[2] / "agents" / "razar"
+
+mission_name = "agents.razar.mission_logger"
+mission_spec = importlib.util.spec_from_file_location(mission_name, base / "mission_logger.py")
+mission_logger = importlib.util.module_from_spec(mission_spec)
+sys.modules[mission_name] = mission_logger
+assert mission_spec and mission_spec.loader
+mission_spec.loader.exec_module(mission_logger)
+
+retro_bootstrap = types.ModuleType("retro_bootstrap")
+def _dummy_bootstrap():
+    return []
+retro_bootstrap.bootstrap_from_docs = _dummy_bootstrap
+sys.modules["agents.razar.retro_bootstrap"] = retro_bootstrap
+
+stub = types.ModuleType("agents.razar")
+stub.mission_logger = mission_logger
+stub.retro_bootstrap = retro_bootstrap
+sys.modules["agents.razar"] = stub
 
 spec = importlib.util.spec_from_file_location(
-    "razar_cli", Path(__file__).resolve().parents[2] / "agents" / "razar" / "cli.py"
+    "agents.razar.cli", base / "cli.py"
 )
 cli = importlib.util.module_from_spec(spec)
+sys.modules["agents.razar.cli"] = cli
 assert spec and spec.loader
 spec.loader.exec_module(cli)
 
@@ -39,3 +61,17 @@ def test_timeline_displays_boot_history(tmp_path, capsys):
     out = capsys.readouterr().out.strip()
     assert "alpha" in out
     assert "start" in out
+
+
+def test_bootstrap_invokes_retro_bootstrap(monkeypatch, capsys):
+    called = []
+
+    def fake_bootstrap_from_docs():
+        called.append(True)
+        return [Path("mod.py")]
+
+    monkeypatch.setattr(cli.retro_bootstrap, "bootstrap_from_docs", fake_bootstrap_from_docs)
+    cli.main(["bootstrap", "--from-docs"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert called
+    assert out == ["mod.py"]


### PR DESCRIPTION
## Summary
- rebuild python modules referenced in docs with `retro_bootstrap` and package stubs
- expose emergency `razar bootstrap --from-docs` CLI
- document reconstruction workflow and limitations

## Testing
- `pip install pytest-cov`
- `pytest tests/agents/test_razar_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0069b754c832e96ec6001c680943e