### PR TITLE
Add ignition startup integration test and docs

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -34,11 +34,12 @@
         "pyyaml",
         "prometheus_client"
       ],
-      "tests": [
-        "tests/test_razar_health_checks.py",
-        "tests/agents/razar/test_boot_orchestrator.py",
-        "tests/agents/razar/test_crown_handshake.py"
-      ],
+        "tests": [
+            "tests/test_razar_health_checks.py",
+            "tests/agents/razar/test_boot_orchestrator.py",
+            "tests/agents/razar/test_crown_handshake.py",
+            "tests/ignition/test_full_stack.py"
+        ],
       "status": "active",
       "metrics": {
         "coverage": 1.0

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/the_absolute_pytest.md
+++ b/docs/the_absolute_pytest.md
@@ -27,6 +27,13 @@ Run tests as usual and inspect the metrics file or have Prometheus scrape the pa
    - `pytest_coverage_percent` to ensure coverage stays above thresholds.
 3. Enable alerts on coverage drops or runtime increases to trigger reviews via `crown_prompt_orchestrator`.
 
+## Ignition Full Stack Test
+
+`tests/ignition/test_full_stack.py` simulates a minimal boot sequence. It stubs
+the Crown handshake, initializes the `MemoryStore`, confirms agent channel
+availability, and routes an operator command. Use it as a template for
+integration-style startup tests when external services are unavailable.
+
 ## Failure Analysis
 
 - Pytest writes detailed logs to `logs/pytest.log`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_crown_handshake.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_mission_brief_rotation.py"),
     str(ROOT / "tests" / "test_operator_api.py"),
+    str(ROOT / "tests" / "ignition" / "test_full_stack.py"),
 }
 
 

--- a/tests/ignition/test_full_stack.py
+++ b/tests/ignition/test_full_stack.py
@@ -1,0 +1,73 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from razar.crown_handshake import CrownResponse
+from agents.nazarick.trust_matrix import TrustMatrix
+from agents.operator_dispatcher import OperatorDispatcher
+from memory_store import MemoryStore
+
+
+__version__ = "0.1.0"
+
+
+def test_full_stack_startup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate full startup path and verify critical subsystems."""
+
+    # avoid heavy imports during boot orchestrator load
+    monkeypatch.setitem(sys.modules, "razar.doc_sync", types.ModuleType("doc_sync"))
+    monkeypatch.setitem(
+        sys.modules, "razar.health_checks", types.ModuleType("health_checks")
+    )
+    monkeypatch.setitem(sys.modules, "agents.guardian", types.ModuleType("guardian"))
+    monkeypatch.setitem(sys.modules, "agents.cocytus", types.ModuleType("cocytus"))
+
+    from razar import boot_orchestrator as bo
+
+    # --- mission brief exchange -------------------------------------------------
+    monkeypatch.setattr(bo, "LOGS_DIR", tmp_path)
+    monkeypatch.setattr(bo, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setenv("CROWN_WS_URL", "ws://example")
+
+    class DummyHandshake:
+        def __init__(self, url: str) -> None:  # pragma: no cover - trivial
+            self.url = url
+
+        async def perform(self, brief_path: str) -> CrownResponse:
+            assert Path(brief_path).exists()
+            return CrownResponse("ack", [], {})
+
+    monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+    launched: list[list[str]] = []
+    monkeypatch.setattr(bo.subprocess, "Popen", lambda cmd: launched.append(cmd))
+
+    result = bo._perform_handshake([{"name": "glm"}])
+    assert result.acknowledgement == "ack"
+    assert launched, "GLM4V should launch when capability missing"
+
+    archive_dir = tmp_path / "mission_briefs"
+    archived = [p for p in archive_dir.glob("*.json") if "_response" not in p.name]
+    assert archived, "Archived mission brief not found"
+
+    state = json.loads((tmp_path / "state.json").read_text())
+    assert state["capabilities"] == []
+
+    # --- memory initialization ---------------------------------------------------
+    store = MemoryStore(tmp_path / "mem.sqlite", snapshot_interval=1)
+    store.add("00", [0.1, 0.2, 0.3], {"kind": "test"})
+    assert store.search([0.1, 0.2, 0.3], 1)[0][0] == "00"
+
+    # --- agent channels ----------------------------------------------------------
+    tm = TrustMatrix(tmp_path / "trust.db")
+    assert tm.lookup_protocol("shalltear").startswith("nazarick_rank")
+    tm.close()
+
+    # --- operator command routing -----------------------------------------------
+    dispatcher = OperatorDispatcher(
+        {"overlord": ["crown"]}, log_dir=tmp_path / "ops", worm_dir=tmp_path / "worm"
+    )
+    res = dispatcher.dispatch("overlord", "crown", lambda: {"ack": "ping"})
+    assert res == {"ack": "ping"}


### PR DESCRIPTION
## Summary
- add full stack startup test covering mission brief exchange, memory init, agent channels, and operator command routing
- document new ignition test in the Absolute Pytest guide
- register test in component index and whitelist for collection

## Testing
- `pytest tests/ignition/test_full_stack.py --cov=tests/ignition/test_full_stack.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3a8c08528832eabae8b11af6d68b3