### PR TITLE
docs: require onboarding summaries for key documents

### DIFF
--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -9,14 +9,20 @@ The files listed here are foundational and must never be deleted or renamed.
 
 These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming.
 
+Contributors must also record a brief summary of each protected document in `onboarding_confirm.yml`. Each summary should describe the document's **purpose**, **scope**, and **key rules**.
+
 ## Onboarding Confirmation
 
-After completing the [onboarding checklist](onboarding/README.md), create an `onboarding_confirm.yml` file in the repository root that records the hash of each required document:
+After completing the [onboarding checklist](onboarding/README.md), create an `onboarding_confirm.yml` file in the repository root that records the hash and summary of each required document:
 
 ```yaml
 documents:
-  docs/architecture_overview.md: <sha256>
-  docs/The_Absolute_Protocol.md: <sha256>
+  AGENTS.md:
+    sha256: <sha256>
+    summary: "Guidelines for repository operations and agent conduct."
+  docs/The_Absolute_Protocol.md:
+    sha256: <sha256>
+    summary: "Core contribution rules and governance."
 ```
 
 The `confirm-reading` pre-commit hook verifies this file and blocks commits if any listed document changes.


### PR DESCRIPTION
## Summary
- require contributors to add purpose/scope/rules summaries for protected docs in `onboarding_confirm.yml`
- update onboarding confirmation example with summary fields

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/KEY_DOCUMENTS.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0e4e95e70832e9e518bb1b9b655b6