### PR TITLE
docs: clarify Mermaid diagram workflow

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -84,6 +84,13 @@ similar to the RAZAR component links to summarize relationships:
 
 All diagrams must include a brief textual description and an accompanying Mermaid code block. Binary image formats (PNG, JPG, etc.) must not be committed.
 
+#### Mermaid Diagram Workflow
+
+- Write narrative explanation first.
+- Represent visuals with Mermaid code blocks.
+- Run `pre-commit run --files <changed_docs>` to trigger the `block-binaries` hook.
+- Convert existing binary diagrams to Mermaid before committing.
+
 ### Configuration File Documentation
 
 Any new configuration file must be accompanied by documentation that outlines its schema and includes a minimal working example. Review existing patterns such as [boot_config.json](RAZAR_AGENT.md#boot_configjson), [razar_env.yaml](RAZAR_AGENT.md#razar_envyaml), and the log formats in the [logging guidelines](logging_guidelines.md).

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -12,5 +12,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: a34817f1b28d9a84b35765c116057f5b636e4fc2f875716d381cb945fcdc9f07
   docs/system_blueprint.md: b5a8e64eef9944268fa64099d4720e2ca34d610f206fb3de413ac1cdbae00c3d
-  docs/The_Absolute_Protocol.md: 0ab722d6e42d8e9cb37fb6b610207c4f2f2a03442ebb941a92530bf03d61f904
+  docs/The_Absolute_Protocol.md: d93794d2adb45485ec65bbc46b2ed60971a835ea0995cdfcf24b242e67dd65a2
   docs/KEY_DOCUMENTS.md: 6241317602807983e7fc8808eb1ada7f54b976dd0c9e58164d963b1797e50cc6


### PR DESCRIPTION
## Summary
- clarify Mermaid diagram workflow in The Absolute Protocol
- update onboarding hash for The Absolute Protocol

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_summaries.py`
- `python -m pre_commit run --files docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`

## Change justification
I added a Mermaid diagram workflow subsection to The Absolute Protocol to clarify required diagram steps, expecting contributors to convert binaries and trigger block-binary checks.

------
https://chatgpt.com/codex/tasks/task_e_68b1fb68a44c832e9d1261f05872acec