### PR TITLE
docs: add Albedo state machine diagram

### DIFF
--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -38,7 +38,20 @@ export GLM_API_URL=https://glm.example.com/glm41v_9b
 python -m INANNA_AI.main --duration 3 --personality albedo
 ```
 
-Each invocation cycles through Nigredo, Albedo, Rubedo and Citrinitas states before returning to Nigredo for a continuous loop. You can also use the layer programmatically:
+Each invocation cycles through Nigredo, Albedo, Rubedo and Citrinitas states before returning to Nigredo for a continuous loop.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Nigredo
+    Nigredo --> Albedo
+    Albedo --> Rubedo
+    Rubedo --> Citrinitas
+    Citrinitas --> Nigredo
+```
+
+The Mermaid source lives at [assets/albedo_state_machine.mmd](assets/albedo_state_machine.mmd).
+
+You can also use the layer programmatically:
 
 ```python
 from orchestrator import MoGEOrchestrator
@@ -157,4 +170,10 @@ Typical output is:
 ```
 Citrinitas speaks in golden clarity: proceed
 ```
+
+## Version History
+
+| Version | Date       | Summary |
+|---------|------------|---------|
+| 0.1.0   | 2025-08-29 | Added state machine diagram and initial version table. |
 

--- a/docs/assets/albedo_state_machine.mmd
+++ b/docs/assets/albedo_state_machine.mmd
@@ -1,0 +1,6 @@
+stateDiagram-v2
+    [*] --> Nigredo
+    Nigredo --> Albedo
+    Albedo --> Rubedo
+    Rubedo --> Citrinitas
+    Citrinitas --> Nigredo


### PR DESCRIPTION
## Summary
- embed Albedo layer state machine diagram and link to Mermaid source
- add version history table for Albedo layer
- regenerate documentation index

## Testing
- `pre-commit run --files docs/assets/albedo_state_machine.mmd docs/ALBEDO_LAYER.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce0ab514832eb8d9bef9e32a3fed