### PR TITLE
Document Albedo layer Nazarick agent triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added recovery playbook documenting snapshot restoration steps.
 - Mapped cortex, emotional, mental, spiritual and narrative memory stores in
   `docs/memory_architecture.md`.
+- Documented Nazarick agent triggers for Albedo state transitions and added
+  state-to-channel table; refreshed `docs/INDEX.md`.
 
 
 ### Documentation

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -1,6 +1,6 @@
 # Albedo Personality Layer
 
-The **Albedo** layer introduces a stateful persona that drives responses through a remote GLM (Generative Language Model). All related modules live under `INANNA_AI/personality_layers/albedo`.
+The **Albedo** layer signals Nazarick agents while introducing a stateful persona that drives responses through a remote GLM (Generative Language Model). All related modules live under `INANNA_AI/personality_layers/albedo`.
 
 ## Project structure
 
@@ -77,6 +77,22 @@ The Mermaid source lives at [assets/albedo_state.mmd](assets/albedo_state.mmd).
 | Albedo | Rubedo | Synthesis or resolve cues | Fiery transformation |
 | Rubedo | Citrinitas | Insight or clarity signals | Enlightened guidance |
 | Citrinitas | Nigredo | Cycle completion | Return to shadow baseline |
+
+### Nazarick agent triggers
+
+State shifts can alert specific Nazarick servants to intervene:
+
+- Nigredo → Albedo engages the **Sebas Compassion Module**.
+- Albedo → Rubedo alerts the **Cocytus Prompt Arbiter**.
+- Rubedo → Citrinitas summons the **Demiurge Strategic Simulator**.
+- Citrinitas → Nigredo pings the **Pandora Persona Emulator**.
+
+| State | Agent ID | Channel |
+| --- | --- | --- |
+| Nigredo | Pandora Persona Emulator | `#treasure-vault` |
+| Albedo | Sebas Compassion Module | `#royal-suite` |
+| Rubedo | Cocytus Prompt Arbiter | `#glacier-prison` |
+| Citrinitas | Demiurge Strategic Simulator | `#lava-pits` |
 
 You can also use the layer programmatically:
 
@@ -239,6 +255,7 @@ Citrinitas speaks in golden clarity: proceed
 
 | Version | Date       | Summary |
 |---------|------------|---------|
+| 0.3.0   | 2025-08-31 | Added Nazarick agent triggers and state-channel table. |
 | 0.2.0   | 2025-08-30 | Documented transition inputs and outputs; externalized state diagram. |
 | 0.1.0   | 2025-08-29 | Added state machine diagram and initial version table. |
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -169,7 +169,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
 | [ABZU_DEPLOYMENT.md](ABZU_DEPLOYMENT.md) | ABZU Deployment | This guide outlines the environment preparation, boot order, and rollback steps for deploying ABZU. | - |
 | [ABZU_SUBSYSTEM_OVERVIEW.md](ABZU_SUBSYSTEM_OVERVIEW.md) | ABZU Subsystem Overview | The diagram below outlines how the primary subsystems collaborate within ABZU. | - |
-| [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | The **Albedo** layer introduces a stateful persona that drives responses through a remote GLM (Generative Language Mo... | - |
+| [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | The **Albedo** layer signals Nazarick agents while introducing a stateful persona that drives responses through a rem... | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |
 | [CORPUS_MEMORY.md](CORPUS_MEMORY.md) | Corpus Memory | This repository preserves several collections of source texts used by the music and language tools. Each directory se... | - |


### PR DESCRIPTION
## Summary
- note Albedo state shifts now notify specific Nazarick servants
- map each alchemical state to an agent ID and channel
- refresh documentation index and changelog

## Testing
- `pre-commit run --files CHANGELOG.md docs/ALBEDO_LAYER.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b2c6fde420832e9d9b6aa880d86a1c