### PR TITLE
docs: extend onboarding summaries

### DIFF
--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -13,7 +13,7 @@ The files listed here are foundational and must never be deleted or renamed.
 
 These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming. When related components change, update the corresponding document in the same commit to keep information synchronized.
 
-Contributors must also record a brief summary of each protected document in `onboarding_confirm.yml`. Each summary should describe the document's **purpose**, **scope**, and **key rules**.
+Contributors must also record a brief summary of each protected document in `onboarding_confirm.yml`. Each summary should describe the document's **purpose**, **scope**, **key rules**, and include one **actionable insight**.
 
 ## Onboarding Confirmation
 
@@ -24,9 +24,11 @@ documents:
   AGENTS.md:
     sha256: <sha256>
     summary: "Guidelines for repository operations and agent conduct."
+    insight: "Always run pre-commit on changed files."
   docs/The_Absolute_Protocol.md:
     sha256: <sha256>
     summary: "Core contribution rules and governance."
+    insight: "Review checklist before opening a pull request."
 ```
 
 The `confirm-reading` pre-commit hook verifies this file and blocks commits if any listed document changes.

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -13,6 +13,7 @@ Before opening a pull request, confirm each item:
   - [AGENTS.md](../AGENTS.md)
   - [Documentation Protocol](documentation_protocol.md)
   - [System Blueprint](system_blueprint.md)
+- [ ] `onboarding_confirm.yml` includes purpose, scope, key rules, and one actionable insight for each [key document](KEY_DOCUMENTS.md)
 - [ ] Module `__version__` fields bumped for user-facing changes
 - [ ] Connectors implement `start_call`, `close_peers`, and expose `__version__`
 - [ ] If a connector is added or modified, update [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) with version and service details

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -2,7 +2,7 @@ documents:
   AGENTS.md: 08aab5d3dabd13cc0937d5e6574bbed143346c5340c13578224336c1ecdc2671
   docs/architecture_overview.md: 3e08f2cf4a214c19aead33191c08b32f8f4e8ddd57333b29fbe5e2596e9cdad2
   docs/project_overview.md: 4f4b07972085bc9341a56b1fb85f37da8354e726a73e10f03613fcc5f83b76b1
-  docs/The_Absolute_Protocol.md: 9aa283794b0bf1191edbbd20e1b6ab69af78def1c862b76e590238503df2a6d3
+  docs/The_Absolute_Protocol.md: 0dfb9b3353cd130a0e3c1ebe6477816e58f8f3e909c837c762aa1212fbf80969
   docs/vector_memory.md: 8aff26e4a32740fc3599e3cae555f8b7700a61c6734adb87fbcaaaba69349a34
   docs/rag_pipeline.md: 24d2154f4a2db1aceba6aaf05c03bc6c34119ba58b82159345f5d2c0eb36e0dc
   docs/rag_music_oracle.md: b506c9213c26af25dc0e295b11215dd19d6a1100cfb7902e64be47120784c7d6
@@ -10,3 +10,4 @@ documents:
   docs/persona_api_guide.md: 767d276cddcb865a844c3e730aa2affc9d57ab6ebb52f3c4c05040288c94121f
   docs/spiral_cortex_terminal.md: 863463fb3e7b92021d747b5f4bdc4cb20e608469d64ed69917bf8be7b8177724
   docs/connectors/CONNECTOR_INDEX.md: 7351cc9cf5ceca2ba1ac59c40121ce74f7070fc936f31b49b86abd151596e9fa
+  docs/KEY_DOCUMENTS.md: 4518abae68ad5399c74ac558d6cfd911ca886e19c2f2a6dace58f23f7adc59cd


### PR DESCRIPTION
## Summary
- require actionable insight in onboarding summaries for key documents
- reference onboarding summary requirement in Contributor Awareness Checklist
- update onboarding confirmation hashes

## Testing
- `pre-commit run --files docs/KEY_DOCUMENTS.md docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`
- `python tools/doc_indexer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b197cec420832ea8427440b5c9ec0c