### PR TITLE
fix(preprocess): surface cache read errors

### DIFF
--- a/INANNA_AI_AGENT/preprocess.py
+++ b/INANNA_AI_AGENT/preprocess.py
@@ -92,8 +92,9 @@ def preprocess_texts(
             try:
                 processed[name] = json.loads(cache_file.read_text(encoding="utf-8"))
                 continue
-            except Exception as exc:
-                logger.warning("Failed to read token cache %s: %s", cache_file, exc)
+            except Exception:
+                logger.exception("Failed to read token cache %s", cache_file)
+                raise
         tokens = tokenize(normalize_whitespace(strip_markdown(text)))
         processed[name] = tokens
         cache_file.write_text(json.dumps(tokens), encoding="utf-8")
@@ -126,8 +127,9 @@ def generate_embeddings(
             try:
                 embeddings[name] = np.load(cache_file)
                 continue
-            except Exception as exc:
-                logger.warning("Failed to read embedding cache %s: %s", cache_file, exc)
+            except Exception:
+                logger.exception("Failed to read embedding cache %s", cache_file)
+                raise
 
         text = " ".join(tokens)
         emb = model.encode(text)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -75,12 +76,12 @@ def test_preprocess_warns_on_bad_cache(tmp_path, caplog):
     config.write_text(json.dumps({"source_paths": [str(text_dir)]}), encoding="utf-8")
     texts = source_loader.load_sources(config)
     cache_dir = tmp_path / "cache"
-    tokens = preprocess.preprocess_texts(texts, cache_dir)
+    preprocess.preprocess_texts(texts, cache_dir)
     cache_file = cache_dir / "sample.md.tokens.json"
     cache_file.write_text("corrupted", encoding="utf-8")
-    with caplog.at_level("WARNING"):
-        tokens2 = preprocess.preprocess_texts(texts, cache_dir)
-    assert tokens2 == tokens
+    with caplog.at_level("ERROR"):
+        with pytest.raises(Exception):
+            preprocess.preprocess_texts(texts, cache_dir)
     assert "Failed to read token cache" in caplog.text
 
 
@@ -103,9 +104,9 @@ def test_generate_embeddings_warns_on_bad_cache(tmp_path, monkeypatch, caplog):
     preprocess.generate_embeddings(tokens, cache_dir=cache_dir, model_name="dummy")
     cache_file = cache_dir / "sample.embed.npy"
     cache_file.write_text("corrupted", encoding="utf-8")
-    with caplog.at_level("WARNING"):
-        embeds = preprocess.generate_embeddings(
-            tokens, cache_dir=cache_dir, model_name="dummy"
-        )
-    assert embeds["sample"].shape == (1,)
+    with caplog.at_level("ERROR"):
+        with pytest.raises(Exception):
+            preprocess.generate_embeddings(
+                tokens, cache_dir=cache_dir, model_name="dummy"
+            )
     assert "Failed to read embedding cache" in caplog.text


### PR DESCRIPTION
## Summary
- raise errors and log stack trace when token/embedding cache files are unreadable
- update preprocess tests to expect errors on corrupt caches

## Testing
- `pre-commit run --files INANNA_AI_AGENT/preprocess.py tests/test_preprocess.py`
- `pytest --cov-fail-under=0 tests/test_preprocess.py` *(tests skipped: requires unavailable resources)*


------
https://chatgpt.com/codex/tasks/task_e_68b80e19a890832e91da61db29888adc