### PR TITLE
fix: raise NotImplementedError for missing RL env

### DIFF
--- a/memory/mental.py
+++ b/memory/mental.py
@@ -111,7 +111,14 @@ if gym is not None and np is not None:
 else:  # pragma: no cover - dependencies missing
 
     class _ContextEnv:  # type: ignore[no-redef]
-        pass
+        """Stub environment indicating reinforcement learning is disabled."""
+
+        def __init__(
+            self, *args: Any, **kwargs: Any
+        ) -> None:  # pragma: no cover - runtime guard
+            raise NotImplementedError(
+                "gymnasium or numpy not installed; reinforcement learning is disabled"
+            )
 
 
 def init_rl_model() -> None:


### PR DESCRIPTION
## Summary
- raise NotImplementedError in `_ContextEnv` when gymnasium or numpy are missing

## Testing
- `pre-commit run --files memory/mental.py`
- `python scripts/verify_versions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7827c3610832e98b01f840a1fcce1