### PR TITLE
Remove floor client node_modules and document npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ data/training/
 
 # Local virtual environment
 .venv/
+
+# Node dependencies
 node_modules/
 floor_client/node_modules/
+
+# Floor client build output
 floor_client/dist/

--- a/docs/frontend_dependencies.md
+++ b/docs/frontend_dependencies.md
@@ -2,6 +2,8 @@
 
 This page outlines the core libraries used by the `floor_client` interface. Refer to each project's documentation for full usage details.
 
+Run `npm install` inside `floor_client` to install these packages. The `node_modules/` directory is created locally and excluded from version control.
+
 - [**React**](https://react.dev/) and [**React DOM**](https://react.dev/reference/react-dom) – component framework for building interactive UIs.
 - [**Socket.IO Client**](https://socket.io/docs/v4/client-api/) – real-time event transport over WebSockets.
 - [**Vite**](https://vitejs.dev/) with [**@vitejs/plugin-react**](https://vitejs.dev/plugins/) – development server and build tool optimized for React.

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -9,6 +9,7 @@ This React/Tailwind interface renders floors with channel tiles and streams mess
    cd floor_client
    npm install
    ```
+   This creates `node_modules/`, which is excluded from version control.
 2. Start the development server:
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- ensure floor_client node_modules is ignored
- clarify floor client dependency installation

## Testing
- `pre-commit run --files .gitignore docs/frontend_dependencies.md docs/ui/README.md docs/INDEX.md`

## Change justification
I did remove the floor_client node_modules directory on floor_client to obtain a lean repository, expecting contributors to install dependencies locally.

------
https://chatgpt.com/codex/tasks/task_e_68b7192c8590832e874f414c4dc94db4