### PR TITLE
docs: add RAZAR run log example

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -791,6 +791,15 @@ python -m razar.boot_orchestrator
 python -m razar.crown_handshake path/to/brief.json
 ```
 
+```console
+$ python -m razar.boot_orchestrator --mission demo
+[2025-09-21 12:00:00] INFO boot_orchestrator: starting mission demo
+[2025-09-21 12:00:05] INFO crown_link: handshake acknowledged
+RAZAR ready.
+$ tail -n 1 logs/razar_mission.log
+2025-09-21T12:00:05Z INFO boot_orchestrator Mission demo boot sequence complete
+```
+
 ## Placeholder remediation
 
 The `check-placeholders` pre-commit hook blocks commits containing `TODO` or


### PR DESCRIPTION
## Summary
- add console session and log output example to RAZAR agent guide

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/INDEX.md`

## Change Justification
- improves RAZAR documentation; no functional code changes

------
https://chatgpt.com/codex/tasks/task_e_68b35d815768832e8a4f7cb3eb9dc9a9