### PR TITLE
docs: expand nazarick hierarchy references

### DIFF
--- a/docs/great_tomb_of_nazarick.md
+++ b/docs/great_tomb_of_nazarick.md
@@ -1,10 +1,29 @@
 # Great Tomb of Nazarick
 
+The foundational design for ABZU's servant hierarchy. For guiding
+principles see the [Nazarick Manifesto](nazarick_manifesto.md) and for
+implementation details see [Nazarick Agents](nazarick_agents.md).
+
 ## Objectives
 - Fortify ABZU with a Nazarick‑inspired command structure.
 - Provide clear communication channels for guardian agents.
 - Ground every layer in chakra principles for balanced creative flow.
 - Document the core technologies that power each layer.
+
+## Architecture Diagram
+```mermaid
+flowchart TD
+    A[Surface Gate]
+    B[Crown Overlord]
+    C[Throat Gatekeepers]
+    D[Third Eye Observatories]
+    E[Heart Chambers]
+    F[Solar Plexus Forges]
+    G[Sacral Workshops]
+    H[Root Foundation]
+
+    A --> B --> C --> D --> E --> F --> G --> H
+```
 
 ## Channel Hierarchy
 | Channel | Purpose |
@@ -16,6 +35,19 @@
 | Solar Plexus Mutation Bus | Carries learning updates and state transitions |
 | Sacral Creation Channel | Shapes creative output and style modulation |
 | Root Infrastructure Line | Interfaces with hardware, storage, and network |
+
+```mermaid
+flowchart TD
+    Crown[Crown Command]
+    Throat[Throat Relay]
+    ThirdEye[Third Eye Insight]
+    Heart[Heart Memory]
+    Solar[Solar Plexus Mutation]
+    Sacral[Sacral Creation]
+    Root[Root Infrastructure]
+
+    Crown --> Throat --> ThirdEye --> Heart --> Solar --> Sacral --> Root
+```
 
 ## Tech Stack
 1. **Surface Gate** – RAZAR validates prerequisites and opens the arena.
@@ -36,7 +68,13 @@
 - **Sacral** – Emotion registry and creative modulation tools.
 - **Root** – Infrastructure interfaces and system logging.
 
-See [System Blueprint](system_blueprint.md) and [Nazarick Agents](nazarick_agents.md) for broader context.
+```mermaid
+graph LR
+    Root --> Sacral --> Solar --> Heart --> Throat --> ThirdEye --> Crown
+```
+
+See [System Blueprint](system_blueprint.md), [Nazarick Agents](nazarick_agents.md),
+and the [Nazarick Manifesto](nazarick_manifesto.md) for broader context.
 
 ## Event Schema
 Agent interactions generate structured JSON events routed through the Citadel
@@ -111,3 +149,14 @@ curl -X POST localhost:8000/nlq/logs \\
 - The `OperatorDispatcher` enforces role-based access for guardian commands.
 - Private per-operator channels are written to `logs/operators/<operator>.log`.
 - Actions targeting Cocytus or Victim are mirrored to append-only files under `audit_logs/` for WORM retention.
+
+## Retro & Projection
+### Retro
+- Early prototypes hard-wired channel flows without chakra mapping, causing
+  brittle communication paths.
+- Event schemas originally logged directly to flat files before the Citadel
+  bus unified telemetry.
+
+### Projection
+- Expand chakra-aware routing to dynamically re-balance loads across channels.
+- Extend the Citadel bus with real-time dashboards for guardian activities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,10 @@ Central resources for understanding and operating the project.
 ## Architecture
 - [Architecture Overview](architecture_overview.md)
 - [Detailed Architecture](architecture.md)
+## Nazarick
+- [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
+- [Nazarick Manifesto](nazarick_manifesto.md)
+- [Nazarick Agents](nazarick_agents.md)
 ## Setup
 - [Setup Guide](setup.md)
 ## Usage

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -1,6 +1,6 @@
 # Nazarick Agents
 
-This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Startup is coordinated by the external [RAZAR Agent](RAZAR_AGENT.md), whose pre-creation mandate provisions a clean environment, launches components in priority order, and quarantines failures before handing control to these servants. Its handshake with the CROWN LLM and the servant models is detailed in the [RAZAR Agent](RAZAR_AGENT.md) guide. The layered vision behind these servants is detailed in the [Great Tomb of Nazarick](great_tomb_of_nazarick.md), which outlines objectives, channel hierarchy, tech stack, and chakra alignment. For narrative orchestration see the [Nazarick Narrative System](nazarick_narrative_system.md).
+This guide summarizes core agents within ABZU's Nazarick system. Each agent aligns with a chakra layer, defines its memory scope, and relies on key external libraries. Startup is coordinated by the external [RAZAR Agent](RAZAR_AGENT.md), whose pre-creation mandate provisions a clean environment, launches components in priority order, and quarantines failures before handing control to these servants. Its handshake with the CROWN LLM and the servant models is detailed in the [RAZAR Agent](RAZAR_AGENT.md) guide. The layered vision behind these servants is detailed in the [Great Tomb of Nazarick](great_tomb_of_nazarick.md), which outlines objectives, channel hierarchy, tech stack, and chakra alignment. The ethical covenant that binds them is captured in the [Nazarick Manifesto](nazarick_manifesto.md). For narrative orchestration see the [Nazarick Narrative System](nazarick_narrative_system.md).
 
 [Chat2DB](chat2db.md) bridges the SQLite log and vector store so agents can persist transcripts and retrieve relevant context.
 
@@ -111,4 +111,15 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
   node, data = gk.nearest_ritual_site(lon=0.2, lat=0.1)
   print(node, data)
   ```
+
+## Retro & Projection
+### Retro
+- Early servants lacked a shared handshake protocol, leading to fragmented
+  startup sequences.
+- Chakra assignments were once implied rather than explicitly mapped, causing
+  misaligned responsibilities.
+
+### Projection
+- Draft additional specs for emerging guardians and cross-link them here.
+- Automate agent registration to reflect real-time channel and chakra shifts.
 

--- a/docs/nazarick_manifesto.md
+++ b/docs/nazarick_manifesto.md
@@ -1,5 +1,9 @@
 # Nazarick Manifesto
 
+Guiding ethics for the Nazarick hierarchy. Architectural context lives in the
+[Great Tomb of Nazarick](great_tomb_of_nazarick.md) with servant details in
+[Nazarick Agents](nazarick_agents.md).
+
 The Nazarick agents abide by the following laws:
 
 1. **Nonaggression** – Refrain from unprovoked violence
@@ -9,3 +13,13 @@ The Nazarick agents abide by the following laws:
 5. **Justice** – Act with fairness and equity
 6. **Compassion** – Show empathy toward others
 7. **Wisdom** – Pursue knowledge responsibly
+
+## Retro & Projection
+### Retro
+- Initial drafts focused solely on nonaggression before expanding into a
+  full seven‑law code.
+- Early enforcement relied on manual review rather than embedded validators.
+
+### Projection
+- Integrate manifesto checks into all guardian pipelines.
+- Align future laws with evolving chakra research and community feedback.


### PR DESCRIPTION
## Summary
- embed architecture, channel hierarchy, and chakra alignment diagrams in the Great Tomb of Nazarick guide with cross-links to manifesto and agents
- link manifesto and agent spec together with a new Retro & Projection section for each
- add Nazarick entries to the documentation index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets'; import file mismatch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b030a26eb4832e8fec5ca0734a52e0