### PR TITLE
Document code style tooling

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -5,26 +5,34 @@ This project follows a lightweight style that is largely compatible with
 existing code base. The following guidelines should be observed when submitting
 changes.
 
-## General
+## Formatting
+- Format code with [`black`](https://black.readthedocs.io/). The
+  `pre-commit` hooks run Black automatically on staged files.
 - Target **Python 3.10** or later.
 - Use **4 spaces** per indentation level. Tabs are not allowed.
-- Keep lines under **88 characters** when practical.
+- Keep lines under **88 characters** when practical. Black enforces this
+  limit.
 - Use `from __future__ import annotations` at the top of new modules that make
   use of forward references.
-- Organise imports in three groups separated by blank lines: standard library,
-  third‑party packages, and local modules.
+- Organise imports in three groups separated by blank lines: standard
+  library, third-party packages, and local modules.
 - Prefer `pathlib.Path` over raw string paths.
 
 ## Naming
+The following conventions are checked by `flake8` rules via
+[`ruff`](https://docs.astral.sh/ruff/):
+
 - Modules and packages use **lower_case_with_underscores**.
 - Classes use **CapWords**.
 - Functions and variables use **lower_case_with_underscores**.
 - Constants are written in **UPPER_CASE_WITH_UNDERSCORES**.
 
 ## Docstrings and Comments
-- Public modules, classes and functions should include **triple‑quoted
-  docstrings** describing purpose and parameters.
-- Use one line of summary followed by a blank line and additional details.
+- Public modules, classes and functions should include **triple-quoted
+  docstrings** describing purpose and parameters. PEP 257 compliance is
+  validated with `pydocstyle` checks (run through `ruff`).
+- Start with a one-line summary in the imperative mood, followed by a blank
+  line and additional context.
 - Inline comments should be short and start with a capital letter.
 
 ## Typing

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 - [Documentation Index](docs/index.md) – curated starting points
 - [Full Documentation Inventory](docs/INDEX.md)
 - [Developer Onboarding](docs/developer_onboarding.md)
+- [Code Style Guide](CODE_STYLE.md)
 - [Nazarick Agents](docs/nazarick_agents.md)
 - [Chakra Koan System](docs/chakra_koan_system.md)
 - [Chakra Version Manifest](docs/chakra_versions.json)

--- a/docs/CONTRIBUTOR_HANDBOOK.md
+++ b/docs/CONTRIBUTOR_HANDBOOK.md
@@ -11,6 +11,9 @@ Install the required tools before working on the project:
 - **pre-commit** – run linters and formatters via `pre-commit install`.
 - **Docker** *(optional)* – build and run containerized services.
 
+Follow the [Code Style Guide](../CODE_STYLE.md) for formatting,
+naming, and docstring conventions.
+
 Key commands:
 
 ```bash


### PR DESCRIPTION
## Summary
- expand CODE_STYLE with formatting, naming and docstring rules
- note Black, flake8/ruff and pydocstyle enforcement
- link the style guide from README and contributor handbook

## Testing
- `pre-commit run --files CODE_STYLE.md docs/CONTRIBUTOR_HANDBOOK.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0938d7b04832e8e383a4de194df59