### PR TITLE
Document INANNA components and validate index

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,9 @@ repos:
     language: python
     pass_filenames: false
     files: ^(connectors/|docs/connectors/CONNECTOR_INDEX.md)
+  - id: validate-component-index
+    name: Validate component index entries
+    entry: python scripts/validate_component_index.py
+    language: system
+    pass_filenames: false
+    files: ^docs/component_index.md

--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -5,60 +5,60 @@ Generated automatically. Lists each Python file with its description and externa
 | File | Description | Dependencies |
 | --- | --- | --- |
 | `INANNA_AI/__init__.py` | Core package for the INANNA AI helpers. | None |
-| `INANNA_AI/adaptive_learning.py` | No description | core |
-| `INANNA_AI/audio_emotion_listener.py` | No description | librosa, numpy, sounddevice |
-| `INANNA_AI/context.py` | No description | None |
-| `INANNA_AI/corpus_memory.py` | No description | chromadb, crown_config, numpy, sentence_transformers |
+| `INANNA_AI/adaptive_learning.py` | Adaptive agents tuning validation thresholds and wording with PPO. | core |
+| `INANNA_AI/audio_emotion_listener.py` | Capture microphone audio and infer speaker emotion. | librosa, numpy, sounddevice |
+| `INANNA_AI/context.py` | Store recent user prompts in a small context memory. | None |
+| `INANNA_AI/corpus_memory.py` | Manage Chroma-based embeddings of project text files. | chromadb, crown_config, numpy, sentence_transformers |
 | `INANNA_AI/db_storage.py` | SQLite helpers to store voice interactions. | None |
 | `INANNA_AI/defensive_network_utils.py` | Defensive network helpers for monitoring and secure POST requests. | requests, scapy |
-| `INANNA_AI/emotion_analysis.py` | No description | librosa, numpy, opensmile, torch, transformers |
-| `INANNA_AI/emotional_memory.py` | No description | None |
-| `INANNA_AI/emotional_synaptic_engine.py` | No description | None |
+| `INANNA_AI/emotion_analysis.py` | Lightweight emotion analysis utilities using audio features. | librosa, numpy, opensmile, torch, transformers |
+| `INANNA_AI/emotional_memory.py` | Log model interactions with detected emotions in JSONL. | None |
+| `INANNA_AI/emotional_synaptic_engine.py` | Map emotions to voice filter parameters using memory. | None |
 | `INANNA_AI/ethical_validator.py` | Validate user prompts before hitting the language model. | numpy, sentence_transformers |
 | `INANNA_AI/existential_reflector.py` | Generate a short self-description using a placeholder GLM endpoint. | requests |
 | `INANNA_AI/gate_orchestrator.py` | Simple gate orchestrator translating text to/from complex vectors. | core, numpy, torch |
 | `INANNA_AI/gates.py` | Signature helpers for the RFA core. | cryptography |
 | `INANNA_AI/glm_analyze.py` | Analyze Python modules using a placeholder GLM endpoint. | INANNA_AI, requests |
 | `INANNA_AI/glm_init.py` | Summarize project purpose using a placeholder GLM endpoint. | INANNA_AI, requests |
-| `INANNA_AI/glm_integration.py` | No description | requests |
+| `INANNA_AI/glm_integration.py` | Wrapper for a placeholder GLM endpoint with error handling. | requests |
 | `INANNA_AI/learning/__init__.py` | Utilities for fetching external learning data. | None |
