### PR TITLE
Add Bana engine and Primordials components

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -230,6 +230,79 @@
       "version": "0.0.1",
       "path": "services/primordials_service",
       "purpose": "Hosts DeepSeek-V3 invocation endpoints",
+      "dependencies": [
+        "fastapi"
+      ],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 5,
+      "adr": null
+    },
+    {
+      "id": "bana_engine",
+      "chakra": "heart",
+      "type": "agent",
+      "version": "0.0.1",
+      "path": "agents/bana",
+      "purpose": "Biosignal-driven narrative generation",
+      "dependencies": [
+        "biosppy",
+        "numpy",
+        "transformers"
+      ],
+      "tests": [
+        "tests/agents/test_bana.py",
+        "tests/agents/test_bana_narrator.py"
+      ],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "bana_events_dataset",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/bana/events.jsonl",
+      "purpose": "Structured event logs for narrative generation",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "bana_narratives_dataset",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/bana/narratives.jsonl",
+      "purpose": "Curated story samples for fine-tuning",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "primordials_config",
+      "chakra": "crown",
+      "type": "config",
+      "version": "0.0.1",
+      "path": "schemas/primordials_config.schema.yaml",
+      "purpose": "Configuration schema for Primordials service",
       "dependencies": [],
       "tests": [],
       "status": "experimental",

--- a/docs/bana_engine.md
+++ b/docs/bana_engine.md
@@ -2,6 +2,8 @@
 
 This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sources, event processing, and where generated stories are saved.
 
+See the corresponding entries in [component_index.json](../component_index.json) for metadata on the engine and its datasets.
+
 ## Mistral 7B Fine‑Tuning
 
 - **Base model:** `mistralai/Mistral-7B-v0.3`

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -123,6 +123,7 @@ These agents draw from the chakra structure outlined in the [Developer Onboardin
 - **Manifesto:** [Nazarick Manifesto](nazarick_manifesto.md)
 - **Channel:** [Biosphere Lab](system_blueprint.md#floor-4-biosphere-lab)
 - **Dependencies:** `biosppy`, `transformers`, `numpy`
+- **Component entry:** [component_index.json](../component_index.json)
 - **Quick start:**
 
   ```python

--- a/docs/primordials_service.md
+++ b/docs/primordials_service.md
@@ -2,6 +2,8 @@
 
 The Primordials service hosts the DeepSeek-V3 language model for internal orchestration tasks. It exposes HTTP endpoints for invoking the model, requesting inspirational prompts, and reporting service health.
 
+See the [component index entry](../component_index.json) for metadata on this service.
+
 ## Deployment
 
 DeepSeek-V3 runs within an isolated container and loads weights on startup. The service requires access to GPU resources and the model checkpoints provided by the deployment pipeline.

--- a/docs/schemas/component_index.json
+++ b/docs/schemas/component_index.json
@@ -5,38 +5,42 @@
   "required": ["components"],
   "properties": {
     "$schema": {"type": "string"},
+    "system_version": {"type": "string"},
+    "index_version": {"type": "number"},
     "components": {
       "type": "array",
       "items": {
         "type": "object",
         "required": ["id", "chakra", "type", "version"],
-        "properties": {
-          "id": {"type": "string"},
-          "chakra": {"type": "string"},
-          "type": {"type": "string"},
-          "version": {"type": "string"},
-          "path": {"type": "string"},
-          "purpose": {"type": "string"},
-          "dependencies": {
-            "type": "array",
-            "items": {"type": "string"}
-          },
-          "tests": {
-            "type": "array",
-            "items": {"type": "string"}
-          },
-          "status": {"type": "string"},
-          "metrics": {
-            "type": "object",
-            "properties": {
-              "coverage": {"type": "number"}
+          "properties": {
+            "id": {"type": "string"},
+            "chakra": {"type": "string"},
+            "type": {"type": "string"},
+            "version": {"type": "string"},
+            "path": {"type": "string"},
+            "purpose": {"type": "string"},
+            "dependencies": {
+              "type": "array",
+              "items": {"type": "string"}
             },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
+            "tests": {
+              "type": "array",
+              "items": {"type": "string"}
+            },
+            "status": {"type": "string"},
+            "metrics": {
+              "type": "object",
+              "properties": {
+                "coverage": {"type": "number"}
+              },
+              "additionalProperties": false
+            },
+            "ignition_stage": {"type": "number"},
+            "adr": {"type": ["string", "null"]}
+          },
+          "additionalProperties": false
+        }
       }
-    }
   },
   "additionalProperties": false
 }

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -51,6 +51,7 @@ closing the loop and keeping the operator at the center of guidance.
   - [Persona API Guide](persona_api_guide.md) – conventions for persona profiles and hooks
   - [Nazarick Manifesto](nazarick_manifesto.md) – narrative charter governing personas
   - [Chat2DB Interface](chat2db.md) – bridge between the relational log and vector store
+  - [Primordials Service](primordials_service.md) – DeepSeek-V3 orchestration service
 - **Operational guides**
   - [Operations Guide](operations.md) – runbooks for deployment and maintenance
 - [Monitoring Guide](monitoring.md) – telemetry collection and alerting

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -17,6 +17,12 @@ documents:
       purpose: High-level system architecture.
       scope: Entire platform.
       insight: Align new modules with existing architecture.
+  docs/bana_engine.md:
+    sha256: 33184b164f2ea14748b1ab7a9afdfc837cf30c8836cb1384f255149e1fc5a6c4
+    summary:
+      purpose: Bana narrative engine guide.
+      scope: Training data and workflow.
+      insight: Reference for narrative generation components.
   docs/documentation_protocol.md:
     sha256: ae84f16638303413f944fd3a2b0adf70679c3ee82c06eefa2ab18c1141468239
     summary:
@@ -102,7 +108,7 @@ documents:
       scope: Connector development.
       insight: Follow guidelines to ensure interoperability.
   docs/system_blueprint.md:
-    sha256: 38a378de3383a13a8da60090031721d84a49b6d6f98a9d0ce2f2f488810ed7b6
+    sha256: 9dbc78e94b65d33a06886a5eafae23d9f9564104061a40e65600c34fb50511c9
     summary:
       purpose: Architectural blueprint overview.
       scope: System-wide architecture.


### PR DESCRIPTION
## Summary
- register primordials service and Bana engine, including datasets and config, in `component_index.json`
- link Primordials and Bana docs to component index and document schema
- broaden component index schema with versioning and ignition metadata

## Testing
- `python tools/doc_indexer.py`
- `python - <<'PY'
import json, jsonschema
schema=json.load(open('docs/schemas/component_index.json'))
data=json.load(open('component_index.json'))
jsonschema.validate(data, schema)
print('component_index.json is valid')
PY`
- `pre-commit run --files component_index.json docs/bana_engine.md docs/primordials_service.md docs/nazarick_agents.md docs/system_blueprint.md docs/schemas/component_index.json onboarding_confirm.yml docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b36ca72084832eb4bed8bdd5d5d324