### PR TITLE
Add protocol compliance dashboard and update release protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Introduced protocol compliance dashboard and required dashboard updates each release cycle in The Absolute Protocol.
 - Introduced lifecycle `status` and `adr` link requirements for `component_index.json` and provided `docs/adr/ADR_TEMPLATE.md`.
 - Introduced co-creation and AI ethics frameworks with cross-links from README and The Absolute Protocol.
 - Expanded connector registry schema with purpose and service fields and updated The Absolute Protocol accordingly.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -190,7 +190,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | Bootstrapper for local services and mission brief exchange with the CROWN stack. | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/checkpoint_manager.py`, `../razar/cocreation_planner.py`, `../razar/crown_link.py`, `../razar/doc_sync.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.46 **Last updated:** 2025-09-24 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.47 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |
@@ -288,6 +288,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [persona_api_guide.md](persona_api_guide.md) | Persona API Guide | This guide walks developers through the persona utilities that power Albedo interactions.  It shows how to update tru... | - |
 | [project_overview.md](project_overview.md) | Project Overview | For a consolidated reference covering mission, architecture and workflow, see [CRYSTAL_CODEX.md](../CRYSTAL_CODEX.md)... | - |
 | [project_plan.md](project_plan.md) | Project Plan | This project plan outlines quarter-level goals and owners for components currently scoring below 7. Refer to [roadmap... | - |
+| [protocol_compliance.md](protocol_compliance.md) | Protocol Compliance | This dashboard provides a high-level view of how major components align with repository protocols. | - |
 | [psychic_loop.md](psychic_loop.md) | Psychic Loop | `mirror_thresholds.json` and `insight_matrix.json` feed the self-reflection cycle that keeps the avatar aligned with... | - |
 | [quarantine_log.md](quarantine_log.md) | Quarantine Log | Failed components are moved to the `quarantine/` directory and recorded below. | - |
 | [quick_start_non_technical.md](quick_start_non_technical.md) | Quick Start Guide (Non-Technical) | Follow these steps to get the system running with minimal setup. | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.46
-**Last updated:** 2025-09-24
+**Version:** v1.0.47
+**Last updated:** 2025-08-30
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module must declare a `__version__` attribute.
@@ -28,6 +28,7 @@ Before opening a pull request, confirm each item:
 - [ ] `onboarding_confirm.yml` logs purpose, scope, key rules, and one actionable insight for every file it tracks, per [KEY_DOCUMENTS.md](KEY_DOCUMENTS.md)
 - [ ] `scripts/verify_doc_summaries.py` confirms `onboarding_confirm.yml` hashes match current files
 - [ ] `docs/INDEX.md` regenerated if docs changed
+- [ ] `DASHBOARD.md` metrics updated for each release cycle
 - [ ] `component_maturity.md` scoreboard updated
 - [ ] New operator channels documented in [Operator Protocol](operator_protocol.md)
 - [ ] Confirm no binary files are introduced

--- a/docs/protocol_compliance.md
+++ b/docs/protocol_compliance.md
@@ -1,0 +1,12 @@
+# Protocol Compliance
+
+This dashboard provides a high-level view of how major components align with repository protocols.
+
+| Component | Version Match | Test Coverage | Docs Complete | Connector Registry |
+|-----------|---------------|---------------|---------------|-------------------|
+| INANNA_AI | Aligned | Extensive unit tests | Partial | n/a |
+| SPIRAL_OS | Aligned | Core paths covered | Partial | n/a |
+| MUSIC_FOUNDATION | Aligned | Basic tests present | Partial | n/a |
+| Connectors | Aligned | Endpoint smoke tests | Partial | Registered |
+
+Consult component-specific docs and `docs/connectors/CONNECTOR_INDEX.md` for detailed entries.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -1,73 +1,73 @@
 documents:
   AGENTS.md:
     sha256: 08aab5d3dabd13cc0937d5e6574bbed143346c5340c13578224336c1ecdc2671
-    summary: "Repository-wide agent instructions."
+    summary: Repository-wide agent instructions.
   docs/ABZU_SUBSYSTEM_OVERVIEW.md:
     sha256: e575ff650f076601f2dae9c09ccc3b0658999204f71a22508aab24c98f050445
-    summary: "Overview of ABZU subsystems."
+    summary: Overview of ABZU subsystems.
   docs/architecture_overview.md:
     sha256: 3e08f2cf4a214c19aead33191c08b32f8f4e8ddd57333b29fbe5e2596e9cdad2
-    summary: "High-level system architecture."
+    summary: High-level system architecture.
   docs/documentation_protocol.md:
     sha256: ae84f16638303413f944fd3a2b0adf70679c3ee82c06eefa2ab18c1141468239
-    summary: "Workflow for updating documentation."
+    summary: Workflow for updating documentation.
   docs/project_overview.md:
     sha256: 4f4b07972085bc9341a56b1fb85f37da8354e726a73e10f03613fcc5f83b76b1
-    summary: "Project goals and scope."
+    summary: Project goals and scope.
   docs/onboarding/README.md:
     sha256: 34f9af9b460e4e59da73545465cece4e5994ada1beb00fe7d91b549816872fac
-    summary: "Onboarding checklist."
+    summary: Onboarding checklist.
   docs/onboarding_walkthrough.md:
     sha256: b7d57d6fe6ee327301e134e36a959474431e7a0c511dd999a168ddad1485cdeb
-    summary: "Step-by-step onboarding walkthrough."
+    summary: Step-by-step onboarding walkthrough.
   docs/vector_memory.md:
     sha256: 8aff26e4a32740fc3599e3cae555f8b7700a61c6734adb87fbcaaaba69349a34
-    summary: "Guide to vector memory subsystem."
+    summary: Guide to vector memory subsystem.
   docs/rag_pipeline.md:
     sha256: 24d2154f4a2db1aceba6aaf05c03bc6c34119ba58b82159345f5d2c0eb36e0dc
-    summary: "Retrieval-augmented generation pipeline."
+    summary: Retrieval-augmented generation pipeline.
   docs/rag_music_oracle.md:
     sha256: b506c9213c26af25dc0e295b11215dd19d6a1100cfb7902e64be47120784c7d6
-    summary: "Music oracle RAG details."
+    summary: Music oracle RAG details.
   docs/vision_system.md:
     sha256: 52d91902d457f14cf4dc46b088a8e2177cd10e3eaa0398ee071d4f1532e74547
-    summary: "Vision system documentation."
+    summary: Vision system documentation.
   docs/persona_api_guide.md:
     sha256: 767d276cddcb865a844c3e730aa2affc9d57ab6ebb52f3c4c05040288c94121f
-    summary: "Persona API usage instructions."
+    summary: Persona API usage instructions.
   docs/spiral_cortex_terminal.md:
     sha256: 863463fb3e7b92021d747b5f4bdc4cb20e608469d64ed69917bf8be7b8177724
-    summary: "Spiral Cortex terminal guide."
+    summary: Spiral Cortex terminal guide.
   docs/communication_interfaces.md:
     sha256: c9d210710b6e3f7bbf943c99d6a40443a8fa67f7c96e5fcdcd4881193923a17a
-    summary: "Communication interfaces overview."
+    summary: Communication interfaces overview.
   docs/connectors/CONNECTOR_INDEX.md:
     sha256: b1a944e21d2cb521673d7f1384599d48e4f9fbe3fa9122438de1f532e28564cd
-    summary: "Registry of connector details."
+    summary: Registry of connector details.
   docs/system_blueprint.md:
     sha256: 38222d01f9105c0cd48ce670f51d26ffb17571c1287c2f5f974dee8aa46cb629
-    summary: "Architectural blueprint overview."
+    summary: Architectural blueprint overview.
   docs/KEY_DOCUMENTS.md:
     sha256: 8fa7aabfdc334c3ef715553ec57994fd6de1cb0d24833c623d286be94e25838e
-    summary: "List of essential repository documents."
+    summary: List of essential repository documents.
   docs/security_model.md:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
-    summary: "Threat model and protections."
+    summary: Threat model and protections.
   docs/The_Absolute_Protocol.md:
-    sha256: 106b5780b19455b2961ffbb4af3a7ec95256aea7319c2d40d7d87b3971bb2758
-    summary: "Core contribution rules."
+    sha256: ec3e0d9cfbdaf8f33c6966b366383125c6aa414b24ea32d8f136c1489693f1ae
+    summary: Core contribution rules.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a
-    summary: "Approved dependencies."
+    summary: Approved dependencies.
   docs/logging_guidelines.md:
     sha256: e090bdc32a69a7f6b144967dd70f163f6fb8322a23671334caa6dbcbc4185cf3
-    summary: "Structured logging requirements."
+    summary: Structured logging requirements.
   docs/api_reference.md:
     sha256: 6273ffa4258f9015f3e1b06d1dadbfd3f03f0585f0fee79bc1ba1c32e2f00721
-    summary: "API endpoints and schemas."
+    summary: API endpoints and schemas.
   docs/operator_protocol.md:
     sha256: e150a741e3c81bdd7bb550ef12e3f9696d8572f508342e99a25b8aed2e06597a
-    summary: "Operator interaction rules."
+    summary: Operator interaction rules.
   docs/RAZAR_AGENT.md:
     sha256: 1358ce15a3413196fb080a8362ac4ef55b6868b031c3a66a0857967cd68f0159
-    summary: "RAZAR agent bootstrap and logging guidance."
+    summary: RAZAR agent bootstrap and logging guidance.


### PR DESCRIPTION
## Summary
- document protocol compliance across major components
- require updating the dashboard each release cycle via the Absolute Protocol
- regenerate documentation index to link dashboard overview

## Testing
- `pre-commit run --files docs/protocol_compliance.md docs/The_Absolute_Protocol.md docs/INDEX.md CHANGELOG.md onboarding_confirm.yml`
- `pytest -q` *(fails: ImportError: cannot import name 'load_config' from 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b2648c2874832ebc3145d6be8c66d3