### PR TITLE
Record boot orchestrator import failure in quarantine log

### DIFF
--- a/docs/quarantine_log.md
+++ b/docs/quarantine_log.md
@@ -11,3 +11,5 @@ To reinstate a component once it is fixed:
 
 | Timestamp (UTC) | Component | Action | Details |
 |-----------------|-----------|--------|---------|
+| 2025-09-02T22:06:32Z | boot_orchestrator | quarantined | dependency: circular import prevents import of run_validated_task from agents.guardian; refactor imports to break cycle |
+


### PR DESCRIPTION
## Summary
- log boot orchestrator ImportError and remediation guidance in quarantine log
- normalize quarantine log formatting

## Testing
- `python razar/boot_orchestrator.py` *(fails: ImportError: cannot import name 'run_validated_task')*
- `python - <<'PY'
from razar.issue_analyzer import analyze_text
text = "ImportError: cannot import name 'run_validated_task' from partially initialized module 'agents.guardian' (most likely due to a circular import)"
print(analyze_text(text))
PY`
- `python scripts/verify_doc_hashes.py`
- `pre-commit run --files docs/quarantine_log.md docs/INDEX.md`
- `pre-commit run --files docs/quarantine_log.md`


------
https://chatgpt.com/codex/tasks/task_e_68b769fec240832ea35cefebac888ce0