### PR TITLE
docs: add RAZAR config schemas

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -623,6 +623,24 @@ Sample mission brief:
 
 Defines component launch commands and health checks.
 
+**Schema snippet** ([full schema](schemas/boot_config.schema.json))
+
+```json
+{
+  "type": "object",
+  "required": ["components"],
+  "properties": {
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "command", "health_check"]
+      }
+    }
+  }
+}
+```
+
 ### `razar_env.yaml`
 
 ```yaml
@@ -636,6 +654,21 @@ layers:
 ```
 
 Lists per-layer dependencies for the environment builder.
+
+**Schema snippet** ([full schema](schemas/razar_env.schema.yaml))
+
+```yaml
+type: object
+required:
+  - layers
+properties:
+  layers:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        type: string
+```
 
 ### `logs/razar_state.json`
 
@@ -654,6 +687,21 @@ Lists per-layer dependencies for the environment builder.
 ```
 
 Captures runtime state and handshake capabilities.
+
+**Schema snippet** ([full schema](schemas/razar_state.schema.json))
+
+```json
+{
+  "type": "object",
+  "required": [
+    "last_component",
+    "capabilities",
+    "downtime",
+    "launched_models",
+    "handshake"
+  ]
+}
+```
 
 ## AI Handover
 

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -145,7 +145,7 @@ All diagrams must include a brief textual description and be expressed as Mermai
 
 ### Configuration File Documentation
 
-Any new configuration file must be accompanied by documentation that outlines its schema and includes a minimal working example. Review existing patterns such as [boot_config.json](RAZAR_AGENT.md#boot_configjson), [razar_env.yaml](RAZAR_AGENT.md#razar_envyaml), and the log formats in the [logging guidelines](logging_guidelines.md).
+Any new configuration file must be accompanied by documentation that outlines its schema and includes a minimal working example. Review existing patterns such as [boot_config.json](RAZAR_AGENT.md#boot_configjson) ([schema](schemas/boot_config.schema.json)), [razar_env.yaml](RAZAR_AGENT.md#razar_envyaml) ([schema](schemas/razar_env.schema.yaml)), and the log formats in the [logging guidelines](logging_guidelines.md) alongside [razar_state.json](RAZAR_AGENT.md#logsrazar_statejson) ([schema](schemas/razar_state.schema.json)).
 
 ### Module Versioning
 

--- a/docs/schemas/boot_config.schema.json
+++ b/docs/schemas/boot_config.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RAZAR Boot Configuration",
+  "type": "object",
+  "required": ["components"],
+  "properties": {
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "command", "health_check"],
+        "properties": {
+          "name": {"type": "string"},
+          "command": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1
+          },
+          "health_check": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/razar_env.schema.yaml
+++ b/docs/schemas/razar_env.schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: RAZAR Environment Layers
+type: object
+required:
+  - layers
+properties:
+  layers:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        type: string
+additionalProperties: false

--- a/docs/schemas/razar_state.schema.json
+++ b/docs/schemas/razar_state.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RAZAR State",
+  "type": "object",
+  "required": [
+    "last_component",
+    "capabilities",
+    "downtime",
+    "launched_models",
+    "handshake"
+  ],
+  "properties": {
+    "last_component": {"type": "string"},
+    "capabilities": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "downtime": {"type": "object"},
+    "launched_models": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "handshake": {
+      "type": "object",
+      "required": ["acknowledgement", "capabilities", "downtime"],
+      "properties": {
+        "acknowledgement": {"type": "string"},
+        "capabilities": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "downtime": {"type": "object"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -133,7 +133,7 @@ documents:
       key_rules: Details defenses and threat mitigations.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 9759437b015784856230ec8862867afccaf2d1381b904907d80190dc337a19e5
+    sha256: 5b7d5c2c99f25553e1e7f21bfce1eb1b1813d29195d2050a3bae20c2d48f9f91
     summary:
       purpose: Core contribution rules.
       scope: All contributors.
@@ -175,7 +175,7 @@ documents:
       key_rules: Notes responsibilities and interfaces.
       insight: Review before modifying system protection code.
   docs/RAZAR_AGENT.md:
-    sha256: 6d7a63ebcdd9dbec5367510616f68af4c2bfa2acac0c4d7208e1d421240fd974
+    sha256: 08824a3f631a52ef35dc5cb04ac3ea0d7c2d780766ca56134333f92d38d3827e
     summary:
       purpose: RAZAR agent bootstrap and logging guidance.
       scope: RAZAR agent operations.

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -1,19 +1,34 @@
-"""Validate YAML templates and JSON schema files."""
+"""Validate YAML templates and JSON/YAML schema files."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import yaml
 from jsonschema import validate
 
+__version__ = "0.1.0"
+
 SCHEMAS = [
-    ("insight_matrix.json", "insight_matrix.schema.json"),
-    ("insight_manifest.json", "insight_manifest.schema.json"),
-    ("intent_matrix.json", "intent_matrix.schema.json"),
-    ("mirror_thresholds.json", "mirror_thresholds.schema.json"),
+    ("insight_matrix.json", "schemas/insight_matrix.schema.json"),
+    ("insight_manifest.json", "schemas/insight_manifest.schema.json"),
+    ("intent_matrix.json", "schemas/intent_matrix.schema.json"),
+    ("mirror_thresholds.json", "schemas/mirror_thresholds.schema.json"),
+    ("razar/boot_config.json", "docs/schemas/boot_config.schema.json"),
+    ("razar_env.yaml", "docs/schemas/razar_env.schema.yaml"),
+    ("logs/razar_state.json", "docs/schemas/razar_state.schema.json"),
 ]
+
+
+def _load(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".json":
+        return json.loads(text)
+    if path.suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(text)
+    raise ValueError(f"Unsupported file type: {path.suffix}")
 
 
 def _validate_templates() -> None:
@@ -28,9 +43,9 @@ def _validate_templates() -> None:
 def _validate_schemas() -> None:
     for data_file, schema_file in SCHEMAS:
         data_path = Path(data_file)
-        schema_path = Path("schemas") / schema_file
-        data = json.loads(data_path.read_text(encoding="utf-8"))
-        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        schema_path = Path(schema_file)
+        data = _load(data_path)
+        schema = _load(schema_path)
         validate(data, schema)
 
 


### PR DESCRIPTION
## Summary
- document boot, environment, and state schemas in `RAZAR_AGENT.md`
- add JSON/YAML schemas with CI validation
- link Absolute Protocol config rule to schema files

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/The_Absolute_Protocol.md scripts/validate_configs.py docs/schemas/boot_config.schema.json docs/schemas/razar_env.schema.yaml docs/schemas/razar_state.schema.json docs/INDEX.md onboarding_confirm.yml`
- `pytest tests/narrative_engine/test_biosignal_pipeline.py tests/narrative_engine/test_biosignal_transformation.py` *(fails: ModuleNotFoundError: No module named 'corpus_memory_logging')*

## Action summary
- I documented RAZAR configuration schemas and added validation in CI to obtain consistent configuration checks, expecting CI to enforce schema compliance.

------
https://chatgpt.com/codex/tasks/task_e_68b320467664832e8eab89e6892647ca