### PR TITLE
feat: connect memory scribe to vector backend

### DIFF
--- a/memory_scribe.py
+++ b/memory_scribe.py
@@ -1,14 +1,32 @@
-"""Stub for the Memory Scribe agent.
+"""Interface for recording embeddings in vector memory.
 
 The Memory Scribe manages vector memory interactions within the Heart layer.
 """
 
 from __future__ import annotations
 
+import logging
+
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except Exception:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+
+vector_memory = _vector_memory
+logger = logging.getLogger(__name__)
+
 
 def store_embedding(text: str) -> None:
-    """Placeholder for recording an embedding."""
-    raise NotImplementedError("store_embedding is not implemented yet")
+    """Embed ``text`` and persist it to vector memory."""
+    if vector_memory is None:
+        logger.warning("vector memory backend unavailable")
+        return
+    try:
+        vector_memory.add_vector(text, {})
+    except Exception:  # pragma: no cover - best effort logging
+        logger.warning("vector_memory.add_vector failed", exc_info=True)
 
 
 __all__ = ["store_embedding"]
+if vector_memory is not None:
+    __all__.append("vector_memory")


### PR DESCRIPTION
## Summary
- wire Memory Scribe's `store_embedding` to vector memory backend with graceful fallback

## Testing
- `pre-commit run --files memory_scribe.py`


------
https://chatgpt.com/codex/tasks/task_e_68b77cb67bac832ea53582ad9f14a68a