### PR TITLE
Add task registry audit guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,7 +11,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/good_first_issue.md](../.github/ISSUE_TEMPLATE/good_first_issue.md) | good_first_issue.md | - | - |
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
-| [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | - |
+| [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -305,6 +305,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [rag_music_oracle.md](rag_music_oracle.md) | RAG Music Oracle | `rag_music_oracle.py` answers questions about songs by combining Retrieval Augmented Generation with basic audio emot... | - |
 | [rag_pipeline.md](rag_pipeline.md) | Spiral RAG Pipeline | The Spiral retrieval pipeline turns local documents into embeddings so queries can be answered with context. Files ar... | - |
 | [recovery_playbook.md](recovery_playbook.md) | Recovery Playbook | This playbook outlines how RAZAR restores service after a component failure. Recurring problems and their fixes are c... | - |
+| [registry_audit.md](registry_audit.md) | Registry Audit | This guide describes how to validate `logs/task_registry.jsonl` to keep the task log accurate. | - |
 | [release_notes.md](release_notes.md) | Release Notes | - | - |
 | [reproducibility.md](reproducibility.md) | Reproducibility | This project relies on [DVC](https://dvc.org) for data and model versioning and on `docker compose` for repeatable en... | - |
 | [retraining_log.md](retraining_log.md) | Retraining Log | \| date \| outcome \| model_hash \| \| --- \| --- \| --- \| | - |

--- a/docs/registry_audit.md
+++ b/docs/registry_audit.md
@@ -1,0 +1,32 @@
+# Registry Audit
+
+This guide describes how to validate `logs/task_registry.jsonl` to keep the task log accurate.
+
+## Validation Steps
+
+1. **Check for duplicates**
+   Run a duplicate scan on `task_id` values. Any output indicates a duplicate entry.
+   ```bash
+   jq -r '.task_id' ../logs/task_registry.jsonl | sort | uniq -d
+   ```
+
+2. **Verify chronological order**
+   Ensure entries are sorted by their `timestamp` fields.
+   ```bash
+   jq -r '.timestamp' ../logs/task_registry.jsonl | awk 'NR==1{prev=$1;next}{if($1<prev){print NR":"$0};prev=$1}'
+   ```
+   The command should produce no output; any line number indicates misordered entries.
+
+3. **Identify unresolved tasks**
+   Entries should show a resolved status such as `merged`.
+   ```bash
+   jq -c 'select(.status != "merged")' ../logs/task_registry.jsonl
+   ```
+   Investigate and update any tasks returned by this query.
+
+4. **Seventh task refinement**
+   After six tasks, an automatic seventh task appears to refine `docs/The_Absolute_Protocol.md`. Log this refinement task in the registry as well.
+
+## Maintenance Protocols
+
+Follow the audit guidance in [The Absolute Protocol](The_Absolute_Protocol.md#maintenance-checklist) to align registry validation with repository maintenance practices.


### PR DESCRIPTION
## Summary
- document how to audit `logs/task_registry.jsonl`
- link the audit process to The Absolute Protocol's maintenance checklist

## Testing
- `pre-commit run --files docs/registry_audit.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b56cdcf45c832eab4a2da12d99fabc