### PR TITLE
Add onboarding doc hash verification hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
     entry: python scripts/check_key_documents.py
     language: system
     pass_filenames: false
+  - id: verify-doc-summaries
+    name: Verify onboarding doc hashes current
+    entry: python scripts/verify_doc_summaries.py
+    language: system
+    pass_filenames: false
   - id: doc-indexer
     name: Regenerate documentation index
     entry: python tools/doc_indexer.py

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -187,7 +187,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | - | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/cocreation_planner.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.19 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.20 **Last updated:** 2025-08-29 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -32,3 +32,6 @@ documents:
 ```
 
 The `confirm-reading` pre-commit hook verifies this file and blocks commits if any listed document changes.
+The companion `verify-doc-summaries` hook recomputes hashes for all entries and
+fails if `onboarding_confirm.yml` is out of date, ensuring stored summaries stay
+aligned with their documents.

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.19
-**Last updated:** 2025-08-30
+**Version:** v1.0.20
+**Last updated:** 2025-08-29
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards.
@@ -14,6 +14,7 @@ Before opening a pull request, confirm each item:
   - [Documentation Protocol](documentation_protocol.md)
   - [System Blueprint](system_blueprint.md)
 - [ ] `onboarding_confirm.yml` includes purpose, scope, key rules, and one actionable insight for each [key document](KEY_DOCUMENTS.md)
+- [ ] `scripts/verify_doc_summaries.py` confirms `onboarding_confirm.yml` hashes match current files
 - [ ] Module `__version__` fields bumped for user-facing changes
 - [ ] Connectors implement `start_call`, `close_peers`, and expose `__version__`
 - [ ] If a connector is added or modified, update [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) with version and service details

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -2,7 +2,6 @@ documents:
   AGENTS.md: 08aab5d3dabd13cc0937d5e6574bbed143346c5340c13578224336c1ecdc2671
   docs/architecture_overview.md: 3e08f2cf4a214c19aead33191c08b32f8f4e8ddd57333b29fbe5e2596e9cdad2
   docs/project_overview.md: 4f4b07972085bc9341a56b1fb85f37da8354e726a73e10f03613fcc5f83b76b1
-  docs/The_Absolute_Protocol.md: 8261cb8a8440bf1151699a37a0a194a8f75664250efaffbfff41a4bbbad388ae
   docs/vector_memory.md: 8aff26e4a32740fc3599e3cae555f8b7700a61c6734adb87fbcaaaba69349a34
   docs/rag_pipeline.md: 24d2154f4a2db1aceba6aaf05c03bc6c34119ba58b82159345f5d2c0eb36e0dc
   docs/rag_music_oracle.md: b506c9213c26af25dc0e295b11215dd19d6a1100cfb7902e64be47120784c7d6
@@ -12,4 +11,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: 592ce01e0b6771fa88d1609684ced058a3118b77b86cc436de0a62eebda9d5b9
   docs/system_blueprint.md: b5a8e64eef9944268fa64099d4720e2ca34d610f206fb3de413ac1cdbae00c3d
-  docs/KEY_DOCUMENTS.md: 4518abae68ad5399c74ac558d6cfd911ca886e19c2f2a6dace58f23f7adc59cd
+  docs/The_Absolute_Protocol.md: fae663f4febec67f0512f9698ac42886b016d64d08777bd6641342da2c853894
+  docs/KEY_DOCUMENTS.md: 6241317602807983e7fc8808eb1ada7f54b976dd0c9e58164d963b1797e50cc6

--- a/scripts/verify_doc_summaries.py
+++ b/scripts/verify_doc_summaries.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Check onboarding doc summaries stay in sync with file hashes."""
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIRM = ROOT / "onboarding_confirm.yml"
+
+
+def sha256(path: Path) -> str:
+    """Return the SHA256 hash of a file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    """Exit non-zero if any document hash is outdated or missing."""
+    if not CONFIRM.exists():
+        print(
+            "onboarding_confirm.yml missing. "
+            "Run scripts/confirm_reading.py after reviewing key documents.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        data = yaml.safe_load(CONFIRM.read_text()) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
+        print(f"Failed to parse {CONFIRM}: {exc}", file=sys.stderr)
+        return 1
+
+    docs: dict[str, str] = data.get("documents", {})
+    if not docs:
+        print("onboarding_confirm.yml has no document entries", file=sys.stderr)
+        return 1
+
+    missing_files: list[str] = []
+    mismatched: list[str] = []
+    for rel_path, expected in docs.items():
+        path = ROOT / rel_path
+        if not path.exists():
+            missing_files.append(rel_path)
+            continue
+        if sha256(path) != expected:
+            mismatched.append(rel_path)
+
+    if missing_files or mismatched:
+        for p in missing_files:
+            print(f"Missing document: {p}", file=sys.stderr)
+        for p in mismatched:
+            print(f"Hash mismatch: {p}", file=sys.stderr)
+        print(
+            "Update onboarding_confirm.yml after re-reading changed files.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify_doc_summaries.py` hook to ensure `onboarding_confirm.yml` hashes match key documents
- document the new verification process in KEY_DOCUMENTS and The Absolute Protocol
- update onboarding hashes and index

## Testing
- `pre-commit run --files scripts/verify_doc_summaries.py .pre-commit-config.yaml docs/KEY_DOCUMENTS.md docs/The_Absolute_Protocol.md onboarding_confirm.yml docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b1c148b86c832ea8cdbf55024faf99