### PR TITLE
feat: log audio analysis failure

### DIFF
--- a/rag/orchestrator.py
+++ b/rag/orchestrator.py
@@ -378,8 +378,9 @@ class MoGEOrchestrator:
             if "Extended" in meaning and self._invocation_engine is not None:
                 steps = self._invocation_engine.invoke_ritual("silence_introspection")
                 self._memory_logger.log_ritual_result("silence_introspection", steps)
-        except Exception:
-            pass
+        except Exception:  # pragma: no cover - safeguard
+            logger.exception("silence introspection failed; skipping ritual")
+            self._memory_logger.log_ritual_result("silence_introspection", [])
 
         return result
 


### PR DESCRIPTION
## Summary
- log audio analysis errors in `MoGEOrchestrator.handle_input`
- record skipped ritual when silence introspection fails

## Testing
- `pre-commit run --files rag/orchestrator.py`
- `pytest tests/test_silence_ritual.py tests/test_orchestrator_handle.py --cov=rag/orchestrator.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68b77fe9b508832e905c199a7a797d3c