### PR TITLE
docs: document RAZAR runtime manager and early startup

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -1,14 +1,39 @@
-# RAZAR Agent
+# RAZAR Runtime Manager
 
-## Pre-Creation Mandate
-RAZAR provisions a clean environment before any servant boots. It resets temporary directories, verifies configuration files, and ensures secrets and caches are sanitized.
+The **RAZAR** runtime manager prepares a lightweight environment for service
+components and launches them in a defined priority order. It ensures that each
+component's dependencies are installed in an isolated virtual environment and
+records progress so failed launches can resume from the last healthy component.
 
-## Priority Boot Order
-RAZAR starts services according to an ordered priority list. Each component exposes health and readiness probes; RAZAR waits for green checks before advancing. Components that fail checks are isolated and quarantined to `quarantine/` with logs for review.
+## Environment Setup
 
-## CROWN Handshake
-Once core services are healthy, RAZAR initiates a handshake with the CROWN LLM. The agent exchanges identity tokens, registers servant models, and confirms message routes so downstream agents can communicate through CROWN.
+Dependencies for each component layer are listed in `razar_env.yaml`. When
+RAZAR runs it will:
 
----
+1. Create a virtual environment under `.razar_venv` if one does not already
+   exist.
+2. Install packages required by the targeted components.
+3. Update `PATH` and `VIRTUAL_ENV` so launched subprocesses inherit the
+   environment.
 
-Backlinks: [Nazarick Agents](nazarick_agents.md) | [System Blueprint](system_blueprint.md)
+The last successfully started component is written to
+`logs/razar_state.json`. This allows subsequent runs to resume from the point of
+failure rather than starting from scratch.
+
+## Quarantine Handling
+
+If a component fails to start or does not pass its health check, RAZAR invokes
+`agents.razar.quarantine_manager` to quarantine the component and its module
+path. Quarantined components are skipped on future runs.
+
+## Usage
+
+The runtime manager can be invoked directly:
+
+```bash
+python -m agents.razar.runtime_manager config/razar_config.yaml
+```
+
+`start_dev_agents.py` and `launch_servants.sh` call RAZAR before performing
+other work. You can override the configuration file by setting
+`RAZAR_CONFIG` in the environment.

--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -33,8 +33,9 @@ fi
 
 # Start RAZAR runtime manager before launching servants. This prepares the
 # virtual environment and prerequisite components.
-log "Starting RAZAR runtime manager"
-if ! python -m agents.razar.runtime_manager "${RAZAR_CONFIG:-config/razar_config.yaml}" >>"$LOG_FILE" 2>&1; then
+RAZAR_CONFIG_PATH="${RAZAR_CONFIG:-config/razar_config.yaml}"
+log "Starting RAZAR runtime manager using $RAZAR_CONFIG_PATH"
+if ! python -m agents.razar.runtime_manager "$RAZAR_CONFIG_PATH" >>"$LOG_FILE" 2>&1; then
     log "RAZAR failed to start"
     exit 1
 fi

--- a/start_dev_agents.py
+++ b/start_dev_agents.py
@@ -51,9 +51,11 @@ def load_env(path: Path) -> None:
 def start_razar(config: str = "config/razar_config.yaml") -> None:
     """Invoke the RAZAR runtime manager to launch prerequisites in priority order."""
 
+    logger = logging.getLogger(__name__)
     manager = RuntimeManager(Path(config))
+    logger.info("Launching RAZAR with config %s", config)
     if not manager.run():
-        raise RuntimeError("RAZAR failed to start components")
+        raise RuntimeError(f"RAZAR failed to start components from {config}")
 
 
 def main() -> int:
@@ -155,8 +157,9 @@ def main() -> int:
 
     # Ensure infrastructure components are up before proceeding with the
     # development cycle.
-    razar_config = os.environ.get("RAZAR_CONFIG", "config/razar_config.yaml")
-    start_razar(razar_config)
+    razar_config = Path(os.environ.get("RAZAR_CONFIG", "config/razar_config.yaml"))
+    logger.info("Starting RAZAR runtime manager using %s", razar_config)
+    start_razar(str(razar_config))
 
     spiral_cortex.log_insight("start_dev_agents", [vars(args)], sentiment=0.0)
 


### PR DESCRIPTION
## Summary
- document RAZAR runtime manager and its environment/quarantine behavior
- start_dev_agents and launch_servants now log and run RAZAR before other work

## Testing
- `pytest -q` *(fails: import mismatches and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b055f15c48832e86b29ac5c1860fa4