### PR TITLE
feat: integrate AI handover for boot recovery

### DIFF
--- a/config/razar_config.yaml
+++ b/config/razar_config.yaml
@@ -1,4 +1,5 @@
 dependencies: []
+enable_ai_handover: false
 components:
   - name: memory_store
     priority: 1


### PR DESCRIPTION
## Summary
- call remote AI handover when components fail or are missing
- apply returned patches and retry launch when enabled
- add `enable_ai_handover` flag in config to toggle behavior

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py config/razar_config.yaml`
- `pytest tests/agents/razar/test_boot_sequence.py`

------
https://chatgpt.com/codex/tasks/task_e_68b10602c548832e93b42c14a56086e4