### PR TITLE
Add TimescaleDB and Neo4j schemas with retention policies

### DIFF
--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -2,6 +2,39 @@
 
 Generated automatically. Lists each Python file with its description and external dependencies. See the [Great Tomb of Nazarick](great_tomb_of_nazarick.md) for objectives, channel hierarchy, tech stack, and chakra alignment.
 
+## Storage Schemas
+### TimescaleDB
+```mermaid
+erDiagram
+    agent_events {
+        TIMESTAMPTZ time PK
+        TEXT agent_id
+        TEXT event_type
+        JSONB payload
+    }
+```
+- Hypertable with 30-day retention and indexes on `agent_id` and `event_type`.
+
+```sql
+SELECT * FROM agent_events
+WHERE event_type = 'ritual'
+ORDER BY time DESC LIMIT 10;
+```
+
+### Neo4j
+```mermaid
+graph TD
+    A[Agent] -->|EMITTED| E[Event]
+```
+- Unique `Agent.agent_id` with indexes on `Event.timestamp` and `event_type`.
+
+```cypher
+MATCH (a:Agent)-[:EMITTED]->(e:Event)
+WHERE a.agent_id = 'Aura'
+RETURN e
+ORDER BY e.timestamp DESC LIMIT 10;
+```
+
 | File | Description | Dependencies |
 | --- | --- | --- |
 | `INANNA_AI/__init__.py` | Core package for the INANNA AI helpers. | None |

--- a/schemas/neo4j_agent_events.cypher
+++ b/schemas/neo4j_agent_events.cypher
@@ -1,0 +1,20 @@
+// Neo4j schema and migration script for agent events
+// Node constraints and indexes
+CREATE CONSTRAINT agent_id_unique IF NOT EXISTS
+FOR (a:Agent) REQUIRE a.agent_id IS UNIQUE;
+
+CREATE INDEX event_time_idx IF NOT EXISTS
+FOR (e:Event) ON (e.timestamp);
+
+CREATE INDEX event_type_idx IF NOT EXISTS
+FOR (e:Event) ON (e.event_type);
+
+// Relationship queries
+// Retrieve recent events for an agent
+// MATCH (a:Agent {agent_id: $agent_id})-[:EMITTED]->(e:Event)
+// RETURN e ORDER BY e.timestamp DESC LIMIT 100;
+
+// Find co-emission counts between agents
+// MATCH (a1:Agent)-[:EMITTED]->(e:Event)<-[:EMITTED]-(a2:Agent)
+// RETURN a1.agent_id AS source, a2.agent_id AS collaborator, COUNT(e) AS interactions
+// ORDER BY interactions DESC;

--- a/schemas/timescaledb_agent_events.sql
+++ b/schemas/timescaledb_agent_events.sql
@@ -1,0 +1,18 @@
+-- TimescaleDB schema and migration script for agent_events
+CREATE TABLE IF NOT EXISTS agent_events (
+    time        TIMESTAMPTZ NOT NULL,
+    agent_id    TEXT NOT NULL,
+    event_type  TEXT NOT NULL,
+    payload     JSONB DEFAULT '{}'::JSONB,
+    PRIMARY KEY (time, agent_id)
+);
+
+-- Convert to hypertable for time-series performance
+SELECT create_hypertable('agent_events', 'time', if_not_exists => TRUE);
+
+-- Indexes to accelerate lookups
+CREATE INDEX IF NOT EXISTS agent_events_agent_idx ON agent_events (agent_id, time DESC);
+CREATE INDEX IF NOT EXISTS agent_events_type_idx ON agent_events (event_type);
+
+-- Retention policy: keep 30 days of data
+SELECT add_retention_policy('agent_events', INTERVAL '30 days');


### PR DESCRIPTION
## Summary
- define TimescaleDB `agent_events` hypertable with retention and indexes
- add Neo4j constraints, indexes, and relationship queries
- document schemas and example queries in Great Tomb and component index docs

## Testing
- `pre-commit run --files schemas/timescaledb_agent_events.sql schemas/neo4j_agent_events.cypher docs/great_tomb_of_nazarick.md docs/component_index.md`
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b02c3afcac832eb0c9af723efab73e