### PR TITLE
Show Nazarick agent status in web console

### DIFF
--- a/docs/nazarick_web_console.md
+++ b/docs/nazarick_web_console.md
@@ -1,6 +1,6 @@
 # Nazarick Web Console
 
-The Nazarick Web Console provides a browser-based interface for issuing commands, streaming the avatar, and testing music generation. It talks to the same FastAPI services used by agents and is intended for local development.
+The Nazarick Web Console provides a browser-based interface for issuing commands, streaming the avatar, and testing music generation. It also displays the current roster of Nazarick agents with their launch status and chat channels. It talks to the same FastAPI services used by agents and is intended for local development.
 
 ## Interaction Diagram
 
@@ -53,6 +53,7 @@ The Mermaid source lives at [assets/nazarick_web_console.mmd](assets/nazarick_we
 - **`web_console/index.html`** – static page that loads the console and basic styles.
 - **`web_console/main.js`** – handles command dispatch, emotion glyphs, music prompts, and WebRTC streaming.
 - **`web_console/operator.js`** – helper module exposing `sendCommand`, `startStream`, and `uploadFiles` utilities for operator dashboards.
+- **Agent panel** – lists agents by parsing `agents/nazarick/agent_registry.yaml` and `logs/nazarick_startup.json`. Each entry shows the channel and launch status with buttons to open the chat room or send a command directly to that agent.
 
 ## Dependencies
 

--- a/web_console/index.html
+++ b/web_console/index.html
@@ -19,6 +19,10 @@
     <pre id="transcript" style="margin-top:1rem;"></pre>
     <button id="logs-btn" style="margin-top:1rem;">Show Emotion Logs</button>
     <pre id="emotion-logs" style="display:none;margin-top:1rem;"></pre>
+    <div id="agents-section" style="margin-top:1rem;">
+        <h2>Agents</h2>
+        <ul id="agent-list" style="list-style:none;padding:0;"></ul>
+    </div>
     <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display Nazarick agents in the web console using `logs/nazarick_startup.json`
- allow opening an agent's chat room or sending that agent a command
- document agent panel in `docs/nazarick_web_console.md`

## Testing
- `pre-commit run --files web_console/index.html web_console/main.js docs/nazarick_web_console.md`

------
https://chatgpt.com/codex/tasks/task_e_68b46f9cd9e8832eaeb8bd00ce9cfe6d