### PR TITLE
feat: log crown patches and launch model when GLM4V absent

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -27,7 +27,7 @@
       "id": "razar",
       "chakra": "root",
       "type": "agent",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "path": "agents/razar",
       "purpose": "Bootstraps services and coordinates recovery",
       "dependencies": [

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -492,7 +492,9 @@ plans by combining component priorities, failure counts, and CROWN suggestions.
    [`crown_model_launcher.sh`](../crown_model_launcher.sh), records the
    launch under `launched_models`, appends a `model_launch` event in the
    state file, and archives the trigger as
-   `logs/mission_briefs/<timestamp>_glm4v_launch.json`.
+   `logs/mission_briefs/<timestamp>_glm4v_launch.json`. Any patches applied
+   during the handshake are logged as
+   `logs/mission_briefs/<timestamp>_<component>_patch.json` for audit.
 
    RAZAR maintains at most 20 mission brief archives, rotating older pairs
    from `logs/mission_briefs/` to preserve space while keeping recent

--- a/razar/__init__.py
+++ b/razar/__init__.py
@@ -1,3 +1,3 @@
 """Razar package hosting boot orchestration utilities."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/agents/razar/test_boot_orchestrator.py
+++ b/tests/agents/razar/test_boot_orchestrator.py
@@ -11,19 +11,14 @@ __version__ = "0.1.0"
 
 @pytest.fixture
 def mock_handshake(monkeypatch):
-    """Stub out CrownHandshake to avoid network calls."""
+    """Stub out ``crown_handshake.perform`` to avoid network calls."""
 
     def _mock(response: CrownResponse):
-        class DummyHandshake:
-            def __init__(self, url: str) -> None:  # pragma: no cover - trivial
-                self.url = url
+        async def dummy(brief_path: str) -> CrownResponse:
+            assert Path(brief_path).exists()
+            return response
 
-            async def perform(self, brief_path: str) -> CrownResponse:
-                # ensure brief file exists to mimic real behaviour
-                assert Path(brief_path).exists()
-                return response
-
-        monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+        monkeypatch.setattr(bo.crown_handshake, "perform", dummy)
 
     return _mock
 

--- a/tests/agents/razar/test_ignition_sequence.py
+++ b/tests/agents/razar/test_ignition_sequence.py
@@ -22,15 +22,11 @@ def test_full_ignition_sequence(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("CROWN_WS_URL", "ws://example")
 
     # handshake stub triggers GLM4V launch
-    class DummyHandshake:
-        def __init__(self, url: str) -> None:  # pragma: no cover - simple
-            self.url = url
+    async def dummy_handshake(brief_path: str) -> CrownResponse:
+        assert Path(brief_path).exists()
+        return CrownResponse("ack", [], {})
 
-        async def perform(self, brief_path: str) -> CrownResponse:
-            assert Path(brief_path).exists()
-            return CrownResponse("ack", [], {})
-
-    monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+    monkeypatch.setattr(bo.crown_handshake, "perform", dummy_handshake)
 
     launched: list[list[str]] = []
     monkeypatch.setattr(bo.subprocess, "Popen", lambda cmd: launched.append(cmd))


### PR DESCRIPTION
## Summary
- invoke `crown_handshake.perform` from boot orchestrator and trigger `crown_model_launcher.sh` when GLM4V capability is missing
- record downtime patch actions and expose a convenience handshake wrapper
- document mission brief and patch logging, bump RAZAR component version

## Testing
- `pre-commit run --files razar/crown_handshake.py razar/boot_orchestrator.py razar/__init__.py docs/RAZAR_AGENT.md component_index.json tests/agents/razar/test_boot_orchestrator.py tests/agents/razar/test_ignition_sequence.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4e15c9a58832eb26cd1e0d49ac00f