### PR TITLE
Add memory layer readiness checks and dataset docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.
 - Implemented `bana/narrative_api.py` for narrative retrieval and streaming.
 - Added `scripts/generate_protocol_task.py` to create protocol refinement tasks after six new entries and wired it into nightly CI.
+- Added `scripts/check_memory_layers.py` gating Albedo on successful memory checks and recorded dataset paths in `component_index.json` and `docs/memory_architecture.md`.
 
 ### Documentation Audit
 - Expanded RAZAR agent guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.

--- a/component_index.json
+++ b/component_index.json
@@ -191,6 +191,23 @@
       "adr": null
     },
     {
+      "id": "check_memory_layers",
+      "chakra": "root",
+      "type": "script",
+      "version": "0.1.0",
+      "path": "scripts/check_memory_layers.py",
+      "purpose": "Validate memory stores before persona loading",
+      "dependencies": [],
+      "tests": [],
+      "memory_layers": ["cortex", "emotional", "mental", "spiritual", "narrative"],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 0,
+      "adr": null
+    },
+    {
       "id": "memory_cortex",
       "chakra": "heart",
       "type": "module",
@@ -543,6 +560,86 @@
         "tests/narrative_engine/test_biosignal_transformation.py",
         "tests/narrative_engine/test_ingest_persist_retrieve.py"
       ],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "cortex_memory_log",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/cortex.jsonl",
+      "purpose": "JSONL log for cortex memory layer",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "emotional_memory_db",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/emotions.db",
+      "purpose": "SQLite database for emotional memory",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "mental_memory_log",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/tasks.jsonl",
+      "purpose": "Task flow log for mental memory",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "spiritual_ontology_db",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/ontology.db",
+      "purpose": "SQLite ontology for spiritual memory",
+      "dependencies": [],
+      "tests": [],
+      "status": "experimental",
+      "metrics": {
+        "coverage": 0.0
+      },
+      "ignition_stage": 4,
+      "adr": null
+    },
+    {
+      "id": "narrative_story_log",
+      "chakra": "heart",
+      "type": "dataset",
+      "version": "0.0.1",
+      "path": "data/story.log",
+      "purpose": "Narrative event log for file-backed store",
+      "dependencies": [],
+      "tests": [],
       "status": "experimental",
       "metrics": {
         "coverage": 0.0

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -28,6 +28,22 @@ Ready-made helpers are available for spinning up the storage back ends:
 - [deployment/sqlite/bootstrap_memory_dbs.sh](../deployment/sqlite/bootstrap_memory_dbs.sh)
   creates SQLite files for file‑based stores.
 
+## Configuration paths and datasets
+
+Each layer uses environment variables to locate its file-based store:
+
+| Layer | Variable | Default path |
+|-------|----------|--------------|
+| Cortex | `CORTEX_PATH` | `data/cortex.jsonl` |
+| Emotional | `EMOTION_DB_PATH` | `data/emotions.db` |
+| Mental | `MENTAL_JSON_PATH` | `data/tasks.jsonl` |
+| Spiritual | `SPIRITUAL_DB_PATH` | `data/ontology.db` |
+| Narrative | `NARRATIVE_LOG_PATH` | `data/story.log` |
+
+These datasets are recorded in `component_index.json` for traceability. Run
+`python scripts/check_memory_layers.py` to validate all layers before persona
+modules such as Albedo load.
+
 ## Quick start
 
 1. Start the storage back ends if they are not already running:

--- a/scripts/albedo_demo.py
+++ b/scripts/albedo_demo.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import argparse
 
-from agents.albedo.messaging import compose_message_nazarick, compose_message_rival
-from agents.albedo.trust import update_trust
+import subprocess
+import sys
+from pathlib import Path
 
 
 def main() -> None:
+    subprocess.run(
+        [sys.executable, Path(__file__).with_name("check_memory_layers.py")], check=True
+    )
+
+    from agents.albedo.messaging import compose_message_nazarick, compose_message_rival
+    from agents.albedo.trust import update_trust
+
     parser = argparse.ArgumentParser(description="Simulate Albedo dialogue")
     parser.add_argument("entity", help="Entity name to interact with")
     parser.add_argument(

--- a/scripts/check_memory_layers.py
+++ b/scripts/check_memory_layers.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify memory layers respond with seeded data.
+
+Runs minimal queries against each layer. Raises ``RuntimeError``
+if any layer is empty or unavailable. Used to guard Albedo
+initialisation before persona modules load.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+DATA_DIR = ROOT / "data"
+os.environ.setdefault("CORTEX_PATH", str(DATA_DIR / "cortex.jsonl"))
+os.environ.setdefault("EMOTION_DB_PATH", str(DATA_DIR / "emotions.db"))
+os.environ.setdefault("MENTAL_JSON_PATH", str(DATA_DIR / "tasks.jsonl"))
+os.environ.setdefault("SPIRITUAL_DB_PATH", str(DATA_DIR / "ontology.db"))
+os.environ.setdefault("NARRATIVE_LOG_PATH", str(DATA_DIR / "story.log"))
+
+__version__ = "0.1.0"
+
+from memory.cortex import query_spirals
+from memory.emotional import fetch_emotion_history, get_connection as emotion_conn
+
+try:
+    from memory.mental import query_related_tasks
+except Exception:  # mental layer optional
+    query_related_tasks = None
+from memory.spiritual import lookup_symbol_history, get_connection as spirit_conn
+from memory.narrative_engine import stream_stories
+
+
+def verify_memory_layers() -> None:
+    """Ensure each memory layer returns data."""
+    if not query_spirals(tags=["example"]):
+        raise RuntimeError("cortex layer empty")
+
+    if not fetch_emotion_history(60, conn=emotion_conn()):
+        raise RuntimeError("emotional layer empty")
+
+    if query_related_tasks and not query_related_tasks("taskA"):
+        raise RuntimeError("mental layer empty")
+
+    if not lookup_symbol_history("\u263E", conn=spirit_conn()):
+        raise RuntimeError("spiritual layer empty")
+
+    if not list(stream_stories()):
+        raise RuntimeError("narrative layer empty")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual check
+    verify_memory_layers()
+    print("memory checks passed")


### PR DESCRIPTION
## Summary
- add memory readiness verification script and gate Albedo demo on it
- document default dataset paths for all memory layers and record them in component index
- note memory checks in memory architecture guide

## Testing
- `bash scripts/init_memory_layers.sh`
- `python scripts/check_memory_layers.py`
- `pre-commit run --files CHANGELOG.md component_index.json docs/memory_architecture.md docs/INDEX.md scripts/albedo_demo.py scripts/check_memory_layers.py` *(fails: crown_router.py __version__ 0.1.0 != 0.3.1 in component_index.json, memory/__init__.py __version__ 0.1.2 != 0.3.0 in component_index.json, memory/cortex.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/emotional.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/mental.py __version__ 0.1.1 != 0.3.0 in component_index.json, memory/spiritual.py __version__ 0.1.1 != 0.3.0 in component_index.json, src/core/memory_physical.py missing __version__, src/audio/mix_tracks.py missing __version__, data/biosignals/__init__.py missing __version__)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d3cebae4832ea640416b32ce19bf