### PR TITLE
docs: add documentation protocol and cross-links

### DIFF
--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -1,6 +1,6 @@
 # Developer Onboarding
 
-Quick links: [Development Checklist](development_checklist.md) | [Developer Etiquette](developer_etiquette.md) | [Vision System](vision_system.md)
+Quick links: [Development Checklist](development_checklist.md) | [Developer Etiquette](developer_etiquette.md) | [Documentation Protocol](documentation_protocol.md) | [Vision System](vision_system.md)
 
 ## Project Vision
 

--- a/docs/documentation_protocol.md
+++ b/docs/documentation_protocol.md
@@ -1,0 +1,9 @@
+# Documentation Protocol
+
+Standard workflow for updating documentation and guides.
+
+1. **Check for applicable `AGENTS.md` instructions** to understand directory-specific conventions.
+2. **Update all related documents** whenever a component or guide changes to keep information synchronized.
+3. **Validate changes with** `pre-commit run --files <changed_files>` **before committing.**
+4. **Use traceable commit messages** that capture the rationale for changes and reference affected documents.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,5 +16,6 @@ Central resources for understanding and operating the project.
 
 ## Development
 - [Developer Onboarding](developer_onboarding.md)
+- [Documentation Protocol](documentation_protocol.md)
 - [Development Checklist](development_checklist.md)
 - [Developer Etiquette](developer_etiquette.md)


### PR DESCRIPTION
## Summary
- outline standard documentation workflow in `docs/documentation_protocol.md`
- link protocol from developer onboarding and index

## Testing
- `pre-commit run --files docs/documentation_protocol.md docs/index.md docs/developer_onboarding.md`

------
https://chatgpt.com/codex/tasks/task_e_68b077e588dc832e88047c19b1e437c2