### PR TITLE
docs: expand operator onboarding and console access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 
+- Documented onboarding triple-reading requirement and Nazarick Web Console access in `docs/operator_interface_GUIDE.md` and updated `docs/INDEX.md`.
+
 - Documented chakra-aligned test directories and 90% coverage rule in `docs/the_absolute_pytest.md`.
 - Configured CI to archive `htmlcov/` and log coverage metrics even when tests fail.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -324,7 +324,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [onboarding_walkthrough.md](onboarding_walkthrough.md) | Onboarding Walkthrough | This text-based walkthrough provides a step-by-step path to set up the repository and rebuild the project from a fres... | - |
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |
 | [operations.md](operations.md) | Operations | - | - |
-| [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | - | - |
+| [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
 | [operator_protocol.md](operator_protocol.md) | Operator Protocol | Defines endpoints for operators to dispatch commands and upload assets to agents. | - |
 | [os_guardian.md](os_guardian.md) | OS Guardian | Sources: [`../os_guardian/perception.py`](../os_guardian/perception.py), [`../os_guardian/planning.py`](../os_guardia... | `../os_guardian/action_engine.py`, `../os_guardian/perception.py`, `../os_guardian/planning.py`, `../os_guardian/safety.py` |
 | [os_guardian_container.md](os_guardian_container.md) | OS Guardian Container | This guide covers running the `os_guardian` tools inside Docker. | - |

--- a/docs/operator_interface_GUIDE.md
+++ b/docs/operator_interface_GUIDE.md
@@ -1,7 +1,13 @@
 # Operator Interface Guide
+Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms.
 
 ## Vision
 Defines REST endpoints that let operators control Crown and RAZAR.
+
+## Onboarding
+The [The Absolute Protocol](The_Absolute_Protocol.md) requires triple-reading the
+[Blueprint Spine](blueprint_spine.md) before contributing. Confirm this review
+before operating the interface.
 
 ## Architecture
 - `/operator/command` forwards actions to RAZAR.
@@ -10,6 +16,11 @@ Defines REST endpoints that let operators control Crown and RAZAR.
 
 ## Deployment
 Expose the API via the Crown console and export `OPERATOR_TOKEN` for authentication.
+
+### Nazarick Web Console
+Access the [Nazarick Web Console](nazarick_web_console.md) to monitor agents and
+open their chat rooms. Select an agent to start a room and issue commands
+through the Operator API.
 
 ## Configuration Schemas
 - JSON body: `{ "action": "status", "parameters": {} }`.


### PR DESCRIPTION
## Summary
- document triple-reading onboarding requirement and Nazarick Web Console access in operator_interface_GUIDE
- regenerate docs index to include updated guide summary
- note onboarding and web console guidance in CHANGELOG

## Testing
- `pre-commit run --files docs/operator_interface_GUIDE.md docs/INDEX.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b8369ee2a8832e9a45d001b022a683