### PR TITLE
Add task registry and helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ logs/*
 !logs/bana/
 !logs/bana/*
 !logs/change_intent.jsonl
+!logs/task_registry.jsonl
 
 # Ignore Blender files
 *.blend

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -44,6 +44,21 @@ Omitting any field fails verification checks enforced by `scripts/verify_doc_has
 | [RAZAR AI agents config](../config/razar_ai_agents.json) | Roster of handover agents and authentication settings | Quarterly |
 | [Environment check script](../scripts/check_env.py) | Verifies required packages and tools are installed | Each commit |
 | [Change Intent Ledger](../logs/change_intent.jsonl) | Records commit intents and observed behavior | Each commit |
+| [Task Registry](../logs/task_registry.jsonl) | Records completed tasks with metadata | Each merge |
+
+## Task Registry
+
+`logs/task_registry.jsonl` stores one JSON object per line with the fields:
+
+- `task_id`
+- `description`
+- `component_id`
+- `contributor`
+- `pr_number`
+- `completed_at` – ISO 8601 UTC timestamp
+
+After a pull request merges, contributors run
+`scripts/register_task.py` to append their task entry.
 
 These documents define repository-wide conventions and rules. Repository policy
 and pre-commit checks prevent their removal or renaming. When related components

--- a/docs/development_checklist.md
+++ b/docs/development_checklist.md
@@ -8,6 +8,8 @@ Quick links: [Developer Onboarding](developer_onboarding.md) | [Developer Etique
 - Run `black` for formatting.
 - Run `mypy` for static type checks.
 - Run tests with `pytest`.
+- After merging, record the completed task with `scripts/register_task.py` to
+  append an entry to `logs/task_registry.jsonl`.
 
 ## Adding a New Module
 - Create the module with clear names and docstrings.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -162,7 +162,7 @@ documents:
       key_rules: Align changes with blueprint structure.
       insight: Align changes with blueprint structure.
   docs/KEY_DOCUMENTS.md:
-    sha256: aa1ff0f09543cb28c5a7c954cbcc737208225da05251b1e1715df56d28c96f94
+    sha256: b4ca6cbf983164612b47a7edbecc62e0e62cf3b6c6d60eb44f19acdb3e6b042c
     summary:
       purpose: List of essential repository documents.
       scope: Key repository guides.

--- a/scripts/register_task.py
+++ b/scripts/register_task.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Append completed task details to the task registry."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+REGISTRY_PATH = Path("logs/task_registry.jsonl")
+
+
+def parse_args() -> argparse.Namespace:
+    """Return parsed CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Record a completed task in the registry.",
+    )
+    parser.add_argument(
+        "--task-id", required=True, help="Unique identifier for the task."
+    )
+    parser.add_argument("--description", required=True, help="Short task description.")
+    parser.add_argument("--component-id", required=True, help="Related component ID.")
+    parser.add_argument(
+        "--contributor", required=True, help="Contributor name or handle."
+    )
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Append a task entry to the registry."""
+    args = parse_args()
+    entry = {
+        "task_id": args.task_id,
+        "description": args.description,
+        "component_id": args.component_id,
+        "contributor": args.contributor,
+        "pr_number": args.pr,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with REGISTRY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add JSONL task registry file for recording completed tasks
- provide `scripts/register_task.py` to append task entries
- document registry format in KEY_DOCUMENTS and development checklist

## Testing
- `pre-commit run --files .gitignore scripts/register_task.py logs/task_registry.jsonl docs/KEY_DOCUMENTS.md docs/development_checklist.md onboarding_confirm.yml docs/INDEX.md`
- `python scripts/verify_versions.py`
- `pytest -q` *(fails: ImportError: cannot import name 'load_config' from 'core' and other collection errors)*

## Change justification
I added a task registry file and helper script on our docs and scripts to track merged tasks, expecting contributors to consistently log their completed work.


------
https://chatgpt.com/codex/tasks/task_e_68b4ed01185c832eb3bbeea11d25f9cd