### PR TITLE
chore: clarify connector registry insight

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -131,7 +131,7 @@ documents:
       purpose: Registry of connector details.
       scope: All connectors.
       key_rules: Update registry when connector changes.
-      insight: Update entry whenever a connector changes.
+      insight: Ensure this registry entry is revised whenever a connector changes.
   docs/connectors/README.md:
     sha256: c5aaeeafce2649d5c1bcd6b0501c39aff1c87ea4ee73b1397ba9fa99a786922d
     summary:


### PR DESCRIPTION
## Summary
- clarify onboarding insight for connector index to note registry revisions on connector changes

## Testing
- `pre-commit run --files onboarding_confirm.yml docs/connectors/CONNECTOR_INDEX.md`
- `python scripts/verify_doc_summaries.py` *(fails: Hash mismatch: AGENTS.md, docs/ABZU_SUBSYSTEM_OVERVIEW.md, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b37c69076c832eb24a9b21159134f3