### PR TITLE
Add integration tests for RAZAR handshake and operator API

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -35,7 +35,9 @@
         "prometheus_client"
       ],
       "tests": [
-        "tests/test_razar_health_checks.py"
+        "tests/test_razar_health_checks.py",
+        "tests/agents/razar/test_boot_orchestrator.py",
+        "tests/agents/razar/test_crown_handshake.py"
       ],
       "status": "active",
       "metrics": {
@@ -190,7 +192,9 @@
       "dependencies": [
         "fastapi"
       ],
-      "tests": [],
+      "tests": [
+        "tests/test_operator_api.py"
+      ],
       "status": "active",
       "metrics": {
         "coverage": 1.0

--- a/tests/agents/razar/test_boot_orchestrator.py
+++ b/tests/agents/razar/test_boot_orchestrator.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from razar import boot_orchestrator as bo
+from razar.crown_handshake import CrownResponse
+
+__version__ = "0.1.0"
+
+
+@pytest.fixture
+def mock_handshake(monkeypatch):
+    """Stub out CrownHandshake to avoid network calls."""
+
+    def _mock(response: CrownResponse):
+        class DummyHandshake:
+            def __init__(self, url: str) -> None:  # pragma: no cover - trivial
+                self.url = url
+
+            async def perform(self, brief_path: str) -> CrownResponse:
+                # ensure brief file exists to mimic real behaviour
+                assert Path(brief_path).exists()
+                return response
+
+        monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+
+    return _mock
+
+
+def test_perform_handshake_persists_state_and_launches_model(
+    tmp_path: Path, mock_handshake, monkeypatch
+) -> None:
+    """Handshake results are stored and missing capability triggers launcher."""
+
+    monkeypatch.setattr(bo, "LOGS_DIR", tmp_path)
+    monkeypatch.setattr(bo, "STATE_FILE", tmp_path / "razar_state.json")
+
+    response = CrownResponse("ack", [], {})
+    mock_handshake(response)
+
+    launched: list[list[str]] = []
+    monkeypatch.setattr(bo.subprocess, "Popen", lambda cmd: launched.append(cmd))
+
+    result = bo._perform_handshake([{"name": "alpha"}])
+
+    assert result == response
+    assert launched, "crown model should launch when GLM4V missing"
+    state = json.loads((tmp_path / "razar_state.json").read_text())
+    assert state == {"capabilities": [], "downtime": {}}
+
+
+def test_finalize_metrics_updates_history(monkeypatch) -> None:
+    """Finalize metrics computes success rate and persists history."""
+
+    history: dict = {"history": [], "best_sequence": None, "component_failures": {}}
+    run_metrics = {
+        "timestamp": 0,
+        "components": [
+            {"name": "a", "success": True},
+            {"name": "b", "success": False},
+        ],
+    }
+    saved: dict = {}
+    monkeypatch.setattr(bo, "save_history", lambda data: saved.update(data))
+    monkeypatch.setattr(bo.time, "time", lambda: 1)
+
+    bo.finalize_metrics(run_metrics, history, {"b": 1}, start_time=0)
+
+    assert run_metrics["success_rate"] == 0.5
+    assert run_metrics["total_time"] == 1
+    assert history["best_sequence"]["components"] == ["a"]
+    assert saved["component_failures"]["b"] == 1

--- a/tests/agents/razar/test_crown_handshake.py
+++ b/tests/agents/razar/test_crown_handshake.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from razar import crown_handshake as ch
+
+__version__ = "0.1.0"
+
+
+@pytest.fixture
+def mock_ws(monkeypatch):
+    """Mock websockets connect for handshake."""
+
+    class DummyWS:
+        async def send(self, data):  # pragma: no cover - trivial
+            self.sent = data
+
+        async def recv(self):
+            return json.dumps(
+                {
+                    "ack": "ok",
+                    "capabilities": ["GLM4V"],
+                    "downtime": {"alpha": {"patch": 1}},
+                }
+            )
+
+    class DummyCM:
+        async def __aenter__(self):
+            return DummyWS()
+
+        async def __aexit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
+            return False
+
+    monkeypatch.setattr(
+        ch,
+        "websockets",
+        types.SimpleNamespace(connect=lambda url: DummyCM()),
+    )
+
+
+def test_handshake_records_and_recovers(tmp_path: Path, mock_ws, monkeypatch) -> None:
+    transcript = tmp_path / "dialogues.json"
+
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        ch.recovery_manager, "request_shutdown", lambda c: calls.append(("down", c))
+    )
+    monkeypatch.setattr(
+        ch.recovery_manager, "apply_patch", lambda c, p: calls.append(("patch", c, p))
+    )
+    monkeypatch.setattr(
+        ch.recovery_manager, "resume", lambda c: calls.append(("up", c))
+    )
+
+    brief = tmp_path / "brief.json"
+    brief.write_text(
+        json.dumps({"priority_map": {"a": 0}, "current_status": {}, "open_issues": []})
+    )
+
+    handshake = ch.CrownHandshake("ws://dummy", transcript)
+    resp = asyncio.run(handshake.perform(str(brief)))
+
+    assert resp.capabilities == ["GLM4V"]
+    assert calls == [
+        ("down", "alpha"),
+        ("patch", "alpha", {"patch": 1}),
+        ("up", "alpha"),
+    ]
+    log = json.loads(transcript.read_text())
+    assert [entry["role"] for entry in log] == ["razar", "crown"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,9 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "test_event_bus.py"),
     str(ROOT / "tests" / "narrative_engine" / "test_biosignal_pipeline.py"),
     str(ROOT / "tests" / "crown" / "test_prompt_orchestrator.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_boot_orchestrator.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_crown_handshake.py"),
+    str(ROOT / "tests" / "test_operator_api.py"),
 }
 
 

