### PR TITLE
docs: describe Crown service wake sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linked Operator Protocol from RAZAR agent guide and regenerated docs index.
 - Introduced Connector Health Protocol requiring `scripts/health_check_connectors.py` to pass before merging.
 - Clarified Change Justification rule with mandatory "I did X on Y to obtain Z, expecting behavior B" template.
+- Documented Crown service wake sequence linking servant launch scripts and required `SERVANT_MODELS`/`NAZARICK_ENV` settings; cross-linked ignition flow and regenerated docs index.
 
 ### Added
 

--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -158,6 +158,20 @@ POST /operator/command {"command": "status"}
   `critical` or repeated operator command failures escalates to a human
   operator.
 
+## Service Wake Sequence
+
+After the mission brief handshake, Crown brings its supporting servants
+online. The stack uses [launch_servants.sh](../launch_servants.sh) to read the
+`SERVANT_MODELS` mapping and start the listed Nazarick agents and the Bana
+bio‑adaptive narrator. Each entry maps a servant name to its endpoint; if
+`SERVANT_MODELS` is unset no servants are launched. Set `NAZARICK_ENV` to choose
+the configuration profile (e.g., `dev`, `staging`) so agents load the correct
+settings. For development workflows,
+[start_dev_agents.py](../start_dev_agents.py) bootstraps the same servants after
+RAZAR initializes. With these scripts and environment variables in place, Crown
+signals the agents immediately after the handshake, ensuring they are ready for
+subsequent prompts.
+
 ## Version History
 
 | Version | Date       | Summary |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -174,7 +173,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |
 | [CORPUS_MEMORY.md](CORPUS_MEMORY.md) | Corpus Memory | This repository preserves several collections of source texts used by the music and language tools. Each directory se... | - |
-| [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md) | Crown Agent Overview | The diagram below shows how the main components interact when using the console. A later section outlines deployment... | `../init_crown_agent.py`, `../razar/crown_handshake.py` |
+| [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md) | Crown Agent Overview | The diagram below shows how the main components interact when using the console. A later section outlines deployment... | `../init_crown_agent.py`, `../razar/crown_handshake.py`, `../start_dev_agents.py` |
 | [CRYSTAL_CODEX.md](CRYSTAL_CODEX.md) | CRYSTAL CODEX | The codex gathers the mission, architecture diagrams, module index, dependency matrix, testing strategy and style pol... | `../archetype_feedback_loop.py`, `../auto_retrain.py`, `../insight_compiler.py`, `../learning_mutator.py`, `../music_generation.py`, `../server.py`, `../spiral_memory.py`, `../tools/preflight.py`, `../vector_memory.py`, `../video_stream.py` |
 | [DASHBOARD.md](DASHBOARD.md) | Metrics Dashboard | This dashboard visualises recent model performance and the predicted best LLM. | - |
 | [ETHICS_POLICY.md](ETHICS_POLICY.md) | Ethics Policy | This document outlines the minimum rules for handling data while working with Spiral OS. | - |

--- a/docs/ignition_flow.md
+++ b/docs/ignition_flow.md
@@ -29,6 +29,7 @@ graph LR
 
 ### Crown
 - Guide: [Crown Overview](CROWN_OVERVIEW.md)
+- Service wake sequence: [Service Wake Sequence](CROWN_OVERVIEW.md#service-wake-sequence)
 - Source: [`crown_router.py`](../crown_router.py)
 
 ### INANNA

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -126,7 +126,7 @@ documents:
       key_rules: Update index when components change.
       insight: Add/update entries for component changes.
   docs/CROWN_OVERVIEW.md:
-    sha256: 58c88584d45355968b5c9a243392a00f0b0ae515cbd12b8142de841315cda9bd
+    sha256: 179c5a4f08996de8efe3d623a4ae9f38e302f7bdd73a6eb00770ccfd10b169a3
     summary:
       purpose: Crown agent architecture and routing.
       scope: Crown-to-RAZAR interaction.
@@ -217,7 +217,7 @@ documents:
       key_rules: Review before altering system protection code.
       insight: Review before modifying system protection code.
   docs/INDEX.md:
-    sha256: edb3c62de8e8ffe64f2ae30670c4a6d0e682d7bb6f35a9b3b2efe1e26a7d9b5f
+    sha256: 14a4486100ef2f6394f2d28c1260e240c730b4d7ab1d25070e262712125224a6
     summary:
       purpose: Generated documentation index.
       scope: Repository documentation.


### PR DESCRIPTION
## Summary
- document how Crown wakes Nazarick agents and Bana after handshake
- link ignition flow to new Service Wake Sequence
- regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_hashes.py && echo "hashes ok"`
- `pre-commit run --files CHANGELOG.md docs/CROWN_OVERVIEW.md docs/INDEX.md docs/ignition_flow.md onboarding_confirm.yml`

## Change justification
I added a service wake sequence to the Crown overview so operators know how servant agents are launched after the handshake, expecting clearer deployment guidance.


------
https://chatgpt.com/codex/tasks/task_e_68b45ac0ceec832ea71d97701ba53572