### PR TITLE
Log GLM4V launch events in RAZAR boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted Crown handshake acknowledgement and downtime under `handshake`
   in `logs/razar_state.json`.
 - Logged handshake and model-launch events in `logs/razar_state.json` and mandated mission-brief logging for all handshakes in The Absolute Protocol.
+- Archived GLM-4.1V launch events to `logs/mission_briefs/` and added tests
+  for mission-brief archiving and GLM capability detection.
 - Required a "Change justification" field in the pull request template and documented the statement format in The Absolute Protocol.
 - Documented mission brief archive requirements and maintenance in The Absolute Protocol.
 - Added Operator API and Open Web UI entries to `CONNECTOR_INDEX.md` and expanded protocol checklist for connector registry.

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Stored Crown handshake acknowledgement, capabilities, and downtime under
   `handshake` in `logs/razar_state.json`.
 - Logged handshake and model-launch events in `logs/razar_state.json` and documented event persistence in the deployment guide.
+- Archived GLM-4.1V launch events to `logs/mission_briefs/` and added tests
+  for mission-brief archiving and GLM capability detection.
 - Added module coverage and example run sections to the RAZAR agent guide.
 - Rotated mission brief archives and required Crown availability via `CROWN_WS_URL` before boot.
 - Delegated failure recovery to remote agents via `ai_invoker.handover` and

--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -9,7 +9,7 @@ the last successful component.
 
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import argparse
 import asyncio
@@ -210,6 +210,21 @@ class BootOrchestrator:
         if "GLM-4.1V" not in launches:
             launches.append("GLM-4.1V")
         data["launched_models"] = launches
+
+        archive_dir = self.state_path.parent / "mission_briefs"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = time.strftime("%Y%m%d%H%M%S", time.gmtime())
+        brief_path = archive_dir / f"{timestamp}_glm4v_launch.json"
+        response_path = archive_dir / f"{timestamp}_glm4v_launch_response.json"
+        brief_path.write_text(
+            json.dumps({"event": "model_launch", "model": "GLM-4.1V"}),
+            encoding="utf-8",
+        )
+        response_path.write_text(
+            json.dumps({"status": "triggered"}),
+            encoding="utf-8",
+        )
+        self._rotate_mission_briefs(archive_dir)
 
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         events = data.get("events", [])

