### PR TITLE
docs: reference Module Index in repository blueprint

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -20,6 +20,8 @@ ABZU adheres to a consistent top-level directory layout:
 - `tools/` – Developer tools and automation helpers
 - `notebooks/` – Experimental notebooks and prototypes
 
+Consult the [Module Index](module_index.md) for an overview of modules, classes, and functions within the repository.
+
 See [docs/REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) for detailed guidance on the repository layout.
 
 ## Repository Layout Protocol


### PR DESCRIPTION
## Summary
- link Module Index in The Absolute Protocol's repository blueprint for module and class overview

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md`


------
https://chatgpt.com/codex/tasks/task_e_68b8326f1768832e96981e5c138adcbc