### PR TITLE
Remove unused GenerationMixin stub

### DIFF
--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -71,10 +71,6 @@ class AutoTokenizer:
         return PreTrainedTokenizerFast()
 
 
-class GenerationMixin:
-    pass
-
-
 __all__ = [
     "GPT2Config",
     "GPT2LMHeadModel",
@@ -82,5 +78,4 @@ __all__ = [
     "AutoConfig",
     "AutoModelForCausalLM",
     "AutoTokenizer",
-    "GenerationMixin",
 ]


### PR DESCRIPTION
## Summary
- drop no-op GenerationMixin class and stop exporting it

## Testing
- `pre-commit run --files transformers/__init__.py`
- `pytest tests/test_model.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b773c01528832eb1c1cd376ef22f5f