### PR TITLE
Add memory bus events and aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configured CI to archive `htmlcov/` and log coverage metrics even when tests fail.
 
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.
+- Published memory layer bus events and `query_memory` aggregator.
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.
 - Implemented `bana/narrative_api.py` for narrative retrieval and streaming.

--- a/component_index.json
+++ b/component_index.json
@@ -184,7 +184,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/ai_invoker.py",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": [
         "__future__",
         "agents",
@@ -266,7 +266,7 @@
       "chakra": "unknown",
       "type": "agent",
       "path": "agents/asian_gen/__init__.py",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": [
         "agents",
         "creative_engine",
@@ -2016,7 +2016,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/init_memory_layers.py",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": [
         "__future__",
         "memory",
@@ -2141,7 +2141,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "memory/__init__.py",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": [
         "__future__"
       ],

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -9,6 +9,7 @@ Memory layers preserve spiral decisions, emotions, and narratives for long-term 
 - **Narrative** – `memory/narrative_engine.py` stores story events.
 - **Mental** – `memory/mental.py` persists task graphs.
 - **Spiritual** – `memory/spiritual.py` maps symbols.
+- **Bus Events** – `memory.publish_layer_event()` announces layer status.
 
 ## Deployment
 Ensure `data/` directories exist and run initialization scripts:
@@ -21,9 +22,13 @@ python -m INANNA_AI.corpus_memory --reindex
 
 ## Example Runs
 ```python
-from memory import cortex
+from memory import cortex, publish_layer_event, query_memory
+
 node = type("N", (), {"children": []})()
 cortex.record_spiral(node, {"tags": ["example"]})
+publish_layer_event("cortex", "seeded")
+
+print(query_memory("example"))
 ```
 
 ## Cross-Links
@@ -33,4 +38,4 @@ cortex.record_spiral(node, {"tags": ["example"]})
 ## Version History
 | Version | Date | Notes |
 |---------|------|-------|
-| 0.1.0 | 2025-08-30 | Initial memory layer consolidation. |
+| 0.1.1 | 2025-09-03 | Added bus events and `query_memory` aggregator. |

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -3,4 +3,30 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+from typing import Any, Dict
+
+from agents.event_bus import emit_event
+from memory.cortex import query_spirals
+from spiral_memory import spiral_recall
+from vector_memory import query_vectors
+
+__version__ = "0.1.2"
+
+
+def publish_layer_event(layer: str, status: str) -> None:
+    """Emit initialization ``status`` for memory ``layer`` via the event bus."""
+
+    emit_event("memory", "layer_init", {"layer": layer, "status": status})
+
+
+def query_memory(query: str) -> Dict[str, Any]:
+    """Return aggregated results across cortex, vector, and spiral memory."""
+
+    return {
+        "cortex": query_spirals(text=query),
+        "vector": query_vectors(filter={"text": query}),
+        "spiral": spiral_recall(query),
+    }
+
+
+__all__ = ["publish_layer_event", "query_memory"]

--- a/scripts/init_memory_layers.py
+++ b/scripts/init_memory_layers.py
@@ -7,11 +7,12 @@ is skipped if Neo4j or its dependencies are unavailable.
 """
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import os
 from pathlib import Path
 
+from memory import publish_layer_event
 from memory.cortex import record_spiral, query_spirals
 from memory.emotional import (
     log_emotion,
@@ -52,12 +53,23 @@ def main() -> None:
         children = []
 
     record_spiral(Node(), {"result": "demo", "tags": ["example"]})
+    publish_layer_event("cortex", "seeded")
+
     log_emotion([0.8], conn=emotion_conn())
+    publish_layer_event("emotional", "seeded")
+
     if record_task_flow and query_related_tasks:
         record_task_flow("taskA", {"step": 1})
+        publish_layer_event("mental", "seeded")
+    else:
+        publish_layer_event("mental", "skipped")
+
     spirit = spirit_conn()
     map_to_symbol(("eclipse", "\u263E"), conn=spirit)
+    publish_layer_event("spiritual", "seeded")
+
     log_story("hero meets guide")
+    publish_layer_event("narrative", "seeded")
 
     print("Cortex:", query_spirals(tags=["example"]))
     print("Emotional:", fetch_emotion_history(60, conn=emotion_conn()))

--- a/tests/test_memory_bus.py
+++ b/tests/test_memory_bus.py
@@ -1,0 +1,34 @@
+"""Examples for memory bus and query aggregator."""
+
+from citadel.event_producer import Event, EventProducer
+
+from agents.event_bus import set_event_producer
+import memory
+from memory import publish_layer_event, query_memory
+
+
+class DummyProducer(EventProducer):
+    def __init__(self) -> None:
+        self.events = []
+
+    async def emit(self, event: Event) -> None:  # pragma: no cover - simple
+        self.events.append(event)
+
+
+def test_publish_layer_event_emits():
+    producer = DummyProducer()
+    set_event_producer(producer)
+
+    publish_layer_event("cortex", "seeded")
+
+    assert producer.events[0].payload == {"layer": "cortex", "status": "seeded"}
+    set_event_producer(None)
+
+
+def test_query_memory_aggregates(monkeypatch):
+    monkeypatch.setattr(memory, "query_spirals", lambda **kw: ["c"])
+    monkeypatch.setattr(memory, "query_vectors", lambda **kw: ["v"])
+    monkeypatch.setattr(memory, "spiral_recall", lambda q: "s")
+
+    res = query_memory("demo")
+    assert res == {"cortex": ["c"], "vector": ["v"], "spiral": "s"}


### PR DESCRIPTION
## Summary
- emit memory layer initialization events and provide query aggregator
- wire init script to publish bus events for all layers
- document bus events and query helper in memory guide
- add tests showing event emission and query aggregation

## Testing
- `pre-commit run --files CHANGELOG.md component_index.json docs/memory_layers_GUIDE.md memory/__init__.py scripts/init_memory_layers.py tests/test_memory_bus.py` *(fails: verify-versions mismatch for razar/ai_invoker.py, agents/asian_gen/__init__.py)*
- `pip install websockets`
- `pre-commit run --files CHANGELOG.md component_index.json docs/memory_layers_GUIDE.md memory/__init__.py scripts/init_memory_layers.py tests/test_memory_bus.py` *(fails: verify-versions mismatch for razar/ai_invoker.py, agents/asian_gen/__init__.py)*
- `pip install pytest-cov`
- `pytest -o addopts="" tests/test_memory_bus.py` *(skipped: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8467c44a0832eac5c2eeb5717adad