### PR TITLE
docs: reference feature specs in blueprint

### DIFF
--- a/docs/BLUEPRINT_EXPORT.md
+++ b/docs/BLUEPRINT_EXPORT.md
@@ -35,7 +35,7 @@ These references help track how components rely on one another and make it easy 
 
 ## Feature Specs
 
-Design documents for individual capabilities:
+Design documents for individual capabilities. Each spec in `docs/features` must be referenced here with a permalink:
 
 - Example Feature — https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/features/example_feature.md
 

--- a/docs/features/FEATURE_TEMPLATE.md
+++ b/docs/features/FEATURE_TEMPLATE.md
@@ -18,3 +18,6 @@ Identify modules or packages that will change.
 ## Rollback Plan
 Steps to revert the feature if issues arise.
 
+## Reference
+After finalizing the specification, list the file in [Blueprint Export](../BLUEPRINT_EXPORT.md) under **Feature Specs**.
+

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -5,9 +5,10 @@ Guidelines for authoring feature specification files.
 ## Authoring
 1. Copy [FEATURE_TEMPLATE.md](FEATURE_TEMPLATE.md) to `docs/features/<feature_name>.md`.
 2. Fill out each section with concise, actionable details.
-3. Update [`docs/index.md`](../index.md) and regenerate [`docs/INDEX.md`](../INDEX.md) with `python tools/doc_indexer.py`.
-4. Run `pre-commit run --files <new_file> docs/index.md docs/INDEX.md` before committing.
+3. Add the new file to [Blueprint Export](../BLUEPRINT_EXPORT.md) under **Feature Specs**.
+4. Update [`docs/index.md`](../index.md) and regenerate [`docs/INDEX.md`](../INDEX.md) with `python tools/doc_indexer.py`.
+5. Run `pre-commit run --files <new_file> ../BLUEPRINT_EXPORT.md ../index.md ../INDEX.md` before committing.
 
 ## Storage
-Store completed specifications in this directory. Use kebab-case or snake_case filenames that reflect the feature being described.
+Store completed specifications in this directory using kebab-case or snake_case filenames. Each spec **must** be referenced in `docs/BLUEPRINT_EXPORT.md`.
 


### PR DESCRIPTION
## Summary
- clarify that every feature spec in `docs/features` must appear in Blueprint Export
- add reference guidance in feature spec template

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/BLUEPRINT_EXPORT.md docs/features/FEATURE_TEMPLATE.md docs/features/README.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc0775c0832ebeb761e6bf1eb622