### PR TITLE
Log cache read errors

### DIFF
--- a/INANNA_AI_AGENT/preprocess.py
+++ b/INANNA_AI_AGENT/preprocess.py
@@ -8,6 +8,7 @@ downstream benchmarking.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Dict, List
@@ -22,6 +23,9 @@ except Exception:  # pragma: no cover - optional dependency
     SentenceTransformer = None  # type: ignore
 
 import markdown
+
+
+logger = logging.getLogger(__name__)
 
 
 class _HTMLStripper:
@@ -88,8 +92,8 @@ def preprocess_texts(
             try:
                 processed[name] = json.loads(cache_file.read_text(encoding="utf-8"))
                 continue
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("Failed to read token cache %s: %s", cache_file, exc)
         tokens = tokenize(normalize_whitespace(strip_markdown(text)))
         processed[name] = tokens
         cache_file.write_text(json.dumps(tokens), encoding="utf-8")
@@ -122,8 +126,8 @@ def generate_embeddings(
             try:
                 embeddings[name] = np.load(cache_file)
                 continue
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("Failed to read embedding cache %s: %s", cache_file, exc)
 
         text = " ".join(tokens)
         emb = model.encode(text)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -65,3 +65,47 @@ def test_generate_embeddings_creates_npy(tmp_path, monkeypatch):
         tokens, cache_dir=cache_dir, model_name="dummy"
     )
     assert embeds2["sample"].tolist() == embeds["sample"].tolist()
+
+
+def test_preprocess_warns_on_bad_cache(tmp_path, caplog):
+    text_dir = tmp_path / "INANNA_AI"
+    text_dir.mkdir()
+    (text_dir / "sample.md").write_text("Hello world", encoding="utf-8")
+    config = tmp_path / "source_paths.json"
+    config.write_text(json.dumps({"source_paths": [str(text_dir)]}), encoding="utf-8")
+    texts = source_loader.load_sources(config)
+    cache_dir = tmp_path / "cache"
+    tokens = preprocess.preprocess_texts(texts, cache_dir)
+    cache_file = cache_dir / "sample.md.tokens.json"
+    cache_file.write_text("corrupted", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        tokens2 = preprocess.preprocess_texts(texts, cache_dir)
+    assert tokens2 == tokens
+    assert "Failed to read token cache" in caplog.text
+
+
+def test_generate_embeddings_warns_on_bad_cache(tmp_path, monkeypatch, caplog):
+    tokens = {"sample": ["hello", "world"]}
+
+    class DummyModel:
+        def __init__(self, name: str) -> None:
+            self.calls = []
+
+        def encode(self, text: str):
+            self.calls.append(text)
+            return np.array([len(text)])
+
+    monkeypatch.setattr(
+        preprocess, "SentenceTransformer", lambda name: DummyModel(name)
+    )
+
+    cache_dir = tmp_path / "cache"
+    preprocess.generate_embeddings(tokens, cache_dir=cache_dir, model_name="dummy")
+    cache_file = cache_dir / "sample.embed.npy"
+    cache_file.write_text("corrupted", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        embeds = preprocess.generate_embeddings(
+            tokens, cache_dir=cache_dir, model_name="dummy"
+        )
+    assert embeds["sample"].shape == (1,)
+    assert "Failed to read embedding cache" in caplog.text


### PR DESCRIPTION
## Summary
- log failures reading token or embedding caches so users can spot corrupted files
- test that preprocessing and embedding functions warn when cache data is invalid

## Testing
- `pre-commit run --files INANNA_AI_AGENT/preprocess.py tests/test_preprocess.py`
- `pytest tests/test_preprocess.py -o addopts="" -vv`

------
https://chatgpt.com/codex/tasks/task_e_68b78136f288832eb0f1bab76a1b2e00