### PR TITLE
Add mission logger and error registry

### DIFF
--- a/agents/razar/__init__.py
+++ b/agents/razar/__init__.py
@@ -10,6 +10,7 @@ from .remote_loader import (
     load_remote_gpt_agent,
 )
 from .lifecycle_bus import LifecycleBus
+from . import pytest_runner
 
 _manifesto = Manifesto()
 _trust_matrix = TrustMatrix()
@@ -30,4 +31,5 @@ __all__ = [
     "load_remote_gpt_agent",
     "LifecycleBus",
     "execute_task",
+    "pytest_runner",
 ]

--- a/agents/razar/mission_logger.py
+++ b/agents/razar/mission_logger.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 This module records lifecycle events for RAZAR components in a JSON lines log
 stored at ``logs/razar.log``. Each entry captures:
 
-- ``event`` – type of event such as ``start`` or ``health``
+- ``event`` – type of event such as ``start``, ``error`` or ``recovery``
 - ``component`` – component name
 - ``status`` – outcome or note for the event
 - ``timestamp`` – ISO-8601 time in UTC
 - ``details`` – optional free-form text
 
-Utility helpers are provided for the common events of component starts, health
-results, quarantines and applied patches. The log can be summarised to find the
-last successful component or rendered as a chronological timeline for
+Utility helpers are provided for common events including component starts,
+errors and recovery attempts. Additional helpers retain backward compatible
+names for health checks, quarantines and patches. The log can be summarised to
+find the last successful component or rendered as a chronological timeline for
 debugging.
 """
 
@@ -106,6 +107,18 @@ def log_patch(component: str, patch: str, details: str | None = None) -> None:
     log_event("patch", component, patch, details)
 
 
+def log_error(component: str, error: str, details: str | None = None) -> None:
+    """Record that a component encountered an error."""
+
+    log_event("error", component, error, details)
+
+
+def log_recovery(component: str, status: str, details: str | None = None) -> None:
+    """Record a recovery attempt for a component."""
+
+    log_event("recovery", component, status, details)
+
+
 # ---------------------------------------------------------------------------
 # Backwards compatibility aliases
 # ---------------------------------------------------------------------------
@@ -114,7 +127,6 @@ def log_patch(component: str, patch: str, details: str | None = None) -> None:
 # existing scripts continue to work.
 log_launch = log_start
 log_health_check = log_health
-log_recovery = log_patch
 
 
 # ---------------------------------------------------------------------------

--- a/docs/error_registry.md
+++ b/docs/error_registry.md
@@ -1,0 +1,11 @@
+# Error Registry
+
+This registry tracks recurring issues observed during component startup and operation. Each entry documents symptoms and the steps that resolved the problem.
+
+| Issue | Symptoms | Resolution |
+| --- | --- | --- |
+| network-timeout | Component cannot reach an external service and raises repeated timeout errors. | Verify network connectivity and DNS settings, then retry once the service is reachable. |
+| missing-dependency | Startup fails with an `ImportError` indicating a module is missing. | Install the required package with `pip install <package>` and restart the component. |
+| config-mismatch | Component rejects configuration files due to unexpected fields or schema changes. | Update the configuration to the latest schema and reload the component. |
+
+Add new entries as additional patterns emerge.

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -1,6 +1,8 @@
 # Recovery Playbook
 
 This playbook outlines how RAZAR restores service after a component failure.
+Recurring problems and their fixes are cataloged in the
+[Error Registry](error_registry.md).
 
 ## Boot sequence
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -113,8 +113,9 @@ how priorities are derived and progress is persisted. The broader
 [RAZAR Agent](RAZAR_AGENT.md) guide covers its perpetual ignition loop,
 CROWN LLM diagnostics, and shutdown–repair–restart handshake, and see
 [nazarick_agents.md](nazarick_agents.md) for the in‑world servant lineup.
-When issues surface, consult the [Recovery Playbook](recovery_playbook.md)
-and [Monitoring Guide](monitoring.md).
+When issues surface, consult the [Recovery Playbook](recovery_playbook.md),
+the [Error Registry](error_registry.md) and the
+[Monitoring Guide](monitoring.md).
 
 ### RAZAR: Pre‑Creation Agent
 


### PR DESCRIPTION
## Summary
- extend RAZAR mission logger to record startup, error, and recovery events in JSON lines
- add an error registry documenting recurring issues and link it from blueprint and recovery docs
- expose `pytest_runner` via the `agents.razar` package for easier test access

## Testing
- `pytest tests/test_mission_logger.py tests/agents/test_razar_cli.py tests/agents/razar/test_pytest_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68b041255510832ea992c959040960c5