### PR TITLE
docs: expand biosignal narrative tests

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -399,7 +399,10 @@
       "path": "data/biosignals",
       "purpose": "Anonymized biosignal CSVs for ingestion tests",
       "dependencies": [],
-      "tests": [],
+      "tests": [
+        "tests/narrative_engine/test_biosignal_pipeline.py",
+        "tests/narrative_engine/test_biosignal_transformation.py"
+      ],
       "status": "experimental",
       "metrics": {
         "coverage": 0.0

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -78,7 +78,7 @@ class Node:
     children = []
 
 record_spiral(Node(), {"result": "demo", "tags": ["example"]})
-print(query_spirals(tags=["example"]))
+print(query_spirals(tags=["example"]))  # prints the stored record
 PY
 ```
 
@@ -123,7 +123,7 @@ from memory.emotional import get_connection, log_emotion, fetch_emotion_history
 
 conn = get_connection()
 log_emotion([0.1, 0.2], conn=conn)
-print(fetch_emotion_history(window=60, conn=conn))
+print(fetch_emotion_history(window=60, conn=conn))  # recent emotion vectors
 PY
 ```
 
@@ -166,7 +166,7 @@ from memory.mental import init_rl_model, record_task_flow, query_related_tasks
 
 init_rl_model()
 record_task_flow("taskA", {"step": 1})
-print(query_related_tasks("taskA"))
+print(query_related_tasks("taskA"))  # tasks related to "taskA"
 PY
 ```
 
@@ -212,7 +212,7 @@ from memory.spiritual import get_connection, map_to_symbol, lookup_symbol_histor
 
 conn = get_connection()
 map_to_symbol(("eclipse", "☾"), conn=conn)
-print(lookup_symbol_history("☾", conn=conn))
+print(lookup_symbol_history("☾", conn=conn))  # symbol mapping history
 PY
 ```
 
@@ -256,7 +256,7 @@ python - <<'PY'
 from memory.narrative_engine import log_story, stream_stories
 
 log_story("hero meets guide")
-print(list(stream_stories()))
+print(list(stream_stories()))  # ['hero meets guide']
 PY
 ```
 

--- a/docs/nazarick_narrative_system.md
+++ b/docs/nazarick_narrative_system.md
@@ -36,3 +36,12 @@ flowchart LR
 1. Sensors emit heart rate, skin temperature, and electrodermal activity readings.
 2. `ingest_biosignals.py` reads each CSV row and labels the action as **elevated heart rate** when BPM exceeds 74, otherwise **calm**.
 3. A `StoryEvent` is created for each row and recorded via `log_story` for later retrieval.
+
+## Tests
+
+Validate the ingestion pipeline:
+
+```bash
+pytest tests/narrative_engine/test_biosignal_pipeline.py \
+       tests/narrative_engine/test_biosignal_transformation.py
+```


### PR DESCRIPTION
## Summary
- annotate memory architecture query examples with expected output
- document biosignal ingestion tests in the Nazarick narrative guide
- register biosignal dataset tests in the component index

## Testing
- `python tools/doc_indexer.py`
- `pytest tests/narrative_engine/test_biosignal_pipeline.py tests/narrative_engine/test_biosignal_transformation.py`
- `pre-commit run --files component_index.json docs/INDEX.md docs/memory_architecture.md docs/nazarick_narrative_system.md`
- `pre-commit run --files component_index.json`


------
https://chatgpt.com/codex/tasks/task_e_68b453f42cd8832e88e2b1e897f5f89b