### PR TITLE
docs: align test chakras and archive coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,10 @@ PY
       - name: Run tests with coverage
         run: pytest --cov
       - name: Export coverage metrics
+        if: always()
         run: python scripts/export_coverage.py
       - name: Upload coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: htmlcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 
+- Documented chakra-aligned test directories and 90% coverage rule in `docs/the_absolute_pytest.md`.
+- Configured CI to archive `htmlcov/` and log coverage metrics even when tests fail.
+
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/the_absolute_pytest.md
+++ b/docs/the_absolute_pytest.md
@@ -1,5 +1,21 @@
 # The Absolute Pytest
 
+## Chakra-Aligned Test Layout
+
+Tests mirror the system's chakra map and should live in the matching
+directory under `tests/`:
+
+- `tests/root/`
+- `tests/sacral/`
+- `tests/solar_plexus/`
+- `tests/heart/`
+- `tests/throat/`
+- `tests/third_eye/`
+- `tests/crown/`
+
+Place new tests in the directory corresponding to the component's chakra.
+Continuous integration enforces **≥90 %** coverage for all active components.
+
 ## AI Feedback Loop
 
 - `crown_prompt_orchestrator` reviews Prometheus test metrics after each run.


### PR DESCRIPTION
## Summary
- document chakra-aligned test directories and 90% coverage rule
- archive html coverage reports and metrics even when tests fail

## Testing
- `pre-commit run --files docs/the_absolute_pytest.md .github/workflows/ci.yml CHANGELOG.md docs/INDEX.md`
- `pytest tests/test_hex_to_glyphs_smoke.py -q --override-ini="addopts=--cov=src --cov=agents --cov-fail-under=0"`


------
https://chatgpt.com/codex/tasks/task_e_68b744d2c3d8832e8b17429639002159