### PR TITLE
docs: expand Nazarick agent and console guides

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -281,7 +281,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [onboarding_walkthrough.md](onboarding_walkthrough.md) | Onboarding Walkthrough | This text-based walkthrough provides a step-by-step path to set up the repository and rebuild the project from a fres... | - |
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |
 | [operations.md](operations.md) | Operations | - | - |
-| [operator_protocol.md](operator_protocol.md) | Operator Protocol | Defines HTTP endpoints and WebRTC channels for operator interactions with Crown and RAZAR. | - |
+| [operator_protocol.md](operator_protocol.md) | Operator Protocol | Defines HTTP endpoints and WebRTC channels for operator interactions with Crown and RAZAR. For agent chat rooms and r... | - |
 | [os_guardian.md](os_guardian.md) | OS Guardian | Sources: [`../os_guardian/perception.py`](../os_guardian/perception.py), [`../os_guardian/planning.py`](../os_guardia... | `../os_guardian/action_engine.py`, `../os_guardian/perception.py`, `../os_guardian/planning.py`, `../os_guardian/safety.py` |
 | [os_guardian_container.md](os_guardian_container.md) | OS Guardian Container | This guide covers running the `os_guardian` tools inside Docker. | - |
 | [os_guardian_permissions.md](os_guardian_permissions.md) | OS Guardian Permission Policies | The `safety` module guards high-risk actions executed by the OS Guardian utilities. Permissions are configured with e... | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Curated starting points for understanding and operating the project. For an exha
 - [Nazarick Agents](nazarick_agents.md)
 - [Nazarick Manifesto](nazarick_manifesto.md)
 - [Nazarick Web Console](nazarick_web_console.md)
+- [Operator Protocol](operator_protocol.md)
 ## Setup
 - [Setup Guide](setup.md)
 ## Usage

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -51,29 +51,29 @@ Operator tooling is documented in the [Nazarick Web Console](nazarick_web_consol
 | <a id="asian-gen-creative-engine"></a>AsianGen Creative Engine | 5 | [Scriptorium](system_blueprint.md#floor-5-scriptorium) | Throat |
 | <a id="land-graph-geo-knowledge"></a>LandGraph Geo Knowledge | 1 | [Cartography Room](system_blueprint.md#floor-1-cartography-room) | Root |
 
-## Chat Rooms and Channels
+## Deployment and Responsibilities
 
-Agents communicate through named chat rooms that mirror their channels in the system blueprint. These rooms are available via the [Open Web UI Integration Guide](open_web_ui.md) and the [Operator Protocol](operator_protocol.md).
+Agents communicate through named chat rooms that mirror their channels in the system blueprint. Each servant can be launched individually with `./launch_servants.sh <agent>` and is available via the [Open Web UI Integration Guide](open_web_ui.md) and the [Operator Protocol](operator_protocol.md).
 
-| Agent | Chat Room |
-| --- | --- |
-| Orchestration Master | `#throne-room` |
-| Prompt Orchestrator | `#signal-hall` |
-| QNL Engine | `#insight-observatory` |
-| Memory Scribe | `#memory-vault` |
-| Demiurge Strategic Simulator | `#lava-pits` |
-| Shalltear Fast Inference Agent | `#catacombs` |
-| Cocytus Prompt Arbiter | `#glacier-prison` |
-| Ecosystem Aura Capture | `#jungle-aerie` |
-| Ecosystem Mare Gardener | `#jungle-grove` |
-| Sebas Compassion Module | `#royal-suite` |
-| Victim Security Canary | `#sacrificial-chamber` |
-| Pandora Persona Emulator | `#treasure-vault` |
-| Pleiades Star Map Utility | `#maid-quarters` |
-| Pleiades Signal Router Utility | `#relay-wing` |
-| Bana Bio-Adaptive Narrator | `#biosphere-lab` |
-| AsianGen Creative Engine | `#scriptorium` |
-| LandGraph Geo Knowledge | `#cartography-room` |
+| Agent | Deployment | Responsibilities | Chat Room |
+| --- | --- | --- | --- |
+| Orchestration Master | `./launch_servants.sh orchestration_master` | Boot order and pipeline supervision | `#throne-room` |
+| Prompt Orchestrator | `./launch_servants.sh crown_prompt_orchestrator` | Route prompts and recall context | `#signal-hall` |
+| QNL Engine | `./launch_servants.sh qnl_engine` | Process QNL sequences and insights | `#insight-observatory` |
+| Memory Scribe | `./launch_servants.sh memory_scribe` | Persist transcripts and embeddings | `#memory-vault` |
+| Demiurge Strategic Simulator | `./launch_servants.sh demiurge_strategic_simulator` | Scenario planning and failure forecasts | `#lava-pits` |
+| Shalltear Fast Inference Agent | `./launch_servants.sh shalltear_fast_inference_agent` | Low-latency inference for rapid replies | `#catacombs` |
+| Cocytus Prompt Arbiter | `./launch_servants.sh cocytus_prompt_arbiter` | Filter and validate prompts | `#glacier-prison` |
+| Ecosystem Aura Capture | `./launch_servants.sh ecosystem_aura_capture` | Capture environmental telemetry | `#jungle-aerie` |
+| Ecosystem Mare Gardener | `./launch_servants.sh ecosystem_mare_gardener` | Maintain ecosystem metrics | `#jungle-grove` |
+| Sebas Compassion Module | `./launch_servants.sh sebas_compassion_module` | Apply empathy and moderation checks | `#royal-suite` |
+| Victim Security Canary | `./launch_servants.sh victim_security_canary` | Monitor for security anomalies | `#sacrificial-chamber` |
+| Pandora Persona Emulator | `./launch_servants.sh pandora_persona_emulator` | Emulate stored personas | `#treasure-vault` |
+| Pleiades Star Map Utility | `./launch_servants.sh pleiades_star_map_utility` | Compute celestial alignments | `#maid-quarters` |
+| Pleiades Signal Router Utility | `./launch_servants.sh pleiades_signal_router_utility` | Route signals among servants | `#relay-wing` |
+| Bana Bio-Adaptive Narrator | `./launch_servants.sh bana_bio_adaptive_narrator` | Generate narratives from bio data | `#biosphere-lab` |
+| AsianGen Creative Engine | `./launch_servants.sh asian_gen_creative_engine` | Produce multilingual creative text | `#scriptorium` |
+| LandGraph Geo Knowledge | `./launch_servants.sh land_graph_geo_knowledge` | Provide geospatial queries | `#cartography-room` |
 
 ## Channel Mappings
 

--- a/docs/nazarick_web_console.md
+++ b/docs/nazarick_web_console.md
@@ -61,3 +61,10 @@ sequenceDiagram
 4. Open `index.html` in a browser and grant microphone and camera access.
 5. Enter commands or music prompts. Logs and streams display in real time.
 
+## Extensibility Hooks
+
+- Extend `web_console/main.js` to add custom controls or visualizations.
+- Expose new operations through `web_console/operator.js` so other dashboards can reuse them.
+- Register event listeners in `main.js` to intercept `sendCommand` responses or WebRTC status updates.
+- Implement additional transport modules by following the patterns in [`webrtc_connector.py`](../connectors/webrtc_connector.py).
+

--- a/docs/operator_protocol.md
+++ b/docs/operator_protocol.md
@@ -1,6 +1,6 @@
 # Operator Protocol
 
-Defines HTTP endpoints and WebRTC channels for operator interactions with Crown and RAZAR.
+Defines HTTP endpoints and WebRTC channels for operator interactions with Crown and RAZAR. For agent chat rooms and responsibilities see [Nazarick Agents](nazarick_agents.md).
 
 ## Authentication
 
@@ -47,7 +47,7 @@ curl -X POST \
 
 ## WebRTC Channels
 
-The Nazarick Web Console establishes a WebRTC connection to stream avatar output. Clients may request:
+The [Nazarick Web Console](nazarick_web_console.md) establishes a WebRTC connection to stream avatar output. Clients may request:
 
 - **Video** – avatar frames
 - **Audio** – PCM/WAV audio


### PR DESCRIPTION
## Summary
- document deployment, responsibilities, and chat rooms for each Nazarick agent
- detail web console UI setup and extensibility hooks
- link operator protocol and regenerate doc index

## Testing
- `pre-commit run --files docs/nazarick_agents.md docs/nazarick_web_console.md docs/index.md docs/operator_protocol.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b352cca300832ea670946b15d1cbcb