### PR TITLE
docs: expand Crown overview with model loading sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added "The Absolute pytest" guide for chakra-aligned tests and commit workflow.
 - Introduced Pytest Protocol with >90% coverage, chakra-aligned directories, and component index documentation requirements.
+- Expanded Crown agent overview with model loading sequence diagram and configuration table.
 
 ### Added
 

--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -47,6 +47,32 @@ flowchart LR
 
 The Mermaid source lives at [assets/crown_flow.mmd](assets/crown_flow.mmd).
 
+## Boot Sequence
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+sequenceDiagram
+    participant C as Crown Agent
+    participant F as Config
+    participant I as INANNA
+    participant S as Servant Models
+    C->>F: read glm_api_url & memory_dir
+    C->>I: load_primary()
+    I-->>C: model ready
+    C->>S: load_servants()
+    S-->>C: servants ready
+```
+
+The Mermaid source lives at [assets/crown_boot.mmd](assets/crown_boot.mmd).
+
+## Configuration
+
+| Model | Endpoint key | Memory path |
+|-------|--------------|-------------|
+| INANNA Core | `glm_api_url` | `data/vector_memory` |
+| DeepSeek servant | `servant_models.deepseek` | `data/vector_memory` |
+| Mistral servant | `servant_models.mistral` | `data/vector_memory` |
+| Kimi K2 servant | `servant_models.kimi_k2` | `data/vector_memory` |
 
 ## Memory‑Aided Routing
 
@@ -129,5 +155,6 @@ RAZAR evaluates the command and returns the result, allowing operators to inspec
 
 | Version | Date       | Summary |
 |---------|------------|---------|
+| 0.3.0   | 2025-10-15 | Added boot sequence diagram and configuration table. |
 | 0.2.0   | 2025-09-30 | Added deployment guidance and initial version table. |
 | 0.1.0   | 2025-08-28 | Initial document outlining Crown agent architecture. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/assets/crown_boot.mmd
+++ b/docs/assets/crown_boot.mmd
@@ -1,0 +1,10 @@
+sequenceDiagram
+    participant C as Crown Agent
+    participant F as Config
+    participant I as INANNA
+    participant S as Servant Models
+    C->>F: read glm_api_url & memory_dir
+    C->>I: load_primary()
+    I-->>C: model ready
+    C->>S: load_servants()
+    S-->>C: servants ready


### PR DESCRIPTION
## Summary
- add Mermaid boot sequence diagram showing Crown loading INANNA and servant models
- document GLM endpoint and memory directory mappings
- regenerate documentation index

## Testing
- `pre-commit run --files docs/CROWN_OVERVIEW.md docs/assets/crown_boot.mmd CHANGELOG.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b2c49bf6d8832e8f0b82e1bfd5e826