### PR TITLE
docs: mandate blueprint spine reading in protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Change Justification subsection and PR template field with CI validation.
 - Protocol v1.0.60 now requires `__version__` in every module, connector, and service and mandates documenting configuration schemas (e.g., `boot_config.json`, `primordials_config.yaml`, `operator_api.yaml`) with examples.
 - Linked Operator Protocol from RAZAR agent guide and regenerated docs index.
+- Mandated triple reading of `docs/blueprint_spine.md` in The Absolute Protocol.
 - Introduced Connector Health Protocol requiring `scripts/health_check_connectors.py` to pass before merging.
 - Clarified Change Justification rule with mandatory "I did X on Y to obtain Z, expecting behavior B" template.
 - Documented Crown service wake sequence linking servant launch scripts and required `SERVANT_MODELS`/`NAZARICK_ENV` settings; cross-linked ignition flow and regenerated docs index.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -223,7 +223,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.86 **Last updated:** 2025-09-02 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.87 **Last updated:** 2025-09-03 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |
@@ -241,6 +241,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [avatar_ethics.md](avatar_ethics.md) | Avatar Ethics | The avatar and call features rely on audiovisual data that may reveal personal information. Operators must handle rec... | - |
 | [avatar_pipeline.md](avatar_pipeline.md) | Avatar Pipeline | The avatar pipeline synchronises generated speech with visual animation. It reads configuration from `guides/avatar_c... | - |
 | [bana_engine.md](bana_engine.md) | Bana Engine | This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sourc... | - |
+| [blueprint_spine.md](blueprint_spine.md) | **ABZU Project: Deep-Dive Overview** | - | - |
 | [chakra_architecture.md](chakra_architecture.md) | Chakra Architecture | This document summarizes the major modules aligned with each chakra layer, their operational state, current quality l... | - |
 | [chakra_koan_system.md](chakra_koan_system.md) | Chakra System Koan | A meditative sequence exploring the seven energy centers of Spiral OS. It complements the version manifest, grounding... | - |
 | [chakra_overview.md](chakra_overview.md) | Chakra Overview | This table summarizes each chakra layer's role in the system along with its current semantic version, aggregated qual... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,10 +1,12 @@
 # The Absolute Protocol
 
-**Version:** v1.0.86
-**Last updated:** 2025-09-02
+**Version:** v1.0.87
+**Last updated:** 2025-09-03
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to follow required workflows and standards. Declare a top-level `__version__` for each module, connector, and service. Every pull request and commit message must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B" per the [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format). Agent guides must include sections for **Vision**, **Module Overview**, **Workflow**, **Architecture Diagram**, **Requirements**, **Deployment**, **Config Schemas**, **Version History**, **Cross-links**, **Example Runs**, **Persona & Responsibilities**, and **Component & Link**.
+
+Before touching any code, read [blueprint_spine.md](blueprint_spine.md) three times to internalize the project's structure and intent.
 
 ## Repository Blueprint
 ABZU adheres to a consistent top-level directory layout:


### PR DESCRIPTION
## Summary
- require triple reading of docs/blueprint_spine.md before modifying code
- document blueprint spine requirement in changelog and refresh docs index

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md CHANGELOG.md docs/INDEX.md`

------
https://chatgpt.com/codex/tasks/task_e_68b750307c50832eab8380bd431ed4c6