### PR TITLE
docs: replace operator onboarding images with diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced in-memory story log with SQLite-backed persistence and documented schema.
 
 ### Changed
+- Replaced operator onboarding screenshots with Mermaid diagrams in `docs/operator_interface_GUIDE.md`.
 - Assigned unique component IDs for avatar/audio generation modules and RAZAR health checks to avoid collisions, ensuring component lookups remain unambiguous.
 - Bumped `crown_handshake` to 0.2.4 and `operator_api`/`webrtc_connector` to 0.3.3 and recorded versions in connector registry.
 - Added mission brief and operator chat examples with connector checklist cross-links in Crown and operator docs.

--- a/docs/operator_interface_GUIDE.md
+++ b/docs/operator_interface_GUIDE.md
@@ -9,6 +9,26 @@ The [The Absolute Protocol](The_Absolute_Protocol.md) requires triple-reading th
 [Blueprint Spine](blueprint_spine.md) before contributing. Confirm this review
 before operating the interface.
 
+### Step 1: Select an Agent
+
+```mermaid
+flowchart TD
+    Operator -->|open| Console[Nazarick Web Console]
+    Console -->|choose| Agent[Agent Room]
+```
+
+### Step 2: Issue a Command
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant Crown
+    participant RAZAR
+    Operator->>Crown: POST /operator/command
+    Crown->>RAZAR: forward command
+    RAZAR-->>Operator: status response
+```
+
 ## Architecture
 - `/operator/command` forwards actions to RAZAR.
 - `/operator/upload` sends files and metadata.


### PR DESCRIPTION
## Summary
- replace operator onboarding screenshots with inline Mermaid diagrams
- note mermaid diagrams in changelog

## Testing
- `pre-commit run --files docs/operator_interface_GUIDE.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68b84e617b28832eb33e62e9fa9d25c3