### PR TITLE
docs: add memory layer CLI examples

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -255,7 +255,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [installation.md](installation.md) | Installation | Set up the project either with Conda or Docker. Both methods run the bootstrap script, which verifies the Python vers... | - |
 | [learning_pipeline.md](learning_pipeline.md) | Learning Pipeline | The learning pipeline pairs two utilities: | - |
 | [logging_guidelines.md](logging_guidelines.md) | RAZAR Logging Guidelines | The mission logger records component activity in `logs/razar.log` using one JSON object per line. Each entry contains: | - |
-| [memory_architecture.md](memory_architecture.md) | Memory Architecture | The system layers multiple specialised stores, each recording a different facet of experience. Every layer supports t... | - |
+| [memory_architecture.md](memory_architecture.md) | Memory Architecture | The system layers multiple specialised stores, each recording a different facet of experience. Every layer supports t... | `../memory/cortex.py`, `../memory/emotional.py`, `../memory/mental.py`, `../memory/narrative_engine.py`, `../memory/spiritual.py` |
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Memory Layer | The `memory.cortex` module stores spiral decisions and maintains an index for fast retrieval. Each entry is appended... | - |

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -19,7 +19,9 @@ persistence strategies for each store:
 
 ### Cortex store
 
-`memory/cortex.py` persists application state as JSON lines while maintaining an
+Implementation: [memory/cortex.py](../memory/cortex.py)
+
+The cortex layer persists application state as JSON lines while maintaining an
 inverted index for semantic tags and a full‑text index for tag tokens. Reader
 and writer locks guard the log and index so multiple threads can record and
 query safely. Helper utilities allow concurrent queries and pruning of old
@@ -48,19 +50,25 @@ from spiral_vector_db import init_db as cortex_db
 cortex_collection = cortex_db()
 ```
 
-**Example query**
+**CLI insertion and retrieval**
 
-```python
+```bash
+python - <<'PY'
+from memory.cortex import record_spiral, query_spirals
+
 class Node:
     children = []
 
 record_spiral(Node(), {"result": "demo", "tags": ["example"]})
-query_spirals(tags=["example"])
+print(query_spirals(tags=["example"]))
+PY
 ```
 
 ### Emotional store
 
-`memory/emotional.py` captures emotional reactions and valence values. Entries
+Implementation: [memory/emotional.py](../memory/emotional.py)
+
+The emotional layer captures affective reactions and valence values. Entries
 can be queried to modulate tone or influence downstream reasoning.
 
 **Storage options**
@@ -86,16 +94,23 @@ from spiral_vector_db import init_db as emotion_db
 emotion_collection = emotion_db()
 ```
 
-**Example query**
+**CLI insertion and retrieval**
 
-```python
+```bash
+python - <<'PY'
+from memory.emotional import get_connection, log_emotion, fetch_emotion_history
+
+conn = get_connection()
 log_emotion([0.1, 0.2], conn=conn)
-fetch_emotion_history(window=60, conn=conn)
+print(fetch_emotion_history(window=60, conn=conn))
+PY
 ```
 
 ### Mental store
 
-`memory/mental.py` keeps temporary working memory for in‑progress reasoning and
+Implementation: [memory/mental.py](../memory/mental.py)
+
+The mental layer keeps temporary working memory for in‑progress reasoning and
 planning. Items decay quickly to keep the space focused on current tasks.
 
 **Storage options**
@@ -118,16 +133,23 @@ from memory.mental import init_rl_model, record_task_flow, query_related_tasks
 init_rl_model()  # uses NEO4J_* variables
 ```
 
-**Example query**
+**CLI insertion and retrieval**
 
-```python
+```bash
+python - <<'PY'
+from memory.mental import init_rl_model, record_task_flow, query_related_tasks
+
+init_rl_model()
 record_task_flow("taskA", {"step": 1})
-query_related_tasks("taskA")
+print(query_related_tasks("taskA"))
+PY
 ```
 
 ### Spiritual store
 
-`memory/spiritual.py` maintains ritual insights and symbolic states that extend
+Implementation: [memory/spiritual.py](../memory/spiritual.py)
+
+The spiritual layer maintains ritual insights and symbolic states that extend
 beyond immediate computation. These records provide long‑range guidance during
 ceremonial flows.
 
@@ -153,18 +175,25 @@ from spiral_vector_db import init_db as spirit_db
 spirit_collection = spirit_db()
 ```
 
-**Example query**
+**CLI insertion and retrieval**
 
-```python
+```bash
+python - <<'PY'
+from memory.spiritual import get_connection, map_to_symbol, lookup_symbol_history
+
+conn = get_connection()
 map_to_symbol(("eclipse", "☾"), conn=conn)
-lookup_symbol_history("☾", conn=conn)
+print(lookup_symbol_history("☾", conn=conn))
+PY
 ```
 
 ### Narrative store
 
-`memory/narrative_engine.py` outlines interfaces for recording story events.
-Each event binds an actor, an action and optional symbolism so later modules can
-weave a coherent narrative thread across memories.
+Implementation: [memory/narrative_engine.py](../memory/narrative_engine.py)
+
+The narrative layer outlines interfaces for recording story events. Each event
+binds an actor, an action and optional symbolism so later modules can weave a
+coherent narrative thread across memories.
 
 **Storage options**
 
@@ -187,9 +216,13 @@ from spiral_vector_db import init_db as narrative_db
 narrative_collection = narrative_db()
 ```
 
-**Example query**
+**CLI insertion and retrieval**
 
-```python
+```bash
+python - <<'PY'
+from memory.narrative_engine import log_story, stream_stories
+
 log_story("hero meets guide")
-list(stream_stories())
+print(list(stream_stories()))
+PY
 ```


### PR DESCRIPTION
## Summary
- add CLI insertion and retrieval examples for each memory layer
- regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/memory_architecture.md docs/INDEX.md`

## Change justification
I added CLI examples on memory_architecture.md to show insertion and retrieval for each memory layer to make the docs actionable, expecting contributors to replicate memory operations easily.

------
https://chatgpt.com/codex/tasks/task_e_68b2090910d0832eae8052a7e34078b5