### PR TITLE
Add ai_agent config and document schema

### DIFF
--- a/config/razar_config.yaml
+++ b/config/razar_config.yaml
@@ -1,5 +1,10 @@
 dependencies: []
 enable_ai_handover: false
+ai_agent:
+  name: ""
+  endpoint: ""
+  auth_token: ""
+  models: []
 components:
   - name: memory_store
     priority: 1

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -181,6 +181,42 @@ ordered build plan saved to `logs/razar_cocreation_plans.json`.
 
 ## Code Considerations
 
+### `razar_config.yaml`
+
+**Schema**
+
+```yaml
+dependencies: []
+enable_ai_handover: false
+ai_agent:
+  name: string
+  endpoint: string
+  auth_token: string
+  models: [string, ...]  # optional fallback models
+components:
+  - name: string
+    priority: int
+    command: string
+```
+
+**Example**
+
+```yaml
+dependencies: []
+enable_ai_handover: false
+ai_agent:
+  name: demo
+  endpoint: http://localhost:3000
+  auth_token: token
+  models:
+    - gpt-4
+    - gpt-3.5
+components:
+  - name: memory_store
+    priority: 1
+    command: "echo 'starting memory_store'"
+```
+
 ### `boot_config.json`
 
 **Schema**


### PR DESCRIPTION
## Summary
- add `ai_agent` with optional fallback models to `razar_config.yaml`
- document `razar_config.yaml` schema including `ai_agent` block

## Testing
- `pre-commit run --files config/razar_config.yaml docs/RAZAR_AGENT.md`


------
https://chatgpt.com/codex/tasks/task_e_68b173f98624832e95d1bb1ad4e7a372