### PR TITLE
feat: require onboarding confirmation marker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,33 @@
 # Run `pre-commit autoupdate` after dependency upgrades.
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
-    hooks:
-      - id: ruff
-        args: ["--fix"]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-  - repo: local
-    hooks:
-      - id: check-key-documents
-        name: Check key documents exist
-        entry: python scripts/check_key_documents.py
-        language: system
-        pass_filenames: false
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.11
+  hooks:
+  - id: ruff
+    args:
+    - --fix
+- repo: https://github.com/psf/black
+  rev: 24.4.2
+  hooks:
+  - id: black
+    language_version: python3
+- repo: https://github.com/pycqa/flake8
+  rev: 7.1.0
+  hooks:
+  - id: flake8
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.3.0
+  hooks:
+  - id: pydocstyle
+- repo: local
+  hooks:
+  - id: confirm-reading
+    name: Confirm onboarding reading
+    entry: python scripts/confirm_reading.py
+    language: system
+    pass_filenames: false
+  - id: check-key-documents
+    name: Check key documents exist
+    entry: python scripts/check_key_documents.py
+    language: system
+    pass_filenames: false

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -8,3 +8,13 @@ The files listed here are foundational and must never be deleted or renamed.
 - [The Absolute Protocol](The_Absolute_Protocol.md)
 
 These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming.
+
+## Onboarding Confirmation
+
+After completing the [onboarding checklist](onboarding/README.md), create a `.reading_complete` file in the repository root:
+
+```bash
+touch .reading_complete
+```
+
+A pre-commit hook blocks commits until this marker exists.

--- a/scripts/confirm_reading.py
+++ b/scripts/confirm_reading.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Ensure the onboarding checklist has been completed."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKER = ROOT / ".reading_complete"
+
+
+def main() -> int:
+    """Exit non-zero if the reading completion marker is missing."""
+    if not MARKER.exists():
+        message = (
+            "Onboarding checklist not confirmed. "
+            "Create '.reading_complete' in the repo root "
+            "after completing the checklist."
+        )
+        print(message, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script that blocks commits until `.reading_complete` exists
- wire `confirm_reading` into pre-commit hooks
- document how to create the marker after finishing the onboarding checklist

## Testing
- `pre-commit run --files scripts/confirm_reading.py .pre-commit-config.yaml docs/KEY_DOCUMENTS.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0dac32040832eb5cdfbc70d5ec971