--- a/component_index.json
+++ b/component_index.json
@@ -27,7 +27,7 @@
       "id": "razar",
       "chakra": "root",
       "type": "agent",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "path": "agents/razar",
       "purpose": "Bootstraps services and coordinates recovery",
       "dependencies": [
@@ -37,6 +37,7 @@
         "tests": [
             "tests/test_razar_health_checks.py",
             "tests/agents/razar/test_boot_orchestrator.py",
+            "tests/agents/razar/test_boot_orchestrator_logging.py",
             "tests/agents/razar/test_crown_handshake.py",
             "tests/ignition/test_full_stack.py"
         ],

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -319,9 +319,10 @@ plans by combining component priorities, failure counts, and CROWN suggestions.
    under the `handshake` key in
    [logs/razar_state.json](../logs/razar_state.json). If the advertised
    capabilities omit `GLM4V`, the orchestrator executes
-   [`crown_model_launcher.sh`](../crown_model_launcher.sh) and records the
-   launch under `launched_models` while also setting `glm4v_present` in the
-   state file.
+   [`crown_model_launcher.sh`](../crown_model_launcher.sh), records the
+   launch under `launched_models`, appends a `model_launch` event in the
+   state file, and archives the trigger as
+   `logs/mission_briefs/<timestamp>_glm4v_launch.json`.
 
    RAZAR maintains at most 20 mission brief archives, rotating older pairs
    from `logs/mission_briefs/` to preserve space while keeping recent

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -231,7 +231,7 @@ documents:
       key_rules: Use defined agents and pipelines when transforming biosignals.
       insight: Reference for converting biosignals into multi-modal narrative outputs.
   docs/RAZAR_AGENT.md:
-    sha256: 4bec6b0739c7e0f5c20197f23a19455fe1948fffcfdc05528d9abf66491d2d0b
+    sha256: d3c0255a6fa585d7ff9ac86cedd854000cf663d7eabe4c46975837f3b9441c1c
     summary:
       purpose: Comprehensive RAZAR agent guide.
       scope: RAZAR agent workflows and deployment.

--- a/tests/agents/razar/test_boot_orchestrator_logging.py
+++ b/tests/agents/razar/test_boot_orchestrator_logging.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.razar import boot_orchestrator as bo
+from razar.crown_handshake import CrownResponse
+
+__version__ = "0.1.0"
+
+
+@pytest.fixture
+def stub_handshake(monkeypatch):
+    """Stub CrownHandshake.perform to return a predefined response."""
+
+    def _stub(response: CrownResponse) -> None:
+        class DummyHandshake:
+            def __init__(self, url: str) -> None:  # pragma: no cover - trivial
+                self.url = url
+
+            async def perform(self, brief_path: str) -> CrownResponse:
+                assert Path(brief_path).exists()
+                return response
+
+        monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+
+    return _stub
+
+
+def _basic_orchestrator(tmp_path: Path, monkeypatch) -> bo.BootOrchestrator:
+    monkeypatch.setattr(
+        bo,
+        "parse_system_blueprint",
+        lambda _: [{"name": "alpha", "priority": 0, "order": 0, "health_check": None}],
+    )
+    return bo.BootOrchestrator(
+        blueprint=tmp_path / "bp.md",
+        config=tmp_path / "cfg.yaml",
+        ignition=tmp_path / "Ignition.md",
+        state=tmp_path / "razar_state.json",
+    )
+
+
+def test_handshake_archives_and_persists(
+    tmp_path: Path, stub_handshake, monkeypatch
+) -> None:
+    """Mission brief and response files are archived and state captures handshake."""
+
+    orch = _basic_orchestrator(tmp_path, monkeypatch)
+    stub_handshake(CrownResponse("ack", ["GLM4V"], {}))
+    monkeypatch.setenv("CROWN_WS_URL", "ws://example")
+    monkeypatch.setattr(bo.mission_logger, "log_event", lambda *a, **k: None)
+
+    response = orch._perform_handshake()
+    orch._persist_handshake(response)
+
+    archive_dir = tmp_path / "mission_briefs"
+    files = {p.name for p in archive_dir.glob("*.json")}
+    assert any(not name.endswith("_response.json") for name in files)
+    assert any(name.endswith("_response.json") for name in files)
+
+    state = json.loads((tmp_path / "razar_state.json").read_text())
+    assert state["handshake"]["acknowledgement"] == "ack"
+
+
+def test_glm4v_launch_logging(tmp_path: Path, monkeypatch) -> None:
+    """Missing GLM4V capability triggers launch and archives the event."""
+
+    orch = _basic_orchestrator(tmp_path, monkeypatch)
+    monkeypatch.setattr(bo.mission_logger, "log_event", lambda *a, **k: None)
+
+    called: list[list[str]] = []
+    monkeypatch.setattr(
+        bo.subprocess, "run", lambda cmd, check=False: called.append(cmd)
+    )
+
+    orch._ensure_glm4v([])
+
+    assert called, "launcher should run when GLM4V missing"
+    archive = list((tmp_path / "mission_briefs").glob("*_glm4v_launch.json"))
+    assert archive, "GLM4V launch should be archived"
+
+    state = json.loads((tmp_path / "razar_state.json").read_text())
+    assert state["glm4v_present"] is False
+    assert "GLM-4.1V" in state["launched_models"]
+
+
+def test_glm4v_presence_skips_launch(tmp_path: Path, monkeypatch) -> None:
+    """Advertised GLM4V capability prevents launcher execution."""
+
+    orch = _basic_orchestrator(tmp_path, monkeypatch)
+    monkeypatch.setattr(bo.mission_logger, "log_event", lambda *a, **k: None)
+
+    called: list[list[str]] = []
+
+    def fake_run(cmd, check=False):  # pragma: no cover - defensive
+        called.append(cmd)
+
+    monkeypatch.setattr(bo.subprocess, "run", fake_run)
+
+    orch._ensure_glm4v(["GLM4V"])
+
+    assert not called, "launcher should not run when GLM4V present"
+    state = json.loads((tmp_path / "razar_state.json").read_text())
+    assert state["glm4v_present"] is True
+    assert "launched_models" not in state


### PR DESCRIPTION
## Summary
- Archive GLM-4.1V model launches in `logs/mission_briefs` and record them in `logs/razar_state.json`
- Add tests for mission-brief archiving and GLM capability detection
- Document mission-brief and state logging for GLM launches

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py tests/agents/razar/test_boot_orchestrator_logging.py docs/RAZAR_AGENT.md CHANGELOG.md CHANGELOG_razar.md component_index.json onboarding_confirm.yml`
- `PYTHONPATH=. pytest tests/agents/razar/test_boot_orchestrator_logging.py tests/agents/razar/test_mission_brief_rotation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3b579cb48832eb68f6c72611a2819