### PR TITLE
Start Primordials service during boot

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -46,6 +46,15 @@ Layer-specific packages are defined in
 [razar_env.yaml](../razar_env.yaml) and documented in
 [dependencies.md](dependencies.md).
 
+## Deployment
+
+The orchestrator prepares core services before handing control to CROWN:
+
+1. Launch the Primordials container.
+2. Poll its `/health` endpoint until a `200` response confirms readiness.
+3. Perform the Crown handshake and persist returned capabilities to `logs/razar_state.json`.
+4. If the GLM‑4.1V model is absent, trigger `crown_model_launcher.sh` to load it.
+
 ## Module Overviews
 
 ### `boot_orchestrator.py`


### PR DESCRIPTION
## Summary
- launch Primordials container at RAZAR boot and wait on /health before Crown handshake
- persist handshake capabilities and trigger GLM4V launch if absent
- document boot deployment sequence in RAZAR agent guide

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py docs/RAZAR_AGENT.md docs/INDEX.md`
- `pytest tests/agents/razar/test_boot_orchestrator.py::test_perform_handshake_persists_state_and_launches_model -q` *(fails: ModuleNotFoundError: No module named 'corpus_memory_logging')*

------
https://chatgpt.com/codex/tasks/task_e_68b3585814b0832e9348f671a05dbb6f