--- a/tests/test_operator_api.py
+++ b/tests/test_operator_api.py
@@ -1,0 +1,89 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import operator_api
+
+__version__ = "0.1.0"
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch) -> TestClient:
+    """Return a test client with isolated upload directory."""
+
+    app = FastAPI()
+    app.include_router(operator_api.router)
+    monkeypatch.chdir(tmp_path)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_dispatch(monkeypatch):
+    """Patch dispatcher to control remote agent responses."""
+
+    def _mock(*, result=None, error: str | None = None):
+        def dispatch(operator, agent, func, *args, **kwargs):
+            if error is not None:
+                raise PermissionError(error)
+            return result if result is not None else func(*args, **kwargs)
+
+        monkeypatch.setattr(operator_api._dispatcher, "dispatch", dispatch)
+
+    return _mock
+
+
+def test_command_dispatches(client: TestClient, mock_dispatch) -> None:
+    mock_dispatch(result={"ack": "noop"})
+    resp = client.post(
+        "/operator/command",
+        json={"operator": "overlord", "agent": "crown", "command": "noop"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"result": {"ack": "noop"}}
+
+
+def test_command_requires_fields(client: TestClient) -> None:
+    resp = client.post("/operator/command", json={"operator": "overlord"})
+    assert resp.status_code == 400
+
+
+def test_upload_stores_and_forwards(client: TestClient, monkeypatch) -> None:
+    captured: dict[str, dict] = {}
+
+    def dispatch(operator, agent, func, meta):
+        captured["meta"] = meta
+        return {"ok": True}
+
+    monkeypatch.setattr(operator_api._dispatcher, "dispatch", dispatch)
+    resp = client.post(
+        "/operator/upload",
+        data={"operator": "overlord", "metadata": json.dumps({"x": 1})},
+        files={"files": ("a.txt", b"hi")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["stored"] == ["a.txt"]
+    assert captured["meta"] == {"x": 1}
+    assert (Path("uploads") / "a.txt").read_text() == "hi"
+
+
+def test_upload_invalid_metadata(client: TestClient) -> None:
+    resp = client.post(
+        "/operator/upload",
+        data={"operator": "overlord", "metadata": "not json"},
+        files={"files": ("a.txt", b"hi")},
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_permission_error(client: TestClient, mock_dispatch) -> None:
+    mock_dispatch(error="denied")
+    resp = client.post(
+        "/operator/upload",
+        data={"operator": "overlord", "metadata": "{}"},
+        files={"files": ("a.txt", b"hi")},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- test boot orchestrator handshake and metrics persistence
- exercise Crown handshake over mocked websockets
- verify operator API command and upload endpoints

## Testing
- `PYTHONPATH=. pytest tests/agents/razar/test_boot_orchestrator.py tests/agents/razar/test_crown_handshake.py tests/test_operator_api.py -q`
- `coverage report -m operator_api.py razar/crown_handshake.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc2d2c54832e902ae9b4d00c9cb6