### PR TITLE
docs: record razar coverage and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced Pytest Protocol with >90% coverage, chakra-aligned directories, and component index documentation requirements.
 - Expanded Crown agent overview with model loading sequence diagram and configuration table.
 - Documented change justification rule and mandated four-part onboarding summaries; updated pull request template with connector/index checklist.
+- Documented module coverage and example runs in RAZAR agent guide.
 
 ### Added
 

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   triggered `crown_model_launcher.sh` when `GLM4V` capability is absent.
 - Stored Crown handshake acknowledgement, capabilities, and downtime under
   `handshake` in `logs/razar_state.json`.
+- Added module coverage and example run sections to the RAZAR agent guide.
 
 ### Changed
 - Boot orchestrator now persists the handshake response before starting

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -21,6 +21,13 @@ launches each service in priority order. By aligning this startup flow with the
 architecture outlined in the [System Blueprint](system_blueprint.md), RAZAR acts
 as the bootstrap agent that grounds ABZU in a coherent foundation.
 
+## Module Coverage
+
+Tests in [`tests/agents/razar/`](../tests/agents/razar/) exercise the boot
+orchestrator and supporting helpers. Coverage results roll into the repository
+report ([coverage.svg](../coverage.svg)), ensuring each module's behaviour is
+verified during continuous integration.
+
 ## Requirements
 
 Core dependencies:
@@ -693,6 +700,16 @@ provided, and the suggestion returned.
 **Rollback**
 
 If tests fail or regressions appear, RAZAR reverts to the previous state and records the failure for manual review.
+
+## Example Runs
+
+```bash
+# Launch the orchestrator with defaults
+python -m razar.boot_orchestrator
+
+# Perform a standalone Crown handshake
+python -m razar.crown_handshake path/to/brief.json
+```
 
 ## Placeholder remediation
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -175,7 +175,7 @@ documents:
       key_rules: Notes responsibilities and interfaces.
       insight: Review before modifying system protection code.
   docs/RAZAR_AGENT.md:
-    sha256: 9bc753d6765809a47ab0c78561f2f535c80d634ce8b7bef30f0f6e07c0382a09
+    sha256: 6d7a63ebcdd9dbec5367510616f68af4c2bfa2acac0c4d7208e1d421240fd974
     summary:
       purpose: RAZAR agent bootstrap and logging guidance.
       scope: RAZAR agent operations.


### PR DESCRIPTION
## Summary
- detail test coverage for RAZAR modules
- illustrate boot orchestrator and handshake invocations
- track doc changes in changelogs and onboarding hash

## Testing
- `pre-commit run doc-indexer --files docs/RAZAR_AGENT.md docs/INDEX.md`
- `pre-commit run --files docs/RAZAR_AGENT.md docs/INDEX.md CHANGELOG.md CHANGELOG_razar.md onboarding_confirm.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b30eb40a70832eb3425181267a9613