### PR TITLE
Add nightly CI workflow

### DIFF
--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -1,0 +1,33 @@
+name: Nightly CI
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest --junitxml=pytest.xml
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: pytest.xml
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add nightly CI GitHub workflow to run pre-commit and pytest daily

## Testing
- `pre-commit run --files .github/workflows/nightly_ci.yml`
- `pytest -q` *(fails: unrecognized arguments: --cov=src --cov=agents --cov-fail-under=0.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b09560055c832eada329744139d4c6