### PR TITLE
Chore: enforce blueprint sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ PY
             requirements.txt
             dev-requirements.txt
 
+      - name: Ensure blueprint synchronized
+        run: git diff --name-only origin/$GITHUB_BASE_REF...HEAD | xargs python scripts/ensure_blueprint_sync.py
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,7 @@ repos:
     language: system
     pass_filenames: false
     files: ^docs/
+  - id: ensure-blueprint-sync
+    name: Ensure blueprint updated with core changes
+    entry: python scripts/ensure_blueprint_sync.py
+    language: system

--- a/.reading_complete
+++ b/.reading_complete
@@ -1,0 +1,1 @@
+onboarding complete

--- a/docs/CONTRIBUTOR_HANDBOOK.md
+++ b/docs/CONTRIBUTOR_HANDBOOK.md
@@ -49,7 +49,8 @@ pytest
 1. Create or update tests in `tests/`.
 2. Implement the feature in `src/` or relevant modules.
 3. Update documentation in `docs/`.
-4. Run `pre-commit run --files <changed_files>` and `pytest`.
+4. If `src/` or top-level service files change, update `docs/system_blueprint.md`; a pre-commit hook enforces this.
+5. Run `pre-commit run --files <changed_files>` and `pytest`.
 
 ### Submitting a Pull Request
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -687,6 +687,10 @@ deployments with user accounts and persistent chats.
 - [Documentation Index](index.md) – curated entry points.
 - Regenerate [INDEX.md](INDEX.md) with `python tools/doc_indexer.py` for a full inventory; existing entries stay intact and new versions of generated files are appended.
 
+## Version History
+
+- 2025-08-28: Added blueprint synchronization check to ensure the blueprint is updated when core services change.
+
 ---
 
 Backlinks: [System Blueprint](system_blueprint.md) | [Component Index](component_index.md)

--- a/scripts/ensure_blueprint_sync.py
+++ b/scripts/ensure_blueprint_sync.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Verify blueprint doc updates accompany core code changes."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+BLUEPRINT = Path("docs/system_blueprint.md")
+
+
+def main(paths: list[str]) -> int:
+    """Return non-zero if blueprint was not updated alongside core changes."""
+    changed = [Path(p) for p in paths]
+    blueprint_touched = BLUEPRINT in changed
+
+    def is_service_file(path: Path) -> bool:
+        return path.suffix == ".py" and path.parent == Path(".")
+
+    relevant = [p for p in changed if str(p).startswith("src/") or is_service_file(p)]
+
+    if relevant and not blueprint_touched:
+        files = "\n".join(str(p) for p in relevant)
+        message = (
+            "docs/system_blueprint.md must be updated when core files change:\n" + files
+        )
+        print(message, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add ensure_blueprint_sync script to verify system blueprint updates when core code changes
- integrate blueprint check into pre-commit and CI workflow
- document blueprint sync requirement in contributor handbook and blueprint version history

## Testing
- `pre-commit run --files scripts/ensure_blueprint_sync.py .pre-commit-config.yaml .github/workflows/ci.yml docs/CONTRIBUTOR_HANDBOOK.md docs/system_blueprint.md .reading_complete`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68b0def8c74c832eaf4a0eee52081ef0