### PR TITLE
docs: document component index protocol

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "./schemas/component_index.schema.json",
+  "components": [
+    {
+      "id": "server",
+      "chakra": "crown",
+      "type": "service",
+      "version": "0.1.0",
+      "path": "server.py",
+      "description": "HTTP entry point for Spiral OS"
+    }
+  ]
+}

--- a/docs/CRYSTAL_CODEX.md
+++ b/docs/CRYSTAL_CODEX.md
@@ -103,6 +103,21 @@ For per‑module descriptions and external dependencies see the generated
 [server.py](../server.py), [vector_memory.py](../vector_memory.py) and
 [learning_mutator.py](../learning_mutator.py).
 
+## Component Index Protocol
+`component_index.json` provides a machine‑readable inventory of every module.
+Each component entry must include:
+
+- `id` – unique identifier
+- `chakra` – associated chakra layer
+- `type` – module or service classification
+- `version` – component version string
+
+The file must conform to
+[`component_index.schema.json`](../schemas/component_index.schema.json).
+Update [`component_index.json`](../component_index.json) whenever a component
+is added, removed or modified and regenerate
+[`component_index.md`](component_index.md).
+
 ## Agent Instructions
 
 ### INANNA_AI

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/schemas/component_index.schema.json
+++ b/schemas/component_index.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Component Index",
+  "type": "object",
+  "required": ["components"],
+  "properties": {
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "chakra", "type", "version"],
+        "properties": {
+          "id": {"type": "string"},
+          "chakra": {"type": "string"},
+          "type": {"type": "string"},
+          "version": {"type": "string"},
+          "path": {"type": "string"},
+          "description": {"type": "string"},
+          "dependencies": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- document Component Index Protocol and cross-link machine-readable index and schema
- add component_index.json and JSON schema
- regenerate documentation index

## Testing
- `pre-commit run --files docs/CRYSTAL_CODEX.md component_index.json schemas/component_index.schema.json docs/INDEX.md`
- `pytest tests/narrative_engine/test_biosignal_pipeline.py`

## Change justification
"I documented the Component Index Protocol in the CRYSTAL CODEX and added the JSON index and schema to clarify required fields, expecting contributors to follow a consistent update process."

------
https://chatgpt.com/codex/tasks/task_e_68b22bbc6c5c832e92528e1c2425d306