### PR TITLE
test: add Bana narrative multitrack test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_orchestrator.py"),
     str(ROOT / "tests" / "test_play_ritual_music_smoke.py"),
     str(ROOT / "tests" / "test_play_ritual_music.py"),
+    str(ROOT / "tests" / "test_bana_narrative_engine.py"),
     str(ROOT / "tests" / "test_mix_tracks_emotion.py"),
     str(ROOT / "tests" / "test_sonic_emotion_mapper.py"),
     str(ROOT / "tests" / "test_transformation_smoke.py"),

--- a/tests/test_bana_narrative_engine.py
+++ b/tests/test_bana_narrative_engine.py
@@ -1,0 +1,21 @@
+"""Tests for Bana narrative engine multitrack composition."""
+
+from pathlib import Path
+import csv
+
+from memory.narrative_engine import StoryEvent, compose_multitrack_story
+
+
+def test_multitrack_tracks_present():
+    """Biosignal events yield full multitrack story output."""
+    csv_path = Path("data/biosignals/sample_biosignals.csv")
+    events = []
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            action = "elevated heart rate" if float(row["heart_rate"]) > 74 else "calm"
+            events.append(StoryEvent(actor="subject", action=action))
+    result = compose_multitrack_story(events)
+    assert set(result) == {"prose", "audio", "visual", "usd"}
+    assert result["prose"]
+    for track in ("audio", "visual", "usd"):
+        assert isinstance(result[track], list) and result[track]


### PR DESCRIPTION
## Summary
- ingest biosignal samples and compose multitrack narrative output
- test Bana narrative engine emits prose, audio, visual, and USD tracks
- whitelist the new Bana narrative test in the suite

## Testing
- `python -m scripts.ingest_biosignals`
- `pytest tests/test_bana_narrative_engine.py -vv --cov=src --cov=agents --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b76cdf07cc832ebaa2bf3d57eb7209