### PR TITLE
docs: add ABZU deployment guide

### DIFF
--- a/docs/ABZU_DEPLOYMENT.md
+++ b/docs/ABZU_DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# ABZU Deployment
+
+This guide outlines the environment preparation, boot order, and rollback steps for deploying ABZU.
+
+## Environment setup
+
+1. Install pinned dependencies using the steps in [environment_setup.md](environment_setup.md).
+2. Copy `secrets.env.template` to `secrets.env` and fill in required credentials.
+3. Build the Docker image or set up a virtual environment before launching any agents.
+
+## Component launch sequence
+
+1. **RAZAR Agent** – construct the runtime and validate prerequisites. See the [RAZAR Agent deployment](RAZAR_AGENT.md#deployment) section.
+2. **CROWN stack** – start core orchestration services as described in the [CROWN deployment guide](CROWN_OVERVIEW.md#deployment).
+3. **Albedo layer** – enable persona behavior after CROWN is online. Review the [Albedo conversation loop](ALBEDO_LAYER.md#conversation-loop) for startup details.
+4. **Nazarick agents** – once RAZAR hands off control, activate servant agents as needed. Refer to [nazarick_agents.md](nazarick_agents.md) for component roles and launch notes.
+
+## Rollback strategy
+
+- Use the [Recovery Playbook](recovery_playbook.md) for component level failures; RAZAR's quarantine utilities can isolate unhealthy services.
+- Revert Docker images or Git tags when deployments introduce regressions.
+- After rollback, rerun the launch sequence to restore the stack.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -166,6 +166,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../SEVEN_DIMENSIONAL_MUSIC.md](../SEVEN_DIMENSIONAL_MUSIC.md) | 7‑Dimensional Music System | This system layers sound so different beings perceive a single track in unique ways. A core melody becomes the human... | - |
 | [../benchmarks/README.md](../benchmarks/README.md) | Benchmarks | Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`. | - |
 | [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
+| [ABZU_DEPLOYMENT.md](ABZU_DEPLOYMENT.md) | ABZU Deployment | This guide outlines the environment preparation, boot order, and rollback steps for deploying ABZU. | - |
 | [ABZU_SUBSYSTEM_OVERVIEW.md](ABZU_SUBSYSTEM_OVERVIEW.md) | ABZU Subsystem Overview | The diagram below outlines how the primary subsystems collaborate within ABZU. | - |
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | The **Albedo** layer introduces a stateful persona that drives responses through a remote GLM (Generative Language Mo... | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -66,7 +66,7 @@ Each agent document must cover:
 - Functional Workflows
 - Architecture diagram
 - Requirements
-- Deployment workflow
+- Deployment workflow with environment setup, launch sequence, rollback strategy, and cross-links to subsystem-specific deployment sections (e.g., RAZAR Agent, Albedo Layer, Nazarick agents)
 - Configuration schemas
 - Version history
 - Cross-links

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -13,5 +13,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: a34817f1b28d9a84b35765c116057f5b636e4fc2f875716d381cb945fcdc9f07
   docs/system_blueprint.md: b5a8e64eef9944268fa64099d4720e2ca34d610f206fb3de413ac1cdbae00c3d
-  docs/The_Absolute_Protocol.md: d93794d2adb45485ec65bbc46b2ed60971a835ea0995cdfcf24b242e67dd65a2
+  docs/The_Absolute_Protocol.md: 0d08748949d09523d8825d52610b75db956a3133cec4594fdabed2eb9a01c725
   docs/KEY_DOCUMENTS.md: 6241317602807983e7fc8808eb1ada7f54b976dd0c9e58164d963b1797e50cc6


### PR DESCRIPTION
## Summary
- document ABZU environment setup, launch order, and rollback strategy
- add cross-links to RAZAR, CROWN, Albedo, and Nazarick deployment docs
- clarify documentation standards for deployment details and cross-linking

## Testing
- `pre-commit run --files docs/ABZU_DEPLOYMENT.md docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b1fe0996c0832e964236984c3ff34a