### PR TITLE
docs: maintain connector index

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -222,7 +222,7 @@ The `verify-versions` pre-commit hook scans staged Python files and fails if thi
 
 ### Connector Guidelines
 
-Connectors bridge the language engine to external communication layers. Follow the architecture in [Video Engine and Connector Design](design.md) when implementing new back ends. Each connector must:
+Connectors bridge the language engine to external communication layers. The canonical list of available connectors lives in [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md). Follow the architecture in [Video Engine and Connector Design](design.md) when implementing new back ends. Each connector must:
 
 - implement `start_call(path: str) -> None` to initiate a stream
 - provide `close_peers() -> Awaitable[None]` to release resources

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -1,13 +1,6 @@
 # Connector Index
 
-Canonical registry of ABZU's connectors. Each entry lists the purpose, version,
-primary service endpoints, linked agents, authentication method, status, and
-links to source code and documentation. Operator interface entries detail the
-supported chat, file, image, audio, and video flows. Update this index whenever
-a connector's interface changes. For shared patterns across connectors see the
-[Connector Overview](README.md). This index is cross‑referenced from
-[Key Documents](../KEY_DOCUMENTS.md) and
-[The Absolute Protocol](../The_Absolute_Protocol.md).
+Canonical registry of ABZU's connectors. Each entry lists the purpose, version, primary service endpoints, linked agents, authentication method, status, and links to source code and documentation. Operator interface entries detail the supported chat, file, image, audio, and video flows. Update this index whenever a connector's interface changes. For shared patterns across connectors see the [Connector Overview](README.md). This index is cross‑referenced from [Key Documents](../KEY_DOCUMENTS.md) and [The Absolute Protocol](../The_Absolute_Protocol.md).
 
 | id | purpose | version | auth | endpoints | linked agents | status | code | docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -177,7 +177,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: bb9851b7d3cab5c317284890b65d2d5cdfa966e9b06a614acc431f452fb0f725
+    sha256: e328253a6fd074fb21fec2aed1de7211f597c461aabfcf21997362d42fe636b8
     summary:
       purpose: Core contribution rules.
       scope: All contributors.


### PR DESCRIPTION
## Summary
- fix connector index formatting and ensure entries include purpose, version, endpoints, auth, status, and code/doc links
- cross-link connector index from The Absolute Protocol's connector guidelines
- refresh onboarding confirmations

## Testing
- `pre-commit run --files docs/connectors/CONNECTOR_INDEX.md docs/The_Absolute_Protocol.md onboarding_confirm.yml docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b574bb025c832e9e9fc0d6e31c1885