### PR TITLE
Add milestone doc and memory store regression test

### DIFF
--- a/docs/ABSOLUTE_MILESTONES.md
+++ b/docs/ABSOLUTE_MILESTONES.md
@@ -1,0 +1,11 @@
+# Absolute Milestones
+
+This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull request.
+
+## Past Milestones
+- **Initial architecture export (2023-09)** — established core documentation set. [Spec](BLUEPRINT_EXPORT.md) · [PR #10](https://github.com/DINGIRABZU/ABZU/pull/10)
+- **Memory sharding (2024-02)** — introduced horizontally scalable vector storage. [Spec](features/example_feature.md) · [PR #85](https://github.com/DINGIRABZU/ABZU/pull/85)
+
+## Upcoming Milestones
+- **Root chakra upgrade (Q3 2024)** — lays the foundation for the memory pipeline. [Spec](roadmap.md) · [PR #200](https://github.com/DINGIRABZU/ABZU/pull/200)
+- **Crown chakra integration (Q1 2026)** — unifies cross-layer agent orchestration. [Spec](roadmap.md) · [PR #260](https://github.com/DINGIRABZU/ABZU/pull/260)

--- a/docs/BLUEPRINT_EXPORT.md
+++ b/docs/BLUEPRINT_EXPORT.md
@@ -23,6 +23,7 @@ Replace `<commit>` in each permalink with the desired commit hash to reference a
 | Mission | Project mission statement | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/MISSION.md |
 | Vision | Long-term vision for the project | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/VISION.md |
 | Release Notes | Historical release information | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/release_notes.md |
+| Absolute Milestones | Summary of past and upcoming release milestones | https://github.com/DINGIRABZU/ABZU/blob/<commit>/docs/ABSOLUTE_MILESTONES.md |
 
 ## Dependency Overview
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -164,6 +164,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../README_QNL_OS.md](../README_QNL_OS.md) | QNL Integration Overview | The Quantum Narrative Language (QNL) bridges textual symbols with music in Spiral OS. This document explains where th... | - |
 | [../SEVEN_DIMENSIONAL_MUSIC.md](../SEVEN_DIMENSIONAL_MUSIC.md) | 7‑Dimensional Music System | This system layers sound so different beings perceive a single track in unique ways. A core melody becomes the human... | - |
 | [../benchmarks/README.md](../benchmarks/README.md) | Benchmarks | Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`. | - |
+| [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | The **Albedo** layer introduces a stateful persona that drives responses through a remote GLM (Generative Language Mo... | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -16,6 +16,7 @@ The Absolute Protocol governs all other guides. Review subordinate protocols as 
   - [Pull Request Template](../.github/pull_request_template.md) – required PR structure.
   - [Documentation Index](index.md) – high-level entry point.
   - [Generated Index](INDEX.md) – auto-generated list of all docs.
+  - [Absolute Milestones](ABSOLUTE_MILESTONES.md) – summary of past and upcoming milestones.
   - [Issue & Feature Templates](../.github/ISSUE_TEMPLATE/) – templates for new issues and features.
 
 ## Consultation Order

--- a/tests/memory/test_memory_store_fallback.py
+++ b/tests/memory/test_memory_store_fallback.py
@@ -1,0 +1,15 @@
+import memory_store as ms
+
+
+def test_add_search_and_delete_without_optional_dependencies(tmp_path, monkeypatch):
+    monkeypatch.setattr(ms, "faiss", None)
+    monkeypatch.setattr(ms, "np", None)
+    db = tmp_path / "store.sqlite"
+    store = ms.MemoryStore(db)
+    store.add("a", [1.0, 0.0], {"n": "a"})
+    store.add("b", [0.0, 1.0], {"n": "b"})
+    ids = [r[0] for r in store.search([1.0, 0.0], 2)]
+    assert "a" in ids and "b" in ids
+    store.delete(["a"])
+    ids_after = [r[0] for r in store.search([1.0, 0.0], 2)]
+    assert "a" not in ids_after


### PR DESCRIPTION
## Summary
- add Absolute Milestones timeline and reference from core docs
- cover MemoryStore fallback behavior with regression test

## Testing
- `pytest tests/test_adaptive_learning.py tests/test_archetype_shift.py tests/test_albedo_state_machine.py tests/memory/test_sharded_memory_store.py tests/memory/test_vector_memory.py tests/memory/test_memory_store_fallback.py`
- `pre-commit run --files tests/memory/test_memory_store_fallback.py docs/ABSOLUTE_MILESTONES.md docs/BLUEPRINT_EXPORT.md docs/The_Absolute_Protocol.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0cdddea5c832ea55916d274cd3c5d