### PR TITLE
feat: enforce component coverage and validate index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,18 +63,23 @@ jobs:
             ~/.cache/huggingface
             INANNA_AI/models
           key: ${{ runner.os }}-models-${{ hashFiles('download_models.py') }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt -r dev-requirements.txt
-            pip install -e .
-        - name: Verify required pytest plugins
-          run: python - <<'PY'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+          pip install jsonschema
+      - name: Verify required pytest plugins
+        run: python - <<'PY'
 import importlib, sys
 sys.exit(0 if importlib.util.find_spec('pytest_cov') else 1)
 PY
-        - name: Run tests
+      - name: Run tests
         run: pytest --cov
+      - name: Export coverage metrics
+        run: python scripts/export_coverage.py
+      - name: Validate component index schema
+        run: jsonschema -i component_index.json docs/schemas/component_index.json
 
   ci:
     runs-on: ubuntu-latest

--- a/component_index.json
+++ b/component_index.json
@@ -14,7 +14,10 @@
       "tests": [
         "tests/test_server.py"
       ],
-      "status": "stable"
+      "status": "stable",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "razar",
@@ -30,7 +33,10 @@
       "tests": [
         "tests/test_razar_health_checks.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "crown",
@@ -45,7 +51,10 @@
       "tests": [
         "tests/test_crown_initialization.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "inanna",
@@ -60,7 +69,10 @@
       "tests": [
         "tests/test_inanna_ai.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "albedo",
@@ -75,7 +87,10 @@
       "tests": [
         "tests/test_albedo_personality.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "nazarick",
@@ -90,7 +105,10 @@
       "tests": [
         "tests/test_nazarick_messaging.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "memory_layers",
@@ -105,7 +123,10 @@
       "tests": [
         "tests/test_spiral_memory.py"
       ],
-      "status": "alpha"
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "narrative_engine",
@@ -118,7 +139,10 @@
       "tests": [
         "tests/narrative_engine/test_biosignal_pipeline.py"
       ],
-      "status": "experimental"
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      }
     },
     {
       "id": "operator_interface",
@@ -131,7 +155,10 @@
         "fastapi"
       ],
       "tests": [],
-      "status": "draft"
+      "status": "draft",
+      "metrics": {
+        "coverage": 0.0
+      }
     }
   ]
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/schemas/component_index.json
+++ b/docs/schemas/component_index.json
@@ -25,7 +25,14 @@
             "type": "array",
             "items": {"type": "string"}
           },
-          "status": {"type": "string"}
+          "status": {"type": "string"},
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "coverage": {"type": "number"}
+            },
+            "additionalProperties": false
+          }
         },
         "additionalProperties": false
       }

--- a/scripts/export_coverage.py
+++ b/scripts/export_coverage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Export coverage metrics to component_index.json and enforce thresholds."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = REPO_ROOT / "component_index.json"
+COVERAGE_JSON = REPO_ROOT / "coverage.json"
+ACTIVE_STATUSES = {"stable", "alpha"}
+THRESHOLD = 90.0
+
+
+def main() -> None:
+    """Generate coverage report, update component metrics and enforce threshold."""
+    subprocess.run(
+        ["coverage", "json", "-i", "--fail-under=0", "-o", str(COVERAGE_JSON)],
+        check=True,
+    )
+    with COVERAGE_JSON.open("r", encoding="utf-8") as fh:
+        coverage_data = json.load(fh)["files"]
+    with INDEX_PATH.open("r", encoding="utf-8") as fh:
+        index = json.load(fh)
+
+    failures: list[tuple[str, float]] = []
+
+    for component in index.get("components", []):
+        path = REPO_ROOT / component["path"]
+        files: list[float] = []
+        for fname, data in coverage_data.items():
+            fpath = Path(fname)
+            try:
+                rel = fpath.relative_to(REPO_ROOT)
+            except ValueError:
+                rel = fpath
+            if path.is_dir():
+                try:
+                    rel.relative_to(path)
+                except ValueError:
+                    continue
+            else:
+                if rel != path:
+                    continue
+            files.append(data["summary"]["percent_covered"])
+        coverage = round(sum(files) / len(files), 2) if files else 0.0
+        metrics = component.setdefault("metrics", {})
+        metrics["coverage"] = coverage
+        if component.get("status") in ACTIVE_STATUSES and coverage < THRESHOLD:
+            failures.append((component.get("id", "unknown"), coverage))
+
+    INDEX_PATH.write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+
+    if failures:
+        for comp, cov in failures:
+            print(f"{comp} coverage {cov}% below {THRESHOLD}%", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run coverage export script and validate component index schema in CI
- track coverage metrics for components

## Testing
- `pytest --cov` *(fails: Form data requires "python-multipart" to be installed)*
- `python scripts/export_coverage.py` *(fails: server coverage 0.0% below 90.0%)*
- `jsonschema -i component_index.json docs/schemas/component_index.json`
- `pre-commit run --files .github/workflows/ci.yml docs/schemas/component_index.json scripts/export_coverage.py component_index.json docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b22e983d34832eafb4e61f20e7215b