### PR TITLE
docs: detail albedo state transitions

### DIFF
--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -42,14 +42,28 @@ Each invocation cycles through Nigredo, Albedo, Rubedo and Citrinitas states bef
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Nigredo
-    Nigredo --> Albedo
-    Albedo --> Rubedo
-    Rubedo --> Citrinitas
-    Citrinitas --> Nigredo
+    state "Nigredo" as N
+    state "Albedo" as A
+    state "Rubedo" as R
+    state "Citrinitas" as C
+
+    [*] --> N
+    N --> A: affection|joy / cleansed reply
+    A --> R: synthesis|resolve / fiery response
+    R --> C: insight|clarity / enlightened guidance
+    C --> N: cycle / shadow reset
 ```
 
-The Mermaid source lives at [assets/albedo_state_machine.mmd](assets/albedo_state_machine.mmd).
+The Mermaid source lives at [assets/albedo_state.mmd](assets/albedo_state.mmd).
+
+### Transition details
+
+| From | To | Inputs | Outputs |
+| --- | --- | --- | --- |
+| Nigredo | Albedo | Affection or joy triggers | Cleansed reflection |
+| Albedo | Rubedo | Synthesis or resolve cues | Fiery transformation |
+| Rubedo | Citrinitas | Insight or clarity signals | Enlightened guidance |
+| Citrinitas | Nigredo | Cycle completion | Return to shadow baseline |
 
 You can also use the layer programmatically:
 
@@ -175,5 +189,6 @@ Citrinitas speaks in golden clarity: proceed
 
 | Version | Date       | Summary |
 |---------|------------|---------|
+| 0.2.0   | 2025-08-30 | Documented transition inputs and outputs; externalized state diagram. |
 | 0.1.0   | 2025-08-29 | Added state machine diagram and initial version table. |
 

--- a/docs/assets/albedo_state.mmd
+++ b/docs/assets/albedo_state.mmd
@@ -1,0 +1,11 @@
+stateDiagram-v2
+    state "Nigredo" as N
+    state "Albedo" as A
+    state "Rubedo" as R
+    state "Citrinitas" as C
+
+    [*] --> N
+    N --> A: affection|joy / cleansed reply
+    A --> R: synthesis|resolve / fiery response
+    R --> C: insight|clarity / enlightened guidance
+    C --> N: cycle / shadow reset


### PR DESCRIPTION
## Summary
- add dedicated Mermaid state diagram for the Albedo layer
- embed diagram in ALBEDO_LAYER guide and document transition inputs and outputs

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/assets/albedo_state.mmd docs/ALBEDO_LAYER.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b20253b25c832eb4d4f513ca11acda