### PR TITLE
feat: generate ignition doc from priority registry

### DIFF
--- a/docs/Ignition.md
+++ b/docs/Ignition.md
@@ -15,24 +15,24 @@ RAZAR coordinates system boot and records runtime health. Components are grouped
 ## Priority 2
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 2 | Chat Gateway | Probe `/chat/health` and watch latency. | ⚠️ |
-| 3 | CROWN LLM | Send a dummy prompt and inspect response time. | ⚠️ |
-| 4 | Vision Adapter | Verify prediction FPS meets the expected threshold. | ⚠️ |
+| 2 | Chat Gateway | - | ⚠️ |
+| 3 | CROWN LLM | - | ⚠️ |
+| 4 | Vision Adapter | - | ⚠️ |
 
 ## Priority 3
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 5 | Audio Device | Run an audio loopback test. | ⚠️ |
+| 5 | Audio Device | - | ⚠️ |
 
 ## Priority 4
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 6 | Avatar | Verify avatar frame rendering. | ⚠️ |
+| 6 | Avatar | - | ⚠️ |
 
 ## Priority 5
 | Order | Component | Health Check | Status |
 | --- | --- | --- | --- |
-| 7 | Video | Probe the video stream endpoint. | ⚠️ |
+| 7 | Video | - | ⚠️ |
 
 ## Regeneration
 RAZAR monitors component events and rewrites this file whenever a priority or health state changes. Status markers update to:

--- a/docs/component_priorities.yaml
+++ b/docs/component_priorities.yaml
@@ -1,3 +1,4 @@
+# Component priority registry for RAZAR ignition
 memory_store:
   priority: P1
   criticality: core

--- a/razar/__main__.py
+++ b/razar/__main__.py
@@ -31,7 +31,7 @@ def _cmd_stop(args: argparse.Namespace) -> None:
 
 
 def _cmd_build_ignition(args: argparse.Namespace) -> None:
-    build_ignition(Path(args.blueprint), Path(args.output))
+    build_ignition(Path(args.registry), Path(args.output), state=Path(args.state))
 
 
 def _cmd_timeline(_: argparse.Namespace) -> None:
@@ -96,12 +96,18 @@ def main() -> None:  # pragma: no cover - CLI entry point
     p_stop.set_defaults(func=_cmd_stop)
 
     p_ignition = sub.add_parser(
-        "build-ignition", help="Regenerate docs/Ignition.md from the blueprint"
+        "build-ignition",
+        help="Regenerate docs/Ignition.md from the component registry",
     )
     p_ignition.add_argument(
-        "--blueprint",
-        default=Path(__file__).resolve().parents[1] / "docs" / "system_blueprint.md",
-        help="Path to system_blueprint.md",
+        "--registry",
+        default=Path(__file__).resolve().parents[1] / "docs" / "component_priorities.yaml",
+        help="Path to component priority registry",
+    )
+    p_ignition.add_argument(
+        "--state",
+        default=Path(__file__).resolve().parents[1] / "logs" / "razar_state.json",
+        help="Path to boot state file",
     )
     p_ignition.add_argument(
         "--output",

--- a/razar/doc_sync.py
+++ b/razar/doc_sync.py
@@ -144,7 +144,7 @@ def update_component_docs() -> None:
 def sync_docs() -> None:
     """Regenerate ignition docs, blueprint and component inventory."""
 
-    build_ignition(BLUEPRINT_PATH, IGNITION_PATH)
+    build_ignition(PRIORITY_PATH, IGNITION_PATH, state=ROOT / "logs" / "razar_state.json")
     try:
         bus = LifecycleBus()
         statuses = bus.get_statuses()


### PR DESCRIPTION
## Summary
- add component priority registry for RAZAR
- build ignition doc from registry and boot state
- cover registry builder with unit tests

## Testing
- `pytest tests/agents/razar/test_ignition_builder.py -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68b05278d0d0832eaffbe6c2ec808cc6