### PR TITLE
docs: reference Absolute Protocol across documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation.
 - Follow the naming and structuring conventions described there when creating new docs.
 - Review and refresh [docs/system_blueprint.md](docs/system_blueprint.md) before committing changes to components or documentation.
+- Consult [docs/The_Absolute_Protocol.md](docs/The_Absolute_Protocol.md) for core contribution rules.
 - Run `pre-commit run --files <modified files>` on all changed files before committing.
 
 Deeper `AGENTS.md` files in subdirectories may override or extend these rules for files within their scope.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 - [Chakra Version Manifest](docs/chakra_versions.json)
 
 ## Start Here
+- Consult [The Absolute Protocol](docs/The_Absolute_Protocol.md) for repository rules and workflows.
 - Review the [Blueprint Export](docs/BLUEPRINT_EXPORT.md) snapshot for versioned links to core documentation.
 - Walk through the [Onboarding Guide](docs/onboarding_guide.md) (v1.0.0, updated 2025-08-28) to rebuild or extend the system using those docs alone.
 

--- a/docs/BLUEPRINT_EXPORT.md
+++ b/docs/BLUEPRINT_EXPORT.md
@@ -7,6 +7,7 @@ Replace `<commit>` in each permalink with the desired commit hash to reference a
 |---|---|---|
 | CRYSTAL CODEX | Mission, architecture diagrams, and setup walkthrough | https://github.com/DINGIRABZU/ABZU/blob/<commit>/CRYSTAL_CODEX.md |
 | Repository README | High-level project overview and entry points | https://github.com/DINGIRABZU/ABZU/blob/<commit>/README.md |
+| The Absolute Protocol | Consolidated contribution rules and workflows | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/The_Absolute_Protocol.md |
 | System Blueprint | Overall system blueprint and component map | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/system_blueprint.md |
 | Architecture Overview | Component interactions and architectural layers | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/architecture_overview.md |
 | Setup Guide | Standard environment setup instructions | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/setup.md |

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Curated starting points for understanding and operating the project. For an exha
 - [How to Use](how_to_use.md)
 
 ## Development
+- [The Absolute Protocol](The_Absolute_Protocol.md) (v1.0.0, updated 2025-08-28)
 - [Developer Etiquette](developer_etiquette.md)
 - [Developer Onboarding](developer_onboarding.md)
 - [Development Checklist](development_checklist.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -15,6 +15,7 @@ exhaustive module inventory.
 - **High‑level docs**
   - [Documentation Index](index.md) – gateway to every guide
   - [Blueprint Export](BLUEPRINT_EXPORT.md) – versioned snapshot of key documents and dependencies
+  - [The Absolute Protocol](The_Absolute_Protocol.md) – consolidated repository rules
   - [Onboarding Guide](onboarding_guide.md) – step‑by‑step setup and rebuild walkthrough
   - [Project Overview](project_overview.md) – explains Spiral OS goals and scope
   - [Architecture Overview](architecture_overview.md) – shows how major components fit together


### PR DESCRIPTION
## Summary
- add The Absolute Protocol to README start-here list and doc index
- expose Absolute Protocol in Blueprint Export and system blueprint
- remind contributors about Absolute Protocol in AGENTS instructions

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files README.md AGENTS.md docs/index.md docs/BLUEPRINT_EXPORT.md docs/system_blueprint.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0b339dda4832e91df7c2ebd8f8983