### PR TITLE
feat: support operator file uploads to RAZAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforced Crown availability during boot and rotated mission brief archives under `logs/mission_briefs/`.
 - Added Connector Guidelines section requiring version fields, endpoint documentation, and registry updates, enforced by a pre-commit check.
 - Crown prompt orchestrator reviews test metrics and logs remediation suggestions to corpus memory.
-- Extended Operator API and web console to support file uploads with metadata forwarded to Crown and documented `/operator/upload` authentication and rate limits.
+- Extended Operator API and web console to support file uploads with metadata relayed to RAZAR via Crown, and documented `/operator/upload` authentication and rate limits.
 - Pytest runs export coverage, session duration, and failure metrics via `prometheus_client` to `monitoring/pytest_metrics.prom`, and CI uploads the metrics artifact.
 - Implemented AI handover workflow that delegates failures to remote agents,
   logging invocations and applied patch diffs.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -140,7 +140,8 @@ individual tiers.
 RAZAR operates as service 0, validating the environment and enforcing the
 startup order. It rewrites [Ignition.md](Ignition.md) with status markers so
 operators can track health at a glance. The [Operator API](../operator_api.py)
-(v0.1.0) supports `/operator/command` and `/operator/upload` channels detailed in
+(v0.1.0) supports `/operator/command` and `/operator/upload` channels, forwarding
+upload metadata to RAZAR as detailed in
 [operator_protocol.md](operator_protocol.md). The broader
 [RAZAR Agent](RAZAR_AGENT.md) guide explains how priorities are derived and
 progress is persisted. CROWN LLM diagnostics and shutdown–repair–restart

--- a/tests/test_operator_api.py
+++ b/tests/test_operator_api.py
@@ -54,9 +54,13 @@ def test_command_requires_fields(client: TestClient) -> None:
 def test_upload_stores_and_forwards(client: TestClient, monkeypatch) -> None:
     captured: dict[str, dict] = {}
 
-    def dispatch(operator, agent, func, meta):
-        captured["meta"] = meta
-        return {"ok": True}
+    def dispatch(operator, agent, func, *args):
+        if operator == "overlord" and agent == "crown":
+            return func(*args)
+        if operator == "crown" and agent == "razar":
+            captured["meta"] = args[0]
+            return {"ok": True}
+        raise AssertionError("unexpected dispatch")
 
     monkeypatch.setattr(operator_api._dispatcher, "dispatch", dispatch)
     resp = client.post(

--- a/web_console/operator.js
+++ b/web_console/operator.js
@@ -50,5 +50,27 @@ function uploadFiles(files, metadata = {}, operator = 'overlord') {
     }).then(resp => resp.json());
 }
 
-export { API_URL, BASE_URL, OFFER_URL, UPLOAD_URL, sendCommand, startStream, uploadFiles };
+function uploadFile(file, metadata = {}, operator = 'overlord') {
+    return uploadFiles([file], metadata, operator);
+}
+
+function uploadMedia(blob, filename, metadata = {}, operator = 'overlord') {
+    const formData = new FormData();
+    formData.append('files', blob, filename);
+    formData.append('operator', operator);
+    formData.append('metadata', JSON.stringify(metadata));
+    return fetch(UPLOAD_URL, { method: 'POST', body: formData }).then(resp => resp.json());
+}
+
+export {
+    API_URL,
+    BASE_URL,
+    OFFER_URL,
+    UPLOAD_URL,
+    sendCommand,
+    startStream,
+    uploadFiles,
+    uploadFile,
+    uploadMedia
+};
 


### PR DESCRIPTION
## Summary
- add upload handlers in web console for files and media
- route `/operator/upload` through Crown to relay metadata to RAZAR
- document authentication, rate limits, and examples for operator protocol

## Testing
- `pre-commit run --files web_console/operator.js operator_api.py docs/operator_protocol.md docs/system_blueprint.md CHANGELOG.md tests/test_operator_api.py docs/INDEX.md`
- `PYTHONPATH=. pytest tests/test_operator_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68b34c1adcb8832e80ab4f27bbd97193