### PR TITLE
docs: link Chat2DB and persona layers

### DIFF
--- a/docs/chat2db.md
+++ b/docs/chat2db.md
@@ -29,8 +29,8 @@ Agents → Chat Gateway → Chat2DB → {SQLite, Vector Store}
    from spiral_vector_db import init_db
 
    db_storage.init_db()
-   init_db()  # sets up the Chroma collection
-   ```
+ init_db()  # sets up the Chroma collection
+  ```
 2. Record a message:
    ```python
    db_storage.save_interaction("hello", "neutral", "response.wav")
@@ -41,6 +41,10 @@ Agents → Chat Gateway → Chat2DB → {SQLite, Vector Store}
 
    insert_embeddings([{"text": "hello world"}])
    matches = query_embeddings("hello")
+   ```
+4. Retrieve conversation history:
+   ```python
+   history = db_storage.fetch_interactions(limit=10)
    ```
 The interface is stateless; components import these helpers as needed. See the
 [system blueprint](system_blueprint.md#chat2db-interface) for how Chat2DB fits in

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -24,6 +24,8 @@ interlock.
   - [RAZAR Agent](RAZAR_AGENT.md) – pre-creation mandate, priority boot order with health checks and quarantine, and a handshake with the CROWN LLM and servant models
   - [Nazarick Agents](nazarick_agents.md) – roster of specialized servants
   - [ALBEDO Layer](ALBEDO_LAYER.md) – persona modules and archetypal behavior hooks
+  - [Persona API Guide](persona_api_guide.md) – conventions for persona profiles and hooks
+  - [Nazarick Manifesto](nazarick_manifesto.md) – narrative charter governing personas
   - [Chat2DB Interface](chat2db.md) – bridge between the relational log and vector store
 - **Operational guides**
   - [Operations Guide](operations.md) – runbooks for deployment and maintenance
@@ -60,9 +62,11 @@ interlock.
 ### Agent & Nazarick Hierarchy
 
 Agents follow a Nazarick-inspired command chain. The roster and roles live in
-[nazarick_agents.md](nazarick_agents.md). Persona behaviors originate from
-[persona_api_guide.md](persona_api_guide.md) and are implemented in component
-modules cataloged in [component_index.md](component_index.md).
+[nazarick_agents.md](nazarick_agents.md). Component implementations are
+cataloged in [component_index.md](component_index.md), while personalities draw
+from the [ALBEDO Layer](ALBEDO_LAYER.md) and
+[Persona API Guide](persona_api_guide.md). Agents persist dialogue context
+through the [Chat2DB Interface](chat2db.md).
 
 ### Floor and Channel Hierarchy
 


### PR DESCRIPTION
## Summary
- expand Chat2DB usage docs with interaction history retrieval
- reference ALBEDO layer, persona guides, and Chat2DB in the system blueprint
- connect agent section to component index and personality resources

## Testing
- `pytest --maxfail=1 --strict-markers` *(fails: import file mismatch for tests/test_quarantine_manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b0602eb420832ea0daedc3661e285d