### PR TITLE
chore: enforce coverage metrics in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,13 @@ PY
         run: pytest --cov
       - name: Export coverage metrics
         run: python scripts/export_coverage.py
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov
       - name: Validate component index schema
-        run: jsonschema -i component_index.json docs/schemas/component_index.json
+        run: jsonschema -i component_index.json schemas/component_index.schema.json
 
   ci:
     runs-on: ubuntu-latest

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/the_absolute_pytest.md
+++ b/docs/the_absolute_pytest.md
@@ -44,6 +44,14 @@ Follow this sequence when adding or updating tests:
 4. **AI review** – obtain feedback from review agents.
 5. **Archive** – finalize in version control.
 
+## CI checks
+
+The [CI workflow](../.github/workflows/ci.yml) runs `pytest --cov`,
+produces an HTML report in `htmlcov/`, and exports coverage metrics to
+`component_index.json`. Components with `active` status must maintain at
+least 90% coverage. The workflow also validates `component_index.json`
+against the JSON schema.
+
 ## References
 
 - [Testing Guide](testing.md)

--- a/schemas/component_index.schema.json
+++ b/schemas/component_index.schema.json
@@ -5,6 +5,8 @@
   "required": ["components"],
   "properties": {
     "$schema": {"type": "string"},
+    "system_version": {"type": "string"},
+    "index_version": {"type": "integer"},
     "components": {
       "type": "array",
       "items": {
@@ -32,6 +34,13 @@
           },
           "adr": {
             "type": ["string", "null"]
+          },
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "coverage": {"type": "number"}
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false

--- a/scripts/export_coverage.py
+++ b/scripts/export_coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Export coverage metrics to component_index.json and enforce thresholds."""
+"""Export coverage metrics to component_index.json, generate HTML reports, and enforce thresholds."""
 
 from __future__ import annotations
 
@@ -11,16 +11,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INDEX_PATH = REPO_ROOT / "component_index.json"
 COVERAGE_JSON = REPO_ROOT / "coverage.json"
-ACTIVE_STATUSES = {"stable", "alpha"}
+ACTIVE_STATUSES = {"active"}
 THRESHOLD = 90.0
+__version__ = "0.1.0"
 
 
 def main() -> None:
-    """Generate coverage report, update component metrics and enforce threshold."""
+    """Generate coverage reports, update metrics and enforce thresholds."""
     subprocess.run(
         ["coverage", "json", "-i", "--fail-under=0", "-o", str(COVERAGE_JSON)],
         check=True,
     )
+    subprocess.run(["coverage", "html", "-i"], check=True)
     with COVERAGE_JSON.open("r", encoding="utf-8") as fh:
         coverage_data = json.load(fh)["files"]
     with INDEX_PATH.open("r", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- fail CI when active components fall below 90% coverage
- validate component index using jsonschema
- document CI coverage checks for pytest

## Testing
- `pytest --cov` *(fails: No module named 'websockets')*
- `python scripts/export_coverage.py` *(fails: Command '['coverage', 'json', ...] returned non-zero exit status 1)*
- `jsonschema -i component_index.json schemas/component_index.schema.json`


------
https://chatgpt.com/codex/tasks/task_e_68b2a6d43a6c832e9f4a1477ef2cd16d