### PR TITLE
Log schema update errors

### DIFF
--- a/spiral_memory.py
+++ b/spiral_memory.py
@@ -50,8 +50,8 @@ def _connect(db_path: Path) -> sqlite3.Connection:
             conn.execute("ALTER TABLE events ADD COLUMN glyph_path TEXT")
         if "phrase" not in cols:
             conn.execute("ALTER TABLE events ADD COLUMN phrase TEXT")
-    except Exception:  # pragma: no cover - best effort
-        pass
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.exception("failed to ensure event table schema: %s", exc)
     return conn
 
 


### PR DESCRIPTION
## Summary
- log exceptions when ensuring spiral-memory event table schema

## Testing
- `python -m pre_commit run --files spiral_memory.py`
- `pytest tests/test_spiral_memory.py` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b778b7ffa8832e9c1e39ce206bb987