### PR TITLE
docs: expand operator protocol

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -69,7 +69,7 @@ documents:
     sha256: 6273ffa4258f9015f3e1b06d1dadbfd3f03f0585f0fee79bc1ba1c32e2f00721
     summary: API endpoints and schemas.
   docs/operator_protocol.md:
-    sha256: e150a741e3c81bdd7bb550ef12e3f9696d8572f508342e99a25b8aed2e06597a
+    sha256: 721c9a2aa2172ab01f6cc4a664813463289ddcbf39c25ce7da879ccd4d1fc57d
     summary: Operator interaction rules.
   docs/os_guardian.md:
     sha256: 1b32ad1d78f3b19332b6dfc1c06c4ad8ea9578d0d850947712c33ec04e184eab


### PR DESCRIPTION
## Summary
- document /operator/command and /operator/upload endpoints
- describe WebRTC channels, authentication, rate limits, and fallback rules
- update onboarding confirmations and regenerate documentation index

## Testing
- `pre-commit run --files docs/operator_protocol.md onboarding_confirm.yml docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b2cb138348832e83aa65b633e07f88