### PR TITLE
Log and re-raise snapshot restore errors in ShardedMemoryStore

### DIFF
--- a/memory_store.py
+++ b/memory_store.py
@@ -281,11 +281,11 @@ class ShardedMemoryStore:
         if self.snapshot_dir.exists():
             try:
                 self.restore(self.snapshot_dir)
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "failed to restore snapshot from %s", self.snapshot_dir
                 )
-                raise
+                raise exc
 
     # ------------------------------------------------------------------
     @property


### PR DESCRIPTION
## Summary
- capture exceptions when restoring shard snapshots
- log failures and re-raise the original error in `ShardedMemoryStore.__init__`

## Testing
- `pre-commit run --files memory_store.py`
- `pytest tests/memory/test_sharded_memory_store.py` *(fails: Required test coverage of 90% not reached. Total coverage: 0.29%)*

------
https://chatgpt.com/codex/tasks/task_e_68b808df993c832eaad0341e874c1b93