### PR TITLE
Use crown_handshake.perform for mission brief exchange

### DIFF
--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -9,7 +9,7 @@ the last successful component.
 
 from __future__ import annotations
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 import argparse
 import asyncio
@@ -38,7 +38,8 @@ from . import (
     quarantine_manager,
 )
 from .ignition_builder import DEFAULT_STATUS, parse_system_blueprint
-from razar.crown_handshake import CrownHandshake, CrownResponse
+from razar import crown_handshake
+from razar.crown_handshake import CrownResponse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -144,9 +145,7 @@ class BootOrchestrator:
         response_path = archive_dir / f"{timestamp}_response.json"
 
         try:
-            url = os.environ["CROWN_WS_URL"]
-            handshake = CrownHandshake(url)
-            response = asyncio.run(handshake.perform(str(brief_path)))
+            response = asyncio.run(crown_handshake.perform(str(brief_path)))
             details = json.dumps(
                 {"capabilities": response.capabilities, "downtime": response.downtime}
             )

--- a/tests/agents/razar/test_boot_orchestrator_logging.py
+++ b/tests/agents/razar/test_boot_orchestrator_logging.py
@@ -11,18 +11,14 @@ __version__ = "0.1.0"
 
 @pytest.fixture
 def stub_handshake(monkeypatch):
-    """Stub CrownHandshake.perform to return a predefined response."""
+    """Stub crown_handshake.perform to return a predefined response."""
 
     def _stub(response: CrownResponse) -> None:
-        class DummyHandshake:
-            def __init__(self, url: str) -> None:  # pragma: no cover - trivial
-                self.url = url
+        async def dummy(brief_path: str) -> CrownResponse:
+            assert Path(brief_path).exists()
+            return response
 
-            async def perform(self, brief_path: str) -> CrownResponse:
-                assert Path(brief_path).exists()
-                return response
-
-        monkeypatch.setattr(bo, "CrownHandshake", DummyHandshake)
+        monkeypatch.setattr(bo.crown_handshake, "perform", dummy)
 
     return _stub
 


### PR DESCRIPTION
## Summary
- invoke `crown_handshake.perform` in the RAZAR boot orchestrator
- launch `crown_model_launcher.sh` when GLM4V capability is absent
- update tests for new handshake invocation

## Testing
- `pre-commit run --files agents/razar/boot_orchestrator.py tests/agents/razar/test_boot_orchestrator_logging.py`
- `pytest tests/agents/razar/test_boot_orchestrator_logging.py tests/agents/razar/test_boot_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b579b14f8c832e84903a781e525ede