### PR TITLE
Add blueprint spine acknowledgment to pull request checklist

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -77,6 +77,7 @@ During onboarding, contributors record purpose, scope, key rules, and an actiona
 Confirm these items before submitting a pull request:
 
  - [ ] Key-document summaries verified with `scripts/verify_doc_hashes.py`
+ - [ ] [blueprint_spine.md](blueprint_spine.md) read and acknowledged
  - [ ] Version bumps applied and synchronized in `component_index.json`
  - [ ] If any component or connector changes, rebuild `component_index.json` and confirm registry updates
  - [ ] Connector registry updated for added or modified connectors ([docs/connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md))


### PR DESCRIPTION
## Summary
- require contributors to confirm they have read and acknowledged docs/blueprint_spine.md in The Absolute Protocol's Core Pull Request Checklist

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md`

------
https://chatgpt.com/codex/tasks/task_e_68b8337fa938832eb862139b2381d11e