### PR TITLE
docs: align chakra links and add backlinks

### DIFF
--- a/docs/chat2db.md
+++ b/docs/chat2db.md
@@ -3,7 +3,9 @@
 Chat2DB connects conversational agents to persistent storage. It logs
 transcripts, feedback and model metrics in a lightweight SQLite database while
 maintaining a vector index for semantic search. The bridge lets the system
-recall prior interactions and fetch relevant context during dialogue.
+recall prior interactions and fetch relevant context during dialogue. The
+service abides by the [Nazarick Manifesto](nazarick_manifesto.md) and channels
+the [Heart chakra](chakra_overview.md#heart) via the [Memory Vault](system_blueprint.md#floor-4-memory-vault).
 
 ## Architecture
 
@@ -43,6 +45,10 @@ Agents → Chat Gateway → Chat2DB → {SQLite, Vector Store}
 The interface is stateless; components import these helpers as needed. See the
 [system blueprint](system_blueprint.md#chat2db-interface) for how Chat2DB fits in
 the overall stack.
+
+---
+
+Backlinks: [System Blueprint](system_blueprint.md) | [Component Index](component_index.md)
 
 ## Agent Interactions
 Chat2DB sits between the chat gateway and memory utilities. Agents interact with it in several ways:

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -8,30 +8,30 @@ This guide summarizes core agents within ABZU's Nazarick system. Each agent alig
 
 | Agent | Floor | Channel | Chakra |
 | --- | --- | --- | --- |
-| <a id="orchestration-master"></a>Orchestration Master | 7 | [Throne Room](system_blueprint.md#throne-room) | Crown |
-| <a id="prompt-orchestrator"></a>Prompt Orchestrator | 5 | [Signal Hall](system_blueprint.md#signal-hall) | Throat |
-| <a id="qnl-engine"></a>QNL Engine | 6 | [Insight Observatory](system_blueprint.md#insight-observatory) | Third Eye |
-| <a id="memory-scribe"></a>Memory Scribe | 4 | [Memory Vault](system_blueprint.md#memory-vault) | Heart |
-| <a id="demiurge-strategic-simulator"></a>Demiurge Strategic Simulator | 7 | [Lava Pits](system_blueprint.md#lava-pits) | Crown |
-| <a id="shalltear-fast-inference-agent"></a>Shalltear Fast Inference Agent | 1‑3 | [Catacombs](system_blueprint.md#catacombs) | Root–Solar Plexus |
-| <a id="cocytus-prompt-arbiter"></a>Cocytus Prompt Arbiter | 5 | [Glacier Prison](system_blueprint.md#glacier-prison) | Throat |
-| <a id="ecosystem-aura-capture"></a>Ecosystem Aura Capture | 6 | [Jungle Aerie](system_blueprint.md#jungle-aerie) | Third Eye |
-| <a id="ecosystem-mare-gardener"></a>Ecosystem Mare Gardener | 6 | [Jungle Grove](system_blueprint.md#jungle-grove) | Third Eye |
-| <a id="sebas-compassion-module"></a>Sebas Compassion Module | 9 | [Royal Suite](system_blueprint.md#royal-suite) | Crown |
-| <a id="victim-security-canary"></a>Victim Security Canary | 8 | [Sacrificial Chamber](system_blueprint.md#sacrificial-chamber) | Crown |
-| <a id="pandora-persona-emulator"></a>Pandora Persona Emulator | 10 | [Treasure Vault](system_blueprint.md#treasure-vault) | Crown |
-| <a id="pleiades-star-map-utility"></a>Pleiades Star Map Utility | 9 | [Maid Quarters](system_blueprint.md#maid-quarters) | Crown |
-| <a id="pleiades-signal-router-utility"></a>Pleiades Signal Router Utility | 9 | [Relay Wing](system_blueprint.md#relay-wing) | Crown |
-| <a id="bana-bio-adaptive-narrator"></a>Bana Bio-Adaptive Narrator | 4 | [Biosphere Lab](system_blueprint.md#biosphere-lab) | Heart |
-| <a id="asian-gen-creative-engine"></a>AsianGen Creative Engine | 5 | [Scriptorium](system_blueprint.md#scriptorium) | Throat |
-| <a id="land-graph-geo-knowledge"></a>LandGraph Geo Knowledge | 1 | [Cartography Room](system_blueprint.md#cartography-room) | Root |
+| <a id="orchestration-master"></a>Orchestration Master | 7 | [Throne Room](system_blueprint.md#floor-7-throne-room) | Crown |
+| <a id="prompt-orchestrator"></a>Prompt Orchestrator | 5 | [Signal Hall](system_blueprint.md#floor-5-signal-hall) | Throat |
+| <a id="qnl-engine"></a>QNL Engine | 6 | [Insight Observatory](system_blueprint.md#floor-6-insight-observatory) | Third Eye |
+| <a id="memory-scribe"></a>Memory Scribe | 4 | [Memory Vault](system_blueprint.md#floor-4-memory-vault) | Heart |
+| <a id="demiurge-strategic-simulator"></a>Demiurge Strategic Simulator | 7 | [Lava Pits](system_blueprint.md#floor-7-lava-pits) | Crown |
+| <a id="shalltear-fast-inference-agent"></a>Shalltear Fast Inference Agent | 1‑3 | [Catacombs](system_blueprint.md#floor-1-3-catacombs) | Root–Solar Plexus |
+| <a id="cocytus-prompt-arbiter"></a>Cocytus Prompt Arbiter | 5 | [Glacier Prison](system_blueprint.md#floor-5-glacier-prison) | Throat |
+| <a id="ecosystem-aura-capture"></a>Ecosystem Aura Capture | 6 | [Jungle Aerie](system_blueprint.md#floor-6-jungle-aerie) | Third Eye |
+| <a id="ecosystem-mare-gardener"></a>Ecosystem Mare Gardener | 6 | [Jungle Grove](system_blueprint.md#floor-6-jungle-grove) | Third Eye |
+| <a id="sebas-compassion-module"></a>Sebas Compassion Module | 9 | [Royal Suite](system_blueprint.md#floor-9-royal-suite) | Crown |
+| <a id="victim-security-canary"></a>Victim Security Canary | 8 | [Sacrificial Chamber](system_blueprint.md#floor-8-sacrificial-chamber) | Crown |
+| <a id="pandora-persona-emulator"></a>Pandora Persona Emulator | 10 | [Treasure Vault](system_blueprint.md#floor-10-treasure-vault) | Crown |
+| <a id="pleiades-star-map-utility"></a>Pleiades Star Map Utility | 9 | [Maid Quarters](system_blueprint.md#floor-9-maid-quarters) | Crown |
+| <a id="pleiades-signal-router-utility"></a>Pleiades Signal Router Utility | 9 | [Relay Wing](system_blueprint.md#floor-9-relay-wing) | Crown |
+| <a id="bana-bio-adaptive-narrator"></a>Bana Bio-Adaptive Narrator | 4 | [Biosphere Lab](system_blueprint.md#floor-4-biosphere-lab) | Heart |
+| <a id="asian-gen-creative-engine"></a>AsianGen Creative Engine | 5 | [Scriptorium](system_blueprint.md#floor-5-scriptorium) | Throat |
+| <a id="land-graph-geo-knowledge"></a>LandGraph Geo Knowledge | 1 | [Cartography Room](system_blueprint.md#floor-1-cartography-room) | Root |
 
 | Agent | Role | Chakra | Memory Scope | External Libraries | Channel | Stub |
 | --- | --- | --- | --- | --- | --- | --- |
-| [Orchestration Master](#orchestration-master) | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [7 / Throne Room](system_blueprint.md#throne-room) | [orchestration_master.py](../orchestration_master.py) |
-| [Prompt Orchestrator](#prompt-orchestrator) | Prompt routing, agent interface, context recall via [Chat2DB](chat2db.md) | Throat | Prompt/response JSON payloads | LLM APIs | [5 / Signal Hall](system_blueprint.md#signal-hall) | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
-| [QNL Engine](#qnl-engine) | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [6 / Insight Observatory](system_blueprint.md#insight-observatory) | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |
-| [Memory Scribe](#memory-scribe) | Voice avatar configuration and memory storage via [Chat2DB](chat2db.md) | Heart | `voice_avatar_config.yaml`, embedding records | Vector database | [4 / Memory Vault](system_blueprint.md#memory-vault) | [memory_scribe.py](../memory_scribe.py) |
+| [Orchestration Master](#orchestration-master) | High-level orchestration and launch control | Crown | `pipeline` YAML, `ritual_profile.json` | Model runtime, container services | [7 / Throne Room](system_blueprint.md#floor-7-throne-room) | [orchestration_master.py](../orchestration_master.py) |
+| [Prompt Orchestrator](#prompt-orchestrator) | Prompt routing, agent interface, context recall via [Chat2DB](chat2db.md) | Throat | Prompt/response JSON payloads | LLM APIs | [5 / Signal Hall](system_blueprint.md#floor-5-signal-hall) | [crown_prompt_orchestrator.py](../crown_prompt_orchestrator.py) |
+| [QNL Engine](#qnl-engine) | Insight and QNL processing | Third Eye | `mirror_thresholds.json`, QNL glyph sequences | Audio toolchain | [6 / Insight Observatory](system_blueprint.md#floor-6-insight-observatory) | [SPIRAL_OS/qnl_engine.py](../SPIRAL_OS/qnl_engine.py) |
+| [Memory Scribe](#memory-scribe) | Voice avatar configuration and memory storage via [Chat2DB](chat2db.md) | Heart | `voice_avatar_config.yaml`, embedding records | Vector database | [4 / Memory Vault](system_blueprint.md#floor-4-memory-vault) | [memory_scribe.py](../memory_scribe.py) |
 
 These agents draw from the chakra structure outlined in the [Developer Onboarding guide](developer_onboarding.md) and [Chakra Architecture](chakra_architecture.md).
 
@@ -39,25 +39,26 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 
 | Agent | Responsibilities | Channel | Path |
 | --- | --- | --- | --- |
-| [Demiurge Strategic Simulator](#demiurge-strategic-simulator) | Long-term planning, failure forecasting, scenario stress-testing | [7 / Lava Pits](system_blueprint.md#lava-pits) | [agents/demiurge/strategic_simulator.py](../agents/demiurge/strategic_simulator.py) |
-| [Shalltear Fast Inference Agent](#shalltear-fast-inference-agent) | Burst compute, load shedding, monitors API quotas | [1‑3 / Catacombs](system_blueprint.md#catacombs) | [agents/shalltear/fast_inference_agent.py](../agents/shalltear/fast_inference_agent.py) |
-| [Cocytus Prompt Arbiter](#cocytus-prompt-arbiter) | Logical sanitization, legal parsing, audits model bias | [5 / Glacier Prison](system_blueprint.md#glacier-prison) | [agents/cocytus/prompt_arbiter.py](../agents/cocytus/prompt_arbiter.py) |
-| [Ecosystem Aura Capture](#ecosystem-aura-capture) | Data harvesting, environmental telemetry, sensor health checks | [6 / Jungle Aerie](system_blueprint.md#jungle-aerie) | [agents/ecosystem/aura_capture.py](../agents/ecosystem/aura_capture.py) |
-| [Ecosystem Mare Gardener](#ecosystem-mare-gardener) | Infrastructure metrics, performance trend analysis, capacity planning advisories | [6 / Jungle Grove](system_blueprint.md#jungle-grove) | [agents/ecosystem/mare_gardener.py](../agents/ecosystem/mare_gardener.py) |
-| [Sebas Compassion Module](#sebas-compassion-module) | Empathy modeling, emotional safety buffer, conflict signal resolution | [9 / Royal Suite](system_blueprint.md#royal-suite) | [agents/sebas/compassion_module.py](../agents/sebas/compassion_module.py) |
-| [Victim Security Canary](#victim-security-canary) | Security alerts, intrusion detection, anomaly threshold tracking | [8 / Sacrificial Chamber](system_blueprint.md#sacrificial-chamber) | [agents/victim/security_canary.py](../agents/victim/security_canary.py) |
-| [Pandora Persona Emulator](#pandora-persona-emulator) | Persona emulation, scenario roleplay, identity consistency checks | [10 / Treasure Vault](system_blueprint.md#treasure-vault) | [agents/pandora/persona_emulator.py](../agents/pandora/persona_emulator.py) |
-| [Pleiades Star Map Utility](#pleiades-star-map-utility) | Celestial navigation utilities, cosmic alignment calculations | [9 / Maid Quarters](system_blueprint.md#maid-quarters) | [agents/pleiades/star_map.py](../agents/pleiades/star_map.py) |
-| [Pleiades Signal Router Utility](#pleiades-signal-router-utility) | Cross-agent signal routing, fallback relay strategies | [9 / Relay Wing](system_blueprint.md#relay-wing) | [agents/pleiades/signal_router.py](../agents/pleiades/signal_router.py) |
-| [Bana Bio-Adaptive Narrator](#bana-bio-adaptive-narrator) | Biosignal-driven narrative generation | [4 / Biosphere Lab](system_blueprint.md#biosphere-lab) | [agents/bana/bio_adaptive_narrator.py](../agents/bana/bio_adaptive_narrator.py) |
-| [AsianGen Creative Engine](#asian-gen-creative-engine) | Multilingual generation with locale codes, runtime SentencePiece fallback | [5 / Scriptorium](system_blueprint.md#scriptorium) | [agents/asian_gen/creative_engine.py](../agents/asian_gen/creative_engine.py) |
-| [LandGraph Geo Knowledge](#land-graph-geo-knowledge) | Landscape graph, ritual site queries | [1 / Cartography Room](system_blueprint.md#cartography-room) | [agents/land_graph/geo_knowledge.py](../agents/land_graph/geo_knowledge.py) |
+| [Demiurge Strategic Simulator](#demiurge-strategic-simulator) | Long-term planning, failure forecasting, scenario stress-testing | [7 / Lava Pits](system_blueprint.md#floor-7-lava-pits) | [agents/demiurge/strategic_simulator.py](../agents/demiurge/strategic_simulator.py) |
+| [Shalltear Fast Inference Agent](#shalltear-fast-inference-agent) | Burst compute, load shedding, monitors API quotas | [1‑3 / Catacombs](system_blueprint.md#floor-1-3-catacombs) | [agents/shalltear/fast_inference_agent.py](../agents/shalltear/fast_inference_agent.py) |
+| [Cocytus Prompt Arbiter](#cocytus-prompt-arbiter) | Logical sanitization, legal parsing, audits model bias | [5 / Glacier Prison](system_blueprint.md#floor-5-glacier-prison) | [agents/cocytus/prompt_arbiter.py](../agents/cocytus/prompt_arbiter.py) |
+| [Ecosystem Aura Capture](#ecosystem-aura-capture) | Data harvesting, environmental telemetry, sensor health checks | [6 / Jungle Aerie](system_blueprint.md#floor-6-jungle-aerie) | [agents/ecosystem/aura_capture.py](../agents/ecosystem/aura_capture.py) |
+| [Ecosystem Mare Gardener](#ecosystem-mare-gardener) | Infrastructure metrics, performance trend analysis, capacity planning advisories | [6 / Jungle Grove](system_blueprint.md#floor-6-jungle-grove) | [agents/ecosystem/mare_gardener.py](../agents/ecosystem/mare_gardener.py) |
+| [Sebas Compassion Module](#sebas-compassion-module) | Empathy modeling, emotional safety buffer, conflict signal resolution | [9 / Royal Suite](system_blueprint.md#floor-9-royal-suite) | [agents/sebas/compassion_module.py](../agents/sebas/compassion_module.py) |
+| [Victim Security Canary](#victim-security-canary) | Security alerts, intrusion detection, anomaly threshold tracking | [8 / Sacrificial Chamber](system_blueprint.md#floor-8-sacrificial-chamber) | [agents/victim/security_canary.py](../agents/victim/security_canary.py) |
+| [Pandora Persona Emulator](#pandora-persona-emulator) | Persona emulation, scenario roleplay, identity consistency checks | [10 / Treasure Vault](system_blueprint.md#floor-10-treasure-vault) | [agents/pandora/persona_emulator.py](../agents/pandora/persona_emulator.py) |
+| [Pleiades Star Map Utility](#pleiades-star-map-utility) | Celestial navigation utilities, cosmic alignment calculations | [9 / Maid Quarters](system_blueprint.md#floor-9-maid-quarters) | [agents/pleiades/star_map.py](../agents/pleiades/star_map.py) |
+| [Pleiades Signal Router Utility](#pleiades-signal-router-utility) | Cross-agent signal routing, fallback relay strategies | [9 / Relay Wing](system_blueprint.md#floor-9-relay-wing) | [agents/pleiades/signal_router.py](../agents/pleiades/signal_router.py) |
+| [Bana Bio-Adaptive Narrator](#bana-bio-adaptive-narrator) | Biosignal-driven narrative generation | [4 / Biosphere Lab](system_blueprint.md#floor-4-biosphere-lab) | [agents/bana/bio_adaptive_narrator.py](../agents/bana/bio_adaptive_narrator.py) |
+| [AsianGen Creative Engine](#asian-gen-creative-engine) | Multilingual generation with locale codes, runtime SentencePiece fallback | [5 / Scriptorium](system_blueprint.md#floor-5-scriptorium) | [agents/asian_gen/creative_engine.py](../agents/asian_gen/creative_engine.py) |
+| [LandGraph Geo Knowledge](#land-graph-geo-knowledge) | Landscape graph, ritual site queries | [1 / Cartography Room](system_blueprint.md#floor-1-cartography-room) | [agents/land_graph/geo_knowledge.py](../agents/land_graph/geo_knowledge.py) |
 
 ## Bana Bio-Adaptive Narrator {#bana-bio-adaptive-narrator}
 
 - **Role:** Biosignal-driven narrative generation.
 - **Chakra:** Heart
-- **Channel:** [Biosphere Lab](system_blueprint.md#biosphere-lab)
+- **Manifesto:** [Nazarick Manifesto](nazarick_manifesto.md)
+- **Channel:** [Biosphere Lab](system_blueprint.md#floor-4-biosphere-lab)
 - **Dependencies:** `biosppy`, `transformers`, `numpy`
 - **Quick start:**
 
@@ -72,7 +73,8 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 
 - **Role:** Multilingual text generation with locale codes and offline fallbacks.
 - **Chakra:** Throat
-- **Channel:** [Scriptorium](system_blueprint.md#scriptorium)
+- **Manifesto:** [Nazarick Manifesto](nazarick_manifesto.md)
+- **Channel:** [Scriptorium](system_blueprint.md#floor-5-scriptorium)
 - **Dependencies:** `transformers`, `sentencepiece`
 - **Quick start:**
 
@@ -97,7 +99,8 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 
 - **Role:** Landscape graph utilities and ritual site queries.
 - **Chakra:** Root
-- **Channel:** [Cartography Room](system_blueprint.md#cartography-room)
+- **Manifesto:** [Nazarick Manifesto](nazarick_manifesto.md)
+- **Channel:** [Cartography Room](system_blueprint.md#floor-1-cartography-room)
 - **Dependencies:** `networkx`, `geopandas` *(optional)*
 - **Quick start:**
 
@@ -122,4 +125,8 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 ### Projection
 - Draft additional specs for emerging guardians and cross-link them here.
 - Automate agent registration to reflect real-time channel and chakra shifts.
+
+---
+
+Backlinks: [System Blueprint](system_blueprint.md) | [Component Index](component_index.md)
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -59,25 +59,25 @@ modules cataloged in [component_index.md](component_index.md).
 
 | Floor | Channel | Chakra | Agents |
 | --- | --- | --- | --- |
-| 7 | <a id="throne-room"></a>Throne Room | Crown | [Orchestration Master](nazarick_agents.md#orchestration-master) |
-| 5 | <a id="signal-hall"></a>Signal Hall | Throat | [Prompt Orchestrator](nazarick_agents.md#prompt-orchestrator) |
-| 6 | <a id="insight-observatory"></a>Insight Observatory | Third Eye | [QNL Engine](nazarick_agents.md#qnl-engine) |
-| 4 | <a id="memory-vault"></a>Memory Vault | Heart | [Memory Scribe](nazarick_agents.md#memory-scribe) |
-| 7 | <a id="lava-pits"></a>Lava Pits | Crown | [Demiurge Strategic Simulator](nazarick_agents.md#demiurge-strategic-simulator) |
-| 1-3 | <a id="catacombs"></a>Catacombs | Root–Solar Plexus | [Shalltear Fast Inference Agent](nazarick_agents.md#shalltear-fast-inference-agent) |
-| 5 | <a id="glacier-prison"></a>Glacier Prison | Throat | [Cocytus Prompt Arbiter](nazarick_agents.md#cocytus-prompt-arbiter) |
-| 6 | <a id="jungle-aerie"></a>Jungle Aerie | Third Eye | [Ecosystem Aura Capture](nazarick_agents.md#ecosystem-aura-capture) |
-| 6 | <a id="jungle-grove"></a>Jungle Grove | Third Eye | [Ecosystem Mare Gardener](nazarick_agents.md#ecosystem-mare-gardener) |
-| 9 | <a id="royal-suite"></a>Royal Suite | Crown | [Sebas Compassion Module](nazarick_agents.md#sebas-compassion-module) |
-| 8 | <a id="sacrificial-chamber"></a>Sacrificial Chamber | Crown | [Victim Security Canary](nazarick_agents.md#victim-security-canary) |
-| 10 | <a id="treasure-vault"></a>Treasure Vault | Crown | [Pandora Persona Emulator](nazarick_agents.md#pandora-persona-emulator) |
-| 9 | <a id="maid-quarters"></a>Maid Quarters | Crown | [Pleiades Star Map Utility](nazarick_agents.md#pleiades-star-map-utility) |
-| 9 | <a id="relay-wing"></a>Relay Wing | Crown | [Pleiades Signal Router Utility](nazarick_agents.md#pleiades-signal-router-utility) |
-| 4 | <a id="biosphere-lab"></a>Biosphere Lab | Heart | [Bana Bio-Adaptive Narrator](nazarick_agents.md#bana-bio-adaptive-narrator) |
-| 5 | <a id="scriptorium"></a>Scriptorium | Throat | [AsianGen Creative Engine](nazarick_agents.md#asian-gen-creative-engine) |
-| 1 | <a id="cartography-room"></a>Cartography Room | Root | [LandGraph Geo Knowledge](nazarick_agents.md#land-graph-geo-knowledge) |
+| 7 | <a id="floor-7-throne-room"></a>Throne Room | Crown | [Orchestration Master](nazarick_agents.md#orchestration-master) |
+| 5 | <a id="floor-5-signal-hall"></a>Signal Hall | Throat | [Prompt Orchestrator](nazarick_agents.md#prompt-orchestrator) |
+| 6 | <a id="floor-6-insight-observatory"></a>Insight Observatory | Third Eye | [QNL Engine](nazarick_agents.md#qnl-engine) |
+| 4 | <a id="floor-4-memory-vault"></a>Memory Vault | Heart | [Memory Scribe](nazarick_agents.md#memory-scribe) |
+| 7 | <a id="floor-7-lava-pits"></a>Lava Pits | Crown | [Demiurge Strategic Simulator](nazarick_agents.md#demiurge-strategic-simulator) |
+| 1-3 | <a id="floor-1-3-catacombs"></a>Catacombs | Root–Solar Plexus | [Shalltear Fast Inference Agent](nazarick_agents.md#shalltear-fast-inference-agent) |
+| 5 | <a id="floor-5-glacier-prison"></a>Glacier Prison | Throat | [Cocytus Prompt Arbiter](nazarick_agents.md#cocytus-prompt-arbiter) |
+| 6 | <a id="floor-6-jungle-aerie"></a>Jungle Aerie | Third Eye | [Ecosystem Aura Capture](nazarick_agents.md#ecosystem-aura-capture) |
+| 6 | <a id="floor-6-jungle-grove"></a>Jungle Grove | Third Eye | [Ecosystem Mare Gardener](nazarick_agents.md#ecosystem-mare-gardener) |
+| 9 | <a id="floor-9-royal-suite"></a>Royal Suite | Crown | [Sebas Compassion Module](nazarick_agents.md#sebas-compassion-module) |
+| 8 | <a id="floor-8-sacrificial-chamber"></a>Sacrificial Chamber | Crown | [Victim Security Canary](nazarick_agents.md#victim-security-canary) |
+| 10 | <a id="floor-10-treasure-vault"></a>Treasure Vault | Crown | [Pandora Persona Emulator](nazarick_agents.md#pandora-persona-emulator) |
+| 9 | <a id="floor-9-maid-quarters"></a>Maid Quarters | Crown | [Pleiades Star Map Utility](nazarick_agents.md#pleiades-star-map-utility) |
+| 9 | <a id="floor-9-relay-wing"></a>Relay Wing | Crown | [Pleiades Signal Router Utility](nazarick_agents.md#pleiades-signal-router-utility) |
+| 4 | <a id="floor-4-biosphere-lab"></a>Biosphere Lab | Heart | [Bana Bio-Adaptive Narrator](nazarick_agents.md#bana-bio-adaptive-narrator) |
+| 5 | <a id="floor-5-scriptorium"></a>Scriptorium | Throat | [AsianGen Creative Engine](nazarick_agents.md#asian-gen-creative-engine) |
+| 1 | <a id="floor-1-cartography-room"></a>Cartography Room | Root | [LandGraph Geo Knowledge](nazarick_agents.md#land-graph-geo-knowledge) |
 
-### Chat2DB Interface and Dependency Flow
+### <a id="chat2db-interface"></a>Chat2DB Interface and Dependency Flow
 
 [Chat2DB](chat2db.md) bridges the chat gateway, relational log and vector
 search store. It depends on `INANNA_AI/db_storage.py` for SQLite tables and
@@ -621,4 +621,8 @@ deployments with user accounts and persistent chats.
 - [Development Workflow](development_workflow.md)
 - [Coding Style](coding_style.md)
 - Index Markdown docs with `python tools/doc_indexer.py` to regenerate `docs/INDEX.md`; existing entries stay intact and new versions of generated files are appended.
+
+---
+
+Backlinks: [System Blueprint](system_blueprint.md) | [Component Index](component_index.md)
 


### PR DESCRIPTION
## Summary
- standardize floor anchor IDs in the system blueprint
- cross-link agents and services to manifesto and chakra layers
- add backlinks to system blueprint and component index across updated docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets'; test file import mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68b031b5d6dc832eb7d60b09b6ef6352