### PR TITLE
Add registry validation scripts and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,24 @@ jobs:
       - name: Run bandit security scan
         run: bandit -r . -x tests,docs --severity-level high --confidence-level high
 
+  registry-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema
+      - name: Validate component index json
+        run: python scripts/check_component_index_json.py
+      - name: Validate connector index
+        run: python scripts/check_connector_index.py
+      - name: Validate dependency registry
+        run: python scripts/check_dependency_registry.py
+
   pytest:
     runs-on: ubuntu-latest
     env:

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -56,6 +56,14 @@ graph LR
 | [Change Intent Ledger](../logs/change_intent.jsonl) | Records commit intents and observed behavior | Each commit |
 | [Task Registry](../logs/task_registry.jsonl) | Records completed tasks with metadata | Each merge |
 
+## Validation Commands
+
+Run these helpers to verify key registries stay consistent:
+
+- `python scripts/check_component_index_json.py`
+- `python scripts/check_connector_index.py`
+- `python scripts/check_dependency_registry.py`
+
 ## Task Registry
 
 `logs/task_registry.jsonl` stores one JSON object per line with the fields:

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 6c1592230727090bbec1f9c40be42ffec9797d77d865e52ace21167660abe0e2
+    sha256: 5fed5b90a1946934741c8d8f44540db2a8aa7381ec3a2ee28f797d1f62db6258
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/scripts/check_component_index_json.py
+++ b/scripts/check_component_index_json.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Wrapper to validate component_index.json."""
+from __future__ import annotations
+
+from validate_component_index_json import main as validate
+
+__version__ = "0.1.0"
+
+if __name__ == "__main__":
+    raise SystemExit(validate())

--- a/scripts/check_dependency_registry.py
+++ b/scripts/check_dependency_registry.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Wrapper to validate docs/dependency_registry.md."""
+from __future__ import annotations
+
+from verify_dependencies import main as verify
+
+__version__ = "0.1.0"
+
+if __name__ == "__main__":
+    raise SystemExit(verify())


### PR DESCRIPTION
## Summary
- add wrapper scripts for component index and dependency registry validation
- run registry validation scripts in CI workflow
- document registry validation commands in key docs

## Testing
- `pre-commit run --files scripts/check_component_index_json.py scripts/check_dependency_registry.py .github/workflows/ci.yml docs/KEY_DOCUMENTS.md onboarding_confirm.yml`
- `python scripts/check_component_index_json.py`
- `python scripts/check_connector_index.py`
- `python scripts/check_dependency_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74bfec9dc832eb4720c998af530b0