### PR TITLE
docs: add RAZAR remote flow mermaid diagram

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -35,6 +35,22 @@ Documentation Sync, Checkpoint Manager, Crown Link, Adaptive Orchestrator, and
 Co-creation Planner provide additional coordination around the core boot flow.
 The Mermaid source lives at [assets/razar_architecture.mmd](assets/razar_architecture.mmd).
 
+## Remote agent flow
+
+RAZAR can fetch and integrate remote agents at runtime. The flow below shows how the remote loader downloads a module, runs configuration and patch hooks, and records the interaction:
+
+```mermaid
+flowchart LR
+    start([Remote Loader]) --> fetch{Fetch Agent}
+    fetch -->|HTTP/Git| agent[Remote Agent]
+    agent --> config[configure()]
+    agent --> patch[patch()]
+    config --> log[(Audit Log)]
+    patch --> log
+```
+
+The Mermaid source lives at [assets/razar_remote_flow.mmd](assets/razar_remote_flow.mmd).
+
 ## Components & Links
 
 | Source Module | Related Docs |

--- a/docs/assets/razar_remote_flow.mmd
+++ b/docs/assets/razar_remote_flow.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    start([Remote Loader]) --> fetch{Fetch Agent}
+    fetch -->|HTTP/Git| agent[Remote Agent]
+    agent --> config[configure()]
+    agent --> patch[patch()]
+    config --> log[(Audit Log)]
+    patch --> log


### PR DESCRIPTION
## Summary
- add remote loader flow diagram in Mermaid format
- document remote agent flow in RAZAR Agent guide
- regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/RAZAR_AGENT.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b182677c40832eb19643e7c278757f