### PR TITLE
docs: add vision section for RAZAR agent

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -183,7 +183,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [MISSION.md](MISSION.md) | Mission | - | - |
 | [PROJECT_STATUS.md](PROJECT_STATUS.md) | Project Status | This document summarizes the current state of the ABZU codebase. It serves as a living roadmap covering repository la... | - |
 | [QUALITY_EVALUATION.md](QUALITY_EVALUATION.md) | Quality Evaluation | - | - |
-| [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | The RAZAR agent bootstraps local services in a controlled environment.  It creates a Python virtual environment, inst... | - |
+| [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | - | - |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.3 **Last updated:** 2025-08-29 | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -1,8 +1,12 @@
 # RAZAR Agent
 
-The RAZAR agent bootstraps local services in a controlled environment.  It
-creates a Python virtual environment, installs any component dependencies and
-then launches each component in priority order.
+## Vision
+
+The RAZAR agent bootstraps local services in a controlled environment. It
+creates a Python virtual environment, installs component dependencies, and
+launches each service in priority order. By aligning this startup flow with the
+architecture outlined in the [System Blueprint](system_blueprint.md), RAZAR acts
+as the bootstrap agent that grounds ABZU in a coherent foundation.
 
 ## Prioritized pytest runner
 


### PR DESCRIPTION
## Summary
- document RAZAR's role as ABZU's bootstrap agent in a new Vision section
- link RAZAR to the System Blueprint
- regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/RAZAR_AGENT.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0e8879994832ea77adc3cab4c7aec