### PR TITLE
feat: enhance RAZAR handover and boot logging

### DIFF
--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Rotated mission brief archives and required Crown availability via `CROWN_WS_URL` before boot.
 - Delegated failure recovery to remote agents via `ai_invoker.handover` and
   logged invocations and patch results.
+- Added retry logic and patch-attempt logging to `ai_invoker.handover`.
 - Added `scripts/validate_ignition.py` to traverse the RAZAR → Crown → INANNA → Albedo → Nazarick → operator interface chain and capture readiness in `logs/ignition_validation.json`.
 - Linked environment schema and example fields in the RAZAR agent guide.
 - Recorded applied patch diffs in `logs/razar_ai_patches.json`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -86,6 +86,33 @@ Layer-specific packages are defined in
 [razar_env.yaml](../razar_env.yaml) and documented in
 [dependencies.md](dependencies.md).
 
+## Configuration Schemas
+
+`boot_config.json` lists components for the boot sequence. Each entry
+specifies a component `name`, startup `command`, and `health_check` command:
+
+```json
+{
+  "components": [
+    {"name": "service", "command": ["python", "service.py"], "health_check": ["curl", "http://localhost:8000/health"]}
+  ]
+}
+```
+
+`razar_env.yaml` maps layers to the Python dependencies installed by the
+environment builder:
+
+```yaml
+layers:
+  razar:
+    - pyyaml
+  inanna:
+    - requests
+```
+
+See [`boot_config.json`](../razar/boot_config.json) and
+[`razar_env.yaml`](../razar_env.yaml) for full examples.
+
 
 ## Deployment Workflow
 


### PR DESCRIPTION
## Summary
- log patch attempts with retry logic in `ai_invoker.handover`
- archive mission briefs and auto-launch GLM-4.1V when missing during boot
- document RAZAR configuration schemas and update changelog

## Testing
- `python -m pre_commit run --files CHANGELOG_razar.md docs/RAZAR_AGENT.md razar/ai_invoker.py razar/boot_orchestrator.py docs/INDEX.md` *(fails: verify-versions)*
- `pytest tests/agents/razar/test_ai_invoker.py tests/agents/razar/test_boot_orchestrator.py` *(fails: coverage 90% threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68b59c58ecc8832e9ec4d1e198e009be