### PR TITLE
docs: add narrative engine flow diagram and links

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/assets/narrative_engine_flow.mmd
+++ b/docs/assets/narrative_engine_flow.mmd
@@ -1,0 +1,6 @@
+%% Mermaid diagram of narrative engine flow
+flowchart LR
+    E[Event] --> M[Mistral]
+    M --> T{Multi-track outputs}
+    T --> Mem[Memory]
+    T --> Op[Operator]

--- a/docs/nazarick_narrative_system.md
+++ b/docs/nazarick_narrative_system.md
@@ -209,3 +209,15 @@ pytest tests/narrative_engine/test_biosignal_pipeline.py \
 | 0.1.1 | 2025-10-17 | Added SQLite persistence layer and schema details. |
 | 0.2.0 | 2025-10-17 | Introduced event structurizer and Chroma-backed search. |
 | 0.3.0 | 2025-10-17 | Added multitrack output schema and sample. |
+| 0.4.0 | 2025-08-31 | Added flow diagram and Components & Links section. |
+
+## Components & Links
+
+| Source Module | Related Docs |
+| --- | --- |
+| [scripts/ingest_biosignals.py](../scripts/ingest_biosignals.py) | [Bana Engine](bana_engine.md) |
+| [agents/bana/bio_adaptive_narrator.py](../agents/bana/bio_adaptive_narrator.py) | [Bana Engine](bana_engine.md) |
+| [bana/event_structurizer.py](../bana/event_structurizer.py) | [Bana Engine](bana_engine.md) |
+| [memory/narrative_engine.py](../memory/narrative_engine.py) | [Memory Architecture](memory_architecture.md) |
+
+See [assets/narrative_engine_flow.mmd](assets/narrative_engine_flow.mmd) for the event → Mistral → multi-track outputs → memory/operator flow.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -222,7 +222,7 @@ documents:
       key_rules: Review before altering system protection code.
       insight: Review before modifying system protection code.
   docs/INDEX.md:
-    sha256: 424d2744a3516d48eb257920576814bf2095d6d267213bbf03f01f4990378c4f
+    sha256: 78f7683a85786e5ba114f99cc37ff3c7c9321409149b5f7a349ba46f4db2b6f2
     summary:
       purpose: Generated documentation index.
       scope: Repository documentation.
@@ -236,13 +236,20 @@ documents:
       key_rules: Maintain curated documentation entry points.
       insight: Add Crown overview to architecture section.
   docs/nazarick_narrative_system.md:
-    sha256: c4102b8dff3b8cff8390ebef875583b1e0cc0ea3b04b92be52b4f6903b5b9aca
+    sha256: dfd66c57f6af09f203ea9227608771c6860af7126eec00a2aa70898cb4a6ff90
     summary:
       purpose: Guide to how biosignals become narrative events within the Nazarick
         domain.
       scope: Nazarick narrative system.
       key_rules: Use defined agents and pipelines when transforming biosignals.
       insight: Reference for converting biosignals into multi-modal narrative outputs.
+  docs/assets/narrative_engine_flow.mmd:
+    sha256: 9b418b5de9a790064dca91375f560d6378c8d111a0c563deafb637a8e65284d9
+    summary:
+      purpose: Mermaid flow diagram of event→Mistral→multi-track outputs→memory/operator.
+      scope: Nazarick narrative system pipeline.
+      key_rules: Visual reference for narrative engine routing.
+      insight: Consult to understand event propagation to memory and operator.
   docs/RAZAR_AGENT.md:
     sha256: eb733a36bb7ba9cba6ba07919e5b8754302a191e000b979467d98c234814e532
     summary:


### PR DESCRIPTION
## Summary
- add Mermaid flow diagram showing event → Mistral → multi-track outputs → memory/operator
- extend Nazarick narrative system guide with version history and components & links section
- regenerate documentation index and update onboarding confirmation

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_hashes.py`
- `pre-commit run --files docs/assets/narrative_engine_flow.mmd docs/nazarick_narrative_system.md docs/INDEX.md onboarding_confirm.yml`

## Change Justification
I added a Mermaid flow chart and component references on the Nazarick narrative system docs to clarify event routing, expecting contributors to visualize pipeline flow and locate related modules.


------
https://chatgpt.com/codex/tasks/task_e_68b4af4972dc832ebdb2e624483f2827