### PR TITLE
docs: enforce no placeholder rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,9 @@ repos:
     entry: python scripts/check_no_binaries.py
     language: system
     pass_filenames: false
-  - id: check-no-placeholders
+  - id: check-placeholders
     name: Check for TODO/FIXME markers
-    entry: python scripts/check_no_placeholders.py
+    entry: python scripts/check_placeholders.py
     language: system
   - id: verify-versions
     name: Ensure modules declare __version__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Quality
 
 - Verified repository passes `ruff` and `black` checks.
+- Enforced "No Placeholder" rule with `check-placeholders` pre-commit hook and
+  documented remediation steps in agent guides.
 
 ### Vector Memory
 

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+- Documented remediation steps for placeholder violations in RAZAR agent
+  guide.
+
 ## [0.1.0] - 2025-08-30
 
 ### Added

--- a/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
+++ b/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
@@ -66,6 +66,12 @@ python INANNA_AI.py --list
 
 The song is saved as `qnl_hex_song.wav` and the metadata JSON in `qnl_hex_song.json` unless overridden with `--wav` and `--json`.
 
+## Placeholder remediation
+
+The `check-placeholders` pre-commit hook prevents commits that include `TODO`
+or `FIXME`. Remove the marker or open an issue to track the work, then rerun
+`pre-commit run --files <paths>` before committing.
+
 ## Source Texts
 
 The agent loads Markdown writings from the `INANNA_AI` and `GENESIS` folders

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -576,6 +576,12 @@ The Mermaid source lives at [assets/ai_handover_flow.mmd](assets/ai_handover_flo
 
 If tests fail or regressions appear, RAZAR reverts to the previous state and records the failure for manual review.
 
+## Placeholder remediation
+
+The `check-placeholders` pre-commit hook blocks commits containing `TODO` or
+`FIXME`. Replace these markers with complete code or open an issue describing
+the outstanding work, then re-run `pre-commit run --files <paths>`.
+
 ## Version History
 
 | Version | Date | Summary |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -190,7 +190,9 @@ preserve handshake history for auditing.
 #### No placeholder comments
 
 `TODO` and `FIXME` markers are prohibited in committed code. Open an issue or
-implement the required change instead of leaving placeholders.
+implement the required change instead of leaving placeholders. The
+`check-placeholders` pre-commit hook runs `scripts/check_placeholders.py` to
+block commits that include these markers.
 
 ### API Contract Protocol
 

--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -262,7 +262,7 @@ Generated automatically. Lists each Python file with its description and externa
 | `scripts/check_connector_index.py` | Ensure touched connectors have registry entries. | None |
 | `scripts/check_key_documents.py` | Verify that key documents exist. | yaml |
 | `scripts/check_no_binaries.py` | Fail if any staged files are detected as binary. | None |
-| `scripts/check_no_placeholders.py` | Fail if files contain TODO or FIXME placeholders. | None |
+| `scripts/check_placeholders.py` | Fail if files contain TODO or FIXME placeholders. | None |
 | `scripts/component_inventory.py` | No description | None |
 | `scripts/confirm_reading.py` | Ensure required onboarding documents have been read. | yaml |
 | `scripts/data_validate.py` | Validate training data schema using TensorFlow Data Validation. | tensorflow_data_validation |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -54,7 +54,7 @@ documents:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
     summary: "Threat model and protections."
   docs/The_Absolute_Protocol.md:
-    sha256: ccd2be1d91a9dbae628747391e00b7c51322b907e236456bc37dee87cf2325f1
+    sha256: 21d306ea7686561a4be4b5fdf2246d4dd16c04b2bcdac47939d2baa75072c64f
     summary: "Core contribution rules."
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a

--- a/scripts/check_placeholders.py
+++ b/scripts/check_placeholders.py
@@ -6,6 +6,8 @@ import re
 import sys
 from pathlib import Path
 
+__version__ = "0.1.0"
+
 PLACEHOLDER_RE = re.compile(r"(#|//)\s*(TODO|FIXME)\b")
 IGNORED_SUFFIXES = {".md"}
 


### PR DESCRIPTION
## Summary
- forbid TODO/FIXME placeholders via `check-placeholders` pre-commit hook
- document remediation for placeholder violations in RAZAR and INANNA agent guides
- note the new rule and hook in The Absolute Protocol and changelogs

## Testing
- `pre-commit run --files scripts/check_placeholders.py .pre-commit-config.yaml docs/The_Absolute_Protocol.md docs/RAZAR_AGENT.md INANNA_AI_AGENT/README_INANNA_AI_AGENT.md CHANGELOG.md CHANGELOG_razar.md docs/component_index.md onboarding_confirm.yml docs/INDEX.md`
- `pytest tests/narrative_engine/test_biosignal_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68b25fb1c234832eaf961ab2ca69d5e1