### PR TITLE
chore: safeguard key documents

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,10 @@ repos:
     rev: 6.3.0
     hooks:
       - id: pydocstyle
+  - repo: local
+    hooks:
+      - id: check-key-documents
+        name: Check key documents exist
+        entry: python scripts/check_key_documents.py
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,6 @@
 - Review and refresh [docs/system_blueprint.md](docs/system_blueprint.md) before committing changes to components or documentation.
 - Consult [docs/The_Absolute_Protocol.md](docs/The_Absolute_Protocol.md) for core contribution rules.
 - Run `pre-commit run --files <modified files>` on all changed files before committing.
+- Preserve the files listed in [docs/KEY_DOCUMENTS.md](docs/KEY_DOCUMENTS.md); a pre-commit hook fails if any are missing.
 
 Deeper `AGENTS.md` files in subdirectories may override or extend these rules for files within their scope.

--- a/config/key_documents.yml
+++ b/config/key_documents.yml
@@ -1,0 +1,5 @@
+# List of key files that must always exist
+files:
+  - AGENTS.md
+  - docs/The_Absolute_Protocol.md
+  - docs/KEY_DOCUMENTS.md

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -177,6 +177,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [INANNA_CORE.md](INANNA_CORE.md) | INANNA Core Configuration | `crown_config/INANNA_CORE.yaml` defines the default settings used by the Crown agent. Each option can be overridden b... | - |
 | [Ignition.md](Ignition.md) | Ignition | RAZAR coordinates system boot and records runtime health. Components are grouped by priority so operators can track s... | - |
 | [JSON_STRUCTURES.md](JSON_STRUCTURES.md) | JSON Structures and Invocations | This page describes the small JSON files used by Spiral OS and how to trigger registered invocations. | - |
+| [KEY_DOCUMENTS.md](KEY_DOCUMENTS.md) | Key Documents | The files listed here are foundational and must never be deleted or renamed. | - |
 | [LLM_FRAMEWORKS.md](LLM_FRAMEWORKS.md) | LLM Framework Comparison | Several open-source frameworks aim to simplify working with large language models. Below is a short overview of popul... | - |
 | [LLM_MODELS.md](LLM_MODELS.md) | LLM Models | This document describes the language models used in SPIRAL_OS and how to download them. | - |
 | [MISSION.md](MISSION.md) | Mission | - | - |

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -1,0 +1,10 @@
+# Key Documents
+
+The files listed here are foundational and must never be deleted or renamed.
+
+## Protected Files
+
+- [AGENTS.md](../AGENTS.md)
+- [The Absolute Protocol](The_Absolute_Protocol.md)
+
+These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming.

--- a/scripts/check_key_documents.py
+++ b/scripts/check_key_documents.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Verify that key documents exist."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "config" / "key_documents.yml"
+
+
+def main() -> int:
+    """Exit with non-zero status if any key document is missing."""
+    data = yaml.safe_load(CONFIG.read_text())
+    files = data.get("files", [])
+    missing = [f for f in files if not (ROOT / f).exists()]
+    if missing:
+        for f in missing:
+            print(f"Missing required file: {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document repository key files and mark them as undeletable
- add pre-commit check to verify key files exist
- reference key documents policy in AGENTS instructions

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files AGENTS.md docs/KEY_DOCUMENTS.md config/key_documents.yml scripts/check_key_documents.py .pre-commit-config.yaml docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0d637d5b0832e9d01c8441ca2a9ed