### PR TITLE
docs: expand albedo layer responsibilities and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added recovery playbook documenting snapshot restoration steps.
 - Mapped cortex, emotional, mental, spiritual and narrative memory stores in
   `docs/memory_architecture.md`.
+- Documented Albedo layer personas and deployment logging.
 - Expanded `docs/bana_engine.md` with architecture diagram, dependencies, dataset paths, failure scenarios, and version history; exposed `__version__` in Bana modules and synced `component_index.json`.
 - Documented ignition flow from RAZAR through Bana to operator interface in
   `docs/ignition_flow.md`.

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -94,6 +94,17 @@ State shifts can alert specific Nazarick servants to intervene:
 | Rubedo | Cocytus Prompt Arbiter | `#glacier-prison` |
 | Citrinitas | Demiurge Strategic Simulator | `#lava-pits` |
 
+### Persona & Responsibilities
+
+Each chromatic state embodies a narrative role with its own emotional tone:
+
+| State | Role | Emotional Context |
+| --- | --- | --- |
+| Nigredo | Breaks down perception and exposes core wounds | Grief, emptiness |
+| Albedo | Washes the shadow with compassionate reflection | Hope, empathy |
+| Rubedo | Forges insight into decisive action | Passion, resolve |
+| Citrinitas | Illuminates the path toward equilibrium | Wisdom, serenity |
+
 You can also use the layer programmatically:
 
 ```python
@@ -257,6 +268,32 @@ Typical output is:
 
 ```
 Citrinitas speaks in golden clarity: proceed
+```
+
+## Deployment & Logging
+
+The layer reads configuration from `config/albedo_config.yaml`:
+
+```yaml
+glm:
+  endpoint: https://glm.example.com/glm41v_9b
+  api_key: ${GLM_API_KEY}
+logging:
+  conversation: logs/albedo_layer.log
+  metrics: logs/albedo_metrics.jsonl
+```
+
+Launch the layer with:
+
+```bash
+python -m INANNA_AI.main --personality albedo --config config/albedo_config.yaml
+```
+
+A successful run writes structured logs such as:
+
+```text
+INFO albedo.layer state=Nigredo msg="I love Alice" emotion=affection
+INFO albedo.layer state=Albedo msg="Response text" emotion=joy
 ```
 
 ## Version History


### PR DESCRIPTION
## Summary
- detail Albedo state's persona responsibilities and emotional tones
- add deployment & logging guidance with sample config and log lines
- record update in changelog

## Testing
- `pre-commit run --files docs/ALBEDO_LAYER.md docs/INDEX.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b4840ecdb8832e8708ac80cd3f74d7