### PR TITLE
Log Crown handshake state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mandated end-to-end run examples with logs covering normal operation and failure recovery in agent docs.
 - Archived Crown handshake responses alongside mission briefs and
   auto-launched `GLM4V` when missing from advertised capabilities.
+- Persisted Crown handshake acknowledgement and downtime under `handshake`
+  in `logs/razar_state.json`.
 - Required a "Change justification" field in the pull request template and documented the statement format in The Absolute Protocol.
 - Documented mission brief archive requirements and maintenance in The Absolute Protocol.
 - Added Operator API and Open Web UI entries to `CONNECTOR_INDEX.md` and expanded protocol checklist for connector registry.

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added logging requirement for RAZAR ↔ Crown ↔ Operator exchanges in `logs/interaction_log.jsonl`.
 - Persisted CROWN handshake responses to `logs/mission_briefs/` and
   triggered `crown_model_launcher.sh` when `GLM4V` capability is absent.
+- Stored Crown handshake acknowledgement, capabilities, and downtime under
+  `handshake` in `logs/razar_state.json`.
 
 ## [0.1.0] - 2025-08-30
 

--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -9,7 +9,7 @@ the last successful component.
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import argparse
 import asyncio
@@ -85,9 +85,14 @@ class BootOrchestrator:
         if response is not None:
             data["capabilities"] = response.capabilities
             data["downtime"] = response.downtime
+            data["handshake"] = asdict(response)
         else:
             data.setdefault("capabilities", [])
             data.setdefault("downtime", {})
+            data.setdefault(
+                "handshake",
+                {"acknowledgement": "", "capabilities": [], "downtime": {}},
+            )
         self.state_path.parent.mkdir(parents=True, exist_ok=True)
         self.state_path.write_text(json.dumps(data), encoding="utf-8")
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -210,11 +210,12 @@ plans by combining component priorities, failure counts, and CROWN suggestions.
    `crown_handshake.perform()`, archives the mission brief to
    `logs/mission_briefs/<timestamp>.json`, saves the handshake
    response to `logs/mission_briefs/<timestamp>_response.json`, logs
-   capabilities in `logs/razar.log`, persists them in
-   [logs/razar_state.json](../logs/razar_state.json), and launches
-   [`crown_model_launcher.sh`](../crown_model_launcher.sh) when the
-   returned capabilities lack `GLM4V`, recording the launch under
-   `launched_models`.
+   capabilities in `logs/razar.log`, and persists the full response under
+   the `handshake` key in
+   [logs/razar_state.json](../logs/razar_state.json). If the returned
+   capabilities lack `GLM4V` it launches
+   [`crown_model_launcher.sh`](../crown_model_launcher.sh), recording the
+   launch under `launched_models`.
 
 4. **Launch** – start the boot orchestrator to bring components online:
 

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -161,18 +161,22 @@ Connectors bridge the language engine to external communication layers. Follow t
 
 Track all connectors in [`docs/connectors/CONNECTOR_INDEX.md`](connectors/CONNECTOR_INDEX.md). Each entry must list the connector name, `__version__`, purpose, service, endpoints, protocols, status, and links to documentation and source code. See [Connector Overview](connectors/README.md) for shared design patterns and maintenance rules. Update this registry whenever a connector is added, removed, or its interface changes.
 
-#### Crown Handshake
-
-Mission briefs exchanged during the Crown Handshake are archived at
-`logs/mission_briefs/<timestamp>.json`. Keep this directory maintained to
-preserve handshake history for auditing.
-
 ## Subsystem Protocols
 
 - [Operator Protocol](operator_protocol.md) – outlines `/operator/command`, role checks, and Crown's relay to RAZAR.
 - [Ignition Sequence Protocol](ignition_sequence_protocol.md) – mandates logging points and escalation during boot.
 - [Co-creation Escalation](co_creation_escalation.md) – defines when RAZAR seeks Crown or operator help and the logging for each tier.
 - [Logging & Observability Protocol](#logging--observability-protocol) – structured logging and metrics requirements.
+- [Crown Handshake Protocol](#crown-handshake-protocol) – archives mission briefs and persists handshake responses.
+
+### Crown Handshake Protocol
+
+Mission briefs are archived to `logs/mission_briefs/<timestamp>.json`. The
+boot orchestrator must invoke `crown_handshake.perform()` before launching
+components and persist the returned acknowledgement, capabilities, and downtime
+under the `handshake` key in `logs/razar_state.json`. Maintain these archives
+so operators can audit the exchange and reconcile advertised capabilities with
+runtime behaviour.
 
 ### RAZAR ↔ Crown ↔ Operator Interaction Logging
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -57,7 +57,7 @@ documents:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
     summary: Threat model and protections.
   docs/The_Absolute_Protocol.md:
-    sha256: e389ed6f67a7e6862c433e0d04aab9d50870367b4b384cdf0682aca618824202
+    sha256: b58625b0684d56985594fa528fbf0e7b0a23be9e46a27440e92051c79ddc277e
     summary: Core contribution rules.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a
@@ -75,7 +75,7 @@ documents:
     sha256: 1b32ad1d78f3b19332b6dfc1c06c4ad8ea9578d0d850947712c33ec04e184eab
     summary: OS Guardian subsystem overview.
   docs/RAZAR_AGENT.md:
-    sha256: 3b3b99875d19fbc360ee4ae412f103b18e4665a45c3513163b0c16df9f80f089
+    sha256: fa977879701f829020a23e9b8566485d684a05343a6d5fb5637ced13b14a1c49
     summary: RAZAR agent bootstrap and logging guidance.
   docs/onboarding/test_planning.md:
     sha256: dbacb76c8b866af82bf7531b5facf9ffb9de708c9a55cec042fba1c19e9dc7a0


### PR DESCRIPTION
## Summary
- capture Crown handshake acknowledgment, capabilities, and downtime in `logs/razar_state.json`
- document mission brief archive and handshake state in RAZAR deployment guide
- add Crown Handshake Protocol section to The Absolute Protocol and regenerate docs index

## Testing
- `pytest tests/narrative_engine/test_biosignal_pipeline.py`
- `pytest tests/agents/razar/test_boot_orchestrator.py tests/agents/razar/test_boot_sequence.py tests/agents/razar/test_ignition_sequence.py`
- `pre-commit run --files agents/razar/boot_orchestrator.py docs/RAZAR_AGENT.md docs/The_Absolute_Protocol.md docs/INDEX.md CHANGELOG.md CHANGELOG_razar.md onboarding_confirm.yml`
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_summaries.py` *(fails: Hash mismatch: AGENTS.md ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf542088832e90aaa74ffc515712