### PR TITLE
docs: capture pytest failure lessons

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -3,6 +3,7 @@
 This document summarizes test failures from `pytest -vv` run on 2025-08-30.
 
 ## Missing environment or resource
+See [Missing dependency checklist](../the_absolute_pytest.md#missing-dependency-checklist).
 - [tests/agents/razar/test_crown_link.py](../../tests/agents/razar/test_crown_link.py): Module `websockets` not installed.
   - *Suggested fix*: add `websockets` to project dependencies.
 - [tests/crown/test_initialization.py](../../tests/crown/test_initialization.py): Module `omegaconf` not installed.
@@ -13,10 +14,12 @@ This document summarizes test failures from `pytest -vv` run on 2025-08-30.
   - *Suggested fix*: pin compatible `scikit-learn`/`numpy` versions.
 
 ## Data mismatch or library issue
+See [Library compatibility checks](../the_absolute_pytest.md#library-compatibility-checks).
 - [tests/test_dashboard_app.py](../../tests/test_dashboard_app.py) and [tests/test_dashboard_qnl_mixer.py](../../tests/test_dashboard_qnl_mixer.py): Plotly theme configuration sets a string where a numeric array is expected, causing `AttributeError: 'str' object has no attribute 'dtype'`.
   - *Suggested fix*: adjust Plotly configuration to supply numeric color values.
 
 ## Code defects / test configuration
+See [Fixture-writing guidelines](../the_absolute_pytest.md#fixture-writing-guidelines).
 - [tests/test_quarantine_manager.py](../../tests/test_quarantine_manager.py) and [tests/test_vector_memory.py](../../tests/test_vector_memory.py): `import file mismatch` due to duplicate test module names under different paths.
   - *Suggested fix*: rename one of the duplicate test modules or adjust `PYTHONPATH` to avoid conflicts.
 - [tests/test_voice_cloner_cli.py](../../tests/test_voice_cloner_cli.py): `ImportError` for `load_config` in `core`.

--- a/docs/the_absolute_pytest.md
+++ b/docs/the_absolute_pytest.md
@@ -39,3 +39,24 @@ Run tests as usual and inspect the metrics file or have Prometheus scrape the pa
 
   The archive can be shared with AI reviewers alongside entries recorded via
   `corpus_memory_logging.log_test_failure`.
+
+## Lessons from Failure Inventory
+
+The [Failure Inventory](testing/failure_inventory.md) catalogs common issues discovered in the test suite. Apply the following guidelines to avoid repeating them.
+
+### Missing dependency checklist
+
+- Use `importlib.util.find_spec` or `pytest.importorskip` to handle optional libraries.
+- Record new packages in `requirements.txt` and `dependency_registry.md`.
+- Document installation steps in related module guides.
+
+### Fixture-writing guidelines
+
+- Give fixtures unique module names to avoid import mismatches.
+- Isolate side effects with `tmp_path`, `monkeypatch`, or other pytest fixtures.
+- Guard external resources with `@pytest.mark.skipif` when prerequisites are absent.
+
+### Library compatibility checks
+
+- Pin library versions when upstream changes break APIs.
+- Validate input shapes and dtypes to catch mismatches early.


### PR DESCRIPTION
## Summary
- Teach missing dependency checklist and fixture-writing tips in Pytest guide
- Link failure inventory categories to relevant sections of the guide
- Regenerate documentation index

## Testing
- `pre-commit run doc-indexer --files docs/the_absolute_pytest.md docs/testing/failure_inventory.md docs/INDEX.md`
- `pre-commit run --files docs/the_absolute_pytest.md docs/testing/failure_inventory.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b315a00868832ea1ceec656824e0c6