### PR TITLE
Annotate tests by chakra and component with coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ import importlib, sys
 sys.exit(0 if importlib.util.find_spec('pytest_cov') else 1)
 PY
       - name: Run tests
-        run: pytest --cov
+        run: pytest --cov --cov-fail-under=90
       - name: Export coverage metrics
         run: python scripts/export_coverage.py
       - name: Upload coverage report

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,10 @@
 [pytest]
 pythonpath = src
-addopts = --cov=src --cov=agents --cov-fail-under=0.5 --log-cli-level=INFO
+addopts = --cov=src --cov=agents --cov-fail-under=90 --log-cli-level=INFO
 filterwarnings =
     ignore:.*audioop.*:DeprecationWarning
     ignore:Couldn't find ffmpeg or avconv.*:RuntimeWarning
     ignore:enable_nested_tensor is True, but self.use_nested_tensor is False.*:UserWarning
+markers =
+    chakra(name): chakra layer associated with a test
+    component(name): component under test

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,12 @@
 # Test suite notes
 
-## Chakra test organization
+## Chakra and component organization
 
-Tests are grouped by chakra to mirror the system architecture. Chakra-specific
-subdirectories such as `tests/root` and `tests/crown` hold integration tests for those layers. Other tests remain at the top level or in feature folders.
+Tests are annotated with `chakra` and `component` markers derived from
+`component_index.json`. Use `pytest -m "chakra('heart')"` to run Heart layer
+tests or filter by component with `pytest -m "component('bana')"`. Directory
+structure remains available for broad organization, but markers provide the
+canonical grouping.
 
 ## Hugging Face hub stub
 


### PR DESCRIPTION
## Summary
- tag tests with `chakra` and `component` metadata from `component_index.json`
- document how to filter tests by chakra/component and run CI with `pytest --cov --cov-fail-under=90`

## Testing
- `pytest tests/root/test_chakra_integration.py --cov-fail-under=0`
- `pre-commit run --files pytest.ini tests/conftest.py tests/README.md .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b59049203c832e9bb18da1e5f72ca5