### PR TITLE
Chore: clarify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,23 +10,20 @@ assignees: []
 
 A clear and concise description of what the bug is.
 
-## To Reproduce
+## Steps to Reproduce
 
-Steps to reproduce the behavior:
+Provide a clear sequence that triggers the bug:
 
 1. Go to '...'
 1. Run '...'
 1. See error
 
-## Expected behavior
+## Expected vs. Actual Behavior
 
-A clear and concise description of what you expected to happen.
+- **Expected:** What you thought would happen.
+- **Actual:** What actually happened, including any error messages.
 
-## Actual behavior
-
-What actually happened when running the steps above. Include any error messages or unexpected results.
-
-## Debug logs/Stack trace
+## Debug Logs / Stack Traces
 
 Attach or link to any relevant log output or stack traces. Use gists, Pastebin, or file attachments for lengthy logs.
 
@@ -43,7 +40,7 @@ Provide detailed information to help reproduce the issue:
 - Python version: [e.g. 3.11]
 - Environment details (virtualenv, Docker, hardware, relevant packages): [...]
 
-## Related specs or modules
+## Linked Specs or Modules
 
 Reference any related specifications, modules, or feature documentation. Provide links or file paths so others can easily find them.
 


### PR DESCRIPTION
## Summary
- expand bug report template to request reproduction steps, expected vs. actual outcomes, debug logs or stack traces, and links to relevant specs or modules.

## Linked issue/feature spec
- N/A

## Checklist
- [x] Tests run <!-- `pre-commit run --files .github/ISSUE_TEMPLATE/bug_report.md docs/INDEX.md` -->
- [x] Docs updated <!-- updated bug report template -->
- [x] Index regenerated <!-- `python tools/doc_indexer.py` -->

------
https://chatgpt.com/codex/tasks/task_e_68b0cd042db0832e95550ee71668f7fd