### PR TITLE
Clarify pre-commit policy and add version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
+      - name: Verify pre-commit version
+        run: |
+          expected=$(grep -Po '(?<=pre-commit==)[0-9.]+(?=")' pyproject.toml)
+          installed=$(pre-commit --version | awk '{print $NF}')
+          if [ "$installed" != "$expected" ]; then
+            echo "pre-commit $expected required, found $installed"
+            exit 1
+          fi
       - name: Run pre-commit
         run: pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# Run `pre-commit autoupdate` after dependency upgrades.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,15 @@ the result:
 uv pip compile --no-deps pyproject.toml -o requirements.lock
 ```
 
+After upgrading dependencies, refresh pre-commit hooks and commit the updated
+`.pre-commit-config.yaml`:
+
+```bash
+pre-commit autoupdate
+pre-commit run --files .pre-commit-config.yaml
+git add .pre-commit-config.yaml
+```
+
 ## Coding Style
 
 Follow the conventions in [CODE_STYLE.md](CODE_STYLE.md). Highlights include:
@@ -90,6 +99,7 @@ coverage report
 
 - Keep changes focused; submit separate PRs for unrelated fixes.
 - Ensure documentation is updated and tests pass.
+- Pull requests that fail `pre-commit run --all-files` will not be merged.
 - Register new modules in [docs/component_priorities.yaml](docs/component_priorities.yaml) with a priority (P1–P5), criticality tag, and issue categories so RAZAR can orchestrate startup.
 - Record project-wide documentation or architectural changes in
   [docs/system_blueprint.md](docs/system_blueprint.md) by adding a new


### PR DESCRIPTION
## Summary
- ensure pull requests passing `pre-commit run --all-files` are required for merge
- document running `pre-commit autoupdate` and committing `.pre-commit-config.yaml`
- verify the pre-commit version in CI against `pyproject.toml`

## Testing
- `pre-commit run --files CONTRIBUTING.md .pre-commit-config.yaml .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b0a0d79044832e8d14890c5fba5b9b