### PR TITLE
docs: expand INANNA setup and memory queries

### DIFF
--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -91,6 +91,19 @@ corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
    This builds the Chroma index under `data/vector_memory/chroma` and
    confirms the vector store path.
 
+   Verify the collection and optionally expose it for inspection:
+
+   ```bash
+   python - <<'PY'
+   from spiral_vector_db import init_db
+   col = init_db()
+   print("records:", col.count())
+   PY
+
+   # optional: run a standalone Chroma API server
+   python -m chromadb --path data/vector_memory/chroma --port 8030 &
+   ```
+
 3. **Launch servant model endpoints**
 
    Define the endpoints via `SERVANT_MODELS` and run the launcher:
@@ -101,7 +114,12 @@ corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
    ```
 
    Each endpoint must expose a `/health` route and accept a JSON body
-   `{"prompt": "..."}`.
+   `{"prompt": "..."}`. Confirm they are reachable:
+
+   ```bash
+   curl -f http://localhost:8002/health
+   curl -f http://localhost:8003/health
+   ```
 
 4. **Start INANNA core**
 

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -9,7 +9,8 @@ of experience. Every layer supports two storage back‑end families:
 
 Environment variables toggle the back‑end and location for each layer. The
 sections below outline initialisation commands, back‑end options and
-persistence strategies for each store:
+persistence strategies for each store. Each section also includes a minimal
+query example:
 
 - **Cortex** – persistent application state with semantic tags.
 - **Emotional** – affective snapshots mirroring the agent's mood.
@@ -67,6 +68,8 @@ cortex_collection = cortex_db()
 
 #### Query example
 
+Store and retrieve a record:
+
 ```bash
 python - <<'PY'
 from memory.cortex import record_spiral, query_spirals
@@ -112,6 +115,8 @@ emotion_collection = emotion_db()
 
 #### Query example
 
+Store and retrieve a record:
+
 ```bash
 python - <<'PY'
 from memory.emotional import get_connection, log_emotion, fetch_emotion_history
@@ -152,6 +157,8 @@ init_rl_model()  # uses NEO4J_* variables
 ```
 
 #### Query example
+
+Store and retrieve a record:
 
 ```bash
 python - <<'PY'
@@ -197,6 +204,8 @@ spirit_collection = spirit_db()
 
 #### Query example
 
+Store and retrieve a record:
+
 ```bash
 python - <<'PY'
 from memory.spiritual import get_connection, map_to_symbol, lookup_symbol_history
@@ -239,6 +248,8 @@ narrative_collection = narrative_db()
 ```
 
 #### Query example
+
+Store and retrieve a record:
 
 ```bash
 python - <<'PY'


### PR DESCRIPTION
## Summary
- detail reindexing, optional Chroma server launch, and servant health checks in `INANNA_CORE` setup
- highlight query snippets for each memory layer in `memory_architecture`

## Testing
- `pre-commit run --files docs/INANNA_CORE.md docs/memory_architecture.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b348bfaf14832ebbc50aeac2f4276b