### PR TITLE
docs: add subsystem flow diagrams

### DIFF
--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -11,6 +11,19 @@ The **Albedo** layer introduces a stateful persona that drives responses through
 
 `AlbedoPersonality` calls `detect_state_trigger()` to extract entities and emotional cues, builds a state specific prompt and updates shadow metrics after each response.
 
+## Flow
+
+```mermaid
+flowchart LR
+    input[Prompt] --> detect[detect_state_trigger()]
+    detect --> build[Build Prompt]
+    build --> glm[GLM Endpoint]
+    glm --> reply[Response]
+    reply --> update[Update Shadow Metrics]
+```
+
+The Mermaid source lives at [assets/albedo_flow.mmd](assets/albedo_flow.mmd).
+
 ## Configuring the GLM endpoint
 
 `GLMIntegration` reads the endpoint and API key from environment variables by default.  Override them when instantiating the class or set `GLM_API_URL` and `GLM_API_KEY`:

--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -32,6 +32,21 @@ User commands enter through the **Crown Console**. The **Crown Agent** sends
 requests to the GLM service and keeps recent history in memory. The
 **State Transition Engine** tracks ritual phrases and emotional cues. It may
 delegate a prompt to one of the registered servant models when appropriate.
+## Flow
+
+```mermaid
+flowchart LR
+    user[User] --> console[Crown Console]
+    console --> agent[Crown Agent]
+    agent --> ste[State Transition Engine]
+    ste --> glm[GLM Service]
+    ste --> servants[Servant Models]
+    glm --> response[Reply]
+    servants --> response
+```
+
+The Mermaid source lives at [assets/crown_flow.mmd](assets/crown_flow.mmd).
+
 
 ## Memory‑Aided Routing
 

--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -2,6 +2,20 @@
 
 `crown_config/INANNA_CORE.yaml` defines the default settings used by the Crown agent. Each option can be overridden by an environment variable, allowing different deployments without editing the file.
 
+## Flow
+
+```mermaid
+flowchart LR
+    user[User Input] --> crown[Crown Agent]
+    crown --> inanna[INANNA Core]
+    inanna --> glm[GLM Service]
+    inanna --> memory[Vector Memory]
+    memory --> inanna
+    glm --> reply[Response]
+```
+
+The Mermaid source lives at [assets/inanna_flow.mmd](assets/inanna_flow.mmd).
+
 ## Fields
 
 - **`glm_api_url`** – Base URL for the GLM service. Override with `GLM_API_URL`.

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -36,6 +36,18 @@ Layer-specific packages are defined in
 [razar_env.yaml](../razar_env.yaml) and documented in
 [dependencies.md](dependencies.md).
 
+## Boot flow
+
+```mermaid
+flowchart LR
+    Start --> Env[Build Environment]
+    Env --> Launch[Launch Services]
+    Launch --> Handshake[Crown Handshake]
+    Handshake --> Ready[Operational]
+```
+
+The Mermaid source lives at [assets/razar_flow.mmd](assets/razar_flow.mmd).
+
 ## Architecture
 
 The RAZAR agent coordinates multiple modules during startup. The diagram below

--- a/docs/assets/albedo_flow.mmd
+++ b/docs/assets/albedo_flow.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+    input[Prompt] --> detect[detect_state_trigger()]
+    detect --> build[Build Prompt]
+    build --> glm[GLM Endpoint]
+    glm --> reply[Response]
+    reply --> update[Update Shadow Metrics]

--- a/docs/assets/crown_flow.mmd
+++ b/docs/assets/crown_flow.mmd
@@ -1,0 +1,8 @@
+flowchart LR
+    user[User] --> console[Crown Console]
+    console --> agent[Crown Agent]
+    agent --> ste[State Transition Engine]
+    ste --> glm[GLM Service]
+    ste --> servants[Servant Models]
+    glm --> response[Reply]
+    servants --> response

--- a/docs/assets/inanna_flow.mmd
+++ b/docs/assets/inanna_flow.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    user[User Input] --> crown[Crown Agent]
+    crown --> inanna[INANNA Core]
+    inanna --> glm[GLM Service]
+    inanna --> memory[Vector Memory]
+    memory --> inanna
+    glm --> reply[Response]

