### PR TITLE
docs: expand crown deployment overview

### DIFF
--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -63,3 +63,16 @@ descriptions.
 ## Mission Brief Handshake
 
 Before diagnostics begin, RAZAR shares a short mission brief with the Crown stack. The brief summarises the priority map, current status and any open issues and is sent via the WebSocket helper `razar/crown_handshake.py`. Crown replies with an acknowledgment and a capability list so RAZAR knows which tools are available for the session. Each exchange is recorded to `logs/razar_crown_dialogues.json` for later review.
+
+## Deployment
+
+1. Configure the environment with [`init_crown_agent.py`](../init_crown_agent.py). This script prepares memory directories, registers servant models, and validates the GLM endpoint.
+2. Exchange a mission brief using [`razar/crown_handshake.py`](../razar/crown_handshake.py) so RAZAR and the Crown stack agree on available capabilities before entering the boot cycle.
+3. Launch the console to begin a session after the handshake completes.
+
+## Version History
+
+| Version | Date       | Summary |
+|---------|------------|---------|
+| 0.2.0   | 2025-09-30 | Added deployment guidance and initial version table. |
+| 0.1.0   | 2025-08-28 | Initial document outlining Crown agent architecture. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -170,7 +170,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |
 | [CORPUS_MEMORY.md](CORPUS_MEMORY.md) | Corpus Memory | This repository preserves several collections of source texts used by the music and language tools. Each directory se... | - |
-| [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md) | Crown Agent Overview | The diagram below shows how the main components interact when using the console. | - |
+| [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md) | Crown Agent Overview | The diagram below shows how the main components interact when using the console. | `../init_crown_agent.py`, `../razar/crown_handshake.py` |
 | [CRYSTAL_CODEX.md](CRYSTAL_CODEX.md) | CRYSTAL CODEX | The codex gathers the mission, architecture diagrams, module index, dependency matrix, testing strategy and style pol... | `../archetype_feedback_loop.py`, `../auto_retrain.py`, `../insight_compiler.py`, `../learning_mutator.py`, `../music_generation.py`, `../server.py`, `../spiral_memory.py`, `../tools/preflight.py`, `../vector_memory.py`, `../video_stream.py` |
 | [DASHBOARD.md](DASHBOARD.md) | Metrics Dashboard | This dashboard visualises recent model performance and the predicted best LLM. | - |
 | [ETHICS_POLICY.md](ETHICS_POLICY.md) | Ethics Policy | This document outlines the minimum rules for handling data while working with Spiral OS. | - |


### PR DESCRIPTION
## Summary
- document how to deploy and handshake the Crown agent
- add version history for Crown overview
- refresh documentation index

## Testing
- `pre-commit run --files docs/CROWN_OVERVIEW.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca0e2f48832ea8b8188cfde47c09