### PR TITLE
Add dependency audit workflow and maintenance docs

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -20,7 +20,7 @@ jobs:
         run: python -m pip install pip-audit
 
       - name: Run pip-audit
-        run: pip-audit -r requirements.txt --format json --output pip-audit.json --severity high --strict
+        run: pip-audit -r requirements.txt -r dev-requirements.txt --format json --output pip-audit.json --severity high --strict
 
       - name: Upload pip audit report
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recorded sample biosignal datasets and tests covering ingestion, persistence, and retrieval.
 - Enforced ≥90% coverage in CI workflows; pipelines fail when thresholds are not met.
 - Added `scan_todo_fixme` pre-commit hook to block `TODO`/`FIXME` markers and documented rule in The Absolute Protocol.
+- Added GitHub Actions workflow `dependency-audit.yml` to run `pip-audit` and `npm audit`, failing on high-severity vulnerabilities and uploading reports.
 
 ### Documentation Audit
 - Expanded RAZAR agent guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -164,7 +164,25 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../README_OPERATOR.md](../README_OPERATOR.md) | Operator Guide | This repository contains several command line utilities for working with the INANNA music tools and Quantum Narrative... | - |
 | [../README_QNL_OS.md](../README_QNL_OS.md) | QNL Integration Overview | The Quantum Narrative Language (QNL) bridges textual symbols with music in Spiral OS. This document explains where th... | - |
 | [../SEVEN_DIMENSIONAL_MUSIC.md](../SEVEN_DIMENSIONAL_MUSIC.md) | 7‑Dimensional Music System | This system layers sound so different beings perceive a single track in unique ways. A core melody becomes the human... | - |
+| [../agents/nazarick/albedo_agent_template.md](../agents/nazarick/albedo_agent_template.md) | Sacred Connection System | womb_reconnection_engine.py# Eternal return to source nursing_interface.py# Continuous nourishment from ZOHAR quantum... | - |
 | [../agents/nazarick/albedo_character.md](../agents/nazarick/albedo_character.md) | albedo_character.md | - | - |
+| [../agents/nazarick/aura&mare_character.md](../agents/nazarick/aura&mare_character.md) | aura&mare_character.md | - | - |
+| [../agents/nazarick/cocytus_agent_template.md](../agents/nazarick/cocytus_agent_template.md) | cocytus_agent_template.md | - | - |
+| [../agents/nazarick/cocytus_character.md](../agents/nazarick/cocytus_character.md) | cocytus_character.md | - | - |
+| [../agents/nazarick/demiurge_character.md](../agents/nazarick/demiurge_character.md) | demiurge_character.md | - | - |
+| [../agents/nazarick/demurge_agent_template.md](../agents/nazarick/demurge_agent_template.md) | demurge_agent_template.md | - | - |
+| [../agents/nazarick/gargantua_agent_template.md](../agents/nazarick/gargantua_agent_template.md) | gargantua_agent_template.md | - | - |
+| [../agents/nazarick/gargantua_character.md](../agents/nazarick/gargantua_character.md) | gargantua_character.md | - | - |
+| [../agents/nazarick/nazarick_core_architecture.md](../agents/nazarick/nazarick_core_architecture.md) | nazarick_core_architecture.md | - | - |
+| [../agents/nazarick/pandora_agent_template.md](../agents/nazarick/pandora_agent_template.md) | pandora_agent_template.md | - | - |
+| [../agents/nazarick/pandora_character.md](../agents/nazarick/pandora_character.md) | pandora_character.md | - | - |
+| [../agents/nazarick/pleiades_agent_template.md](../agents/nazarick/pleiades_agent_template.md) | pleiades_agent_template.md | - | - |
+| [../agents/nazarick/pleiades_character.md](../agents/nazarick/pleiades_character.md) | pleiades_character.md | - | - |
+| [../agents/nazarick/sebastiara_agent_template.md](../agents/nazarick/sebastiara_agent_template.md) | sebastiara_agent_template.md | - | - |
+| [../agents/nazarick/sebastiara_character.md](../agents/nazarick/sebastiara_character.md) | sebastiara_character.md | - | - |
+| [../agents/nazarick/shalltear_agent_template.md](../agents/nazarick/shalltear_agent_template.md) | shalltear_agent_template.md | - | - |
+| [../agents/nazarick/shalltear_character.md](../agents/nazarick/shalltear_character.md) | shalltear_character.md | - | - |
+| [../agents/nazarick/victim_character.md](../agents/nazarick/victim_character.md) | victim_character.md | - | - |
 | [../agents/nazarick/zohar-zero_character.md](../agents/nazarick/zohar-zero_character.md) | zohar-zero_character.md | - | - |
 | [../benchmarks/README.md](../benchmarks/README.md) | Benchmarks | Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`. | - |
 | [../data/biosignals/README.md](../data/biosignals/README.md) | Biosignal Acquisition Guidelines | This directory hosts anonymized biosignal samples used by the Nazarick Narrative System. | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -464,7 +464,7 @@ Narrative modules must maintain traceability by:
 - [ ] Audit documents in KEY_DOCUMENTS.md quarterly and log overdue items with `scripts/schedule_doc_audit.py`.
 - [ ] Run `pre-commit run --files docs/The_Absolute_Protocol.md docs/dependency_registry.md docs/INDEX.md onboarding_confirm.yml`.
 - [ ] Run component tests with `pytest --cov` and attach the coverage badge or report to the PR.
-- [ ] Run dependency audits (`pip-audit` for Python and `npm audit` for `floor_client`); fail on high-severity findings and upload reports as artifacts.
+- [ ] Run dependency audits (`pip-audit` for Python and `npm audit` for `floor_client`) via the GitHub Actions workflow `.github/workflows/dependency-audit.yml`; it fails on high-severity findings and uploads JSON reports as artifacts.
 - [ ] Run `scripts/verify_doc_hashes.py` to confirm `onboarding_confirm.yml` hashes.
 - [ ] Ensure connectors appear in the connector registry [CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md).
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 6bd412200e33432dccc00cdb8c9438e576bb5456c87ce9ba3e936ee17430d8bd
+    sha256: 6c1592230727090bbec1f9c40be42ffec9797d77d865e52ace21167660abe0e2
     summary:
       purpose: Core contribution rules.
       scope: All contributors.


### PR DESCRIPTION
## Summary
- audit Python and Node dependencies in CI with pip-audit and npm audit
- document dependency audit workflow in The Absolute Protocol
- record workflow in changelog and update doc hash

## Testing
- `python scripts/verify_versions.py`
- `python scripts/verify_doc_hashes.py`
- `pre-commit run --files .github/workflows/dependency-audit.yml docs/The_Absolute_Protocol.md docs/INDEX.md CHANGELOG.md onboarding_confirm.yml`
- `pytest --maxfail=1` *(fails: unrecognized arguments --cov=src --cov=agents --cov-fail-under=90)*

### Change justification
I did extend dependency audits in CI to obtain automated Python and Node vulnerability reports, expecting builds to fail on high-severity findings.

------
https://chatgpt.com/codex/tasks/task_e_68b72fd92690832eb9640e95f24c1169