### PR TITLE
Log CROWN capabilities and ensure GLM-4.1V model availability

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -172,9 +172,10 @@ plans by combining component priorities, failure counts, and CROWN suggestions.
    ```
 
    During a full boot the orchestrator calls
-   `crown_handshake.perform()`, records the reply in
+   `crown_handshake.perform()`, logs the returned capabilities to
+   `logs/razar.log`, records them in
    [logs/razar_state.json](../logs/razar_state.json), and if the
-   `GLM4V` capability is missing runs
+   `GLM-4.1V` capability is missing runs
    [`crown_model_launcher.sh`](../crown_model_launcher.sh), logging the
    launch under `launched_models`.
 


### PR DESCRIPTION
## Summary
- Log CROWN handshake capabilities and check for GLM-4.1V before booting components
- Launch crown_model_launcher.sh when GLM-4.1V is missing
- Document handshake logging and GLM-4.1V launch sequence

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py docs/RAZAR_AGENT.md docs/INDEX.md`
- `pytest tests/agents/razar/test_boot_sequence.py`

------
https://chatgpt.com/codex/tasks/task_e_68b20e9dfa38832eab6bb72b1d4b1336