-| `INANNA_AI/learning/github_metadata.py` | No description | crown_config, requests |
-| `INANNA_AI/learning/github_scraper.py` | No description | crown_config, requests, sentence_transformers |
-| `INANNA_AI/learning/project_gutenberg.py` | No description | bs4, crown_config, requests, sentence_transformers |
-| `INANNA_AI/learning/training_guide.py` | No description | None |
-| `INANNA_AI/listening_engine.py` | No description | core, numpy |
-| `INANNA_AI/love_matrix.py` | No description | None |
-| `INANNA_AI/main.py` | No description | learning, numpy, personality_layers, rag |
+| `INANNA_AI/learning/github_metadata.py` | Fetch star counts and update dates for GitHub repos. | crown_config, requests |
+| `INANNA_AI/learning/github_scraper.py` | Download repository READMEs, commits and embed them. | crown_config, requests, sentence_transformers |
+| `INANNA_AI/learning/project_gutenberg.py` | Retrieve, clean and embed texts from Project Gutenberg. | bs4, crown_config, requests, sentence_transformers |
+| `INANNA_AI/learning/training_guide.py` | Parse training guide categories and extract GitHub repo URLs. | None |
+| `INANNA_AI/listening_engine.py` | Real-time microphone listener extracting audio features. | core, numpy |
+| `INANNA_AI/love_matrix.py` | Define Great Mother archetype name constants. | None |
+| `INANNA_AI/main.py` | CLI for voice loop and data ingestion commands. | learning, numpy, personality_layers, rag |
 | `INANNA_AI/network_utils/__init__.py` | Network monitoring utilities. | None |
 | `INANNA_AI/network_utils/__main__.py` | Command line entry for network utilities. | None |
 | `INANNA_AI/network_utils/analysis.py` | Basic traffic analysis for PCAP files. | scapy |
 | `INANNA_AI/network_utils/capture.py` | Packet capture helpers using scapy or pyshark. | scapy |
 | `INANNA_AI/network_utils/config.py` | Configuration helpers for network utilities. | None |
 | `INANNA_AI/personality_layers/__init__.py` | Personality layers for INANNA AI. | albedo |
-| `INANNA_AI/personality_layers/albedo/__init__.py` | No description | SPIRAL_OS |
-| `INANNA_AI/personality_layers/albedo/alchemical_persona.py` | No description | MUSIC_FOUNDATION, numpy |
-| `INANNA_AI/personality_layers/albedo/enlightened_prompt.py` | No description | None |
-| `INANNA_AI/personality_layers/albedo/glm_integration.py` | No description | None |
-| `INANNA_AI/personality_layers/albedo/state_contexts.py` | No description | None |
-| `INANNA_AI/personality_layers/citrinitas_layer.py` | No description | None |
-| `INANNA_AI/personality_layers/nigredo_layer.py` | No description | None |
-| `INANNA_AI/personality_layers/rubedo_layer.py` | No description | None |
-| `INANNA_AI/response_manager.py` | No description | None |
-| `INANNA_AI/retrain_and_deploy.py` | No description | crown_config, mlflow |
+| `INANNA_AI/personality_layers/albedo/__init__.py` | Albedo persona generating responses via GLM and states. | SPIRAL_OS |
+| `INANNA_AI/personality_layers/albedo/alchemical_persona.py` | Track alchemical state transitions and metrics. | MUSIC_FOUNDATION, numpy |
+| `INANNA_AI/personality_layers/albedo/enlightened_prompt.py` | Compose prompts tailored to state and entity type. | None |
+| `INANNA_AI/personality_layers/albedo/glm_integration.py` | Expose GLMIntegration with quantum context support. | None |
+| `INANNA_AI/personality_layers/albedo/state_contexts.py` | Templates for prompts in each alchemical state. | None |
+| `INANNA_AI/personality_layers/citrinitas_layer.py` | Citrinitas personality offering enlightened guidance. | None |
+| `INANNA_AI/personality_layers/nigredo_layer.py` | Nigredo personality emphasizing shadow transformation. | None |
+| `INANNA_AI/personality_layers/rubedo_layer.py` | Rubedo personality expressing fiery completion. | None |
+| `INANNA_AI/response_manager.py` | Dialogue manager blending audio cues with text replies. | None |
+| `INANNA_AI/retrain_and_deploy.py` | Fine-tune and deploy models when new embeddings appear. | crown_config, mlflow |
 | `INANNA_AI/rfa_7d.py` | Random Field Array 7D with quantum-like execution and DNA serialization. | numpy, qutip |
 | `INANNA_AI/silence_reflection.py` | Detect sustained silence and suggest a short meaning. | numpy |
