### PR TITLE
feat(test): expose pytest metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ PY
         with:
           name: htmlcov
           path: htmlcov
+      - name: Upload pytest metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-metrics
+          path: monitoring/pytest_metrics.prom
       - name: Validate component index schema
         run: jsonschema -i component_index.json schemas/component_index.schema.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified Release Management Protocol with semantic versioning rules and checklist references.
 - Required logging of RAZAR ↔ Crown ↔ Operator exchanges in `logs/interaction_log.jsonl` and referenced rules in RAZAR and operator docs.
 - Crown prompt orchestrator reviews test metrics and logs remediation suggestions to corpus memory.
-- Pytest runs export duration and failure metrics via `prometheus_client` to `monitoring/pytest_metrics.prom`.
+- Pytest runs export coverage, session duration, and failure metrics via `prometheus_client` to `monitoring/pytest_metrics.prom`, and CI uploads the metrics artifact.
 
 ### Quality
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -38,7 +38,7 @@ exhaustive module inventory.
   - [Operations Guide](operations.md) – runbooks for deployment and maintenance
 - [Monitoring Guide](monitoring.md) – telemetry collection and alerting
 - [Deployment Guide](deployment.md) – rollout procedures and environment setup
-- **Pytest Observability** – `tests/conftest.py` exports Prometheus metrics to `monitoring/pytest_metrics.prom` and records failing tests with `corpus_memory_logging.log_test_failure`. `crown_prompt_orchestrator.py` reviews these metrics and logs suggestions via `corpus_memory_logging.py`.
+- **Pytest Observability** – `tests/conftest.py` exports Prometheus metrics (coverage, session runtime, failure counts) to `monitoring/pytest_metrics.prom` and records failing tests with `corpus_memory_logging.log_test_failure`. `crown_prompt_orchestrator.py` reviews these metrics and logs suggestions via `corpus_memory_logging.py`.
   - [Testing Guide](testing.md) – validation steps and smoke tests
 - **Legacy & ethics texts**
   - [INANNA Core](INANNA_CORE.md) – chronicles the system’s mythic lineage and mission

--- a/docs/the_absolute_pytest.md
+++ b/docs/the_absolute_pytest.md
@@ -11,10 +11,21 @@
 - `tests/conftest.py` instruments pytest using `prometheus_client`.
 - Metrics:
   - `pytest_test_duration_seconds` histogram captures per-test runtimes.
+  - `pytest_session_duration_seconds` gauge records total runtime for the test session.
+  - `pytest_coverage_percent` gauge stores overall coverage when `--cov` is used.
   - `pytest_test_failures_total` counter increments on failed tests.
 - At session end metrics are written to `monitoring/pytest_metrics.prom` for scraping by Prometheus.
 
 Run tests as usual and inspect the metrics file or have Prometheus scrape the path for dashboarding and alerting.
+
+## Dashboard Setup
+
+1. Configure Prometheus to watch `monitoring/pytest_metrics.prom` using a `file_sd_config` target.
+2. In Grafana, add panels for:
+   - `rate(pytest_test_failures_total[5m])` to track failure spikes.
+   - `pytest_session_duration_seconds` to monitor overall runtime.
+   - `pytest_coverage_percent` to ensure coverage stays above thresholds.
+3. Enable alerts on coverage drops or runtime increases to trigger reviews via `crown_prompt_orchestrator`.
 
 ## Failure Analysis
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -45,7 +45,7 @@ documents:
     sha256: b1a944e21d2cb521673d7f1384599d48e4f9fbe3fa9122438de1f532e28564cd
     summary: Registry of connector details.
   docs/system_blueprint.md:
-    sha256: 38222d01f9105c0cd48ce670f51d26ffb17571c1287c2f5f974dee8aa46cb629
+    sha256: 34a07cfbed34be43a6653fa8615bfa8eb7aaf28d87aa72ce4da076969ac0ed80
     summary: Architectural blueprint overview.
   docs/KEY_DOCUMENTS.md:
     sha256: 8fa7aabfdc334c3ef715553ec57994fd6de1cb0d24833c623d286be94e25838e


### PR DESCRIPTION
## Summary
- export coverage and session runtime metrics from pytest via Prometheus
- document pytest metrics dashboard setup
- upload pytest metrics artifact in CI

## Testing
- `pre-commit run --files tests/conftest.py docs/the_absolute_pytest.md docs/system_blueprint.md .github/workflows/ci.yml CHANGELOG.md onboarding_confirm.yml docs/INDEX.md`
- `PYTHONPATH=.:src pytest -o addopts="" tests/test_core_scipy_smoke.py --cov=corpus_memory_logging --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ae5f64e0832e9893f4cc21d3ec50