### PR TITLE
Provide stub RL environment when deps missing

### DIFF
--- a/memory/mental.py
+++ b/memory/mental.py
@@ -111,14 +111,25 @@ if gym is not None and np is not None:
 else:  # pragma: no cover - dependencies missing
 
     class _ContextEnv:  # type: ignore[no-redef]
-        """Stub environment indicating reinforcement learning is disabled."""
+        """Stub environment used when RL dependencies are missing."""
 
-        def __init__(
-            self, *args: Any, **kwargs: Any
-        ) -> None:  # pragma: no cover - runtime guard
-            raise NotImplementedError(
-                "gymnasium or numpy not installed; reinforcement learning is disabled"
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+            """Initialise stub environment and note RL support is unavailable."""
+            logger.info(
+                "gymnasium or numpy not installed; reinforcement learning is disabled",
             )
+            self.observation_space = None
+            self.action_space = None
+
+        def reset(self, *args: Any, **kwargs: Any) -> tuple[None, Dict[str, Any]]:
+            """Raise to indicate RL features are not operational."""
+            raise NotImplementedError("reinforcement learning is disabled")
+
+        def step(
+            self, *args: Any, **kwargs: Any
+        ) -> tuple[None, float, bool, bool, Dict[str, Any]]:
+            """Raise to indicate RL features are not operational."""
+            raise NotImplementedError("reinforcement learning is disabled")
 
 
 def init_rl_model() -> None:


### PR DESCRIPTION
## Summary
- add a stub _ContextEnv that logs and raises when RL dependencies are absent

## Testing
- `pre-commit run --files memory/mental.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80f6781f8832e9eb200a9c2c6edaa