### PR TITLE
Add ignition builder tests and component priorities registry

### DIFF
--- a/agents/razar/ignition_builder.py
+++ b/agents/razar/ignition_builder.py
@@ -1,11 +1,13 @@
 """Update ``docs/Ignition.md`` from the component priority registry.
 
-This module reads component definitions from ``docs/component_priorities.yaml``
-and writes a grouped table to ``docs/Ignition.md``.  Status markers
-(``✅``/``⚠️``/``❌``) are derived from the last successful component recorded in
-``logs/razar_state.json`` and the quarantine registry.  The original blueprint
-parsing helper :func:`parse_system_blueprint` is retained for compatibility with
-the boot orchestrator.
+Components are defined in ``docs/component_priorities.yaml`` with three pieces
+of metadata: ``priority`` (``P1``–``P5``), ``criticality`` and ``issue_type``.
+The builder groups entries by priority and writes a Markdown table to
+``docs/Ignition.md``.  Status markers (``✅``/``⚠️``/``❌``) are derived from the
+last successful component recorded in ``logs/razar_state.json`` and the
+quarantine registry.  The original blueprint parsing helper
+:func:`parse_system_blueprint` is retained for compatibility with the boot
+orchestrator.
 """
 
 from __future__ import annotations

--- a/docs/component_priorities.yaml
+++ b/docs/component_priorities.yaml
@@ -2,39 +2,28 @@
 memory_store:
   priority: P1
   criticality: core
-  issue_categories:
-    - config
-    - runtime
+  issue_type: runtime
 chat_gateway:
   priority: P2
   criticality: core
-  issue_categories:
-    - runtime
-    - integration
+  issue_type: runtime
 crown_llm:
   priority: P2
   criticality: core
-  issue_categories:
-    - config
-    - runtime
+  issue_type: config
 vision_adapter:
   priority: P2
   criticality: optional
-  issue_categories:
-    - integration
+  issue_type: integration
 audio_device:
   priority: P3
   criticality: optional
-  issue_categories:
-    - runtime
+  issue_type: runtime
 avatar:
   priority: P4
   criticality: optional
-  issue_categories:
-    - runtime
-    - integration
+  issue_type: integration
 video:
   priority: P5
   criticality: optional
-  issue_categories:
-    - integration
+  issue_type: integration

--- a/tests/agents/razar/test_ignition_builder.py
+++ b/tests/agents/razar/test_ignition_builder.py
@@ -38,13 +38,11 @@ def _write_registry(path: Path) -> None:
             "alpha:\n"
             "  priority: P1\n"
             "  criticality: core\n"
-            "  issue_categories:\n"
-            "    - runtime\n"
+            "  issue_type: runtime\n"
             "beta:\n"
             "  priority: P2\n"
             "  criticality: optional\n"
-            "  issue_categories:\n"
-            "    - config\n"
+            "  issue_type: config\n"
         ),
         encoding="utf-8",
     )
@@ -76,6 +74,18 @@ def test_quarantined_component_marked(monkeypatch, tmp_path: Path) -> None:
     build_ignition(registry, output)
     content = output.read_text(encoding="utf-8")
     assert "| 2 | Beta | - | ❌ |" in content
+
+
+def test_build_ignition_defaults(tmp_path: Path) -> None:
+    """When no state is supplied all components default to a warning marker."""
+
+    registry = tmp_path / "component_priorities.yaml"
+    _write_registry(registry)
+    output = tmp_path / "Ignition.md"
+    build_ignition(registry, output)
+    content = output.read_text(encoding="utf-8")
+    assert "| 1 | Alpha | - | ⚠️ |" in content
+    assert "| 2 | Beta | - | ⚠️ |" in content
 
 
 def test_cli_build_ignition(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- document component priorities with priority level, criticality and issue type
- clarify ignition builder metadata consumption in docstring
- expand ignition builder tests to cover default status generation

## Testing
- `pytest tests/agents/razar/test_ignition_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b067ec7178832e9d38a656d1f91981