### PR TITLE
docs: expand memory architecture examples

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -253,7 +253,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [installation.md](installation.md) | Installation | Set up the project either with Conda or Docker. Both methods run the bootstrap script, which verifies the Python vers... | - |
 | [learning_pipeline.md](learning_pipeline.md) | Learning Pipeline | The learning pipeline pairs two utilities: | - |
 | [logging_guidelines.md](logging_guidelines.md) | RAZAR Logging Guidelines | The mission logger records component activity in `logs/razar.log` using one JSON object per line. Each entry contains: | - |
-| [memory_architecture.md](memory_architecture.md) | Memory Architecture | The system layers multiple specialised stores, each recording a different facet of experience: | - |
+| [memory_architecture.md](memory_architecture.md) | Memory Architecture | The system layers multiple specialised stores, each recording a different facet of experience. Each section below sho... | - |
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Memory Layer | The `memory.cortex` module stores spiral decisions and maintains an index for fast retrieval. Each entry is appended... | - |

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -1,7 +1,8 @@
 # Memory Architecture
 
 The system layers multiple specialised stores, each recording a different facet
-of experience:
+of experience. Each section below shows how to initialise the store and run a
+basic query:
 
 - **Cortex** – persistent application state with semantic tags.
 - **Emotional** – affective snapshots mirroring the agent's mood.
@@ -17,15 +18,60 @@ and writer locks guard the log and index so multiple threads can record and
 query safely. Helper utilities allow concurrent queries and pruning of old
 entries.
 
+**Initialisation**
+
+```python
+from memory.cortex import record_spiral, query_spirals
+# Files are created on first use; no explicit setup is required.
+```
+
+**Example query**
+
+```python
+class Node:
+    children = []
+
+record_spiral(Node(), {"result": "demo", "tags": ["example"]})
+query_spirals(tags=["example"])
+```
+
 ### Emotional store
 
 `memory/emotional.py` captures emotional reactions and valence values. Entries
 can be queried to modulate tone or influence downstream reasoning.
 
+**Initialisation**
+
+```python
+from memory.emotional import get_connection, log_emotion, fetch_emotion_history
+conn = get_connection()
+```
+
+**Example query**
+
+```python
+log_emotion([0.1, 0.2], conn=conn)
+fetch_emotion_history(window=60, conn=conn)
+```
+
 ### Mental store
 
 `memory/mental.py` keeps temporary working memory for in‑progress reasoning and
 planning. Items decay quickly to keep the space focused on current tasks.
+
+**Initialisation**
+
+```python
+from memory.mental import init_rl_model, record_task_flow, query_related_tasks
+init_rl_model()
+```
+
+**Example query**
+
+```python
+record_task_flow("taskA", {"step": 1})
+query_related_tasks("taskA")
+```
 
 ### Spiritual store
 
@@ -33,8 +79,35 @@ planning. Items decay quickly to keep the space focused on current tasks.
 beyond immediate computation. These records provide long‑range guidance during
 ceremonial flows.
 
+**Initialisation**
+
+```python
+from memory.spiritual import get_connection, map_to_symbol, lookup_symbol_history
+conn = get_connection()
+```
+
+**Example query**
+
+```python
+map_to_symbol(("eclipse", "☾"), conn=conn)
+lookup_symbol_history("☾", conn=conn)
+```
+
 ### Narrative store
 
 `memory/narrative_engine.py` outlines interfaces for recording story events.
 Each event binds an actor, an action and optional symbolism so later modules can
 weave a coherent narrative thread across memories.
+
+**Initialisation**
+
+```python
+from memory.narrative_engine import log_story, stream_stories
+```
+
+**Example query**
+
+```python
+log_story("hero meets guide")
+list(stream_stories())
+```


### PR DESCRIPTION
## Summary
- expand memory architecture overview with init and query snippets for each store
- regenerate documentation index

## Testing
- `pre-commit run --files docs/memory_architecture.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b1d3513690832e8c1149fe9c269ccb