### PR TITLE
docs: clarify review tiers in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,11 @@ coverage report
   version entry; do not modify or remove prior content. After updates, run
   `python tools/doc_indexer.py` to refresh `docs/INDEX.md`.
 - Lint Markdown files with `markdownlint` and verify links using `markdown-link-check`.
-- Request review from a maintainer and address feedback promptly.
+
+### Review Process
+
+- **Maintainer review (required):** Every PR must be reviewed by at least one project maintainer.
+- **Domain expert review (optional):** For changes touching specialized areas such as security, infrastructure, or ML pipelines, request a review from a domain expert. Mention the domain in the PR description and tag the appropriate expert or ask a maintainer to loop them in.
+- **Reviewer expectations:** Ensure tests and linters pass, confirm documentation and style guidelines are followed, and provide constructive feedback. Escalate to additional reviewers if deeper expertise is needed.
 
 By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- define maintainer and optional domain expert review tiers
- outline reviewer expectations and how to request additional expertise

## Testing
- `pre-commit run --files CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_68b096f881e8832ea2867f9f32eae7fd