### PR TITLE
docs: add component index references to agent guides

### DIFF
--- a/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
+++ b/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
@@ -2,6 +2,17 @@
 
 This directory contains a small command line tool for activating the INANNA chant and for generating a QNL song from a hex string.
 
+## Component Index Entry
+
+- **ID:** `inanna_ai_agent`
+- **Path:** `INANNA_AI_AGENT`
+
+To update the index when modules evolve:
+
+1. Adjust `component_index.json` with new paths or identifiers.
+2. Run `python scripts/component_inventory.py` to rebuild component tables.
+3. Refresh the docs index via `pre-commit run doc-indexer --files INANNA_AI_AGENT/README_INANNA_AI_AGENT.md docs/INDEX.md`.
+
 ## Installation
 
 Use `pip` to install the required dependencies:

--- a/component_index.json
+++ b/component_index.json
@@ -75,6 +75,22 @@
       }
     },
     {
+      "id": "inanna_ai_agent",
+      "chakra": "heart",
+      "type": "agent",
+      "version": "0.1.0",
+      "path": "INANNA_AI_AGENT",
+      "purpose": "CLI for INANNA rituals",
+      "dependencies": [
+        "transformers"
+      ],
+      "tests": [],
+      "status": "alpha",
+      "metrics": {
+        "coverage": 0.0
+      }
+    },
+    {
       "id": "albedo",
       "chakra": "crown",
       "type": "agent",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -2,6 +2,17 @@
 
 Bootstrapper for local services and mission brief exchange with the CROWN stack.
 
+## Component Index Entry
+
+- **ID:** `razar`
+- **Path:** `agents/razar`
+
+To update the index when RAZAR modules evolve:
+
+1. Edit `component_index.json` with new paths or identifiers.
+2. Run `python scripts/component_inventory.py` to rebuild component tables.
+3. Regenerate the docs index with `pre-commit run doc-indexer --files docs/RAZAR_AGENT.md docs/INDEX.md`.
+
 ## Vision
 
 The RAZAR agent bootstraps local services in a controlled environment. It


### PR DESCRIPTION
## Summary
- document component index entries for RAZAR and INANNA agents
- describe updating component index when modules move
- update component_index.json and regenerate documentation index

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md INANNA_AI_AGENT/README_INANNA_AI_AGENT.md component_index.json docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b2303ce324832e82a38959db6ccfa3