### PR TITLE
docs: add AGENTS and Absolute Protocol checks to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,8 @@ below.
 ## Checklist
 - [ ] Tests run <!-- Required: list tests run, e.g., `pytest` -->
 - [ ] Docs updated <!-- Required: describe updates or state 'N/A' -->
+- [ ] AGENTS.md instructions followed <!-- Required: confirm compliance with [AGENTS.md](../AGENTS.md) -->
+- [ ] Absolute Protocol consulted <!-- Required: confirm reference to [docs/The_Absolute_Protocol.md](../docs/The_Absolute_Protocol.md) -->
 - [ ] Index regenerated <!-- Required: confirm `python tools/doc_indexer.py` -->
 - [ ] Co-creation framework checked <!-- Required: confirm alignment with `docs/co_creation_framework.md` -->
 - [ ] AI ethics framework adhered <!-- Required: confirm principles in `docs/ai_ethics_framework.md` -->

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -408,3 +408,4 @@ Common mistakes and their resolutions:
    ```
 
    Open a pull request on GitHub. See [CONTRIBUTING.md](../CONTRIBUTING.md) for deeper guidelines.
+   Confirm that the PR template checkboxes for [AGENTS.md](../AGENTS.md) instructions and [The Absolute Protocol](The_Absolute_Protocol.md) are checked.

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -14,3 +14,8 @@ Follow this reading order before contributing:
    - [Spiral Cortex Terminal](../spiral_cortex_terminal.md)
 
 Confirm each item before starting code changes.
+
+When submitting a pull request, ensure you can check:
+
+- [ ] [AGENTS.md](../AGENTS.md) instructions followed
+- [ ] [The Absolute Protocol](../The_Absolute_Protocol.md) consulted

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -44,5 +44,5 @@ Using only the documents above you can reconstruct the project:
 With the architecture, workflow, and validation steps in hand, you can implement new features or adjust existing modules. Reference domain-specific guides in the `docs/` directory and follow the security practices outlined in [Security Model](security_model.md).
 
 ## 8. Share Knowledge
-Update documentation when adding features so others can replicate your work. The [Developer Manual](developer_manual.md) and [Contribution Guide](contribution_guide.md) describe expectations for pull requests and reviews.
+Update documentation when adding features so others can replicate your work. The [Developer Manual](developer_manual.md) and [Contribution Guide](contribution_guide.md) describe expectations for pull requests and reviews. Ensure the pull request template checkboxes for [AGENTS.md](../AGENTS.md) and [The Absolute Protocol](The_Absolute_Protocol.md) are completed.
 


### PR DESCRIPTION
## Summary
- require PR authors to confirm AGENTS.md instructions and Absolute Protocol
- mention new checklist items in onboarding docs

## Testing
- `pre-commit run --files .github/pull_request_template.md docs/onboarding/README.md docs/developer_onboarding.md docs/onboarding_guide.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0e03678f8832e969ce09a8d484d5e