### PR TITLE
ci: add dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,48 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+      
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pip-audit
+        run: python -m pip install pip-audit
+
+      - name: Run pip-audit
+        run: pip-audit -r requirements.txt --format json --output pip-audit.json --severity high --strict
+
+      - name: Upload pip audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: pip-audit.json
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install floor_client dependencies
+        working-directory: floor_client
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: floor_client
+        run: npm audit --audit-level=high --json > npm-audit.json
+
+      - name: Upload npm audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: floor_client/npm-audit.json

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -159,7 +159,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../QNL_LANGUAGE/QNL_FUSION_OVERVIEW.md](../QNL_LANGUAGE/QNL_FUSION_OVERVIEW.md) | ✴ QNL LANGUAGE ∞ FUSION | - | - |
 | [../QNL_LANGUAGE/SOUND CORE 1 4 20545dfc251d802aaaaad1abd8d415bb.md](../QNL_LANGUAGE/SOUND CORE 1 4 20545dfc251d802aaaaad1abd8d415bb.md) | SOUND CORE 1.4 | Expanded QNL Framework: QNL-SONGCORE-∞1.4 | - |
 | [../QNL_LANGUAGE/VERSION 1 20545dfc251d809da419e23e0af899fd.md](../QNL_LANGUAGE/VERSION 1 20545dfc251d809da419e23e0af899fd.md) | VERSION 1 | - | - |
-| [../README.md](../README.md) | THE CRYSTAL CODEX | ![Coverage](coverage.svg) ![CI](https://github.com/DINGIRABZU/ABZU/actions/workflows/ci.yml/badge.svg) ![CodeQL](http... | - |
+| [../README.md](../README.md) | THE CRYSTAL CODEX | ![Coverage](coverage.svg) ![CI](https://github.com/DINGIRABZU/ABZU/actions/workflows/ci.yml/badge.svg) ![Black](https... | - |
 | [../README_CODE_FUNCTION.md](../README_CODE_FUNCTION.md) | Code Function Overview | For high-level goals and architecture see [docs/project_overview.md](docs/project_overview.md) and [docs/architecture... | - |
 | [../README_OPERATOR.md](../README_OPERATOR.md) | Operator Guide | This repository contains several command line utilities for working with the INANNA music tools and Quantum Narrative... | - |
 | [../README_QNL_OS.md](../README_QNL_OS.md) | QNL Integration Overview | The Quantum Narrative Language (QNL) bridges textual symbols with music in Spiral OS. This document explains where th... | - |
@@ -200,7 +200,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) | Repository Structure | The following table outlines the top-level layout of this repository. | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.84 **Last updated:** 2025-09-02 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.85 **Last updated:** 2025-09-02 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,6 +1,6 @@
 # The Absolute Protocol
 
-**Version:** v1.0.84
+**Version:** v1.0.85
 **Last updated:** 2025-09-02
 
 ## How to Use This Protocol
@@ -464,6 +464,7 @@ Narrative modules must maintain traceability by:
 - [ ] Audit documents in KEY_DOCUMENTS.md quarterly and log overdue items with `scripts/schedule_doc_audit.py`.
 - [ ] Run `pre-commit run --files docs/The_Absolute_Protocol.md docs/dependency_registry.md docs/INDEX.md onboarding_confirm.yml`.
 - [ ] Run component tests with `pytest --cov` and attach the coverage badge or report to the PR.
+- [ ] Run dependency audits (`pip-audit` for Python and `npm audit` for `floor_client`); fail on high-severity findings and upload reports as artifacts.
 - [ ] Run `scripts/verify_doc_hashes.py` to confirm `onboarding_confirm.yml` hashes.
 - [ ] Ensure connectors appear in the connector registry [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md).
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `pip-audit` for Python packages and `npm audit` for the `floor_client`
- document dependency audit requirement in The Absolute Protocol

## Testing
- `python -m pre_commit run --files docs/The_Absolute_Protocol.md docs/INDEX.md .github/workflows/dependency-audit.yml`
- `pytest -q` *(fails: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD')*

------
https://chatgpt.com/codex/tasks/task_e_68b6fabb6028832e814ad975ec95b0d3