### PR TITLE
Add INANNA core routing diagram

### DIFF
--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -16,6 +16,22 @@ flowchart LR
 
 The Mermaid source lives at [assets/inanna_flow.mmd](assets/inanna_flow.mmd).
 
+## Core Interfaces
+
+```mermaid
+flowchart LR
+    inanna[INANNA Core] --> glm[GLM Endpoint]
+    inanna --> memdir[memory_dir/]
+    memdir --> vector[vector_memory/]
+    memdir --> chroma[chroma/]
+    inanna --> router[Servant Model Router]
+    router --> deepseek[deepseek]
+    router --> mistral[mistral]
+    router --> kimi[kimi_k2]
+```
+
+*Figure: GLM endpoint, memory directories, and servant model routing.* The Mermaid source lives at [assets/inanna_core.mmd](assets/inanna_core.mmd).
+
 ## Fields
 
 - **`glm_api_url`** – Base URL for the GLM service. Override with `GLM_API_URL`.

--- a/docs/assets/inanna_core.mmd
+++ b/docs/assets/inanna_core.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    inanna[INANNA Core] --> glm[GLM Endpoint]
+    inanna --> memdir[memory_dir/]
+    memdir --> vector[vector_memory/]
+    memdir --> chroma[chroma/]
+    inanna --> router[Servant Model Router]
+    router --> deepseek[deepseek]
+    router --> mistral[mistral]
+    router --> kimi[kimi_k2]


### PR DESCRIPTION
## Summary
- document GLM endpoint, memory directories, and servant model routing in a new Mermaid diagram
- embed the diagram within INANNA core documentation with a caption

## Testing
- `pre-commit run doc-indexer --files docs/INANNA_CORE.md docs/assets/inanna_core.mmd docs/INDEX.md`
- `pre-commit run --files docs/INANNA_CORE.md docs/assets/inanna_core.mmd docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b24a27a270832e89363dae80eff12f