### PR TITLE
Add narrative retrieval API and document narrative connector

### DIFF
--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -8,12 +8,13 @@ connectors see the [Connector Overview](README.md). This index is
 cross‑referenced from [Key Documents](../KEY_DOCUMENTS.md) and
 [The Absolute Protocol](../The_Absolute_Protocol.md).
 
-| id | purpose | version | endpoints | linked agents | status |
-| --- | --- | --- | --- | --- | --- |
-| `webrtc` | real-time avatar streaming bridge for audio/video | 0.3.2 | `POST /call` | Nazarick Web Console | Experimental |
-| `operator_upload` | operator asset upload API for files, images, audio, and video | 0.3.2 | `POST /operator/upload` | RAZAR | Experimental |
-| `crown_ws` | Crown WebSocket diagnostics channel for chat commands | 0.1.0 | `WS /crown_link`, `POST /glm-command` | Crown | Experimental |
-| `operator_api` | operator chat command dispatch | 0.3.2 | `POST /operator/command` | Orchestration Master | Experimental |
-| `open_web_ui` | browser-based console interface for chat | 0.1.0 | `POST /glm-command` | Crown | Experimental |
-| `telegram_bot` | Telegram channel relay for chat | 0.1.0 | `POST /telegram/webhook` | Nazarick Agents | Experimental |
-| `primordials_api` | metrics bridge to Primordials service | 0.1.1 | `POST /metrics`, `GET /health` | Primordials | Experimental |
+| id | purpose | version | auth | endpoints | linked agents | status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `webrtc` | real-time avatar streaming bridge for audio/video | 0.3.2 | JWT | `POST /call` | Nazarick Web Console | Experimental |
+| `operator_upload` | operator asset upload API for files, images, audio, and video | 0.3.2 | Bearer | `POST /operator/upload` | RAZAR | Experimental |
+| `crown_ws` | Crown WebSocket diagnostics channel for chat commands | 0.1.0 | Bearer | `WS /crown_link`, `POST /glm-command` | Crown | Experimental |
+| `operator_api` | operator chat command dispatch | 0.3.2 | Bearer | `POST /operator/command` | Orchestration Master | Experimental |
+| `open_web_ui` | browser-based console interface for chat | 0.1.0 | Bearer | `POST /glm-command` | Crown | Experimental |
+| `telegram_bot` | Telegram channel relay for chat | 0.1.0 | Bot token | `POST /telegram/webhook` | Nazarick Agents | Experimental |
+| `primordials_api` | metrics bridge to Primordials service | 0.1.1 | Bearer | `POST /metrics`, `GET /health` | Primordials | Experimental |
+| `narrative_api` | narrative retrieval and stream | 0.1.0 | Bearer | `GET /story/log`, `GET /story/stream` | vector_memory | Experimental |

--- a/docs/operator_protocol.md
+++ b/docs/operator_protocol.md
@@ -7,8 +7,10 @@ Defines the interfaces and logging expectations for direct operator interactions
 - **`POST /operator/command`** – forwards structured instructions for RAZAR to execute. The payload must include an `action` field and optional `parameters`. Responses echo the action and report success or failure.
 - **`POST /operator/upload`** – accepts auxiliary files and arbitrary JSON metadata. The body is multipart form data with one or more `files` parts and a `metadata` field; successful uploads return stored paths merged into the metadata payload.
 - **`POST /call`** – negotiates a WebRTC session for real‑time data, audio, and video exchange. Clients send an SDP offer and receive an SDP answer in the response.
+- **`GET /story/log`** – returns stored narratives and memory metadata.
+- **`GET /story/stream`** – streams narratives and memory metadata as JSON lines.
 
-See the [`webrtc`, `operator_upload`, and `crown_ws` entries in the Connector Index](connectors/CONNECTOR_INDEX.md) for versioning and implementation details.
+See the [`webrtc`, `operator_upload`, `crown_ws`, and `narrative_api` entries in the Connector Index](connectors/CONNECTOR_INDEX.md) for versioning and implementation details.
 
 ## Authentication
 
@@ -17,6 +19,10 @@ All requests require an `Authorization` header with a Bearer token carrying the 
 ## Rate Limits
 
 `POST /operator/command` is limited to **60 requests per minute** per operator. `POST /operator/upload` allows **20 uploads per minute**. Exceeding either limit results in `429 Too Many Requests`.
+
+## Narrative Retrieval
+
+Use `GET /story/log` to fetch stored narratives with memory metadata. `GET /story/stream` emits the same data as JSON lines for subscription-style consumption.
 
 ## WebRTC Channels
 

