### PR TITLE
docs: expand narrative system architecture

### DIFF
--- a/scripts/ingest_biosignals.py
+++ b/scripts/ingest_biosignals.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from memory.narrative_engine import StoryEvent, log_story
 
+__version__ = "0.1.0"
+
 DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "biosignals"
 
 


### PR DESCRIPTION
## Summary
- document full narrative architecture from biosignal ingest through memory layers and operator flow
- add dataset schema, versioned storage instructions, and structured test descriptions
- track ingestion script with a `__version__` field for persistence compatibility

## Testing
- `pre-commit run --files docs/nazarick_narrative_system.md scripts/ingest_biosignals.py docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b4e865c314832ea1e47e46f8da6f30