### PR TITLE
feat(memory): modular RL env with dependency checks

### DIFF
--- a/docs/dependency_index.md
+++ b/docs/dependency_index.md
@@ -4,5 +4,8 @@ Generated automatically. Tracks external and internal dependencies across the pr
 
 | Dependency | Description | Source |
 | --- | --- | --- |
+| gymnasium | Reinforcement learning environment | PyPI |
+| numpy | Numerical computing library | PyPI |
+| stable-baselines3 | Reinforcement learning algorithms | PyPI |
 
 Backlinks: [Component Index](component_index.md) | [Connector Index](connectors/CONNECTOR_INDEX.md) | [Test Index](test_index.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,3 +24,18 @@ docker run -it abzu
 
 Pass environment variables with `--env-file` or `-e` as needed for your
 platform.
+
+## Reinforcement learning extras
+
+Components that rely on reinforcement learning require additional libraries:
+
+```bash
+pip install gymnasium numpy stable-baselines3
+```
+
+You can verify their availability with:
+
+```python
+from env_validation import check_rl_packages
+check_rl_packages()
+```

--- a/docs/test_index.md
+++ b/docs/test_index.md
@@ -4,5 +4,6 @@ Generated automatically. Catalog of test modules and scenarios.
 
 | Test | Purpose | Related Components |
 | --- | --- | --- |
+| `tests/integration/test_context_rl.py` | Validate RL context environment reset/step and training loop. | `memory.context_env`, `memory.mental` |
 
 Backlinks: [Component Index](component_index.md) | [Connector Index](connectors/CONNECTOR_INDEX.md) | [Dependency Index](dependency_index.md)

--- a/env_validation.py
+++ b/env_validation.py
@@ -76,6 +76,12 @@ def check_audio_binaries(*, require: bool = True) -> bool:
     return True
 
 
+def check_rl_packages() -> None:
+    """Log warnings if reinforcement learning packages are missing."""
+
+    check_optional_packages(["gymnasium", "numpy", "stable_baselines3"])
+
+
 def parse_servant_models(
     env: str | None = None, *, require: bool = False
 ) -> Dict[str, str]:

--- a/memory/context_env.py
+++ b/memory/context_env.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Any, Dict, Tuple
+
+from core.utils.optional_deps import lazy_import
+
+np = lazy_import("numpy")
+gym = lazy_import("gymnasium")
+
+logger = logging.getLogger(__name__)
+
+if getattr(np, "__stub__", False) or getattr(gym, "__stub__", False):
+
+    class ContextEnv:  # type: ignore[no-redef]
+        """Stub environment when RL dependencies are missing."""
+
+        observation_space = None
+        action_space = None
+
+        def __init__(self, *_: Any, **__: Any) -> None:  # pragma: no cover - stub
+            logger.warning(
+                "gymnasium or numpy not installed; reinforcement learning disabled",
+            )
+
+        def reset(
+            self, *args: Any, **kwargs: Any
+        ) -> Tuple[None, Dict[str, Any]]:  # pragma: no cover - stub
+            raise NotImplementedError("reinforcement learning is disabled")
+
+        def step(
+            self, *args: Any, **kwargs: Any
+        ) -> Tuple[None, float, bool, bool, Dict[str, Any]]:  # pragma: no cover - stub
+            raise NotImplementedError("reinforcement learning is disabled")
+
+else:
+
+    class ContextEnv(gym.Env):  # pragma: no cover - minimal RL env
+        """Minimal environment for context-based reinforcement learning."""
+
+        metadata = {"render.modes": []}
+
+        def __init__(self) -> None:
+            self.observation_space = gym.spaces.Box(
+                low=0.0,
+                high=1.0,
+                shape=(4,),
+                dtype=np.float32,
+            )
+            self.action_space = gym.spaces.Discrete(2)
+            self._state = np.zeros(4, dtype=np.float32)
+
+        def reset(
+            self,
+            *,
+            seed: int | None = None,
+            options: Dict[str, Any] | None = None,
+        ) -> Tuple[Any, Dict[str, Any]]:
+            super().reset(seed=seed)
+            self._state = np.zeros(4, dtype=np.float32)
+            return self._state.copy(), {}
+
+        def step(self, action: int) -> Tuple[Any, float, bool, bool, Dict[str, Any]]:
+            reward = float(action == 1)
+            terminated = True
+            truncated = False
+            self._state = np.random.random(4).astype(np.float32)
+            return self._state.copy(), reward, terminated, truncated, {}
+
+
+__all__ = ["ContextEnv"]

--- a/tests/integration/test_context_rl.py
+++ b/tests/integration/test_context_rl.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.integration
+def test_context_env_training_loop():
+    pytest.importorskip("gymnasium")
+    pytest.importorskip("numpy")
+    pytest.importorskip("stable_baselines3")
+
+    from memory.context_env import ContextEnv
+    from memory import mental
+
+    mental.init_rl_model()
+    assert mental._RL_MODEL is not None
+
+    env = ContextEnv()
+    obs, _ = env.reset()
+    assert env.observation_space.contains(obs)
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, _info = env.step(action)
+    assert env.observation_space.contains(obs)
+
+    size_before = mental._RL_MODEL.replay_buffer.size()
+    mental._update_rl({"a": 1}, reward)
+    assert mental._RL_MODEL.replay_buffer.size() == size_before + 1


### PR DESCRIPTION
## Summary
- add env_validation.check_rl_packages and document RL dependency installation
- move `_ContextEnv` into memory/context_env with realistic spaces
- guard RL model init and updates with warnings when deps missing and add integration test

## Testing
- `pre-commit run --files env_validation.py memory/context_env.py memory/mental.py docs/installation.md docs/dependency_index.md docs/test_index.md docs/INDEX.md tests/integration/test_context_rl.py`
- `pytest tests/integration/test_context_rl.py -q --cov-fail-under=0`

## Change justification
I did modularize RL context env on memory to obtain dependency-aware training, expecting RL routines to run only when packages are installed.

------
https://chatgpt.com/codex/tasks/task_e_68b81a800394832eae5c53d77fae8da8