--- a/narrative_api.py
+++ b/narrative_api.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+
+"""HTTP API for retrieving stored narratives and memory metadata."""
+
+__version__ = "0.1.0"
+
+import json
+from typing import Iterable
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+import corpus_memory_logging
+import vector_memory
+
+router = APIRouter()
+
+
+@router.get("/story/log")
+def story_log(limit: int = 100) -> dict[str, object]:
+    """Return recorded narratives and memory metadata.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of narrative entries to return. ``None`` returns all
+        available entries.
+    """
+
+    narratives = corpus_memory_logging.load_interactions(limit)
+    store = vector_memory._get_store()
+    return {"narratives": narratives, "memory": store.metadata}
+
+
+@router.get("/story/stream")
+def story_stream(limit: int = 100) -> StreamingResponse:
+    """Stream narratives followed by memory metadata as JSON lines."""
+
+    narratives = corpus_memory_logging.load_interactions(limit)
+    store = vector_memory._get_store()
+
+    def _gen() -> Iterable[str]:
+        for entry in narratives:
+            yield json.dumps({"narrative": entry}) + "\n"
+        yield json.dumps({"memory": store.metadata}) + "\n"
+
+    return StreamingResponse(_gen(), media_type="application/json")
+
+
+__all__ = ["router"]

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -133,7 +133,7 @@ documents:
       key_rules: Document operator relay and logging.
       insight: Documents operator relay and mission brief logging.
   docs/connectors/CONNECTOR_INDEX.md:
-    sha256: b04f986afaf3b3c3a0b5e47ff2f5a0aec8a9de9b6b7f9f781d384de1c94292c8
+    sha256: 30412430b2d67aa69c22809e8be6a4fe1c82b61328cc82917b7ea09f818efdc5
     summary:
       purpose: Registry of connector details.
       scope: All connectors.
@@ -151,7 +151,8 @@ documents:
     summary:
       purpose: Ensure connectors respond to health checks before merge.
       scope: All connectors.
-      key_rules: Run `python scripts/health_check_connectors.py` and merge only if it succeeds.
+      key_rules: Run `python scripts/health_check_connectors.py` and merge only if
+        it succeeds.
       insight: Run the health check to catch connector outages early.
   docs/system_blueprint.md:
     sha256: 829f695e39205bfc9e698e44fc6b159cb290aef6209df27bf79f63f63e32865b
@@ -166,7 +167,8 @@ documents:
       purpose: List of essential repository documents.
       scope: Key repository guides.
       key_rules: Record hashes and four-part summaries for protected files.
-      insight: Ensure `onboarding_confirm.yml` includes purpose, scope, key rules, and insight for each key document.
+      insight: Ensure `onboarding_confirm.yml` includes purpose, scope, key rules,
+        and insight for each key document.
   docs/security_model.md:
     sha256: 9f317bf2c71c9a311245a5caef584320900456def4b218615f0838b216333b55
     summary:
@@ -179,8 +181,11 @@ documents:
     summary:
       purpose: Core contribution rules.
       scope: All contributors.
-      key_rules: Provide change justification, align __version__ with component_index.json, maintain key-document summaries, and ensure agent docs include Persona & Responsibilities and Component & Link sections.
-      insight: Align component versions and document summaries; run ignition validation via `validate_ignition.py` and consult `docs/ignition_flow.md` for the sequence.
+      key_rules: Provide change justification, align __version__ with component_index.json,
+        maintain key-document summaries, and ensure agent docs include Persona & Responsibilities
+        and Component & Link sections.
+      insight: Align component versions and document summaries; run ignition validation
+        via `validate_ignition.py` and consult `docs/ignition_flow.md` for the sequence.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a
     summary:
@@ -203,7 +208,7 @@ documents:
       key_rules: Keep implementations aligned with documented API.
       insight: Keep implementations aligned with documented API.
   docs/operator_protocol.md:
-    sha256: 7f92a3f3f118e48ac098fe10e01a946cd4e473ff097e4eb150b0a307061f86fa
+    sha256: b0968dbce29fcfa2d073df89e790b2ca2d66099df5b0eaa718db6e1c564fa45e
     summary:
       purpose: Operator interaction rules.
       scope: Operator channels.
@@ -217,7 +222,7 @@ documents:
       key_rules: Review before altering system protection code.
       insight: Review before modifying system protection code.
   docs/INDEX.md:
-    sha256: d3975e7a9f61d1c2ac27b94a97491495588159e179e8b8ded76b995ad9f2b142
+    sha256: 424d2744a3516d48eb257920576814bf2095d6d267213bbf03f01f4990378c4f
     summary:
       purpose: Generated documentation index.
       scope: Repository documentation.
@@ -233,7 +238,8 @@ documents:
   docs/nazarick_narrative_system.md:
     sha256: 378dffc4746cdd3bb287a564a170beaade90513b6f75ca7fb40ccf8de85a2b0e
     summary:
-      purpose: Guide to how biosignals become narrative events within the Nazarick domain.
+      purpose: Guide to how biosignals become narrative events within the Nazarick
+        domain.
       scope: Nazarick narrative system.
       key_rules: Use defined agents and pipelines when transforming biosignals.
       insight: Reference for converting biosignals into multi-modal narrative outputs.


### PR DESCRIPTION
## Summary
- implement `narrative_api` with versioned `/story/log` and `/story/stream` endpoints returning narrative history and memory metadata
- document `narrative_api` in connector index and operator protocol for querying or streaming narratives

## Testing
- `pre-commit run --files narrative_api.py docs/connectors/CONNECTOR_INDEX.md docs/operator_protocol.md onboarding_confirm.yml docs/INDEX.md` *(fails: Missing Python packages: prometheus_client, websockets; Missing required tools: pyenv)*

------
https://chatgpt.com/codex/tasks/task_e_68b4936e5d1c832ebdd6506102f98e38