### PR TITLE
docs: clarify RAZAR utilities

### DIFF
--- a/agents/razar/cli.py
+++ b/agents/razar/cli.py
@@ -63,7 +63,7 @@ def _cmd_trust(args: argparse.Namespace) -> None:
 
 
 def _cmd_timeline(_: argparse.Namespace) -> None:
-    """Print the boot timeline from the mission log."""
+    """Print the event timeline from the mission log."""
 
     for entry in mission_logger.timeline():
         details = f" - {entry['details']}" if entry.get("details") else ""
@@ -95,7 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
     trust_p.add_argument("entity", help="Entity name")
     trust_p.set_defaults(func=_cmd_trust)
 
-    timeline_p = sub.add_parser("timeline", help="Show boot history")
+    timeline_p = sub.add_parser("timeline", help="Reconstruct mission events")
     timeline_p.set_defaults(func=_cmd_timeline)
 
     bootstrap_p = sub.add_parser("bootstrap", help="Rebuild modules")

--- a/agents/razar/health_checks.py
+++ b/agents/razar/health_checks.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 """Health check routines for RAZAR runtime components.
 
-This module defines probe functions for runtime services and a ``run`` helper
-that executes checks for named services.  Each check returns ``True`` on
-success.  If a check fails and a restart command is configured the component is
-restarted once before reporting failure.  Health status and latency metrics are
-exported via Prometheus when the ``prometheus_client`` package is available.
+The module exposes a collection of service‑specific probe functions used to
+verify the health of core RAZAR services such as Inanna AI, the CROWN LLM,
+memory stores and chat gateways.  A small ``run`` helper dispatches to these
+probes and optionally restarts failing services once before reporting failure.
+When the ``prometheus_client`` package is available, health status and latency
+metrics are exported for external monitoring.
 """
 
 import json

--- a/agents/razar/mission_logger.py
+++ b/agents/razar/mission_logger.py
@@ -15,7 +15,8 @@ Utility helpers are provided for common events including component starts,
 errors and recovery attempts. Additional helpers retain backward compatible
 names for health checks, quarantines and patches. The log can be summarised to
 find the last successful component or rendered as a chronological timeline for
-debugging.
+debugging.  The ``razar timeline`` CLI subcommand uses this module to
+reconstruct mission events.
 """
 
 from dataclasses import dataclass

--- a/agents/razar/quarantine_manager.py
+++ b/agents/razar/quarantine_manager.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 """Utilities for quarantining failing components.
 
-Components that fail during runtime are moved to the repository-level
-``quarantine`` directory and recorded in ``docs/quarantine_log.md``. Remote code
-agents may also submit diagnostic information which is appended to the log. A
-component remains quarantined until it is explicitly resolved or reactivated.
+Components that fail during runtime are moved to the repository‑level
+``quarantine`` directory and a human‑readable entry is appended to
+``docs/quarantine_log.md``.  Remote code agents may also submit diagnostic
+information which is recorded in the same Markdown log.  A component remains
+quarantined until it is explicitly resolved or reactivated.
 """
 
 from datetime import datetime


### PR DESCRIPTION
## Summary
- Document service-specific probes for Inanna AI, CROWN LLM, memory stores and chat gateways
- Explain quarantine manager's Markdown logging
- Note that `razar timeline` reconstructs mission events via `mission_logger`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b05758c70c832eb23d2c8ae407c55c