### PR TITLE
Reinforce doc governance with cross-links and module doc checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,12 @@ repos:
     language: system
     pass_filenames: false
     files: ^component_index.json$
+  - id: require-module-docs
+    name: Require changelog and component index for new modules
+    entry: python scripts/require_module_docs.py
+    language: system
+    pass_filenames: false
+    always_run: true
   - id: verify-dependencies
     name: Verify dependency versions
     entry: python scripts/verify_dependencies.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforced ≥90% coverage in CI workflows; pipelines fail when thresholds are not met.
 - Added `scan_todo_fixme` pre-commit hook to block `TODO`/`FIXME` markers and documented rule in The Absolute Protocol.
 - Added GitHub Actions workflow `dependency-audit.yml` to run `pip-audit` and `npm audit`, failing on high-severity vulnerabilities and uploading reports.
+- Cross-linked `docs/The_Absolute_Protocol.md`, `docs/project_mission_vision.md`, and `docs/nazarick_manifesto.md` for governance and ethics coherence.
+- Added `scripts/require_module_docs.py` pre-commit hook ensuring new modules update `CHANGELOG.md` and `docs/component_index.md`.
+- Added `docs/operator_quickstart.md` summarizing the triple-reading rule and consent logging.
 
 ### Documentation Audit
 - Expanded RAZAR agent guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -327,6 +327,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [operations.md](operations.md) | Operations | - | - |
 | [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
 | [operator_protocol.md](operator_protocol.md) | Operator Protocol | Defines endpoints for operators to dispatch commands and upload assets to agents. | - |
+| [operator_quickstart.md](operator_quickstart.md) | Operator Quickstart | A concise orientation for operators interacting with ABZU. | - |
 | [os_guardian.md](os_guardian.md) | OS Guardian | Sources: [`../os_guardian/perception.py`](../os_guardian/perception.py), [`../os_guardian/planning.py`](../os_guardia... | `../os_guardian/action_engine.py`, `../os_guardian/perception.py`, `../os_guardian/planning.py`, `../os_guardian/safety.py` |
 | [os_guardian_container.md](os_guardian_container.md) | OS Guardian Container | This guide covers running the `os_guardian` tools inside Docker. | - |
 | [os_guardian_permissions.md](os_guardian_permissions.md) | OS Guardian Permission Policies | The `safety` module guards high-risk actions executed by the OS Guardian utilities. Permissions are configured with e... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -6,6 +6,8 @@
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to follow required workflows and standards. Declare a top-level `__version__` for each module, connector, and service. Every pull request and commit message must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B" per the [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format). Agent guides must include sections for **Vision**, **Module Overview**, **Workflow**, **Architecture Diagram**, **Requirements**, **Deployment**, **Config Schemas**, **Version History**, **Cross-links**, **Example Runs**, **Persona & Responsibilities**, and **Component & Link**.
 
+Align contributions with the overarching goals in [project_mission_vision.md](project_mission_vision.md) and the servant ethics defined in the [nazarick_manifesto.md](nazarick_manifesto.md).
+
 Before touching any code, read [blueprint_spine.md](blueprint_spine.md) three times to internalize the project's structure and intent.
 
 ## Repository Blueprint
@@ -99,6 +101,7 @@ Before opening a pull request, confirm each item:
   - [Documentation Protocol](documentation_protocol.md)
   - [System Blueprint](system_blueprint.md)
   - [Project Mission & Vision](project_mission_vision.md) – confirm alignment before proposing major changes
+  - [Nazarick Manifesto](nazarick_manifesto.md) – uphold servant ethics across agents
   - [Key Documents](KEY_DOCUMENTS.md) – verify all entries reviewed within the last quarter
   - [Component Index](component_index.md) – inventory of modules and services with versions and chakra layers
   - [Connector Index](connectors/CONNECTOR_INDEX.md) – canonical connector registry; confirm purpose, version, endpoints, auth method, linked agents, status, operator interface flows, and code/doc links are current

--- a/docs/nazarick_manifesto.md
+++ b/docs/nazarick_manifesto.md
@@ -2,7 +2,7 @@
 
 Guiding ethics for the Nazarick hierarchy. Architectural context lives in the
 [Great Tomb of Nazarick](great_tomb_of_nazarick.md) with servant details in
-[Nazarick Agents](nazarick_agents.md).
+[Nazarick Agents](nazarick_agents.md). See [project_mission_vision.md](project_mission_vision.md) for strategic goals and follow the contribution rules in [The_Absolute_Protocol.md](The_Absolute_Protocol.md).
 
 The Nazarick agents abide by the following laws:
 

--- a/docs/operator_quickstart.md
+++ b/docs/operator_quickstart.md
@@ -1,0 +1,9 @@
+# Operator Quickstart
+
+A concise orientation for operators interacting with ABZU.
+
+## Triple-Reading Rule
+Before issuing commands or editing code, read [blueprint_spine.md](blueprint_spine.md) three times as mandated by the [The Absolute Protocol](The_Absolute_Protocol.md). The repetition ensures the project's structure and intent are internalized.
+
+## Consent Logging
+Record explicit consent for every session. Log the operator, participants, timestamp, and scope in the canonical ledger so actions remain auditable and reversible. Reference the ethical laws in the [nazarick_manifesto.md](nazarick_manifesto.md) when verifying that consent covers all planned interactions.

--- a/docs/project_mission_vision.md
+++ b/docs/project_mission_vision.md
@@ -7,6 +7,8 @@ ABZU ∴ Vision & System Overview (BANA Narrative Engine)
 
 Purpose: This document provides stakeholders and the software architect with a clear, comprehensive vision of ABZU’s mission, ambitions, and unique system architecture. It explains how the BANA Narrative Engine, orchestration agents (RAZAR, Nazarick), INANNA_AI’s memory, and the human–AI interface work together to create ethically grounded, emotionally resonant worlds.
 
+For contribution rules see [The_Absolute_Protocol.md](The_Absolute_Protocol.md) and for servant ethics consult the [nazarick_manifesto.md](nazarick_manifesto.md).
+
 1) Mission
 
 ABZU’s core mission is to cultivate inner awareness in intelligent systems and to project that awareness into immersive, meaningful worlds. Instead of optimizing first for external tasks, ABZU builds a rich internal life – narratives, emotions, values, and memories – and then co‑creates experiences around that inner life. In other words, the system “knows itself” before it interacts with humans, so the worlds it generates are not just settings, but living storyspaces with purpose.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -42,7 +42,7 @@ documents:
       key_rules: Keep contributions aligned with project scope.
       insight: Confirm contributions align with project goals.
   docs/project_mission_vision.md:
-    sha256: e9fcd6d8f460c00aaa02fba3e1760accf06d24c8caa3cb8358e2e5f75aed832e
+    sha256: 7a6eb00309cbcd954facf388f0a805db83d09f0e7fd31c39bebcccede506da1a
     summary:
       purpose: Unified mission and vision for ABZU.
       scope: Project direction and guiding principles.
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 78eb175d65ec0da6058e4d3fe3649c6d68607f62adeb30f8892ac5e9f318515e
+    sha256: 98fcaa5ea4384ab0bb7d91a4a9a5b70525e43795d1886ca37c470a9b074b10f0
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/scripts/require_module_docs.py
+++ b/scripts/require_module_docs.py
@@ -1,0 +1,52 @@
+"""Require changelog and component index updates when new modules are added."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import subprocess
+import sys
+
+REQUIRED_DOCS = {"CHANGELOG.md", "docs/component_index.md"}
+
+
+def get_staged_changes() -> list[tuple[str, str]]:
+    """Return (status, path) for staged files."""
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-status"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    entries: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        status, path = line.split(maxsplit=1)
+        entries.append((status, path))
+    return entries
+
+
+def main() -> int:
+    staged = get_staged_changes()
+    added_modules = [
+        p for s, p in staged if s == "A" and p.startswith("src/") and p.endswith(".py")
+    ]
+    if not added_modules:
+        return 0
+    touched = {p for _, p in staged}
+    missing = REQUIRED_DOCS.difference(touched)
+    if missing:
+        files = "\n".join(sorted(added_modules))
+        msg = (
+            "New modules detected:\n"
+            f"{files}\n"
+            "Add entries to CHANGELOG.md and docs/component_index.md."
+        )
+        print(msg, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- cross-link The Absolute Protocol, Project Mission & Vision, and Nazarick Manifesto for consistent guidance
- add `require_module_docs` pre-commit hook to ensure new modules update CHANGELOG and component index
- provide operator quickstart for triple-reading rule and consent logging

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/project_mission_vision.md docs/nazarick_manifesto.md docs/operator_quickstart.md scripts/require_module_docs.py .pre-commit-config.yaml onboarding_confirm.yml CHANGELOG.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68b851bda914832ea7d4346772b914ba