### PR TITLE
Enforce module and connector version checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ PY
           path: data/archives/component_index_${GITHUB_SHA}.json
       - name: Validate component index schema
         run: jsonschema -i component_index.json schemas/component_index.schema.json
+      - name: Verify component inventory
+        run: python scripts/component_inventory.py
 
   ci:
     runs-on: ubuntu-latest

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -375,6 +375,7 @@ All exchanges between RAZAR, Crown, and Operator must append JSON lines to
 - Maintain clear module boundaries to prevent tight coupling.
 - Every module, connector, and service must declare a `__version__` field for traceability.
 - `scripts/verify_versions.py` verifies source versions match `component_index.json`.
+- Continuous integration runs `scripts/component_inventory.py` to confirm every module has a `__version__` and that connectors are properly registered.
 
 #### Placeholder Elimination
 
@@ -413,6 +414,7 @@ All endpoints must publish machine-validated schemas:
 - Update the registry whenever a connector's interface, version, or status changes.
 - Validate updates with `pre-commit run --files docs/connectors/CONNECTOR_INDEX.md docs/INDEX.md`.
 - Ensure connectors expose a top-level `__version__`, implement `start_call` and `close_peers`, and sync versions with `component_index.json`.
+- CI executes `scripts/component_inventory.py` to fail builds when connector versions mismatch the registry or required entries are missing.
 - Run `python scripts/health_check_connectors.py` before merging to confirm connectors respond.
 
 ### API & Connector Schema Protocol

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 21a6c5e6b1a6c86abce1f04970cd2ea550068e2a845af43e946216544b1bb0dc
+    sha256: 9bb91e21013952dadbf715a4cdff6ef741ad0d1fe4a70d60a731458a58ecfbbd
     summary:
       purpose: Core contribution rules.
       scope: All contributors.


### PR DESCRIPTION
## Summary
- extend component_inventory to enforce `__version__` declarations and cross-check connector registry entries
- fail CI when component inventory reports mismatched versions or missing connector registrations
- clarify Code Harmony and Connector Registry protocols; update onboarding confirmation hash

## Testing
- `pre-commit run --files .github/workflows/ci.yml scripts/component_inventory.py docs/The_Absolute_Protocol.md docs/INDEX.md onboarding_confirm.yml`
- `python scripts/component_inventory.py` *(fails: Missing __version__ declarations: crown_prompt_orchestrator: missing __version__ in crown_prompt_orchestrator.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d5269a2c832eafeedff69e901614