### PR TITLE
Use Hugging Face transformers for GPT-2 generation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,6 +268,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "core" / "test_memory_physical.py"),
     str(ROOT / "tests" / "audio" / "test_mix_tracks.py"),
     str(ROOT / "tests" / "integration" / "test_mix_and_store.py"),
+    str(ROOT / "tests" / "test_transformers_generate.py"),
 }
 
 

--- a/tests/test_transformers_generate.py
+++ b/tests/test_transformers_generate.py
@@ -1,0 +1,33 @@
+"""Tests for huggingface-backed generation."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import torch
+
+import pytest
+
+# Use the real huggingface_hub module instead of the test stub.
+sys.modules.pop("huggingface_hub", None)
+sys.modules.pop("huggingface_hub.utils", None)
+importlib.import_module("huggingface_hub")
+
+from transformers import AutoTokenizer, GPT2LMHeadModel
+
+
+@pytest.mark.parametrize("model_name", ["distilgpt2"])
+def test_generate_returns_text(model_name):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = GPT2LMHeadModel.from_pretrained(model_name)
+    model.to(device)
+
+    prompt = "Hello world"
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
+    outputs = model.generate(**inputs, max_length=20)
+
+    # Decode and ensure new tokens are generated beyond the prompt length
+    generated = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    assert len(generated) > len(prompt)

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,89 +1,47 @@
-"""Lightweight transformer stubs for testing."""
+"""Thin wrapper around the real Hugging Face `transformers` package."""
 
 from __future__ import annotations
 
 __version__ = "0.1.0"
 
-import json
+import importlib
+import sys
 from pathlib import Path
 
+# Temporarily remove the repository root so we can import the actual
+# `transformers` package installed in the environment rather than this wrapper.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_orig_sys_path = list(sys.path)
+sys.modules.pop("transformers", None)
+try:  # pragma: no cover - import guard
+    sys.path = [p for p in sys.path if Path(p).resolve() != _REPO_ROOT]
+    hf = importlib.import_module("transformers")
+finally:
+    sys.path = _orig_sys_path
 
-class GenerationMixin:
-    """Minimal text generation utilities."""
-
-    def generate(self, max_length: int = 1, **kwargs):
-        """Return a sequence of token ids filled with zeros.
-
-        Parameters
-        ----------
-        max_length:
-            Length of the generated sequence.
-        kwargs:
-            Unused additional parameters for API compatibility.
-        """
-
-        return [[0] * max_length]
+_BASE_GPT2 = hf.GPT2LMHeadModel
 
 
-class GPT2Config:
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-    def to_dict(self):
-        return dict(self.__dict__)
-
-    def save_pretrained(self, path):
-        Path(path).mkdir(parents=True, exist_ok=True)
-        (Path(path) / "config.json").write_text(json.dumps(self.to_dict()))
+class GPT2LMHeadModel(_BASE_GPT2):
+    """GPT-2 model thin wrapper."""
 
     @classmethod
-    def from_pretrained(cls, path, *args, **kwargs):
-        data = json.loads((Path(path) / "config.json").read_text())
-        return cls(**data)
+    def from_pretrained(
+        cls, pretrained_model_name_or_path: str = "distilgpt2", **kwargs
+    ):
+        model = _BASE_GPT2.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        model.__class__ = cls
+        return model
 
 
-class GPT2LMHeadModel(GenerationMixin):
-    def __init__(self, config):
-        self.config = config
-
-    @classmethod
-    def from_pretrained(cls, path, *args, **kwargs):
-        cfg = GPT2Config.from_pretrained(path)
-        return cls(cfg)
-
-    @classmethod
-    def from_config(cls, config):
-        return cls(config)
-
-    def save_pretrained(self, path):
-        self.config.save_pretrained(path)
-
-
-class AutoConfig:
-    from_pretrained = GPT2Config.from_pretrained
-
-
-class AutoModelForCausalLM:
-    from_pretrained = GPT2LMHeadModel.from_pretrained
-    from_config = GPT2LMHeadModel.from_config
-
-
-class PreTrainedTokenizerFast:
-    def __init__(self, tokenizer_object=None, unk_token="[UNK]"):
-        self.tokenizer_object = tokenizer_object
-        self.unk_token = unk_token
-        self.vocab_size = len(tokenizer_object.get_vocab()) if tokenizer_object else 0
-
-    def save_pretrained(self, path):
-        Path(path).mkdir(parents=True, exist_ok=True)
-        (Path(path) / "tokenizer.json").write_text("{}")
-
-
-class AutoTokenizer:
-    @classmethod
-    def from_pretrained(cls, path, *args, **kwargs):
-        return PreTrainedTokenizerFast()
-
+# Expose selected utilities from the real library
+GenerationMixin = hf.GenerationMixin
+AutoConfig = hf.AutoConfig
+AutoModelForCausalLM = hf.AutoModelForCausalLM
+AutoTokenizer = hf.AutoTokenizer
+GPT2Config = hf.GPT2Config
+PreTrainedTokenizerFast = hf.PreTrainedTokenizerFast
+hf.GPT2LMHeadModel = GPT2LMHeadModel
 
 __all__ = [
     "GenerationMixin",


### PR DESCRIPTION
## Summary
- swap local transformer stubs for thin wrappers over the real Hugging Face library
- allow optional GPU/CPU placement and expose tokenizer utilities
- add a GPT-2 generation test using distilgpt2

## Testing
- `pre-commit run --files transformers/__init__.py tests/test_transformers_generate.py tests/conftest.py`
- `pytest --no-cov tests/test_transformers_generate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b816ad8ee0832e90848799907af86f