### PR TITLE
docs: add social investor one pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -199,6 +199,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [RAZAR_GUIDE.md](RAZAR_GUIDE.md) | RAZAR Guide | - | - |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) | Repository Structure | The following table outlines the top-level layout of this repository. | - |
+| [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
 | [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.85 **Last updated:** 2025-09-02 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |

--- a/docs/SOCIAL_INVESTOR_ONE_PAGER.md
+++ b/docs/SOCIAL_INVESTOR_ONE_PAGER.md
@@ -1,0 +1,42 @@
+# ABZU: Social Investor One-Pager
+
+---
+
+## Project
+
+ABZU is an open research framework exploring ritual and narrative-driven intelligence. The system blends symbolic reasoning with emotional memory to build adaptive creative tools. Core orchestration happens in the [CROWN kernel](Crown_GUIDE.md), which delegates tasks across persona layers. The [QNL OS](../README_QNL_OS.md) translates quantum narrative representations into music and code. Operational logistics are handled through [Dark Layer Operations](operations.md) to keep deployments transparent and recoverable.
+
+---
+
+## Top 3 Use Cases
+
+1. **Community Education Labs** – modular classroom kits allow students to experiment with voice, vision, and narrative AI while maintaining data sovereignty.
+2. **Cultural Memory Archives** – ingest local stories and music, embed them through the QNL pipeline, and surface them through responsive avatars.
+3. **Accessible Creative Instruments** – provide adaptive music and storytelling companions that respond to emotion and intent in real time.
+
+---
+
+## Why Invest
+
+- **Open Ecosystem** – the project is fully open source, encouraging community stewardship and cross-disciplinary research.
+- **Ethical Framework** – governance follows The Absolute Protocol, prioritising consent, transparency, and equitable access.
+- **Scalable Architecture** – modular subsystems such as the CROWN kernel and QNL OS allow focused funding on high-impact areas.
+
+---
+
+## Impact Metrics
+
+- Active contributors across modules.
+- Deployed community labs or installations.
+- Stories and songs preserved through QNL archives.
+
+---
+
+## Contact
+
+For partnership or funding discussions please reach out via `invest@abzu.ai`.
+
+---
+
+Backlinks: [Project Overview](project_overview.md) | [System Blueprint](system_blueprint.md)
+


### PR DESCRIPTION
## Summary
- add Social Investor One-Pager with links to CROWN kernel, QNL OS, and operations subsystem
- record new documentation in changelog and update docs index

## Testing
- `pre-commit run --files docs/SOCIAL_INVESTOR_ONE_PAGER.md CHANGELOG.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b71282f25c832ea4da66d4e640fdc4