### PR TITLE
feat: add operator dispatcher and log NLQ

### DIFF
--- a/agents/operator_dispatcher.py
+++ b/agents/operator_dispatcher.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Operator command dispatcher with access controls and log mirroring."""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable
+
+
+class OperatorDispatcher:
+    """Dispatch commands from operators to agents with audit logging.
+
+    Parameters
+    ----------
+    access_map:
+        Mapping of operator identifiers to the set of agents they may invoke.
+    log_dir:
+        Directory where per-operator private channels are stored.
+    worm_dir:
+        Directory for append-only mirrors of Cocytus/Victim logs.
+    """
+
+    def __init__(
+        self,
+        access_map: Dict[str, Iterable[str]],
+        *,
+        log_dir: Path | str = Path("logs/operators"),
+        worm_dir: Path | str = Path("audit_logs"),
+    ) -> None:
+        self.access_map = {k: set(v) for k, v in access_map.items()}
+        self.log_dir = Path(log_dir)
+        self.worm_dir = Path(worm_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.worm_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def dispatch(
+        self,
+        operator: str,
+        agent: str,
+        command: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Execute ``command`` on behalf of ``operator`` for ``agent``.
+
+        Raises ``PermissionError`` if the operator lacks access to the agent.
+        All invocations are recorded to per-operator logs. Commands targeting
+        ``cocytus`` or ``victim`` are mirrored to append-only audit logs.
+        """
+
+        if agent not in self.access_map.get(operator, set()):
+            raise PermissionError(f"{operator} cannot access {agent}")
+
+        result = command(*args, **kwargs)
+        record = {
+            "operator": operator,
+            "agent": agent,
+            "command": getattr(command, "__name__", "<callable>"),
+            "args": args,
+            "kwargs": kwargs,
+        }
+        self._record_private(operator, record)
+        if agent.lower() in {"cocytus", "victim"}:
+            self._worm_mirror(agent.lower(), record)
+        return result
+
+    # ------------------------------------------------------------------
+    def _record_private(self, operator: str, record: Dict[str, Any]) -> None:
+        path = self.log_dir / f"{operator}.log"
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    # ------------------------------------------------------------------
+    def _worm_mirror(self, agent: str, record: Dict[str, Any]) -> None:
+        path = self.worm_dir / f"{agent}.log"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+
+__all__ = ["OperatorDispatcher"]

--- a/agents/vanna_data.py
+++ b/agents/vanna_data.py
@@ -85,4 +85,19 @@ def query_db(prompt: str) -> List[Dict[str, Any]]:
     return rows
 
 
-__all__ = ["query_db"]
+def query_logs(prompt: str, db_path: str | Path | None = None) -> List[Dict[str, Any]]:
+    """Query a log database using a natural language ``prompt``.
+
+    The function connects Vanna to the SQLite database at ``db_path`` (defaults
+    to ``logs/events.db``) before delegating to :func:`query_db`.
+    """
+
+    if getattr(vanna, "__stub__", False):  # pragma: no cover - optional dep
+        raise RuntimeError("vanna library is not installed")
+
+    db = Path(db_path) if db_path is not None else Path("logs/events.db")
+    vanna.connect_to_sqlite(str(db))  # type: ignore[attr-defined]
+    return query_db(prompt)
+
+
+__all__ = ["query_db", "query_logs"]

--- a/docs/great_tomb_of_nazarick.md
+++ b/docs/great_tomb_of_nazarick.md
@@ -94,3 +94,20 @@ MATCH (a1:Agent)-[:EMITTED]->(e:Event)<-[:EMITTED]-(a2:Agent)
 RETURN a1.agent_id AS source, a2.agent_id AS collaborator, COUNT(e) AS interactions
 ORDER BY interactions DESC;
 ```
+
+## API Endpoints
+- `POST /nlq` – query databases using Vanna AI.
+- `POST /nlq/logs` – natural language queries against log data via the self-hosted Vanna service.
+- `POST /operator/command` – dispatch operator commands with access controls and logging.
+
+## NLQ Examples
+```bash
+curl -X POST localhost:8000/nlq/logs \\
+     -H 'Content-Type: application/json' \\
+     -d '{"query":"list all failed logins today"}'
+```
+
+## Security Model
+- The `OperatorDispatcher` enforces role-based access for guardian commands.
+- Private per-operator channels are written to `logs/operators/<operator>.log`.
+- Actions targeting Cocytus or Victim are mirrored to append-only files under `audit_logs/` for WORM retention.

--- a/nlq_api.py
+++ b/nlq_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from fastapi import APIRouter
 
-from agents.vanna_data import query_db
+from agents.vanna_data import query_db, query_logs
 from core.utils.optional_deps import lazy_import
 
 router = APIRouter()
@@ -32,6 +32,15 @@ async def nlq_query(data: dict[str, str]) -> dict[str, object]:
     """Execute a natural language query against the database."""
     prompt = data.get("query", "")
     rows = query_db(prompt) if prompt else []
+    return {"rows": rows}
+
+
+@router.post("/nlq/logs")
+async def nlq_logs(data: dict[str, str]) -> dict[str, object]:
+    """Execute a natural language query against the log database."""
+    prompt = data.get("query", "")
+    db_path = data.get("db")
+    rows = query_logs(prompt, db_path=db_path) if prompt else []
     return {"rows": rows}
 
 

--- a/operator_api.py
+++ b/operator_api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Operator command API exposing the :class:`OperatorDispatcher`."""
+
+from fastapi import APIRouter, HTTPException
+
+from agents.operator_dispatcher import OperatorDispatcher
+
+router = APIRouter()
+_dispatcher = OperatorDispatcher({"overlord": ["cocytus", "victim"], "auditor": ["victim"]})
+
+
+@router.post("/operator/command")
+async def dispatch_command(data: dict[str, str]) -> dict[str, object]:
+    """Dispatch an operator command to a target agent."""
+    operator = data.get("operator", "")
+    agent = data.get("agent", "")
+    command_name = data.get("command", "")
+    if not operator or not agent or not command_name:
+        raise HTTPException(status_code=400, detail="operator, agent and command required")
+
+    def _noop() -> dict[str, str]:
+        return {"ack": command_name}
+
+    try:
+        result = _dispatcher.dispatch(operator, agent, _noop)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    return {"result": result}
+
+
+__all__ = ["router"]

--- a/server.py
+++ b/server.py
@@ -57,6 +57,7 @@ from crown_config import settings
 from glm_shell import send_command
 from communication.floor_channel_socket import socket_app
 from nlq_api import router as nlq_router
+from operator_api import router as operator_router
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +177,7 @@ app = FastAPI(lifespan=lifespan)
 app.include_router(video_stream.router)
 app.include_router(webrtc_connector.router)
 app.include_router(nlq_router)
+app.include_router(operator_router)
 
 Instrumentator().instrument(app).expose(app)
 app.mount("/ws", socket_app)


### PR DESCRIPTION
## Summary
- enable Vanna to query log databases with new `/nlq/logs` endpoint
- introduce `OperatorDispatcher` for access-controlled command routing with WORM log mirroring
- expose `/operator/command` API and document endpoints, NLQ examples, and security model

## Testing
- `pytest` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e2f4d18832ea708f05decf8ad94