### PR TITLE
Document INANNA core startup

### DIFF
--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -40,3 +40,35 @@ servant_models:
 
 Environment variables with the same names as listed above override the
 corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
+
+## Setup Steps
+
+1. **Create memory directories**
+
+   ```bash
+   mkdir -p data/vector_memory/{vector_memory,chroma}
+   ```
+
+   This prepares the persistent stores used by `vector_memory.py` and
+   `corpus_memory.py`.
+
+2. **Launch servant model endpoints**
+
+   Define the endpoints via `SERVANT_MODELS` and run the launcher:
+
+   ```bash
+   export SERVANT_MODELS="deepseek=http://localhost:8002,mistral=http://localhost:8003"
+   ./launch_servants.sh
+   ```
+
+   Each endpoint must expose a `/health` route and accept a JSON body
+   `{"prompt": "..."}`.
+
+3. **Start INANNA core**
+
+   The minimal startup script combines the above steps and verifies the
+   configuration:
+
+   ```bash
+   scripts/start_inanna_core.sh
+   ```

--- a/scripts/start_inanna_core.sh
+++ b/scripts/start_inanna_core.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Minimal startup for INANNA core
+set -euo pipefail
+
+MEM_DIR=${MEMORY_DIR:-data/vector_memory}
+# Create required memory directories
+mkdir -p "$MEM_DIR"/{vector_memory,chroma}
+
+# Launch servant model endpoints
+export SERVANT_MODELS=${SERVANT_MODELS:-"deepseek=http://localhost:8002,mistral=http://localhost:8003"}
+"$(dirname "$0")"/../launch_servants.sh
+
+# Initialize INANNA core to verify configuration
+python - <<'PY'
+from init_crown_agent import initialize_crown
+initialize_crown()
+print("INANNA core initialized")
+PY


### PR DESCRIPTION
## Summary
- document how to create memory directories and launch servant model endpoints for INANNA core
- add a minimal startup script that prepares storage, launches servant models, and initializes the core

## Testing
- `pre-commit run --files docs/INANNA_CORE.md scripts/start_inanna_core.sh docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b1ccc1d3ac832e90c50b359e16bf17