### PR TITLE
docs: expand connector registry and guidelines

### DIFF
--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -16,8 +16,8 @@ This requirement is reinforced by The Absolute Protocol's
 | [System Blueprint](system_blueprint.md) | Architectural overview | Quarterly |
 | [Component Index](component_index.md) | Inventory of modules and services | Quarterly |
 | [Component Status](component_status.md) | Tracks component readiness | Quarterly |
-| [Connector Index](connectors/CONNECTOR_INDEX.md) | Canonical registry of connector IDs, purpose, versions, endpoints, auth methods, status, and links to docs and source code | Quarterly |
-| [Connector Overview](connectors/README.md) | Maintenance rules and example schemas for connector implementations | Quarterly |
+| [Connector Index](connectors/CONNECTOR_INDEX.md) | Canonical registry of connector IDs, purpose, versions, endpoints, auth methods, status, and links to docs and source code. Update this index whenever connector details change. | Quarterly |
+| [Connector Overview](connectors/README.md) | Maintenance rules and schema templates for connector implementations | Quarterly |
 | [Security Model](security_model.md) | Threat modeling and protections | Quarterly |
 | [Data Security and Compliance](data_security.md) | Compliance requirements | Quarterly |
 | [Data Manifest](data_manifest.md) | Data sources and types | Quarterly |

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -9,8 +9,8 @@ connector's interface changes. For shared patterns across connectors see the
 
 | id | purpose | version | endpoints | auth | status | docs | code |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `operator_api` | operator command and upload interface | 0.2.0 | `POST /operator/command`, `POST /operator/upload` | Bearer (`operator` role) | Experimental | [Operator Protocol](../operator_protocol.md) | [operator_api.py](../../operator_api.py) |
+| `operator_api` | operator command and upload interface | 0.3.0 | `POST /operator/command`, `POST /operator/upload` | Bearer (`operator` role) | Experimental | [Operator Protocol](../operator_protocol.md) | [operator_api.py](../../operator_api.py) |
 | `webrtc` | real-time avatar streaming bridge | 0.3.0 | `POST /call` | JWT | Experimental | [Nazarick Web Console](../nazarick_web_console.md) | [webrtc_connector.py](../../connectors/webrtc_connector.py) |
-| `primordials_api` | DeepSeek‑V3 orchestration service | 0.1.0 | `POST /invoke`, `POST /inspire`, `GET /health` | Internal | Experimental | [Primordials Service](../primordials_service.md) | — |
-| `crown` | Crown WebSocket and GLM endpoints | 0.1.0 | `WS /crown_link` | None | Experimental | [Crown Agent Overview](../CROWN_OVERVIEW.md) | [crown_link.py](../../agents/razar/crown_link.py) |
-| `future_service` | placeholder for upcoming connectors | 0.0.0 | `TBD` | `TBD` | Planned | — | — |
+| `primordials_api` | DeepSeek‑V3 orchestration service | 0.1.0 | `POST /invoke`, `POST /inspire`, `GET /health` | Internal bearer | Experimental | [Primordials Service](../primordials_service.md) | — |
+| `crown` | Crown WebSocket and GLM endpoints | 0.1.0 | `WS /crown_link`, `POST /glm-command` | None (WS), Bearer (`glm_command_token`) | Experimental | [Crown Agent Overview](../CROWN_OVERVIEW.md) | [crown_link.py](../../agents/razar/crown_link.py) |
+| `future_connector` | placeholder for upcoming connectors | 0.0.0 | `TBD` | `TBD` | Planned | — | — |

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -25,6 +25,21 @@ Connector entries share common fields:
 - **auth** – credentials or handshake requirements.
 - **status** – lifecycle indicator (`experimental`, `active`, `deprecated`).
 
+### Connector Entry Template
+
+```json
+{
+  "id": "example_connector",
+  "purpose": "short description",
+  "version": "1.0.0",
+  "endpoints": ["POST /example"],
+  "auth": "Bearer (token)",
+  "status": "experimental",
+  "docs": "../path_to_doc.md",
+  "code": "../../path_to_code.py"
+}
+```
+
 ### Operator API Examples
 
 #### `/operator/command`
@@ -49,5 +64,6 @@ These conventions keep integration layers consistent, discoverable, and easy to 
 
 ## Version History
 
+- v0.3.0 – added connector entry template and clarified maintenance rules
 - v0.2.0 – condensed overview of maintenance rules and schemas
 - v0.1.0 – initial connector guidelines


### PR DESCRIPTION
## Summary
- flesh out connector registry with versions, endpoints, auth, and status
- add entry template and maintenance rules to connector overview
- note connector docs in key documents table

## Testing
- `pre-commit run --files docs/connectors/CONNECTOR_INDEX.md docs/connectors/README.md docs/KEY_DOCUMENTS.md`

------
https://chatgpt.com/codex/tasks/task_e_68b38975efcc832e89d9ee22d5d30239