### PR TITLE
docs: document doc_indexer usage and verify index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ PY
           pip install -e .
           pip install mypy
 
+      - name: Verify docs index
+        run: |
+          python tools/doc_indexer.py
+          git diff --exit-code docs/INDEX.md
+
       - name: Mypy
         run: mypy
 

--- a/docs/documentation_protocol.md
+++ b/docs/documentation_protocol.md
@@ -4,6 +4,7 @@ Standard workflow for updating documentation and guides.
 
 1. **Check for applicable `AGENTS.md` instructions** to understand directory-specific conventions.
 2. **Update all related documents** whenever a component or guide changes to keep information synchronized.
-3. **Validate changes with** `pre-commit run --files <changed_files>` **before committing.**
-4. **Use traceable commit messages** that capture the rationale for changes and reference affected documents.
+3. **Regenerate `docs/INDEX.md` with `python tools/doc_indexer.py` whenever Markdown files change.**
+4. **Validate changes with** `pre-commit run --files <changed_files>` **before committing.**
+5. **Use traceable commit messages** that capture the rationale for changes and reference affected documents.
 


### PR DESCRIPTION
## Summary
- remind contributors to regenerate `docs/INDEX.md` via `tools/doc_indexer.py` when Markdown changes
- ensure CI fails if the committed docs index is outdated

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/documentation_protocol.md docs/INDEX.md .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b0a301a440832ebd3df5e68165e26e