### PR TITLE
feat: document Nazarick agent component

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -133,11 +133,17 @@
       "type": "agent",
       "version": "0.1.1",
       "path": "agents/nazarick",
-      "purpose": "Guardian hierarchy and narrative scribe",
+      "purpose": "Guardian hierarchy, ethics manifesto, trust matrix and narrative scribe",
       "dependencies": [
-        "memory"
+        "memory",
+        "pyyaml",
+        "redis",
+        "aiokafka"
       ],
       "tests": [
+        "tests/agents/nazarick/test_ethics_manifesto.py",
+        "tests/agents/nazarick/test_trust_matrix.py",
+        "tests/agents/test_narrative_scribe.py",
         "tests/test_nazarick_messaging.py"
       ],
       "status": "active",


### PR DESCRIPTION
## Summary
- expand Nazarick agent metadata with dependencies and tests

## Testing
- `pre-commit run --files component_index.json`
- `pytest tests/agents/nazarick/test_ethics_manifesto.py tests/agents/nazarick/test_trust_matrix.py tests/agents/test_narrative_scribe.py tests/test_nazarick_messaging.py` (fails: ImportError cannot import run_validated_task)
- `pytest tests/agents/nazarick/test_ethics_manifesto.py tests/agents/nazarick/test_trust_matrix.py tests/agents/test_narrative_scribe.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58a9a2a74832ebc2e204a4d5f2282