### PR TITLE
docs: add blueprint spine to onboarding

### DIFF
--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -5,7 +5,8 @@ Follow this reading order before contributing. After reviewing each document, re
 1. [Project Overview](../project_overview.md)
 2. [Architecture Overview](../architecture_overview.md)
 3. [The Absolute Protocol](../The_Absolute_Protocol.md)
-4. Module-specific guides relevant to your work:
+4. [Blueprint Spine](../blueprint_spine.md)
+5. Module-specific guides relevant to your work:
    - [Vector Memory](../vector_memory.md)
    - [RAG Pipeline](../rag_pipeline.md)
    - [RAG Music Oracle](../rag_music_oracle.md)
@@ -17,7 +18,7 @@ Confirm each item before starting code changes.
 
 When submitting a pull request, ensure you can check:
 
-- [ ] [AGENTS.md](../AGENTS.md) instructions followed
+- [ ] [AGENTS.md](../../AGENTS.md) instructions followed
 - [ ] [The Absolute Protocol](../The_Absolute_Protocol.md) consulted
 - [ ] Release notes updated in `CHANGELOG.md` and relevant component changelog(s)
 - [ ] `onboarding_confirm.yml` updated


### PR DESCRIPTION
## Summary
- add Blueprint Spine to onboarding reading list and adjust numbering
- fix AGENTS.md link in onboarding checklist

## Testing
- `pre-commit run --files docs/onboarding/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b835050d94832e85b8748eeb8c6cec