### PR TITLE
Add pytest-cov plugin for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,17 @@ jobs:
             ~/.cache/huggingface
             INANNA_AI/models
           key: ${{ runner.os }}-models-${{ hashFiles('download_models.py') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev-requirements.txt
-          pip install -e .
-          pip install pytest pytest-cov
-      - name: Verify required pytest plugins
-        run: python - <<'PY'
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt -r dev-requirements.txt
+            pip install -e .
+        - name: Verify required pytest plugins
+          run: python - <<'PY'
 import importlib, sys
 sys.exit(0 if importlib.util.find_spec('pytest_cov') else 1)
 PY
-      - name: Run tests
+        - name: Run tests
         run: pytest --cov
 
   ci:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -40,6 +40,8 @@ pyopenssl==25.1.0
     # via spiral-os (pyproject.toml)
 pytest==8.4.1
     # via spiral-os (pyproject.toml)
+pytest-cov==5.0.0
+    # via spiral-os (pyproject.toml)
 python-json-logger==3.3.0
     # via spiral-os (pyproject.toml)
 pyyaml==6.0.2

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,14 @@ flowchart LR
     T --> R[Report]
 ```
 
+## Required pytest plugins
+
+The test suite expects certain plugins to be available:
+
+- `pytest-cov` for coverage reporting via the `--cov` options in `pytest.ini`.
+
+Install them with `pip install -r dev-requirements.txt`.
+
 ## Manual smoke tests
 
 ### Prioritized test tiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "librosa==0.11.0",
     "pydub==0.25.1",
     "pytest==8.4.1",
+    "pytest-cov==5.0.0",
     "markdown==3.8.2",
     "requests==2.32.4",
     "fastapi==0.116.1",


### PR DESCRIPTION
## Summary
- include pytest-cov in dev requirements and project extras
- rely on dev dependencies to provide pytest-cov in CI workflow
- document required pytest plugin in testing guide

## Testing
- `pre-commit run --files dev-requirements.txt pyproject.toml .github/workflows/ci.yml docs/testing.md`
- `pytest tests/agents/razar/test_boot_sequence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0382704f8832e99efebc1d3e9d11b