### PR TITLE
docs: add diagnostics and quarantine references

### DIFF
--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -544,6 +544,23 @@ Robust health checks keep the system stable and observable.
 - During deployment, configure these checks so orchestration platforms only
   advance when readiness reports success.
 
+## Components in Development
+RAZAR tracks modules flagged as experimental in
+[component_status.md](component_status.md) and `component_status.json`.
+These components are not required for baseline operation and may change
+rapidly. During boot RAZAR:
+
+- Marks in‑development components with a warning and delays their startup
+  until explicitly enabled.
+- Falls back to mock implementations if dependencies are missing.
+- Records their status in `logs/razar.log` so contributors can review their
+  readiness.
+
+Consult the [Developer Onboarding](developer_onboarding.md) guide for
+bringing these components online and the
+[Recovery Playbook](recovery_playbook.md) for restoration procedures when
+they fail health checks.
+
 ## Failure Scenarios and Recovery Steps
 - **Memory store unavailable** – Chat gateway returns 503 or CROWN LLM waits
   indefinitely. Restore from snapshots as outlined in
@@ -561,6 +578,16 @@ Robust health checks keep the system stable and observable.
 General guidance: stop the failed service, confirm dependencies, and restart
 following the startup order. For persistent issues, consult the
 [Recovery Playbook](recovery_playbook.md) to restore from snapshots.
+
+## Quarantine and Diagnostics
+Persistent failures trigger RAZAR's quarantine routine. The affected
+component's metadata moves to `quarantine/` and an entry is added to
+[quarantine_log.md](quarantine_log.md). Use the tools in
+[diagnostics.md](diagnostics.md) to repair corrupted state or missing
+dependencies before attempting recovery via the
+[Recovery Playbook](recovery_playbook.md). New contributors should see
+[developer_onboarding.md](developer_onboarding.md) for environment rebuild
+tips.
 
 ## Operations & Monitoring
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,3 +97,13 @@ python agents/razar/pytest_runner.py --resume
 - Missing pytest plugins such as `pytest-cov` will cause command-line options errors. Install required dev dependencies.
 - Duplicate or conflicting test module names can trigger collection errors like "import file mismatch". Remove `__pycache__` files or rename tests to be unique.
 - ImportError during test collection often indicates missing runtime dependencies or incorrect module paths. Verify imports such as `core.load_config` exist or adjust `PYTHONPATH`.
+- Repeated failures tied to a specific service cause RAZAR to quarantine the component and skip dependent tests. Review `logs/razar.log` and [`quarantine_log.md`](quarantine_log.md) for details and run the scripts in [diagnostics.md](diagnostics.md) before retrying.
+
+### Quarantine and Diagnostics
+Use RAZAR's quarantine manager to isolate components that consistently fail:
+
+```bash
+python -m razar.quarantine_manager quarantine <component>
+```
+
+The component's metadata moves to `quarantine/` and an entry records the action in [`quarantine_log.md`](quarantine_log.md). Employ the utilities listed in [diagnostics.md](diagnostics.md) to analyze missing dependencies or corrupted state. Once resolved, follow the [Recovery Playbook](recovery_playbook.md) to restore service and consult [developer_onboarding.md](developer_onboarding.md) for environment rebuild tips.


### PR DESCRIPTION
## Summary
- document in-development components and RAZAR's handling in the system blueprint
- outline quarantine procedures with diagnostic script links
- expand testing guide with common failure modes and quarantine steps

## Testing
- `pre-commit run --files docs/system_blueprint.md docs/testing.md`
- `pytest -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b0491e29f0832ebe87f8c984ea332f