### PR TITLE
chore: add doc-indexer pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,9 @@ repos:
     entry: python scripts/check_key_documents.py
     language: system
     pass_filenames: false
+  - id: doc-indexer
+    name: Regenerate documentation index
+    entry: python tools/doc_indexer.py
+    language: system
+    pass_filenames: false
+    files: ^docs/

--- a/docs/documentation_protocol.md
+++ b/docs/documentation_protocol.md
@@ -5,9 +5,9 @@ Standard workflow for updating documentation and guides.
 1. **Check for applicable `AGENTS.md` instructions** to understand directory-specific conventions.
 2. **Update all related documents** whenever a component or guide changes to keep information synchronized.
 3. **Sync `docs/system_blueprint.md`** whenever components or documentation change to keep the architectural overview current.
-4. **Regenerate `docs/INDEX.md` with `python tools/doc_indexer.py` whenever Markdown files change.** The
-   indexer automatically skips `node_modules`, `dist`, and `build` directories to avoid indexing generated
-   artifacts.
+4. **Ensure `docs/INDEX.md` stays current.** The `doc-indexer` pre-commit hook regenerates the index
+   automatically when files in `docs/` change, skipping `node_modules`, `dist`, and `build`
+   directories to avoid indexing generated artifacts.
 5. **Validate changes with** `pre-commit run --files <changed_files>` **before committing.**
 6. **Use traceable commit messages** that capture the rationale for changes and reference affected documents.
 


### PR DESCRIPTION
## Summary
- add local `doc-indexer` pre-commit hook that regenerates `docs/INDEX.md` when documentation changes
- document the hook in `docs/documentation_protocol.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/documentation_protocol.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0ddb6c2b0832e80edea257f57c070