### PR TITLE
docs: add dependency registry and enforce checks

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -189,7 +189,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | Bootstrapper for local services and mission brief exchange with the CROWN stack. | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/checkpoint_manager.py`, `../razar/cocreation_planner.py`, `../razar/crown_link.py`, `../razar/doc_sync.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.26 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.27 **Last updated:** 2025-08-29 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |
@@ -227,6 +227,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [data_security.md](data_security.md) | Data Security and Compliance | This document outlines how training data should be handled with respect to GDPR and HIPAA regulations. | - |
 | [dependencies.md](dependencies.md) | Dependency Tree | Generated via `pipdeptree`. | - |
 | [dependency-graph.md](dependency-graph.md) | Dependency Graph | Generated with `pipdeptree --packages spiral-os`. | - |
+| [dependency_registry.md](dependency_registry.md) | Dependency Registry | Approved runtimes and libraries with minimum versions. Update this registry when dependencies change and validate upd... | - |
 | [dependency_risks.md](dependency_risks.md) | Dependency Risks | This document outlines the impact of missing optional dependencies and ways to mitigate them. | - |
 | [deployment.md](deployment.md) | Deployment | This guide covers building versioned images and deploying them using Kubernetes or a serverless platform. For vision... | - |
 | [deployment_overview.md](deployment_overview.md) | Deployment Overview | This guide summarises how to launch Spiral OS on a Vast.ai server and how to run the stack locally with Docker Compose. | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.26
-**Last updated:** 2025-08-30
+**Version:** v1.0.27
+**Last updated:** 2025-08-29
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module must declare a `__version__` attribute.
@@ -142,13 +142,13 @@ preserve handshake history for auditing.
 
 ### Technology Registry Protocol
 
-- Record approved runtimes, frameworks, and library versions.
-- Update the registry when dependencies are added, upgraded, or deprecated.
+- Maintain the [Dependency Registry](dependency_registry.md) of approved runtimes, frameworks, and library minimum versions.
+- Update the registry when dependencies are added, upgraded, or deprecated, and validate changes with `pre-commit run --files docs/dependency_registry.md docs/INDEX.md`.
 
 ## Maintenance
 Whenever this file changes:
 1. Regenerate `docs/INDEX.md` with `python tools/doc_indexer.py`.
-2. Run `pre-commit run --files docs/The_Absolute_Protocol.md docs/INDEX.md`.
+2. Run `pre-commit run --files docs/The_Absolute_Protocol.md docs/dependency_registry.md docs/INDEX.md onboarding_confirm.yml`.
 
 ## Protocol Change Process
 Updates to this protocol follow a lightweight governance model:

--- a/docs/dependency_registry.md
+++ b/docs/dependency_registry.md
@@ -1,0 +1,13 @@
+# Dependency Registry
+
+Approved runtimes and libraries with minimum versions.
+Update this registry when dependencies change and validate updates with `pre-commit run --files docs/dependency_registry.md docs/INDEX.md`.
+
+| Name | Minimum Version | Notes |
+| --- | --- | --- |
+| Python | 3.10 | Primary runtime |
+| Node.js | 20 | Web asset pipeline |
+| numpy | 2.2.6 | Numerical computations |
+| opencv-python | 4.12.0.88 | Computer vision operations |
+| requests | 2.32.4 | HTTP client |
+| prometheus-client | 0.20.0 | Metrics export |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -15,5 +15,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: 79449eefce3b82f803e0314a340946b50b361f172c0b51aa3119d8053f8ad1c7
   docs/system_blueprint.md: 06a69749f2b05b3cb6578b63d70faf15b8c8acb467307d8be01cc1764ee2afcd
-  docs/The_Absolute_Protocol.md: 47c805ab0f6b4b6570d08793a8ecf2069098426e2803eb220896cf06b463762c
+  docs/The_Absolute_Protocol.md: 2aa45214bf9d47e4f290ec0e9b02838ac3a1835c8a3a3927c23334585babe6ac
   docs/KEY_DOCUMENTS.md: 6583400d5ea38fba6e44e8b4687c28e5e60a657f54808c45df8654407d76ccac


### PR DESCRIPTION
## Summary
- document approved runtimes and library minimum versions in docs/dependency_registry.md
- link dependency registry and pre-commit validation guidance in Technology Registry Protocol

## Testing
- `pre-commit run --files docs/dependency_registry.md docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b21e7dc280832e8591eef10ee372e2