--- a/docs/assets/memory_flow.mmd
+++ b/docs/assets/memory_flow.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    input[Experience] --> bus[Memory Bus]
+    bus --> cortex[Cortex]
+    bus --> emotional[Emotional]
+    bus --> mental[Mental]
+    bus --> spiritual[Spiritual]
+    bus --> narrative[Narrative]

--- a/docs/assets/narrative_flow.mmd
+++ b/docs/assets/narrative_flow.mmd
@@ -1,0 +1,2 @@
+flowchart LR
+    Sensors --> Normalization --> "Feature Extraction" --> "Event Generator" --> "Narrative Engine" --> Outputs

--- a/docs/assets/nazarick_flow.mmd
+++ b/docs/assets/nazarick_flow.mmd
@@ -1,0 +1,11 @@
+flowchart TD
+    A[Surface Gate]
+    B[Crown Overlord]
+    C[Throat Gatekeepers]
+    D[Third Eye Observatories]
+    E[Heart Chambers]
+    F[Solar Plexus Forges]
+    G[Sacral Workshops]
+    H[Root Foundation]
+
+    A --> B --> C --> D --> E --> F --> G --> H

--- a/docs/assets/razar_flow.mmd
+++ b/docs/assets/razar_flow.mmd
@@ -1,0 +1,5 @@
+flowchart LR
+    Start --> Env[Build Environment]
+    Env --> Launch[Launch Services]
+    Launch --> Handshake[Crown Handshake]
+    Handshake --> Ready[Operational]

--- a/docs/great_tomb_of_nazarick.md
+++ b/docs/great_tomb_of_nazarick.md
@@ -24,6 +24,8 @@ flowchart TD
 
     A --> B --> C --> D --> E --> F --> G --> H
 ```
+The Mermaid source lives at [assets/nazarick_flow.mmd](assets/nazarick_flow.mmd).
+
 
 ## Channel Hierarchy
 | Channel | Purpose |

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -17,6 +17,20 @@ persistence strategies for each store:
 - **Spiritual** – transcendent insights and ritual state.
 - **Narrative** – story events linking actors, actions and symbolism.
 
+## Flow
+
+```mermaid
+flowchart LR
+    input[Experience] --> bus[Memory Bus]
+    bus --> cortex[Cortex]
+    bus --> emotional[Emotional]
+    bus --> mental[Mental]
+    bus --> spiritual[Spiritual]
+    bus --> narrative[Narrative]
+```
+
+The Mermaid source lives at [assets/memory_flow.mmd](assets/memory_flow.mmd).
+
 ### Cortex store
 
 Implementation: [memory/cortex.py](../memory/cortex.py)

--- a/docs/nazarick_narrative_system.md
+++ b/docs/nazarick_narrative_system.md
@@ -9,6 +9,8 @@ Sensors feed a biosignal processing layer that emits structured events for the n
 flowchart LR
     Sensors --> Normalization --> "Feature Extraction" --> "Event Generator" --> "Narrative Engine" --> Outputs
 ```
+The Mermaid source lives at [assets/narrative_flow.mmd](assets/narrative_flow.mmd).
+
 
 ## Biosignal Pipeline
 1. **Sensors** – EEG, heart-rate, and motion devices stream data.


### PR DESCRIPTION
## Summary
- add Mermaid flow diagrams for RAZAR, Crown, INANNA, Albedo, Nazarick, Memory and Narrative subsystems
- link each subsystem doc to its diagram with a dedicated `docs/assets/*_flow.mmd` source
- regenerate documentation index

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/assets/razar_flow.mmd docs/CROWN_OVERVIEW.md docs/assets/crown_flow.mmd docs/INANNA_CORE.md docs/assets/inanna_flow.mmd docs/ALBEDO_LAYER.md docs/assets/albedo_flow.mmd docs/great_tomb_of_nazarick.md docs/assets/nazarick_flow.mmd docs/memory_architecture.md docs/assets/memory_flow.mmd docs/nazarick_narrative_system.md docs/assets/narrative_flow.mmd docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b244bf89fc832e89b9134e9bac8c1b