### PR TITLE
Add fixture for module_builder tests and clarify expectations

### DIFF
--- a/tests/agents/razar/test_module_builder.py
+++ b/tests/agents/razar/test_module_builder.py
@@ -1,8 +1,9 @@
-from __future__ import annotations
-
+from pathlib import Path
 from types import SimpleNamespace
 
 import agents.razar.module_builder as module_builder
+
+__version__ = "0.0.0"
 
 
 def _fake_remote(name: str, url: str, patch_context: str | None = None):
@@ -16,8 +17,10 @@ def _fake_remote(name: str, url: str, patch_context: str | None = None):
 def test_module_builder_creates_module(monkeypatch):
     monkeypatch.setattr(module_builder.remote_loader, "load_remote_agent", _fake_remote)
 
+    template = Path(__file__).resolve().parents[2] / "fixtures" / "razar_base_module.py"
     spec = {
         "component": "agents/razar/generated_component.py",
+        "template": str(template),
         "tests": {
             "tests/test_generated_component.py": (
                 "from agents.razar import generated_component\n"
@@ -35,7 +38,7 @@ def test_module_builder_creates_module(monkeypatch):
     try:
         assert path.exists()
         text = path.read_text(encoding="utf-8")
-        assert "TODO" in text
+        assert "original" in text
         assert "patched" in text
     finally:
         path.unlink(missing_ok=True)

--- a/tests/fixtures/razar_base_module.py
+++ b/tests/fixtures/razar_base_module.py
@@ -1,0 +1,5 @@
+__version__ = "0.0.0"
+
+
+def build():
+    return "original"


### PR DESCRIPTION
## Summary
- seed module builder tests with a real template instead of placeholder content
- assert both template and remote patch outputs in generated module

## Testing
- `PYTHONPATH=. pytest tests/agents/razar/test_module_builder.py -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_68b311e527b4832e846ff3c8d337a0f5