### PR TITLE
Expand subsystem overview documentation

### DIFF
--- a/docs/ABZU_SUBSYSTEM_OVERVIEW.md
+++ b/docs/ABZU_SUBSYSTEM_OVERVIEW.md
@@ -1,0 +1,35 @@
+# ABZU Subsystem Overview
+
+The diagram below outlines how the primary subsystems collaborate within ABZU.
+
+```mermaid
+graph TD
+    UI[User Interface] --> Persona[Persona API]
+    Persona --> Crown[Crown Router]
+    Crown --> RAG[RAG Orchestrator]
+    RAG --> Memory[Vector Memory]
+    RAG --> Data[External Data Sources]
+    Crown --> Insight[Insight Engine]
+    Insight --> Persona
+```
+
+**User Interface → Persona API**
+: User intents enter through the interface and are normalized by the Persona API.
+
+**Persona API → Crown Router**
+: The Persona API forwards structured requests to the Crown Router, which coordinates system-level actions.
+
+**Crown Router → RAG Orchestrator**
+: When knowledge retrieval is required, the Crown Router invokes the RAG Orchestrator to gather context.
+
+**RAG Orchestrator → Vector Memory**
+: The RAG layer queries Vector Memory for stored embeddings relevant to the request.
+
+**RAG Orchestrator → External Data Sources**
+: If additional information is needed, the RAG layer reaches out to external connectors.
+
+**Crown Router → Insight Engine**
+: For higher-order reasoning over the collected context, the Crown Router engages the Insight Engine.
+
+**Insight Engine → Persona API**
+: Synthesized insights flow back through the Persona API before returning to the user.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -166,6 +166,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../SEVEN_DIMENSIONAL_MUSIC.md](../SEVEN_DIMENSIONAL_MUSIC.md) | 7‑Dimensional Music System | This system layers sound so different beings perceive a single track in unique ways. A core melody becomes the human... | - |
 | [../benchmarks/README.md](../benchmarks/README.md) | Benchmarks | Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`. | - |
 | [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
+| [ABZU_SUBSYSTEM_OVERVIEW.md](ABZU_SUBSYSTEM_OVERVIEW.md) | ABZU Subsystem Overview | The diagram below outlines how the primary subsystems collaborate within ABZU. | - |
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | The **Albedo** layer introduces a stateful persona that drives responses through a remote GLM (Generative Language Mo... | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -1,5 +1,6 @@
 documents:
   AGENTS.md: 08aab5d3dabd13cc0937d5e6574bbed143346c5340c13578224336c1ecdc2671
+  docs/ABZU_SUBSYSTEM_OVERVIEW.md: e0bed0b9450322638c9fd24d6573202d8f2ad98d3d7eb7b047e38d914c645252
   docs/architecture_overview.md: 3e08f2cf4a214c19aead33191c08b32f8f4e8ddd57333b29fbe5e2596e9cdad2
   docs/project_overview.md: 4f4b07972085bc9341a56b1fb85f37da8354e726a73e10f03613fcc5f83b76b1
   docs/vector_memory.md: 8aff26e4a32740fc3599e3cae555f8b7700a61c6734adb87fbcaaaba69349a34


### PR DESCRIPTION
## Summary
- replace static subsystem image with mermaid diagram and detailed relationship descriptions
- regenerate documentation index
- record new subsystem overview hash in onboarding confirmations

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/ABZU_SUBSYSTEM_OVERVIEW.md docs/INDEX.md onboarding_confirm.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b1f97d657c832eb8fd4aa52cc3df4c