### PR TITLE
feat: add remote agent loader docs

### DIFF
--- a/agents/razar/remote_loader.py
+++ b/agents/razar/remote_loader.py
@@ -43,6 +43,15 @@ LOG_PATH = Path(__file__).resolve().parents[2] / "logs" / "razar_remote_agents.j
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
+# Public functions exposed by this module
+__all__ = [
+    "load_remote_agent",
+    "load_remote_agent_from_git",
+    "load_remote_gpt_agent",
+    "patch_on_test_failure",
+]
+
+
 class RemoteAgent(Protocol):  # pragma: no cover - typing helper
     """Interface all remote agents must implement.
 

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -37,3 +37,22 @@ python -m agents.razar.runtime_manager config/razar_config.yaml
 `start_dev_agents.py` and `launch_servants.sh` call RAZAR before performing
 other work. You can override the configuration file by setting
 `RAZAR_CONFIG` in the environment.
+
+## Remote Agent Pipeline
+
+RAZAR can extend its capabilities at runtime by pulling helper agents from
+remote locations.  The :mod:`agents.razar.remote_loader` utility supports three
+strategies:
+
+1. **HTTP modules** – download a single Python file from an HTTP(S) endpoint,
+   load it with ``importlib`` and execute its ``configure()`` and ``patch()``
+   hooks.
+2. **Git repositories** – clone a repository via **GitPython** and load a
+   specified module path.
+3. **HTTP GPT services** – interact with a JSON API exposing ``/configure`` and
+   ``/patch`` routes using :mod:`requests`.
+
+Each agent's configuration and any patch suggestions are recorded in
+``logs/razar_remote_agents.json``.  The ``patch_on_test_failure`` helper will
+request a patch from a remote agent when tests fail, apply the returned diff in
+a sandbox and re-run the test suite before committing the change.


### PR DESCRIPTION
## Summary
- expose remote agent loader utilities via `__all__`
- document remote agent pipeline and logging

## Testing
- `pytest tests/agents/razar/test_module_builder.py -q -p no:cov -o addopts=`
- `pytest tests/test_remote_loader.py -q -p no:cov -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b05b561bb8832ebfd2ef5525f2f476