### PR TITLE
feat: add Bana narrative API connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.
+- Implemented `bana/narrative_api.py` for narrative retrieval and streaming.
 
 ### Documentation Audit
 

--- a/bana/narrative_api.py
+++ b/bana/narrative_api.py
@@ -1,0 +1,48 @@
+"""HTTP API for retrieving Bana narratives and memory metadata."""
+
+__version__ = "0.1.0"
+
+import json
+from typing import Iterable
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+import corpus_memory_logging
+import vector_memory
+
+router = APIRouter()
+
+
+@router.get("/story/log")
+def story_log(limit: int = 100) -> dict[str, object]:
+    """Return recorded narratives and memory metadata.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of narrative entries to return. ``None`` returns all
+        available entries.
+    """
+
+    narratives = corpus_memory_logging.load_interactions(limit)
+    store = vector_memory._get_store()
+    return {"narratives": narratives, "memory": store.metadata}
+
+
+@router.get("/story/stream")
+def story_stream(limit: int = 100) -> StreamingResponse:
+    """Stream narratives followed by memory metadata as JSON lines."""
+
+    narratives = corpus_memory_logging.load_interactions(limit)
+    store = vector_memory._get_store()
+
+    def _gen() -> Iterable[str]:
+        for entry in narratives:
+            yield json.dumps({"narrative": entry}) + "\n"
+        yield json.dumps({"memory": store.metadata}) + "\n"
+
+    return StreamingResponse(_gen(), media_type="application/json")
+
+
+__all__ = ["router"]

--- a/component_index.json
+++ b/component_index.json
@@ -287,6 +287,24 @@
       "adr": null
     },
     {
+      "id": "bana_narrative_api",
+      "chakra": "heart",
+      "type": "service",
+      "version": "0.1.0",
+      "path": "bana/narrative_api.py",
+      "purpose": "FastAPI routes for Bana narrative retrieval and streaming",
+      "dependencies": [
+        "fastapi"
+      ],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
       "id": "primordials_api",
       "chakra": "crown",
       "type": "service",

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -17,4 +17,4 @@ cross‑referenced from [Key Documents](../KEY_DOCUMENTS.md) and
 | `open_web_ui` | browser-based console interface for chat | 0.1.0 | Bearer | `POST /glm-command` | Crown | Experimental |
 | `telegram_bot` | Telegram channel relay for chat | 0.1.0 | Bot token | `POST /telegram/webhook` | Nazarick Agents | Experimental |
 | `primordials_api` | metrics bridge to Primordials service | 0.1.1 | Bearer | `POST /metrics`, `GET /health` | Primordials | Experimental |
-| `narrative_api` | narrative retrieval and stream | 0.1.0 | Bearer | `GET /story/log`, `GET /story/stream` | vector_memory | Experimental |
+| `bana_narrative_api` | Bana narrative retrieval and stream | 0.1.0 | Bearer | `GET /story/log`, `GET /story/stream` | vector_memory | Experimental |

--- a/docs/operator_protocol.md
+++ b/docs/operator_protocol.md
@@ -10,7 +10,7 @@ Defines the interfaces and logging expectations for direct operator interactions
 - **`GET /story/log`** – returns stored narratives and memory metadata.
 - **`GET /story/stream`** – streams narratives and memory metadata as JSON lines.
 
-See the [`webrtc`, `operator_upload`, `crown_ws`, and `narrative_api` entries in the Connector Index](connectors/CONNECTOR_INDEX.md) for versioning and implementation details.
+See the [`webrtc`, `operator_upload`, `crown_ws`, and `bana_narrative_api` entries in the Connector Index](connectors/CONNECTOR_INDEX.md) for versioning and implementation details.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- implement Bana narrative API with log and stream endpoints
- document Bana Narrative API connector and link from Operator Protocol
- register API in component index and changelog

## Testing
- `pre-commit run --files CHANGELOG.md bana/narrative_api.py docs/connectors/CONNECTOR_INDEX.md docs/operator_protocol.md component_index.json`
- `python scripts/health_check_connectors.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4a2946994832e9b1db2ccdcad12c1