### PR TITLE
Enforce placeholder ban in codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,7 @@ repos:
     entry: python scripts/check_no_binaries.py
     language: system
     pass_filenames: false
+  - id: check-no-placeholders
+    name: Check for TODO/FIXME markers
+    entry: python scripts/check_no_placeholders.py
+    language: system

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -190,7 +189,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | Bootstrapper for local services and mission brief exchange with the CROWN stack. | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/checkpoint_manager.py`, `../razar/cocreation_planner.py`, `../razar/crown_link.py`, `../razar/doc_sync.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.28 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.29 **Last updated:** 2025-08-31 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -71,10 +71,11 @@ The Mermaid source lives at [assets/razar_remote_flow.mmd](assets/razar_remote_f
 ## Module builder
 
 `agents/razar/module_builder.py` scaffolds new components from a planning
-specification.  Instead of inserting ``# TODO`` markers, the builder requires
-either a path to a template file or an inline implementation snippet.  Patch
-suggestions from remote agents are applied inside an isolated sandbox and the
-included tests are executed.  The module is promoted into the repository only
+specification. Instead of inserting ``# TODO`` or ``# FIXME`` markers, the builder
+requires either a path to a template file or an inline implementation snippet in
+accordance with the [no placeholder comments rule](The_Absolute_Protocol.md#no-placeholder-comments).
+Patch suggestions from remote agents are applied inside an isolated sandbox and the
+included tests are executed. The module is promoted into the repository only
 after the tests pass.
 
 ### Example

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.28
-**Last updated:** 2025-08-30
+**Version:** v1.0.29
+**Last updated:** 2025-08-31
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module must declare a `__version__` attribute.
@@ -146,6 +146,11 @@ preserve handshake history for auditing.
 - Use consistent naming conventions across files, classes, and functions.
 - Maintain clear module boundaries to prevent tight coupling.
 - Every module must declare a `__version__` field for traceability.
+
+#### No placeholder comments
+
+`TODO` and `FIXME` markers are prohibited in committed code. Open an issue or
+implement the required change instead of leaving placeholders.
 
 ### API Contract Protocol
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -15,5 +15,5 @@ documents:
   docs/communication_interfaces.md: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
   docs/connectors/CONNECTOR_INDEX.md: 79449eefce3b82f803e0314a340946b50b361f172c0b51aa3119d8053f8ad1c7
   docs/system_blueprint.md: 06a69749f2b05b3cb6578b63d70faf15b8c8acb467307d8be01cc1764ee2afcd
-  docs/The_Absolute_Protocol.md: 52f73bb5e7d0c18a15e469667d2bef2c983acb1619f08cb419c4a7bdc3808dfc
+  docs/The_Absolute_Protocol.md: 5c75855b1506d4ef3dafa6eb62bf10b8f17ced05b6239aa42e74f017fe5d084c
   docs/KEY_DOCUMENTS.md: 6583400d5ea38fba6e44e8b4687c28e5e60a657f54808c45df8654407d76ccac

--- a/scripts/check_no_placeholders.py
+++ b/scripts/check_no_placeholders.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fail if files contain TODO or FIXME placeholders."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PLACEHOLDER_RE = re.compile(r"(#|//)\s*(TODO|FIXME)\b")
+IGNORED_SUFFIXES = {".md"}
+
+
+def check_file(path: Path) -> list[int]:
+    """Return line numbers containing placeholders in *path*."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (UnicodeDecodeError, FileNotFoundError):
+        return []
+    hits: list[int] = []
+    for idx, line in enumerate(lines, 1):
+        if PLACEHOLDER_RE.search(line):
+            hits.append(idx)
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check provided files for TODO/FIXME markers."""
+    paths = [Path(p) for p in (argv or sys.argv[1:])]
+    failed = False
+    for path in paths:
+        if path.suffix.lower() in IGNORED_SUFFIXES:
+            continue
+        matches = check_file(path)
+        if matches:
+            failed = True
+            for line_no in matches:
+                print(f"{path}:{line_no}: contains TODO/FIXME marker")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add "no placeholder comments" rule to the Absolute Protocol and link from RAZAR Agent's module builder
- Introduce `check-no-placeholders` pre-commit hook with script to block TODO/FIXME markers
- Regenerate docs index and update onboarding confirmation hash

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/check_no_placeholders.py docs/The_Absolute_Protocol.md docs/RAZAR_AGENT.md onboarding_confirm.yml docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b221a788a8832eaeb5e89713a3dbe9