### PR TITLE
docs: add dataset governance protocol and protect data manifest

### DIFF
--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -12,6 +12,7 @@ The files listed here are foundational and must never be deleted or renamed.
 - [Connector Index](connectors/CONNECTOR_INDEX.md) – registry of connector IDs, versions, endpoints, auth methods, and status (see [Connector Overview](connectors/README.md) for patterns and maintenance rules)
 - [Security Model](security_model.md)
 - [Data Security and Compliance](data_security.md)
+- [Data Manifest](data_manifest.md)
 - [RAZAR AI agents config](../config/razar_ai_agents.json) – roster of handover agents and authentication settings
 
 These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming. When related components change, update the corresponding document in the same commit to keep information synchronized.

--- a/docs/data_manifest.md
+++ b/docs/data_manifest.md
@@ -2,6 +2,16 @@
 
 This document enumerates datasets and external resources used by the project.
 
+## Dataset Governance Protocol
+
+When introducing a new dataset:
+
+- Append an entry to `docs/data_manifest.md`.
+- Provide or update schema documentation explaining structure and fields.
+- Add privacy notes clarifying handling of sensitive data and consent.
+- Audit against [Data Security and Compliance](data_security.md) and the
+  [Dependency Registry](dependency_registry.md).
+
 ## Internal datasets
 
 ### `data/emotion_registry.json`

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -16,4 +16,4 @@ documents:
   docs/connectors/CONNECTOR_INDEX.md: b1a944e21d2cb521673d7f1384599d48e4f9fbe3fa9122438de1f532e28564cd
   docs/system_blueprint.md: 38222d01f9105c0cd48ce670f51d26ffb17571c1287c2f5f974dee8aa46cb629
   docs/The_Absolute_Protocol.md: 720d2486bdd1cc21fceb5422e7a2c9022ea66ccd2e4cea38c9ba72aa53659c90
-  docs/KEY_DOCUMENTS.md: 81e266927303be006f93a7bcb0cafa625c2437f26528aaa1e8e4c24dbd61908f
+  docs/KEY_DOCUMENTS.md: a42ae49114f3c348e043fae25406138d35ed18a23f864fb71fa0a55bc64ec712


### PR DESCRIPTION
## Summary
- add Dataset Governance Protocol with schema and privacy requirements for new datasets
- link governance to Data Security and Dependency Registry for auditing
- mark Data Manifest as a protected key document

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/data_manifest.md docs/KEY_DOCUMENTS.md docs/INDEX.md onboarding_confirm.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b24f15b350832eb083695994a69a4d