### PR TITLE
feat: version connectors and update docs

### DIFF
--- a/communication/telegram_bot.py
+++ b/communication/telegram_bot.py
@@ -1,6 +1,8 @@
+"""Telegram bot forwarding messages to the avatar."""
+
 from __future__ import annotations
 
-"""Telegram bot forwarding messages to the avatar."""
+__version__ = "0.1.0"
 
 import logging
 
@@ -16,6 +18,7 @@ class TelegramBot:
     """Telegram bot that routes messages through ``Gateway``."""
 
     def __init__(self, token: str, gateway: Gateway) -> None:
+        """Initialise bot with Telegram token and gateway."""
         self._gateway = gateway
         self._application = Application.builder().token(token).build()
         self._application.add_handler(

--- a/connectors/webrtc_connector.py
+++ b/connectors/webrtc_connector.py
@@ -1,6 +1,8 @@
+"""WebRTC connector for streaming audio files to the browser."""
+
 from __future__ import annotations
 
-"""WebRTC connector for streaming audio files to the browser."""
+__version__ = "0.1.0"
 
 import asyncio
 import logging

--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -5,6 +5,9 @@ various communication channels. The current implementation exposes WebRTC and
 Telegram interfaces, with additional channels pluggable through the gateway
 layer.
 
+Each connector includes a ``__version__`` field for traceability and is tracked
+in the [Connector Index](connectors/CONNECTOR_INDEX.md).
+
 ## Signaling Flow
 
 1. **Client connects** – A client creates a WebRTC offer and sends it to the
@@ -36,6 +39,8 @@ Gateway integrations should verify credentials before forwarding messages.
    or API keys.
 4. Register the adapter in the deployment configuration so that it starts with
    the avatar.
+5. Expose a ``__version__`` field and update the connector registry with the
+   new version number.
 
 Following this pattern keeps message handling consistent while allowing the
 system to expand with minimal changes.

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -4,6 +4,6 @@ For shared patterns across connectors see the [Connector Overview](README.md).
 
 | Name | Version | Endpoint | Auth Method | Status | Links |
 | --- | --- | --- | --- | --- | --- |
-| WebRTC Connector | N/A | `POST /call` | JWT | Experimental | [Docs](../communication_interfaces.md) / [Code](../../connectors/webrtc_connector.py) |
-| Telegram Bot | N/A | Telegram API (polling) | Bot token | Experimental | [Docs](../communication_interfaces.md) / [Code](../../communication/telegram_bot.py) |
+| WebRTC Connector | 0.1.0 | `POST /call` | JWT | Experimental | [Docs](../communication_interfaces.md) / [Code](../../connectors/webrtc_connector.py) |
+| Telegram Bot | 0.1.0 | Telegram API (polling) | Bot token | Experimental | [Docs](../communication_interfaces.md) / [Code](../../communication/telegram_bot.py) |
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -9,5 +9,5 @@ documents:
   docs/vision_system.md: 52d91902d457f14cf4dc46b088a8e2177cd10e3eaa0398ee071d4f1532e74547
   docs/persona_api_guide.md: 767d276cddcb865a844c3e730aa2affc9d57ab6ebb52f3c4c05040288c94121f
   docs/spiral_cortex_terminal.md: 863463fb3e7b92021d747b5f4bdc4cb20e608469d64ed69917bf8be7b8177724
-  docs/connectors/CONNECTOR_INDEX.md: 088cce9a28d61afe143978b57d6ff6bab0f103f8bb79ed23ce0677feaf35eaa6
+  docs/connectors/CONNECTOR_INDEX.md: fddd796ff8b27d827071191b1cd4b317f605c4cafa828a332f988045a2f1e61c
   docs/KEY_DOCUMENTS.md: 4518abae68ad5399c74ac558d6cfd911ca886e19c2f2a6dace58f23f7adc59cd


### PR DESCRIPTION
## Summary
- add `__version__` constants to WebRTC and Telegram connectors
- document connector versions and mention versioning in communication interfaces
- update onboarding confirmation hash

## Testing
- `pre-commit run --files connectors/webrtc_connector.py communication/telegram_bot.py docs/connectors/CONNECTOR_INDEX.md docs/communication_interfaces.md onboarding_confirm.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b1af53ebdc832e8574833169b6c7ce