### PR TITLE
refactor: remove unused boot_sequence placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,9 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced in-memory story log with SQLite-backed persistence and documented schema.
 
 ### Changed
- - Assigned unique component IDs for avatar/audio generation modules and RAZAR health checks to avoid collisions, ensuring component lookups remain unambiguous.
+- Assigned unique component IDs for avatar/audio generation modules and RAZAR health checks to avoid collisions, ensuring component lookups remain unambiguous.
 - Bumped `crown_handshake` to 0.2.4 and `operator_api`/`webrtc_connector` to 0.3.3 and recorded versions in connector registry.
 - Added mission brief and operator chat examples with connector checklist cross-links in Crown and operator docs.
+- Removed unused `boot_sequence` placeholder from `orchestration_master.py`.
 
 ### Chakra Versions
 

--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -146,14 +146,8 @@ def launch_agents_from_config(config_path: Path | None = None) -> Dict[str, bool
     return launched
 
 
-def boot_sequence() -> None:
-    """Placeholder for system boot logic."""
-    raise NotImplementedError("boot_sequence is not implemented yet")
-
-
 __all__ = [
     "AlbedoOrchestrator",
-    "boot_sequence",
     "AGENT_LOOKUP",
     "launch_agents_from_config",
 ]


### PR DESCRIPTION
## Summary
- remove unused `boot_sequence` placeholder from `orchestration_master`
- document removal in `CHANGELOG`

## Testing
- `pre-commit run --files orchestration_master.py CHANGELOG.md`
- `python scripts/verify_versions.py && echo verify_versions ok`
- `pytest tests/test_orchestration_master.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b77af1af44832e9dfcb11a2219120a