### PR TITLE
Refactor console command handlers into helpers

### DIFF
--- a/src/cli/music_helper.py
+++ b/src/cli/music_helper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Utility functions for handling music generation commands."""
+
+import logging
+from pathlib import Path
+
+from INANNA_AI import speaking_engine
+from tools import session_logger
+
+logger = logging.getLogger(__name__)
+
+
+def play_music(orch, prompt: str) -> None:
+    """Generate and play music for ``prompt`` using ``orch``."""
+    if not prompt:
+        print("Usage: /music <prompt>")
+        return
+    try:
+        result = orch.route(
+            prompt,
+            {},
+            text_modality=False,
+            voice_modality=False,
+            music_modality=True,
+        )
+        music_path = result.get("music_path")
+        if not music_path:
+            print("No music generated.")
+            return
+        session_logger.log_audio(Path(music_path))
+        try:
+            speaking_engine.play_wav(music_path)
+        except Exception:  # pragma: no cover - playback may fail
+            logger.exception("music playback failed")
+        print(f"Music saved to {music_path}")
+    except Exception:  # pragma: no cover - generation may fail
+        logger.exception("music generation failed")
+
+
+__all__ = ["play_music"]

--- a/src/cli/sandbox_helper.py
+++ b/src/cli/sandbox_helper.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Run code patches in an isolated sandbox and execute tests."""
+
+import logging
+import subprocess
+from pathlib import Path
+
+from tools import sandbox_session, virtual_env_manager
+
+logger = logging.getLogger(__name__)
+
+
+def run_sandbox(patch_path_str: str) -> None:
+    """Apply a patch file in a sandbox and run tests."""
+    if not patch_path_str:
+        print("Usage: /sandbox <patch-file>")
+        return
+    patch_file = Path(patch_path_str)
+    try:
+        patch_text = patch_file.read_text()
+    except Exception as exc:
+        logger.error("Unable to read patch file: %s", exc)
+        return
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        sandbox_root = sandbox_session.create_sandbox(repo_root, virtual_env_manager)
+        sandbox_session.apply_patch(sandbox_root, patch_text)
+        env = sandbox_root / ".venv"
+        req_file = sandbox_root / "tests" / "requirements.txt"
+        virtual_env_manager.install_requirements(env, req_file)
+        try:
+            result = virtual_env_manager.run(env, ["pytest"], cwd=sandbox_root)
+            print(result.stdout)
+            print("Sandbox tests passed.")
+        except subprocess.CalledProcessError as exc:
+            logger.error("%s", exc.stdout)
+            logger.error("%s", exc.stderr)
+            logger.error("Sandbox tests failed.")
+    except Exception as exc:
+        logger.error("Sandbox error: %s", exc)
+
+
+__all__ = ["run_sandbox"]

--- a/src/cli/voice_clone_helper.py
+++ b/src/cli/voice_clone_helper.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Helper for voice cloning within the console interface."""
+
+import logging
+from pathlib import Path
+
+from audio import voice_cloner
+from INANNA_AI import speaking_engine
+
+logger = logging.getLogger(__name__)
+
+
+def clone_voice(sample_text: str) -> voice_cloner.VoiceCloner | None:
+    """Capture a voice sample and synthesize ``sample_text``.
+
+    Returns the ``VoiceCloner`` instance if cloning succeeds, otherwise ``None``.
+    """
+    try:
+        vc = voice_cloner.VoiceCloner()
+        sample_path = Path("data/voice_sample.wav")
+        out_path = Path("data/voice_clone.wav")
+        vc.capture_sample(sample_path)
+        vc.synthesize(sample_text or "Voice clone ready.", out_path)
+        speaking_engine.play_wav(str(out_path))
+        print("Cloned voice registered for future replies.")
+        return vc
+    except Exception as exc:
+        logger.error("Voice cloning unavailable: %s", exc)
+        return None
+
+
+__all__ = ["clone_voice"]

--- a/tests/test_console_sandbox_command.py
+++ b/tests/test_console_sandbox_command.py
@@ -7,6 +7,7 @@ import subprocess
 import types
 
 from cli import console_interface
+import cli.sandbox_helper as sandbox_helper
 
 
 class DummySession:
@@ -53,12 +54,12 @@ def _setup(monkeypatch, tmp_path, run_behavior):
     monkeypatch.setattr(console_interface, "_wait_for_glm_ready", lambda: object())
     monkeypatch.setattr(console_interface, "MoGEOrchestrator", lambda: object())
     monkeypatch.setattr(
-        console_interface,
+        sandbox_helper,
         "sandbox_session",
         types.SimpleNamespace(create_sandbox=fake_create, apply_patch=fake_apply),
     )
     monkeypatch.setattr(
-        console_interface,
+        sandbox_helper,
         "virtual_env_manager",
         types.SimpleNamespace(install_requirements=fake_install, run=fake_run),
     )


### PR DESCRIPTION
## Summary
- Extract music, sandbox, and voice cloning logic into dedicated helper modules
- Route console commands to these new helpers and simplify `run_repl`
- Adjust sandbox command tests for new helper structure

## Testing
- `pytest tests/test_console_sandbox_command.py::test_sandbox_command_success tests/test_console_sandbox_command.py::test_sandbox_command_failure -q` *(skipped: requires unavailable resources)*
- `pytest tests/test_session_logger.py::test_logging_files_created -q` *(fails: pydantic_core._pydantic_core.ValidationError: 2 validation errors for Config)*
- `pre-commit run --files src/cli/console_interface.py src/cli/music_helper.py src/cli/sandbox_helper.py src/cli/voice_clone_helper.py tests/test_console_sandbox_command.py`

------
https://chatgpt.com/codex/tasks/task_e_68b08cc2b4b0832e933c7dbe950354ab