### PR TITLE
docs: add testing workflow and ignition protocol

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -190,7 +190,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_AGENT.md](RAZAR_AGENT.md) | RAZAR Agent | Bootstrapper for local services and mission brief exchange with the CROWN stack. | `../agents/razar/ai_invoker.py`, `../agents/razar/boot_orchestrator.py`, `../agents/razar/checkpoint_manager.py`, `../agents/razar/code_repair.py`, `../agents/razar/crown_link.py`, `../agents/razar/doc_sync.py`, `../agents/razar/health_checks.py`, `../agents/razar/module_builder.py`, `../agents/razar/quarantine_manager.py`, `../agents/razar/runtime_manager.py`, `../razar/adaptive_orchestrator.py`, `../razar/boot_orchestrator.py`, `../razar/checkpoint_manager.py`, `../razar/cocreation_planner.py`, `../razar/crown_link.py`, `../razar/doc_sync.py`, `../razar/environment_builder.py` |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.48 **Last updated:** 2025-08-31 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.49 **Last updated:** 2025-08-30 | `../agents/example_agent.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |
@@ -255,6 +255,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [hardware_support.md](hardware_support.md) | Hardware Support | - CUDA available: False - ROCm available: False - Intel GPU available: False - Selected device: cpu | - |
 | [how_to_use.md](how_to_use.md) | How to Use Spiral OS Avatar | 1. Run `python start_spiral_os.py` to launch the orchestration engine. This loads the core modules, starts a local Fa... | - |
 | [ignition_map.md](ignition_map.md) | Ignition Map | Summary of components grouped by ignition stage. See [Ignition](Ignition.md) for boot priorities and [component_index... | - |
+| [ignition_sequence_protocol.md](ignition_sequence_protocol.md) | Ignition Sequence Protocol | Defines the required logging checkpoints and escalation flow during the system boot sequence. | - |
 | [index.md](index.md) | Documentation Index | Curated starting points for understanding and operating the project. For an exhaustive, auto-generated inventory of a... | - |
 | [insight_system.md](insight_system.md) | Insight System | The insight system aggregates interaction logs into structured matrices used by reflection and adaptive learning comp... | - |
 | [installation.md](installation.md) | Installation | Set up the project either with Conda or Docker. Both methods run the bootstrap script, which verifies the Python vers... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.48
-**Last updated:** 2025-08-31
+**Version:** v1.0.49
+**Last updated:** 2025-08-30
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module must declare a `__version__` attribute.
@@ -169,6 +169,7 @@ preserve handshake history for auditing.
 ## Subsystem Protocols
 
 - [Operator Protocol](operator_protocol.md) – outlines `/operator/command`, role checks, and Crown's relay to RAZAR.
+- [Ignition Sequence Protocol](ignition_sequence_protocol.md) – mandates logging points and escalation during boot.
 - [Co-creation Escalation](co_creation_escalation.md) – defines when RAZAR seeks Crown or operator help and the logging for each tier.
 - [Logging & Observability Protocol](#logging--observability-protocol) – structured logging and metrics requirements.
 

--- a/docs/ignition_sequence_protocol.md
+++ b/docs/ignition_sequence_protocol.md
@@ -1,0 +1,28 @@
+# Ignition Sequence Protocol
+
+Defines the required logging checkpoints and escalation flow during the
+system boot sequence.
+
+## Mandatory Logging Points
+
+- **Boot start** – record timestamp and environment hash in
+  `logs/razar_boot_history.json`.
+- **Component activation** – log each component start and health check to
+  `logs/razar_state.json`.
+- **Quarantine events** – append affected component IDs and reasons to
+  [`quarantine_log.md`](quarantine_log.md).
+- **Sequence completion** – write final status and coverage snapshot to
+  `logs/ignition_summary.json`.
+
+## Operator Escalation Path
+
+1. **Automated retry** – RAZAR attempts a restart up to three times.
+2. **Crown notification** – persistent failures trigger a Crown alert via
+   `/operator/command`.
+3. **Operator response** – operators consult the
+   [Recovery Playbook](recovery_playbook.md) and resolve outstanding
+   issues.
+4. **Emergency escalation** – unresolved faults escalate to the
+   [Co-creation Escalation](co_creation_escalation.md) protocol for
+   manual intervention and post‑mortem logging.
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,34 @@ flowchart LR
     T --> R[Report]
 ```
 
+## Testing Workflow
+
+1. Run formatting and static checks for the files you touched:
+
+   ```bash
+   pre-commit run --files <changed_files>
+   ```
+
+2. Execute the full test suite with coverage enabled:
+
+   ```bash
+   pytest --cov
+   coverage report
+   coverage-badge -o coverage.svg
+   ```
+
+3. Maintain a **minimum 85% repository coverage** and aim for **≥90%** on
+   modified modules. Update `component_index.json` when coverage metrics change.
+
+4. On failures or drops below thresholds:
+
+   - Inspect `logs/pytest_priority.log` and `logs/razar.log` for details.
+   - Rerun the failing tier with `--maxfail=1` for rapid feedback.
+   - Isolate recurring failures using `python -m razar.quarantine_manager
+     quarantine <component>` and consult [diagnostics.md](diagnostics.md).
+   - Escalate unresolved issues following
+     [co_creation_escalation.md](co_creation_escalation.md).
+
 ## Required pytest plugins
 
 The test suite expects certain plugins to be available:

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -54,7 +54,7 @@ documents:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
     summary: Threat model and protections.
   docs/The_Absolute_Protocol.md:
-    sha256: f961baa356843fee3bf428c2e6f3b0d7ce313d0a7bfc942f11c0d3a720291c68
+    sha256: 8270203ee33516dd4af15a67be9414672412375346cd77f2c924a4bc8be54a68
     summary: Core contribution rules.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a


### PR DESCRIPTION
## Summary
- expand testing guide with workflow covering commands, coverage targets, and escalation steps
- introduce ignition sequence protocol detailing boot logging and operator escalation
- bump Absolute Protocol to v1.0.49 and regenerate docs index

## Testing
- `pre-commit run --files docs/testing.md docs/ignition_sequence_protocol.md docs/The_Absolute_Protocol.md onboarding_confirm.yml docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8838128832e8393bd089ea81bb2