### PR TITLE
Add memory layer init script and update memory architecture docs

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -168,6 +168,23 @@
       "adr": null
     },
     {
+      "id": "init_memory_layers",
+      "chakra": "root",
+      "type": "script",
+      "version": "0.1.0",
+      "path": "scripts/init_memory_layers.sh",
+      "purpose": "Initialize memory stores with sample data",
+      "dependencies": [],
+      "tests": [],
+      "memory_layers": ["cortex", "emotional", "mental", "spiritual", "narrative"],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 0,
+      "adr": null
+    },
+    {
       "id": "memory_cortex",
       "chakra": "heart",
       "type": "module",

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -21,6 +21,37 @@ query example:
 After these layers ignite, RAZAR activates the [Bana engine](bana_engine.md) to
 narrate the system's evolving state.
 
+## Quick start
+
+1. Initialize all layers with the helper script:
+
+```bash
+bash scripts/init_memory_layers.sh
+```
+
+2. Query individual stores to verify the seeded records:
+
+```bash
+# Cortex
+python -c 'from memory.cortex import query_spirals; print(query_spirals(tags=["example"]))'
+
+# Emotional
+python -c 'from memory.emotional import fetch_emotion_history, get_connection; print(fetch_emotion_history("joy", conn=get_connection()))'
+
+# Mental (requires Neo4j dependencies)
+python -c 'from memory.mental import query_related_tasks; print(query_related_tasks("taskA"))'
+
+# Spiritual
+python -c 'from memory.spiritual import lookup_symbol_history, get_connection; conn=get_connection(); print(lookup_symbol_history("\u263E", conn=conn))'
+
+# Narrative
+python -c 'from memory.narrative_engine import stream_stories; print(list(stream_stories()))'
+```
+
+The script seeds each layer using file-based back-ends and prints the results of
+these queries. The sections below describe manual setup and alternative back-end
+options.
+
 ## Flow
 
 ```mermaid

--- a/scripts/init_memory_layers.sh
+++ b/scripts/init_memory_layers.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Initialize memory stores with sample data and show retrieval
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DATA_DIR="$ROOT_DIR/data"
+mkdir -p "$DATA_DIR"
+
+# Configure file-based back-ends
+export CORTEX_BACKEND=file
+export CORTEX_PATH="$DATA_DIR/cortex.jsonl"
+export EMOTION_BACKEND=file
+export EMOTION_DB_PATH="$DATA_DIR/emotions.db"
+export MENTAL_BACKEND=file
+export MENTAL_JSON_PATH="$DATA_DIR/tasks.jsonl"
+export SPIRIT_BACKEND=file
+export SPIRITUAL_DB_PATH="$DATA_DIR/ontology.db"
+export NARRATIVE_BACKEND=file
+export NARRATIVE_LOG_PATH="$DATA_DIR/story.log"
+
+python - <<'PY'
+from memory.cortex import record_spiral, query_spirals
+from memory.emotional import log_emotion, fetch_emotion_history, get_connection as emotion_conn
+try:
+    from memory.mental import record_task_flow, query_related_tasks
+except Exception:  # mental layer optional
+    record_task_flow = query_related_tasks = None
+from memory.spiritual import map_to_symbol, lookup_symbol_history, get_connection as spirit_conn
+from memory.narrative_engine import log_story, stream_stories
+
+class Node:
+    children = []
+
+record_spiral(Node(), {"result": "demo", "tags": ["example"]})
+log_emotion([0.8], conn=emotion_conn())
+if record_task_flow and query_related_tasks:
+    record_task_flow("taskA", {"step": 1})
+conn_spirit = spirit_conn()
+map_to_symbol(("eclipse", "\u263E"), conn=conn_spirit)
+log_story("hero meets guide")
+
+print("Cortex:", query_spirals(tags=["example"]))
+print("Emotional:", fetch_emotion_history(60, conn=emotion_conn()))
+if record_task_flow and query_related_tasks:
+    print("Mental:", query_related_tasks("taskA"))
+else:
+    print("Mental: skipped (missing dependencies)")
+print("Spiritual:", lookup_symbol_history("\u263E", conn=conn_spirit))
+print("Narrative:", list(stream_stories()))
+PY


### PR DESCRIPTION
## Summary
- add `init_memory_layers.sh` to configure memory stores and seed sample data
- document quick-start setup and retrieval commands in `memory_architecture.md`
- reference deployment script in `component_index.json`

## Testing
- `pre-commit run --files docs/memory_architecture.md docs/INDEX.md scripts/init_memory_layers.sh component_index.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4e707d8a8832ea04c9e038f558448