### PR TITLE
docs: expand Nazarick narrative system

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -187,7 +187,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | - | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/cocreation_planner.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.20 **Last updated:** 2025-08-29 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.21 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.20
-**Last updated:** 2025-08-29
+**Version:** v1.0.21
+**Last updated:** 2025-08-30
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards.
@@ -21,6 +21,7 @@ Before opening a pull request, confirm each item:
 - [ ] `docs/INDEX.md` regenerated if docs changed
 - [ ] New operator channels documented in [Operator Protocol](operator_protocol.md)
 - [ ] Confirm no binary files are introduced
+- [ ] Diagrams include explanatory text and a Mermaid code block; binary images are forbidden
 - [ ] Handshake-triggered model launches documented in agent guides and state logs
 
 ## Protocol Hierarchy
@@ -75,6 +76,10 @@ similar to the RAZAR component links to summarize relationships:
 | Source Module | Companion Docs |
 | --- | --- |
 | [agents/example_agent.py](../agents/example_agent.py) | [example_agent.md](example_agent.md), [system_blueprint.md](system_blueprint.md) |
+
+### Diagram Requirements
+
+All diagrams must include a brief textual description and an accompanying Mermaid code block. Binary image formats (PNG, JPG, etc.) must not be committed.
 
 ### Configuration File Documentation
 

--- a/docs/nazarick_narrative_system.md
+++ b/docs/nazarick_narrative_system.md
@@ -1,5 +1,29 @@
 # Nazarick Narrative System
 
+## Requirements
+
+Core dependencies:
+
+- `pydantic`
+- `sqlite3`
+
+Optional tools:
+
+- `mermaid` — for rendering text-based diagrams
+
+## Architecture
+
+The narrative system links agents to shared memory components. Agents emit events that the narrative scribe records and
+forwards to the persona registry, which updates traits and feeds guidance back to agents. The flow below is expressed using
+Mermaid and avoids binary assets.
+
+```mermaid
+flowchart LR
+    Agents -->|emit events| Scribe[Narrative Scribe]
+    Scribe --> Registry[Persona Registry]
+    Registry -->|guidance| Agents
+```
+
 ## Narrative Scribe
 The narrative scribe records events that occur within Nazarick. It collects structured notes from the agents, preserves context, and threads new entries into the ongoing chronicle so future servants can reference past actions.
 
@@ -11,5 +35,16 @@ The persona registry catalogs known personas and their traits. When a new person
 2. The narrative scribe captures the event and links it to the relevant persona entry.
 3. The persona registry updates stored traits and returns guidance to agents.
 4. Downstream systems consume the enriched narrative for memory, analysis, or storytelling.
+
+Example event entry:
+
+```json
+{
+  "agent": "albedo",
+  "action": "greeting",
+  "timestamp": "2025-01-01T12:00:00Z",
+  "context": {"location": "throne_room"}
+}
+```
 
 The narrative scribe and persona registry operate together to maintain a coherent history of activities across Nazarick.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -11,5 +11,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: 592ce01e0b6771fa88d1609684ced058a3118b77b86cc436de0a62eebda9d5b9
   docs/system_blueprint.md: b5a8e64eef9944268fa64099d4720e2ca34d610f206fb3de413ac1cdbae00c3d
-  docs/The_Absolute_Protocol.md: fae663f4febec67f0512f9698ac42886b016d64d08777bd6641342da2c853894
+  docs/The_Absolute_Protocol.md: 2667038835a38c5cfac228bd2b012fa13dc95a5796085a2b2215a71631714385
   docs/KEY_DOCUMENTS.md: 6241317602807983e7fc8808eb1ada7f54b976dd0c9e58164d963b1797e50cc6


### PR DESCRIPTION
## Summary
- replace PNG architecture diagram with text and Mermaid in Nazarick narrative system guide
- extend The Absolute Protocol to forbid binary images and mandate Mermaid diagrams
- refresh onboarding hash and regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/nazarick_narrative_system.md docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8ec4a64832eb667a4482ef784b1