-| `INANNA_AI/sonic_emotion_mapper.py` | No description | yaml |
+| `INANNA_AI/sonic_emotion_mapper.py` | Map emotion and archetype to music and QNL parameters. | yaml |
 | `INANNA_AI/speaking_engine.py` | Generate speech using gTTS with emotion-based style adjustments. | core, crown_config, numpy, tools |
-| `INANNA_AI/speech_loopback_reflector.py` | No description | None |
+| `INANNA_AI/speech_loopback_reflector.py` | Analyze synthesized speech to update voice styles. | None |
 | `INANNA_AI/stt_whisper.py` | Speech-to-text helpers using the Whisper library. | crown_config, whisper |
-| `INANNA_AI/train_soul.py` | No description | core, numpy |
-| `INANNA_AI/tts_bark.py` | No description | bark, numpy |
+| `INANNA_AI/train_soul.py` | Fine-tune the RFA7D core and encode the soul grid. | core, numpy |
+| `INANNA_AI/tts_bark.py` | Bark text-to-speech wrapper with sine-wave fallback. | bark, numpy |
 | `INANNA_AI/tts_coqui.py` | Text-to-speech helpers using the Coqui TTS library. | TTS, numpy |
-| `INANNA_AI/tts_tortoise.py` | No description | numpy, tortoise |
-| `INANNA_AI/tts_xtts.py` | No description | TTS, numpy |
+| `INANNA_AI/tts_tortoise.py` | Tortoise TTS wrapper with fallback sine generation. | numpy, tortoise |
+| `INANNA_AI/tts_xtts.py` | XTTS model wrapper producing speech or sine fallback. | TTS, numpy |
 | `INANNA_AI/utils.py` | Utility helpers for audio processing and logging. | core, numpy |
 | `INANNA_AI/voice_evolution.py` | Helpers to evolve INANNA's vocal style. | crown_config, numpy, yaml |
-| `INANNA_AI/voice_layer_albedo.py` | No description | None |
+| `INANNA_AI/voice_layer_albedo.py` | Voice modulation layer applying tone presets. | None |
 | `INANNA_AI_AGENT/__init__.py` | Convenience imports and CLI exposure for the INANNA AI agent. | None |
 | `INANNA_AI_AGENT/benchmark_preprocess.py` | Benchmark preprocessing of INANNA AI source texts. | None |
 | `INANNA_AI_AGENT/inanna_ai.py` | Command line interface for the INANNA AI system. | INANNA_AI, SPIRAL_OS, yaml |

--- a/scripts/validate_component_index.py
+++ b/scripts/validate_component_index.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Ensure docs/component_index.md has no empty descriptions."""
+from __future__ import annotations
+
+from pathlib import Path
+
+INDEX_PATH = Path("docs/component_index.md")
+
+
+def main() -> int:
+    """Return 0 if all INANNA_AI rows have descriptions."""
+    text = INDEX_PATH.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if not line.startswith("| `") or line.startswith("| File"):
+            continue
+        parts = [p.strip() for p in line.strip().split("|")][1:4]
+        if len(parts) < 2 or not parts[0].startswith("`INANNA_AI/"):
+            continue
+        desc = parts[1]
+        if desc == "" or desc.lower() == "no description":
+            errors.append(f"Line {lineno}: missing description for {parts[0]}")
+    if errors:
+        print("Component index validation failed:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document INANNA_AI modules in component index
- enforce descriptions for INANNA_AI entries via validate_component_index script
- add pre-commit hook for component index validation

## Testing
- `pre-commit run --files docs/component_index.md scripts/validate_component_index.py .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b24225b98c832e8f8e0ec807565d7a