### PR TITLE
docs: define protocol consultation order

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -15,6 +15,21 @@ This document consolidates ABZU's guiding rules. Review it before contributing t
 - [Generated Index](INDEX.md) – auto-generated list of all docs.
 - [Issue Templates](../.github/ISSUE_TEMPLATE/) – templates for new issues.
 
+## Consultation Order
+When contributing, consult resources in this order:
+
+1. **The Absolute Protocol** – canonical repository rules.
+2. **[Contributor Handbook](CONTRIBUTOR_HANDBOOK.md)** – setup and workflows.
+3. **[AGENTS.md](../AGENTS.md)** – directory-specific instructions.
+4. **Feature or Issue Specs** – task-specific requirements.
+
+| Protocol | Maintainer | Update Cadence |
+| --- | --- | --- |
+| The Absolute Protocol | Core Maintainers | Monthly |
+| Contributor Handbook | Documentation Team | Quarterly |
+| AGENTS.md | Repository Maintainers | As needed |
+| Feature/Issue Specs | Feature Owners | Per release |
+
 ## Maintenance
 Whenever this file changes:
 1. Regenerate documentation indices: `python tools/doc_indexer.py`.


### PR DESCRIPTION
## Summary
- document the order in which contributors consult key references
- list maintainers and update cadence for core protocols

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b0b42bfaec832ebbc5fd38cc83c83b