### PR TITLE
Automate protocol refinement task generation

### DIFF
--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: pre-commit run --all-files
       - name: Run pytest
         run: pytest --junitxml=pytest.xml
+      - name: Generate protocol refinement task
+        run: python scripts/generate_protocol_task.py
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.
 - Implemented `bana/narrative_api.py` for narrative retrieval and streaming.
+- Added `scripts/generate_protocol_task.py` to create protocol refinement tasks after six new entries and wired it into nightly CI.
 
 ### Documentation Audit
 
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced Connector Health Protocol requiring `scripts/health_check_connectors.py` to pass before merging.
 - Clarified Change Justification rule with mandatory "I did X on Y to obtain Z, expecting behavior B" template.
 - Documented Crown service wake sequence linking servant launch scripts and required `SERVANT_MODELS`/`NAZARICK_ENV` settings; cross-linked ignition flow and regenerated docs index.
+- Referenced the task cycle script in The Absolute Protocol and refreshed the docs index.
 - Extended component index schema to list Bana memory layers with ignition stages and updated ignition flow to show RAZAR triggering Bana after INANNA memory initialization; cross-linked Bana from RAZAR and memory architecture guides.
 
 ### Added

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -371,6 +371,10 @@ Narrative modules must maintain traceability by:
 - [ ] Run `scripts/verify_doc_hashes.py` to confirm `onboarding_confirm.yml` hashes.
 - [ ] Ensure connectors appear in the connector registry [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md).
 
+## Task Cycle Protocol
+
+`scripts/generate_protocol_task.py` monitors `logs/task_registry.jsonl` and opens a "Refine The Absolute Protocol" issue or creates a stub when six new tasks accumulate.
+
 ## Protocol Change Process
 Updates to this protocol follow a lightweight governance model:
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -177,7 +177,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: fc6945617bd60df2ca65830282cd69c0f4d1c5fffffdcd4e4beac05f1679109e
+    sha256: bae605ee6994c4cba97571c069447162e0d733ae8488e5a5e4ac1b8fab93f54a
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/scripts/generate_protocol_task.py
+++ b/scripts/generate_protocol_task.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Create protocol refinement task after enough registry entries."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib import request
+
+__version__ = "0.1.0"
+
+REGISTRY_PATH = Path("logs/task_registry.jsonl")
+STUB_PATH = Path("logs/refine_protocol_task_stub.md")
+ISSUE_TITLE = "Refine The Absolute Protocol"
+
+
+def load_registry() -> List[Dict[str, Any]]:
+    """Return all entries from the task registry."""
+    if not REGISTRY_PATH.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    with REGISTRY_PATH.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def count_since_last_refinement(entries: List[Dict[str, Any]]) -> int:
+    """Return number of entries since the last refinement task."""
+    last_index = -1
+    for i in range(len(entries) - 1, -1, -1):
+        if entries[i].get("description") == ISSUE_TITLE:
+            last_index = i
+            break
+    return len(entries) - (last_index + 1)
+
+
+def create_issue(count: int) -> Optional[str]:
+    """Attempt to open a GitHub issue; return its URL on success."""
+    token = os.getenv("GITHUB_TOKEN")
+    repo = os.getenv("GITHUB_REPOSITORY")
+    if not token or not repo:
+        return None
+    payload = json.dumps(
+        {
+            "title": ISSUE_TITLE,
+            "body": f"Automatically generated after {count} new tasks.",
+        }
+    ).encode("utf-8")
+    url = f"https://api.github.com/repos/{repo}/issues"
+    req = request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "generate-protocol-task",
+        },
+    )
+    try:
+        with request.urlopen(req) as resp:
+            data = json.load(resp)
+        return data.get("html_url")
+    except Exception:
+        return None
+
+
+def create_stub(count: int) -> str:
+    """Write a local stub file and return its path."""
+    STUB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STUB_PATH.write_text(
+        f"# {ISSUE_TITLE}\n\nAutomatically generated after {count} new tasks.\n",
+        encoding="utf-8",
+    )
+    return STUB_PATH.as_posix()
+
+
+def log_action() -> None:
+    """Append a refinement entry to the registry."""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = {
+        "task_id": f"refine-protocol-{timestamp}",
+        "description": ISSUE_TITLE,
+        "component_id": "protocol",
+        "contributor": "automation",
+        "pr_number": 0,
+        "completed_at": timestamp,
+    }
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with REGISTRY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def main() -> None:
+    """Trigger protocol refinement task when threshold met."""
+    entries = load_registry()
+    count = count_since_last_refinement(entries)
+    if count < 6:
+        print("No refinement needed.")
+        return
+    url = create_issue(count)
+    if url:
+        print(f"Issue created at {url}")
+    else:
+        stub = create_stub(count)
+        print(f"Stub created at {stub}")
+    log_action()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add generate_protocol_task.py to monitor task registry and create "Refine The Absolute Protocol" issue after six entries
- wire generator into nightly CI
- document task cycle protocol in The Absolute Protocol

## Testing
- `pre-commit run --files .github/workflows/nightly_ci.yml CHANGELOG.md docs/The_Absolute_Protocol.md scripts/generate_protocol_task.py onboarding_confirm.yml docs/INDEX.md`
- `python scripts/generate_protocol_task.py`

## Change justification
I did implement a generator script on the task registry to obtain automated protocol refinement prompts, expecting behavior to open an issue after six new tasks.

------
https://chatgpt.com/codex/tasks/task_e_68b4ee57fe00832e93d4a66bc4ec42ce