### PR TITLE
docs: describe event pipeline

### DIFF
--- a/citadel/event_producer.py
+++ b/citadel/event_producer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -14,7 +14,7 @@ class Event:
 
     agent_id: str
     event_type: str
-    payload: dict
+    payload: Dict[str, Any]
     timestamp: datetime = field(default_factory=datetime.utcnow)
 
     def to_json(self) -> str:

--- a/docs/great_tomb_of_nazarick.md
+++ b/docs/great_tomb_of_nazarick.md
@@ -37,3 +37,24 @@
 - **Root** – Infrastructure interfaces and system logging.
 
 See [System Blueprint](system_blueprint.md) and [Nazarick Agents](nazarick_agents.md) for broader context.
+
+## Event Schema
+Agent interactions generate structured JSON events routed through the Citadel
+bus. Each event contains the following fields:
+
+| Field | Description |
+| --- | --- |
+| `agent_id` | Identifier of the emitting agent |
+| `event_type` | Action being recorded |
+| `payload` | Arbitrary metadata for the event |
+| `timestamp` | UTC time the event was created |
+
+## Event Pipeline
+1. Agents call `emit_event` which publishes the JSON payload to Redis or
+   Kafka depending on deployment settings.
+2. The FastAPI processor (`citadel.event_processor`) consumes these streams and
+   persists them to two backends:
+   - **TimescaleDB** for temporal queries over the `agent_events` table.
+   - **Neo4j** for relational exploration of agent interactions.
+3. Downstream services can query either store to reconstruct the activity
+   history of the Great Tomb.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,9 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "nazarick" / "test_trust_matrix.py"),
     str(ROOT / "tests" / "agents" / "test_razar_cli.py"),
     str(ROOT / "tests" / "agents" / "test_razar_blueprint_synthesizer.py"),
+    str(ROOT / "tests" / "test_citadel_event_producer.py"),
+    str(ROOT / "tests" / "test_citadel_event_processor.py"),
+    str(ROOT / "tests" / "agents" / "test_event_bus.py"),
 }
 
 

--- a/tests/test_citadel_event_processor.py
+++ b/tests/test_citadel_event_processor.py
@@ -1,0 +1,16 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from citadel.event_producer import Event
+from citadel.event_processor import process_event
+
+
+def test_process_event_writes_to_all_backends():
+    event = Event(agent_id="a1", event_type="test", payload={})
+    ts_writer = AsyncMock()
+    neo_writer = AsyncMock()
+
+    asyncio.run(process_event(event, ts_writer, neo_writer))
+
+    ts_writer.write_event.assert_awaited_once_with(event)
+    neo_writer.write_event.assert_awaited_once_with(event)


### PR DESCRIPTION
## Summary
- type event payloads for structured JSON emission
- document event schema and pipeline in the Great Tomb guide
- test event processor writing events to TimescaleDB and Neo4j

## Testing
- `pytest tests/test_citadel_event_processor.py tests/test_citadel_event_producer.py tests/agents/test_event_bus.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68b02b395f48832e8d6407a144535736