### PR TITLE
Refresh outdated repo metadata

### DIFF
--- a/ml/data_pipeline.py
+++ b/ml/data_pipeline.py
@@ -52,7 +52,15 @@ def run(embed: bool = False, update: bool = False) -> list[Path]:
     for repo in _load_list(GITHUB_LIST):
         meta = gs.config.GITHUB_DIR / f"{repo.replace('/', '_')}_metadata.json"
         if update and not _repo_up_to_date(repo, meta):
-            pass
+            try:
+                latest = gs.github_metadata.fetch_repo_metadata(repo)
+                meta.parent.mkdir(parents=True, exist_ok=True)
+                meta.write_text(
+                    json.dumps(latest, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+            except Exception:
+                continue
         elif update and meta.is_file():
             continue
         try:


### PR DESCRIPTION
## Summary
- refresh GitHub repo metadata before processing in data pipeline, skipping repos when refresh fails

## Testing
- `pre-commit run --files ml/data_pipeline.py`
- `pytest --no-cov tests/test_data_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b775115378832e932d52edeff23faf