### PR TITLE
Wire biosignal ingest to compose multitrack narratives

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -184,7 +184,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/ai_invoker.py",
-      "version": "0.1.2",
+      "version": "0.1.1",
       "dependencies": [
         "__future__",
         "agents",
@@ -266,7 +266,7 @@
       "chakra": "unknown",
       "type": "agent",
       "path": "agents/asian_gen/__init__.py",
-      "version": "0.1.1",
+      "version": "0.1.0",
       "dependencies": [
         "agents",
         "creative_engine",
@@ -1942,7 +1942,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/ingest_biosignals.py",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": [
         "__future__",
         "csv",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -314,6 +314,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [music_avatar_architecture.md](music_avatar_architecture.md) | Music Avatar Architecture | The Crown agent can reflect on musical input by combining feature extraction with language model reasoning.  The `mus... | - |
 | [music_generation_usage.md](music_generation_usage.md) | Music Generation Usage | Generate audio from text prompts or ritual invocations. | - |
 | [narrative_engine_GUIDE.md](narrative_engine_GUIDE.md) | Narrative Engine Guide | - | - |
+| [narrative_system.md](narrative_system.md) | Narrative System | The narrative system transforms physiological data into cohesive multitrack stories. | - |
 | [nazarick_agents.md](nazarick_agents.md) | Nazarick Agents | Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown. | - |
 | [nazarick_manifesto.md](nazarick_manifesto.md) | Nazarick Manifesto | Guiding ethics for the Nazarick hierarchy. Architectural context lives in the [Great Tomb of Nazarick](great_tomb_of_... | - |
 | [nazarick_narrative_system.md](nazarick_narrative_system.md) | Nazarick Narrative System | The Nazarick Narrative System converts biosignals into narrative events and persistent memory records. | - |

--- a/docs/narrative_system.md
+++ b/docs/narrative_system.md
@@ -1,0 +1,29 @@
+# Narrative System
+
+The narrative system transforms physiological data into cohesive multitrack stories.
+
+## Flow
+
+```mermaid
+graph LR
+    CSV[Biosignal CSV] --> INGEST[ingest_biosignals.py]
+    INGEST --> EVENT[StoryEvent]
+    EVENT --> COMPOSE[compose_multitrack_story]
+    COMPOSE --> PROSE[Prose]
+    COMPOSE --> AUDIO[Audio]
+    COMPOSE --> VISUAL[Visual]
+    COMPOSE --> USD[USD]
+```
+
+## Retrieval Example
+
+```python
+from scripts.ingest_biosignals import ingest_directory
+from memory.narrative_engine import query_events
+
+tracks = ingest_directory()
+print(tracks["prose"])
+
+for event in query_events(agent_id="subject"):
+    print(event["payload"])
+```

--- a/scripts/ingest_biosignals.py
+++ b/scripts/ingest_biosignals.py
@@ -4,34 +4,41 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
+from typing import Any, Dict, List
 
 from data.biosignals import DATASET_HASHES, hash_file
-from memory.narrative_engine import StoryEvent, log_story
+from memory.narrative_engine import StoryEvent, compose_multitrack_story, log_story
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "biosignals"
 
 
-def ingest_file(csv_path: Path) -> None:
+def ingest_file(csv_path: Path) -> List[StoryEvent]:
     """Read ``csv_path`` and log story events derived from its rows."""
     expected = DATASET_HASHES.get(csv_path.name)
     actual = hash_file(csv_path)
     if expected and actual != expected:
         raise ValueError(f"hash mismatch for {csv_path.name}")
 
+    events: List[StoryEvent] = []
     with csv_path.open(newline="", encoding="utf-8") as f:
         for row in csv.DictReader(f):
             action = "elevated heart rate" if float(row["heart_rate"]) > 74 else "calm"
             event = StoryEvent(actor="subject", action=action)
             log_story(event.action)
+            events.append(event)
+    return events
 
 
-def ingest_directory(directory: Path = DATA_DIR) -> None:
-    """Process all CSV files in ``directory``."""
+def ingest_directory(directory: Path = DATA_DIR) -> Dict[str, Any]:
+    """Process all CSV files in ``directory`` and compose a multitrack story."""
+    events: List[StoryEvent] = []
     for csv_path in directory.glob("*.csv"):
-        ingest_file(csv_path)
+        events.extend(ingest_file(csv_path))
+    return compose_multitrack_story(events)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    ingest_directory()
+    tracks = ingest_directory()
+    print(tracks)

--- a/tests/test_bana_narrative_engine.py
+++ b/tests/test_bana_narrative_engine.py
@@ -19,3 +19,22 @@ def test_multitrack_tracks_present():
     assert result["prose"]
     for track in ("audio", "visual", "usd"):
         assert isinstance(result[track], list) and result[track]
+
+
+def test_multitrack_story_content():
+    """`compose_multitrack_story` expands events into expected track data."""
+    events = [
+        StoryEvent(actor="hero", action="smiles"),
+        StoryEvent(actor="villain", action="frowns"),
+    ]
+    result = compose_multitrack_story(events)
+    assert result["prose"] == "hero smiles. villain frowns."
+    assert result["audio"] == [{"cue": "hero_smiles"}, {"cue": "villain_frowns"}]
+    assert result["visual"] == [
+        {"directive": "frame hero smiles"},
+        {"directive": "frame villain frowns"},
+    ]
+    assert result["usd"] == [
+        {"op": "AddPrim", "path": "/hero", "action": "smiles"},
+        {"op": "AddPrim", "path": "/villain", "action": "frowns"},
+    ]


### PR DESCRIPTION
## Summary
- invoke `compose_multitrack_story` during biosignal ingestion for immediate multitrack output
- expand Bana narrative engine tests to validate prose, audio, visual and USD tracks
- document narrative system flow with retrieval example

## Testing
- `pre-commit run --files scripts/ingest_biosignals.py tests/test_bana_narrative_engine.py docs/narrative_system.md component_index.json`
- `pre-commit run --files docs/INDEX.md`
- `pytest -o addopts="" tests/test_bana_narrative_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b849d5d9b8832eb2c4b2f8125f91a0