### PR TITLE
docs: expand inanna core setup

### DIFF
--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -82,7 +82,16 @@ corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
    This prepares the persistent stores used by `vector_memory.py` and
    `corpus_memory.py`.
 
-2. **Launch servant model endpoints**
+2. **Initialize vector and Chroma stores**
+
+   ```bash
+   python -m INANNA_AI.corpus_memory --reindex
+   ```
+
+   This builds the Chroma index under `data/vector_memory/chroma` and
+   confirms the vector store path.
+
+3. **Launch servant model endpoints**
 
    Define the endpoints via `SERVANT_MODELS` and run the launcher:
 
@@ -94,7 +103,7 @@ corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
    Each endpoint must expose a `/health` route and accept a JSON body
    `{"prompt": "..."}`.
 
-3. **Start INANNA core**
+4. **Start INANNA core**
 
    The minimal startup script combines the above steps and verifies the
    configuration:
@@ -102,3 +111,11 @@ corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
    ```bash
    scripts/start_inanna_core.sh
    ```
+
+## Resources
+
+- [Default configuration `crown_config/INANNA_CORE.yaml`](../crown_config/INANNA_CORE.yaml)
+- Test scripts validating the setup:
+  - [tests/test_vector_memory.py](../tests/test_vector_memory.py)
+  - [tests/test_corpus_memory.py](../tests/test_corpus_memory.py)
+  - [tests/test_launch_servants_script.py](../tests/test_launch_servants_script.py)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -178,7 +178,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [DASHBOARD.md](DASHBOARD.md) | Metrics Dashboard | This dashboard visualises recent model performance and the predicted best LLM. | - |
 | [ETHICS_POLICY.md](ETHICS_POLICY.md) | Ethics Policy | This document outlines the minimum rules for handling data while working with Spiral OS. | - |
 | [ETHICS_VALIDATION.md](ETHICS_VALIDATION.md) | Ethics Validation | `EthicalValidator` inspects prompts before they reach the language models. Keyword scanning is combined with a semant... | - |
-| [INANNA_CORE.md](INANNA_CORE.md) | INANNA Core Configuration | `crown_config/INANNA_CORE.yaml` defines the default settings used by the Crown agent. Each option can be overridden b... | - |
+| [INANNA_CORE.md](INANNA_CORE.md) | INANNA Core Configuration | `crown_config/INANNA_CORE.yaml` defines the default settings used by the Crown agent. Each option can be overridden b... | `../tests/test_corpus_memory.py`, `../tests/test_launch_servants_script.py`, `../tests/test_vector_memory.py` |
 | [Ignition.md](Ignition.md) | Ignition | RAZAR coordinates system boot and records runtime health. Components are grouped by priority so operators can track s... | - |
 | [JSON_STRUCTURES.md](JSON_STRUCTURES.md) | JSON Structures and Invocations | This page describes the small JSON files used by Spiral OS and how to trigger registered invocations. | - |
 | [KEY_DOCUMENTS.md](KEY_DOCUMENTS.md) | Key Documents | The files listed here are foundational and must never be deleted or renamed. For each document below, contributors mu... | - |


### PR DESCRIPTION
## Summary
- document initializing vector and chroma stores for INANNA core
- show how to launch servant model endpoints
- link to example config and related tests

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/INANNA_CORE.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b2c60386c8832eaa898bc29bfae093