### PR TITLE
docs: clarify Albedo deployment and logging

### DIFF
--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -1,6 +1,6 @@
 # Albedo Personality Layer
 
-A four-phase state machine powers the **Albedo** layer, signalling Nazarick agents and driving responses through a remote GLM (Generative Language Model). Configuration lives under `config/albedo_config.yaml`, and all related modules reside in `INANNA_AI/personality_layers/albedo`.
+A four-phase state machine powers the **Albedo** layer, signalling Nazarick agents and driving responses through a remote GLM (Generative Language Model). Configuration lives under `config/albedo_config.yaml`, and all related modules reside in `INANNA_AI/personality_layers/albedo`. Mermaid sources for the flow and state machine diagrams live at `docs/assets/albedo_flow.mmd` and `docs/assets/albedo_state_machine.mmd`.
 
 ## Project structure
 
@@ -270,9 +270,9 @@ Typical output is:
 Citrinitas speaks in golden clarity: proceed
 ```
 
-## Deployment & Logging
+## Deployment & Config
 
-The layer reads configuration from `config/albedo_config.yaml`:
+Use `config/albedo_config.yaml` to centralize the GLM endpoint, optional quantum context, and log locations:
 
 ```yaml
 glm:
@@ -289,17 +289,22 @@ Launch the layer with:
 python -m INANNA_AI.main --personality albedo --config config/albedo_config.yaml
 ```
 
-A successful run writes structured logs such as:
+## Logging Expectations
+
+Successful runs emit structured logs to the paths defined in the `logging` section:
 
 ```text
 INFO albedo.layer state=Nigredo msg="I love Alice" emotion=affection
 INFO albedo.layer state=Albedo msg="Response text" emotion=joy
 ```
 
+The `conversation` file captures dialogue transcripts, while `metrics` records state statistics and can be tailored for production deployments.
+
 ## Version History
 
 | Version | Date       | Summary |
 |---------|------------|---------|
+| 0.4.0   | 2025-09-01 | Clarified deployment config and logging expectations. |
 | 0.3.0   | 2025-08-31 | Added Nazarick agent triggers and state-channel table. |
 | 0.2.0   | 2025-08-30 | Documented transition inputs and outputs; externalized state diagram. |
 | 0.1.0   | 2025-08-29 | Added state machine diagram and initial version table. |


### PR DESCRIPTION
## Summary
- clarify where Albedo's flow and state machine mermaid sources live
- separate deployment configuration from logging expectations
- record the update in the version history

## Testing
- `pre-commit run --files docs/ALBEDO_LAYER.md docs/INDEX.md`
- `python scripts/verify_versions.py` *(fails: crown_router.py __version__ 0.1.0 != 0.3.1 in component_index.json, memory/__init__.py __version__ 0.1.2 != 0.3.0 in component_index.json, memory/cortex.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/emotional.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/mental.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/spiritual.py __version__ 0.1.1 != 0.3.0 in component_index.json, src/core/memory_physical.py missing __version__, src/audio/mix_tracks.py missing __version__, data/biosignals/__init__.py missing __version__)*

------
https://chatgpt.com/codex/tasks/task_e_68b587ae8e98832e8739a0be5230c60e