### PR TITLE
feat: add multitrack narrative output

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -151,7 +151,7 @@
       "id": "memory_layers",
       "chakra": "root",
       "type": "subsystem",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "path": "memory",
       "purpose": "Layered memory stores for system state",
       "dependencies": [
@@ -248,15 +248,16 @@
       "id": "narrative_engine",
       "chakra": "heart",
       "type": "module",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "path": "memory/narrative_engine.py",
-      "purpose": "Records and streams story events",
+      "purpose": "Records events and composes multitrack narrative output",
       "dependencies": ["chromadb"],
       "tests": [
         "tests/narrative_engine/test_biosignal_pipeline.py",
         "tests/narrative_engine/test_biosignal_transformation.py",
         "tests/narrative_engine/test_ingestion_to_mistral_output.py",
-        "tests/narrative_engine/test_ingest_persist_retrieve.py"
+        "tests/narrative_engine/test_ingest_persist_retrieve.py",
+        "tests/narrative_engine/test_multitrack_output.py"
       ],
       "status": "experimental",
       "metrics": {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/nazarick_multitrack_sample.json
+++ b/docs/nazarick_multitrack_sample.json
@@ -1,0 +1,6 @@
+{
+  "prose": "Hero draws sword.",
+  "audio": [{"cue": "Hero_draws_sword"}],
+  "visual": [{"directive": "frame Hero draws sword"}],
+  "usd": [{"op": "AddPrim", "path": "/Hero", "action": "draws sword"}]
+}

--- a/docs/nazarick_narrative_system.md
+++ b/docs/nazarick_narrative_system.md
@@ -91,6 +91,43 @@ The SQLite schema comprises:
 `query_events` yields events filtered by agent or type. `stream_stories`
 remains available for legacy text logs.
 
+## Multitrack Output
+
+`compose_multitrack_story` converts a sequence of `StoryEvent` objects into
+four parallel tracks:
+
+| track  | description                              |
+|--------|------------------------------------------|
+| `prose` | Cinematic narration string               |
+| `audio` | List of audio cue dictionaries           |
+| `visual`| List of visual directive dictionaries    |
+| `usd`   | USD composition instructions             |
+
+### Output Schema
+
+```json
+{
+  "prose": "string",
+  "audio": [{"cue": "string"}],
+  "visual": [{"directive": "string"}],
+  "usd": [{"op": "string", "path": "string", "action": "string"}]
+}
+```
+
+### Sample Output
+
+See [`nazarick_multitrack_sample.json`](nazarick_multitrack_sample.json) for a
+complete example:
+
+```json
+{
+  "prose": "Hero draws sword.",
+  "audio": [{"cue": "Hero_draws_sword"}],
+  "visual": [{"directive": "frame Hero draws sword"}],
+  "usd": [{"op": "AddPrim", "path": "/Hero", "action": "draws sword"}]
+}
+```
+
 ## Event–Agent Map
 
 | event action        | servant agent             | memory layer   |
@@ -157,3 +194,4 @@ pytest tests/narrative_engine/test_biosignal_pipeline.py \
 | 0.1.0 | 2025-10-17 | Documented biosignal pipeline, memory hooks, and modules. |
 | 0.1.1 | 2025-10-17 | Added SQLite persistence layer and schema details. |
 | 0.2.0 | 2025-10-17 | Introduced event structurizer and Chroma-backed search. |
+| 0.3.0 | 2025-10-17 | Added multitrack output schema and sample. |

--- a/tests/narrative_engine/test_multitrack_output.py
+++ b/tests/narrative_engine/test_multitrack_output.py
@@ -1,0 +1,13 @@
+from memory.narrative_engine import StoryEvent, compose_multitrack_story
+
+__version__ = "0.1.0"
+
+
+def test_tracks_present():
+    events = [StoryEvent(actor="Hero", action="draws sword")]
+    result = compose_multitrack_story(events)
+    assert set(result) == {"prose", "audio", "visual", "usd"}
+    assert isinstance(result["prose"], str) and result["prose"]
+    for key in ("audio", "visual", "usd"):
+        assert isinstance(result[key], list)
+        assert result[key]


### PR DESCRIPTION
## Summary
- extend narrative engine with `compose_multitrack_story` for prose, audio, visual, and USD tracks
- document multitrack schema with sample output and JSON artifact
- add unit test ensuring all narrative tracks are produced

## Testing
- `pre-commit run --files component_index.json docs/nazarick_narrative_system.md docs/nazarick_multitrack_sample.json memory/narrative_engine.py tests/narrative_engine/test_multitrack_output.py docs/INDEX.md`
- `pytest tests/narrative_engine/test_multitrack_output.py --cov=src --cov=agents --cov-fail-under=0` *(fails: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68b49ee82bfc832e93e6e9f7827fd90d