### PR TITLE
docs: detail remote assistance workflow

### DIFF
--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added configurable agent endpoints and authentication tokens to
   `ai_invoker.handover` and retried components after patches are applied.
 - Operator uploads now store files under operator-specific paths and relay metadata through Crown to RAZAR.
+- Expanded remote assistance workflow with sequence diagram and dedicated invocation and patch logs.
+- Added unit tests for `ai_invoker.handover` and `code_repair.repair_module`.
 
 ### Changed
 - Boot orchestrator now persists the handshake response before starting

--- a/agents/razar/code_repair.py
+++ b/agents/razar/code_repair.py
@@ -8,7 +8,7 @@ the component is reactivated.
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.2.2"
 
 import difflib
 import json
@@ -36,6 +36,7 @@ def _record_patch(component: str, diff: str, tests: str) -> None:
     """Append a patch record to ``PATCH_LOG_PATH``."""
     PATCH_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     record = {
+        "event": "applied",
         "component": component,
         "diff": diff,
         "tests": tests,
@@ -51,7 +52,9 @@ def _record_patch(component: str, diff: str, tests: str) -> None:
     else:
         data = []
     data.append(record)
-    PATCH_LOG_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    PATCH_LOG_PATH.write_text(
+        json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
+    )
 
 
 def _gather_context(module_path: Path, error: str) -> str:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/assets/remote_assistance_sequence.mmd
+++ b/docs/assets/remote_assistance_sequence.mmd
@@ -1,0 +1,13 @@
+sequenceDiagram
+    participant B as boot_orchestrator
+    participant I as ai_invoker
+    participant A as remote_agent
+    participant R as code_repair
+    participant T as tests
+    B->>I: handover(context)
+    I->>A: invoke agent
+    A-->>I: suggestion
+    I->>R: forward suggestion
+    R->>T: run tests
+    T-->>R: results
+    R-->>B: apply & restart

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -231,7 +231,7 @@ documents:
       key_rules: Use defined agents and pipelines when transforming biosignals.
       insight: Reference for converting biosignals into multi-modal narrative outputs.
   docs/RAZAR_AGENT.md:
-    sha256: d3c0255a6fa585d7ff9ac86cedd854000cf663d7eabe4c46975837f3b9441c1c
+    sha256: eb733a36bb7ba9cba6ba07919e5b8754302a191e000b979467d98c234814e532
     summary:
       purpose: Comprehensive RAZAR agent guide.
       scope: RAZAR agent workflows and deployment.

--- a/tests/agents/razar/test_ai_invoker.py
+++ b/tests/agents/razar/test_ai_invoker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import json
 from types import SimpleNamespace
@@ -17,8 +17,10 @@ def test_handover_returns_suggestion_and_logs(monkeypatch, tmp_path: Path) -> No
         return SimpleNamespace(__name__=name), {"config": True}, {"patch": "data"}
 
     monkeypatch.setattr(ai_invoker.remote_loader, "load_remote_agent", fake_loader)
-    log_path = tmp_path / "invocations.json"
-    monkeypatch.setattr(ai_invoker, "LOG_PATH", log_path)
+    inv_log = tmp_path / "invocations.json"
+    patch_log = tmp_path / "patches.json"
+    monkeypatch.setattr(ai_invoker, "INVOCATION_LOG_PATH", inv_log)
+    monkeypatch.setattr(ai_invoker, "PATCH_LOG_PATH", patch_log)
 
     config = {
         "active": "test",
@@ -38,15 +40,17 @@ def test_handover_returns_suggestion_and_logs(monkeypatch, tmp_path: Path) -> No
     )
     assert suggestion == {"patch": "data"}
 
-    records = json.loads(log_path.read_text(encoding="utf-8"))
-    assert records[0]["event"] == "invocation"
-    assert records[0]["name"] == "test"
-    assert records[0]["endpoint"] == "http://example.com/agent.py"
-    assert records[0]["context"] == {"failure": "ctx"}
-    assert records[1]["event"] == "patch_result"
-    assert records[1]["name"] == "test"
-    assert records[1]["config"] == {"config": True}
-    assert records[1]["suggestion"] == {"patch": "data"}
+    inv_records = json.loads(inv_log.read_text(encoding="utf-8"))
+    assert inv_records[0]["event"] == "invocation"
+    assert inv_records[0]["name"] == "test"
+    assert inv_records[0]["endpoint"] == "http://example.com/agent.py"
+    assert inv_records[0]["context"] == {"failure": "ctx"}
+
+    patch_records = json.loads(patch_log.read_text(encoding="utf-8"))
+    assert patch_records[0]["event"] == "suggestion"
+    assert patch_records[0]["name"] == "test"
+    assert patch_records[0]["config"] == {"config": True}
+    assert patch_records[0]["suggestion"] == {"patch": "data"}
 
 
 def test_handover_returns_confirmation(monkeypatch, tmp_path: Path) -> None:
@@ -55,8 +59,10 @@ def test_handover_returns_confirmation(monkeypatch, tmp_path: Path) -> None:
         return SimpleNamespace(__name__=name), {}, None
 
     monkeypatch.setattr(ai_invoker.remote_loader, "load_remote_agent", fake_loader)
-    log_path = tmp_path / "invocations.json"
-    monkeypatch.setattr(ai_invoker, "LOG_PATH", log_path)
+    inv_log = tmp_path / "invocations.json"
+    patch_log = tmp_path / "patches.json"
+    monkeypatch.setattr(ai_invoker, "INVOCATION_LOG_PATH", inv_log)
+    monkeypatch.setattr(ai_invoker, "PATCH_LOG_PATH", patch_log)
 
     config = {
         "agents": [{"name": "alpha", "endpoint": "http://example.com/a.py"}],
@@ -67,10 +73,12 @@ def test_handover_returns_confirmation(monkeypatch, tmp_path: Path) -> None:
     result = ai_invoker.handover(config_path=config_path)
     assert result == {"handover": True}
 
-    records = json.loads(log_path.read_text(encoding="utf-8"))
-    assert records[0]["event"] == "invocation"
-    assert records[0]["name"] == "alpha"
-    assert records[0]["endpoint"] == "http://example.com/a.py"
-    assert records[1]["event"] == "patch_result"
-    assert records[1]["name"] == "alpha"
-    assert "suggestion" not in records[1]
+    inv_records = json.loads(inv_log.read_text(encoding="utf-8"))
+    assert inv_records[0]["event"] == "invocation"
+    assert inv_records[0]["name"] == "alpha"
+    assert inv_records[0]["endpoint"] == "http://example.com/a.py"
+
+    patch_records = json.loads(patch_log.read_text(encoding="utf-8"))
+    assert patch_records[0]["event"] == "no_suggestion"
+    assert patch_records[0]["name"] == "alpha"
+    assert "suggestion" not in patch_records[0]

--- a/tests/agents/razar/test_code_repair.py
+++ b/tests/agents/razar/test_code_repair.py
@@ -1,0 +1,43 @@
+__version__ = "0.2.2"
+
+import json
+from pathlib import Path
+
+import agents.razar.code_repair as code_repair
+
+
+def test_repair_module_applies_patch_and_logs(monkeypatch, tmp_path: Path) -> None:
+    module = tmp_path / "mod.py"
+    module.write_text(
+        "def add(a, b):\n    return a - b\n",
+        encoding="utf-8",
+    )
+
+    test_file = tmp_path / "test_mod.py"
+    test_file.write_text(
+        "from mod import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+        encoding="utf-8",
+    )
+
+    class DummyModel:
+        def complete(self, context: str) -> str:
+            return "def add(a, b):\n    return a + b\n"
+
+    patch_log = tmp_path / "patches.json"
+    monkeypatch.setattr(code_repair, "PATCH_LOG_PATH", patch_log)
+    monkeypatch.setattr(code_repair, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        code_repair.quarantine_manager, "reactivate_component", lambda *a, **k: None
+    )
+    monkeypatch.setattr(code_repair.doc_sync, "sync_docs", lambda: None)
+    monkeypatch.setattr(code_repair, "_run_tests", lambda paths, env: True)
+
+    result = code_repair.repair_module(
+        module, [test_file], "boom", models=[DummyModel()]
+    )
+    assert result is True
+    assert module.read_text(encoding="utf-8").strip().endswith("return a + b")
+
+    records = json.loads(patch_log.read_text(encoding="utf-8"))
+    assert records[0]["event"] == "applied"
+    assert records[0]["component"] == "mod"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_planning_engine.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_pytest_runner.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_ai_invoker.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_code_repair.py"),
     str(ROOT / "tests" / "memory" / "test_sharded_memory_store.py"),
     str(ROOT / "tests" / "vision" / "test_yoloe_adapter.py"),
     str(ROOT / "tests" / "test_persona_profiles_loader.py"),


### PR DESCRIPTION
## Summary
- expand RAZAR agent guide with full remote assistance workflow and sequence diagram
- log handover invocations and patch suggestions separately; record applied patches with event tags
- add unit tests for ai_invoker.handover and code_repair.repair_module

## Testing
- `pre-commit run --files agents/razar/ai_invoker.py agents/razar/code_repair.py tests/agents/razar/test_ai_invoker.py tests/agents/razar/test_code_repair.py docs/RAZAR_AGENT.md docs/assets/remote_assistance_sequence.mmd CHANGELOG_razar.md onboarding_confirm.yml tests/conftest.py docs/INDEX.md`
- `PYTHONPATH=$PWD pytest tests/agents/razar/test_ai_invoker.py tests/agents/razar/test_code_repair.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b42f2e4330832eac7d919fb9a8e0c4