### PR TITLE
docs: expand razar component links

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -184,7 +184,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [MISSION.md](MISSION.md) | Mission | - | - |
 | [PROJECT_STATUS.md](PROJECT_STATUS.md) | Project Status | This document summarizes the current state of the ABZU codebase. It serves as a living roadmap covering repository la... | - |
 | [QUALITY_EVALUATION.md](QUALITY_EVALUATION.md) | Quality Evaluation | - | - |
-| [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | - | `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/cocreation_planner.py`, `../razar/environment_builder.py` |
+| [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | - | `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/cocreation_planner.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.3 **Last updated:** 2025-08-29 | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -39,7 +39,16 @@ The Mermaid source lives at [assets/razar_architecture.mmd](assets/razar_archite
 
 | Source Module | Related Docs |
 | --- | --- |
+| [razar/environment_builder.py](../razar/environment_builder.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [razar/boot_orchestrator.py](../razar/boot_orchestrator.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
 | [agents/razar/runtime_manager.py](../agents/razar/runtime_manager.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [agents/razar/health_checks.py](../agents/razar/health_checks.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [agents/razar/quarantine_manager.py](../agents/razar/quarantine_manager.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [agents/razar/doc_sync.py](../agents/razar/doc_sync.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [agents/razar/checkpoint_manager.py](../agents/razar/checkpoint_manager.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [agents/razar/crown_link.py](../agents/razar/crown_link.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [razar/adaptive_orchestrator.py](../razar/adaptive_orchestrator.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
+| [razar/cocreation_planner.py](../razar/cocreation_planner.py) | [Ignition](Ignition.md), [System Blueprint](system_blueprint.md) |
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- expand RAZAR Agent component table with links for boot sequence modules
- regenerate documentation index to reference new modules

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/RAZAR_AGENT.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b0f59aafb8832ea314798cfcb51ba8