### PR TITLE
Connect ritual inputs to music generation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -311,6 +312,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [module_execution_flow.md](module_execution_flow.md) | Module Execution Flow | Overview of key modules with their inputs, core processing, outputs, and error handling. Flowcharts summarize the exe... | - |
 | [monitoring.md](monitoring.md) | Monitoring | The application writes JSON-formatted logs to `logs/INANNA_AI.log`. The file rotates when it reaches roughly 10 MB, k... | - |
 | [music_avatar_architecture.md](music_avatar_architecture.md) | Music Avatar Architecture | The Crown agent can reflect on musical input by combining feature extraction with language model reasoning.  The `mus... | - |
+| [music_generation_usage.md](music_generation_usage.md) | Music Generation Usage | Generate audio from text prompts or ritual invocations. | - |
 | [narrative_engine_GUIDE.md](narrative_engine_GUIDE.md) | Narrative Engine Guide | - | - |
 | [nazarick_agents.md](nazarick_agents.md) | Nazarick Agents | Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown. | - |
 | [nazarick_manifesto.md](nazarick_manifesto.md) | Nazarick Manifesto | Guiding ethics for the Nazarick hierarchy. Architectural context lives in the [Great Tomb of Nazarick](great_tomb_of_... | - |

--- a/docs/music_generation_usage.md
+++ b/docs/music_generation_usage.md
@@ -1,0 +1,25 @@
+# Music Generation Usage
+
+Generate audio from text prompts or ritual invocations.
+
+## Command line
+
+```bash
+python music_generation.py "lofi beat"
+```
+
+## Ritual invocation
+
+```python
+from music_generation import register_music_invocation
+from invocation_engine import invoke
+
+register_music_invocation("\u266a")
+invoke("\u266a [joy]")
+```
+
+## LLM bridge
+
+```bash
+python music_llm_interface.py --prompt "ambient pad"
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,8 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_music_generation_emotion.py"),
     str(ROOT / "tests" / "test_music_generation_streaming.py"),
     str(ROOT / "tests" / "test_music_backends_missing.py"),
+    str(ROOT / "tests" / "test_music_generation_invocation.py"),
+    str(ROOT / "tests" / "test_music_llm_interface_prompt.py"),
     str(ROOT / "tests" / "test_albedo_state_machine.py"),
     str(ROOT / "tests" / "test_albedo_trust.py"),
     str(ROOT / "tests" / "test_vector_memory_extensions.py"),

--- a/tests/test_music_generation_invocation.py
+++ b/tests/test_music_generation_invocation.py
@@ -1,0 +1,24 @@
+"""Tests for ritual invocation integration with music generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import music_generation as mg
+import invocation_engine as ie
+
+
+def test_invocation_triggers_generation(monkeypatch):
+    ie.clear_registry()
+    temp = Path("generated.wav")
+
+    def fake_generate(prompt, *, emotion=None, **_):
+        assert prompt == "\u266a"  # eighth note symbol
+        assert emotion == "joy"
+        return temp
+
+    monkeypatch.setattr(mg, "generate_from_text", fake_generate)
+    mg.register_music_invocation("\u266a", emotion="joy")
+
+    result = ie.invoke("\u266a [joy]")
+    assert result == [temp]

--- a/tests/test_music_llm_interface_prompt.py
+++ b/tests/test_music_llm_interface_prompt.py
@@ -1,0 +1,73 @@
+"""Tests for generating music via prompt in music_llm_interface."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+# Stub heavy dependencies before importing the module
+pkg = types.ModuleType("INANNA_AI")
+emo = types.ModuleType("INANNA_AI.emotion_analysis")
+emo.analyze_audio_emotion = lambda path: {}
+pkg.emotion_analysis = emo
+sys.modules.setdefault("INANNA_AI", pkg)
+sys.modules.setdefault("INANNA_AI.emotion_analysis", emo)
+
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+# Stub orchestrator to avoid heavy imports
+orch_mod = types.ModuleType("rag.orchestrator")
+
+
+class DummyOrch:
+    def handle_input(self, text):
+        return {"text": text}
+
+
+orch_mod.MoGEOrchestrator = DummyOrch
+rag_pkg = types.ModuleType("rag")
+rag_pkg.orchestrator = orch_mod
+sys.modules.setdefault("rag", rag_pkg)
+sys.modules.setdefault("rag.orchestrator", orch_mod)
+
+import music_llm_interface as mli
+
+
+def test_generate_and_analyze_calls_components(tmp_path, monkeypatch):
+    gen_path = tmp_path / "out.wav"
+
+    def fake_generate(prompt, **kwargs):
+        assert prompt == "beat"
+        gen_path.write_bytes(b"")
+        return gen_path
+
+    def fake_run_interface(path, orchestrator=None):
+        assert path == gen_path
+        return {"ok": True}
+
+    monkeypatch.setattr(mli.music_generation, "generate_from_text", fake_generate)
+    monkeypatch.setattr(mli, "run_interface", fake_run_interface)
+
+    result = mli.generate_and_analyze("beat", emotion="joy")
+    assert result == {"ok": True}
+
+
+def test_cli_prompt_generates_music(tmp_path, monkeypatch, capsys):
+    gen_path = tmp_path / "gen.wav"
+
+    def fake_generate(prompt, **kwargs):
+        gen_path.write_bytes(b"")
+        return gen_path
+
+    def fake_run_interface(path, orchestrator=None):
+        assert path == gen_path
+        return {"done": True}
+
+    monkeypatch.setattr(mli.music_generation, "generate_from_text", fake_generate)
+    monkeypatch.setattr(mli, "run_interface", fake_run_interface)
+
+    mli.main(["--prompt", "beat"])
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {"done": True}


### PR DESCRIPTION
## Summary
- expose `register_music_invocation` to handle ritual callbacks
- allow `music_llm_interface` to generate audio from prompts and register ritual hook
- document sample usage and cover invocation behavior with tests

## Testing
- `PYTHONPATH=/tmp:$PYTHONPATH pytest -o addopts='' tests/test_music_generation_invocation.py tests/test_music_llm_interface_prompt.py`
- `pre-commit run --files music_generation.py music_llm_interface.py tests/test_music_generation_invocation.py tests/test_music_llm_interface_prompt.py tests/conftest.py docs/music_generation_usage.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b82491a928832ebbb379cd276b24c7