### PR TITLE
feat(commitlint): enforce structured commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,3 +95,10 @@ repos:
     entry: python scripts/check_env.py
     language: system
     pass_filenames: false
+
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v9.19.0
+  hooks:
+    - id: commitlint
+      stages: [commit-msg]
+      additional_dependencies: ['@commitlint/cli@17.7.2']

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  plugins: [
+    {
+      rules: {
+        'subject-pattern': ({subject}, when = 'always', value = /^did .+ on .+ to obtain .+, expecting behavior .+$/) => {
+          const negated = when === 'never';
+          const test = value.test(subject);
+          return [
+            negated ? !test : test,
+            `subject must${negated ? ' not' : ''} match ${value}`
+          ];
+        }
+      }
+    }
+  ],
+  rules: {
+    'type-enum': [2, 'always', ['feat']],
+    'scope-empty': [2, 'never'],
+    'subject-empty': [2, 'never'],
+    'subject-pattern': [2, 'always']
+  }
+};

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -1,0 +1,23 @@
+# Contributor Guide
+
+## Commit Message Format
+
+All commits must follow the pattern:
+
+```
+feat(scope): did X on Y to obtain Z, expecting behavior B
+```
+
+- **scope** – identifier for the affected area.
+- **X** – action performed.
+- **Y** – target of the action.
+- **Z** – result produced.
+- **B** – expected behavior after the change.
+
+Example:
+
+```
+feat(api): did bump on rate limiter to obtain faster throughput, expecting behavior stable requests
+```
+
+This structure keeps history self-explanatory and traceable.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -171,6 +171,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [ABZU_SUBSYSTEM_OVERVIEW.md](ABZU_SUBSYSTEM_OVERVIEW.md) | ABZU Subsystem Overview | The diagram below outlines how the primary subsystems collaborate within ABZU. | - |
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Personality Layer | A four-phase state machine powers the **Albedo** layer, signalling Nazarick agents and driving responses through a re... | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
+| [CONTRIBUTOR_GUIDE.md](CONTRIBUTOR_GUIDE.md) | Contributor Guide | - | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |
 | [CORPUS_MEMORY.md](CORPUS_MEMORY.md) | Corpus Memory | This repository preserves several collections of source texts used by the music and language tools. Each directory se... | - |
 | [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md) | Crown Agent Overview | The diagram below shows how the main components interact when using the console. A later section outlines deployment... | `../init_crown_agent.py`, `../razar/crown_handshake.py`, `../start_dev_agents.py` |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -4,7 +4,7 @@
 **Last updated:** 2025-08-31
 
 ## How to Use This Protocol
-This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module, connector, and service must declare a `__version__` attribute, and every pull request must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B." Agent guides must also define **Persona & Responsibilities** and **Component & Link** sections.
+This document consolidates ABZU's guiding rules. Review it before contributing to ensure you follow required workflows and standards. Every module, connector, and service must declare a `__version__` attribute, and every pull request must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B." Commit messages must follow this structure as outlined in the [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format). Agent guides must also define **Persona & Responsibilities** and **Component & Link** sections.
 
 ## Contributor Awareness Checklist
 Before opening a pull request, confirm each item:
@@ -16,6 +16,7 @@ Before opening a pull request, confirm each item:
   - [Project Mission & Vision](project_mission_vision.md) – confirm alignment before proposing major changes
   - [Key Documents](KEY_DOCUMENTS.md) – verify all entries reviewed within the last quarter
   - [Connector Index](connectors/CONNECTOR_INDEX.md) – canonical connector registry; confirm purpose, version, endpoints, linked agents, status, and operator interface flows are current
+- [ ] Commit messages follow [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format)
 - [ ] Agent docs include a **Persona & Responsibilities** section
 - [ ] Agent docs include a **Component & Link** section
 - [ ] Crown availability verified – `CROWN_WS_URL` is set and the Crown server responds to the handshake

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -177,7 +177,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 0650fcc003020e54f2a85565f8e1b0a4ae2a10d9062d03c4120048fc01e4f6dd
+    sha256: dd64392d3e4de789aa562516e13763a5be03310e8fb8111f82d534d5e3f2ab91
     summary:
       purpose: Core contribution rules.
       scope: All contributors.


### PR DESCRIPTION
## Summary
- require commit messages match `feat(scope): did X on Y to obtain Z, expecting behavior B`
- run commitlint at `commit-msg` stage via pre-commit
- document commit message format and link from The Absolute Protocol

## Testing
- `pre-commit run --files commitlint.config.js .pre-commit-config.yaml docs/CONTRIBUTOR_GUIDE.md docs/The_Absolute_Protocol.md onboarding_confirm.yml docs/INDEX.md`
- `pre-commit run --hook-stage commit-msg --commit-msg-filename .git/COMMIT_EDITMSG`


------
https://chatgpt.com/codex/tasks/task_e_68b4d2076ea0832e85ade1bd2195bbf1