### PR TITLE
docs: add test planning guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -276,6 +275,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [nazarick_narrative_system.md](nazarick_narrative_system.md) | Nazarick Narrative System | The Nazarick Narrative System turns raw biosensor readings into adaptive story cues for the tomb. | - |
 | [nazarick_web_console.md](nazarick_web_console.md) | Nazarick Web Console | The Nazarick Web Console provides a browser-based interface for issuing commands, streaming the avatar, and testing m... | `../connectors/webrtc_connector.py`, `../operator_api.py` |
 | [onboarding/README.md](onboarding/README.md) | Onboarding Checklist | Follow this reading order before contributing. After reviewing each document, record its current SHA256 hash in `onbo... | - |
+| [onboarding/test_planning.md](onboarding/test_planning.md) | Test Planning Guide | Instructions for opening a "Test Plan" issue to coordinate tests across chakras and maintain coverage goals. | - |
 | [onboarding_guide.md](onboarding_guide.md) | Onboarding Guide | **Version:** v1.0.0 **Last updated:** 2025-08-28 Diagram: [Onboarding Walkthrough](onboarding_walkthrough.md) – visua... | - |
 | [onboarding_walkthrough.md](onboarding_walkthrough.md) | Onboarding Walkthrough | This text-based walkthrough provides a step-by-step path to set up the repository and rebuild the project from a fres... | - |
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -21,6 +21,7 @@ summary in `onboarding_confirm.yml` to prove the current version was reviewed.
 | [Logging Guidelines](logging_guidelines.md) | Structured logging requirements | Quarterly |
 | [API Reference](api_reference.md) | API endpoints and schemas | Quarterly |
 | [Operator Protocol](operator_protocol.md) | Operator interaction rules | Quarterly |
+| [Test Planning Guide](onboarding/test_planning.md) | Filing "Test Plan" issues defining scope, chakra, and coverage goals | Quarterly |
 | [RAZAR AI agents config](../config/razar_ai_agents.json) | Roster of handover agents and authentication settings | Quarterly |
 
 These documents define repository-wide conventions and rules. Repository policy and pre-commit checks prevent their removal or renaming. When related components change, update the corresponding document in the same commit to keep information synchronized.

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -19,6 +19,7 @@ Before opening a pull request, confirm each item:
 - [ ] `ignition_stage` set for each component in `component_index.json` and reflected in [Ignition Map](ignition_map.md); see [Ignition](Ignition.md) for boot priorities
 - [ ] Each `component_index.json` entry declares a lifecycle `status` (`active`, `deprecated`, or `experimental`) and links to an `adr` describing major changes
 - [ ] Tests follow the Pytest Codex; coverage updated in component index
+- [ ] "Test Plan" issue filed per [Test Planning Guide](onboarding/test_planning.md) outlining scope, chakra, and coverage goals
 - [ ] Connector registry updated:
   - implementations expose `__version__`, implement `start_call`, and `close_peers`
   - [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) entry updated

--- a/docs/onboarding/test_planning.md
+++ b/docs/onboarding/test_planning.md
@@ -1,0 +1,36 @@
+# Test Planning Guide
+
+Instructions for opening a "Test Plan" issue to coordinate tests across chakras and maintain coverage goals.
+
+## Filing a Test Plan Issue
+
+1. Open a new issue using the **Test Plan** template and apply the `test-plan` label.
+2. Link the issue to the feature or bug it supports and to any related pull requests.
+3. Include contact information for the owner responsible for executing the plan.
+
+## Define the Scope
+
+- Describe the features, modules, and scenarios that require validation.
+- Note any out-of-scope areas to prevent redundant effort.
+- Reference companion documents or specifications when available.
+
+## Declare the Chakra
+
+- Identify the chakra layer most affected by the work (e.g., root, sacral, solar plexus, heart, throat, third eye, crown).
+- Use one chakra per issue to keep responsibilities clear.
+- Align test fixtures and data to the chakra's responsibilities.
+
+## Set Coverage Goals
+
+- Record the current test coverage for the affected modules.
+- State the target coverage percentage and the methods used to achieve it.
+- Aim for at least 90% coverage for touched modules while maintaining the repository baseline.
+- Update `component_index.json` and related dashboards when coverage goals are met.
+
+## Checklist
+
+- [ ] Issue links to related work and pull requests
+- [ ] Scope and exclusions documented
+- [ ] Chakra explicitly stated
+- [ ] Coverage goals defined and tracked
+- [ ] Dashboard entries and component index updated when complete

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -54,7 +54,7 @@ documents:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
     summary: Threat model and protections.
   docs/The_Absolute_Protocol.md:
-    sha256: 17c15e533248964d8cccf2062bfdcb8c5cc75e348c2df0a2c1a5be6a8fca33a3
+    sha256: f961baa356843fee3bf428c2e6f3b0d7ce313d0a7bfc942f11c0d3a720291c68
     summary: Core contribution rules.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a
@@ -71,3 +71,6 @@ documents:
   docs/RAZAR_AGENT.md:
     sha256: 1358ce15a3413196fb080a8362ac4ef55b6868b031c3a66a0857967cd68f0159
     summary: RAZAR agent bootstrap and logging guidance.
+  docs/onboarding/test_planning.md:
+    sha256: dbacb76c8b866af82bf7531b5facf9ffb9de708c9a55cec042fba1c19e9dc7a0
+    summary: Guide for filing Test Plan issues.


### PR DESCRIPTION
## Summary
- add test planning guide for filing Test Plan issues
- reference guide from key documents and contributor checklist
- regenerate documentation index and onboarding confirmations

## Testing
- `pre-commit run --files docs/onboarding/test_planning.md docs/KEY_DOCUMENTS.md docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`
- `pytest tests/narrative_engine/test_biosignal_pipeline.py` *(fails: ModuleNotFoundError: corpus_memory_logging)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b0d6a1f0832ebd83ae64d9cac8b4