### PR TITLE
docs: reference blueprint export and onboarding guide in index

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
 ## Start Here
 - Consult [The Absolute Protocol](docs/The_Absolute_Protocol.md) for repository rules and workflows.
-- Review the [Blueprint Export](docs/BLUEPRINT_EXPORT.md) snapshot for versioned links to core documentation.
-- Walk through the [Onboarding Guide](docs/onboarding_guide.md) (v1.0.0, updated 2025-08-28) to rebuild or extend the system using those docs alone.
+- Review the [Blueprint Export](docs/BLUEPRINT_EXPORT.md) snapshot for versioned links to core documentation and consult the [Documentation Index](docs/index.md).
+- Walk through the [Onboarding Guide](docs/onboarding_guide.md) (v1.0.0, updated 2025-08-28) to rebuild or extend the system using those docs alone, or browse the [Documentation Index](docs/index.md) for related guides.
 
 For deeper background, consult the [CRYSTAL CODEX](CRYSTAL_CODEX.md) and the [documentation inventory](docs/INDEX.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Curated starting points for understanding and operating the project. For an exha
 
 ## Architecture
 - [Architecture Overview](architecture_overview.md)
-- [Blueprint Export](BLUEPRINT_EXPORT.md)
+- [Blueprint Export](BLUEPRINT_EXPORT.md) – versioned snapshot of key documents
 - [Detailed Architecture](architecture.md)
 ## Nazarick
 - [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
@@ -21,6 +21,6 @@ Curated starting points for understanding and operating the project. For an exha
 - [Developer Onboarding](developer_onboarding.md)
 - [Development Checklist](development_checklist.md)
 - [Documentation Protocol](documentation_protocol.md)
-- [Onboarding Guide](onboarding_guide.md) (v1.0.0, updated 2025-08-28)
+- [Onboarding Guide](onboarding_guide.md) – step-by-step rebuild using docs alone (v1.0.0, updated 2025-08-28)
 - [Feature Specifications](features/README.md)
 - [Example Feature](features/example_feature.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -4,8 +4,9 @@
 
 The system blueprint maps ABZU’s chakra layers, core services, and agents. It
 acts as a starting compass for new contributors—consult the
-[Documentation Index](index.md) for a full table of contents, read the
-[Project Overview](project_overview.md) to understand goals, review the
+[Documentation Index](index.md) for a full table of contents, including the
+[Blueprint Export](BLUEPRINT_EXPORT.md) and [Onboarding Guide](onboarding_guide.md).
+Read the [Project Overview](project_overview.md) to understand goals, review the
 [Architecture Overview](architecture_overview.md) to see how components
 interlock, and browse the [Component Index](component_index.md) for an
 exhaustive module inventory.


### PR DESCRIPTION
## Summary
- highlight Blueprint Export and Onboarding Guide in the curated documentation index
- cross-link README and System Blueprint to the updated index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files README.md docs/index.md docs/system_blueprint.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0cae3d9f8832e8a1e865a4b8a998b