### PR TITLE
Log and propagate ShardedMemoryStore snapshot restore failures

### DIFF
--- a/memory_store.py
+++ b/memory_store.py
@@ -282,7 +282,10 @@ class ShardedMemoryStore:
             try:
                 self.restore(self.snapshot_dir)
             except Exception:
-                pass
+                logger.exception(
+                    "failed to restore snapshot from %s", self.snapshot_dir
+                )
+                raise
 
     # ------------------------------------------------------------------
     @property


### PR DESCRIPTION
## Summary
- log snapshot restore errors in `ShardedMemoryStore` and propagate them

## Testing
- `pre-commit run --files memory_store.py`
- `pytest --no-cov tests/test_memory_store.py tests/memory/test_sharded_memory_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68b77d669af0832e8e603083171d2dbc