### PR TITLE
Expand Bana narrative engine tests and docs

### DIFF
--- a/docs/narrative_system.md
+++ b/docs/narrative_system.md
@@ -27,3 +27,17 @@ print(tracks["prose"])
 for event in query_events(agent_id="subject"):
     print(event["payload"])
 ```
+
+## Test Invocation
+
+Run the narrative engine tests:
+
+```bash
+pytest tests/test_bana_narrative_engine.py
+```
+
+Run a single test:
+
+```bash
+pytest tests/test_bana_narrative_engine.py::test_multitrack_track_schemas
+```

--- a/tests/data/bana/multitrack_story.json
+++ b/tests/data/bana/multitrack_story.json
@@ -1,0 +1,31 @@
+{
+  "prose": "hero smiles. villain frowns.",
+  "audio": [
+    {
+      "cue": "hero_smiles"
+    },
+    {
+      "cue": "villain_frowns"
+    }
+  ],
+  "visual": [
+    {
+      "directive": "frame hero smiles"
+    },
+    {
+      "directive": "frame villain frowns"
+    }
+  ],
+  "usd": [
+    {
+      "op": "AddPrim",
+      "path": "/hero",
+      "action": "smiles"
+    },
+    {
+      "op": "AddPrim",
+      "path": "/villain",
+      "action": "frowns"
+    }
+  ]
+}

--- a/tests/test_bana_narrative_engine.py
+++ b/tests/test_bana_narrative_engine.py
@@ -2,12 +2,13 @@
 
 from pathlib import Path
 import csv
+import json
 
 from memory.narrative_engine import StoryEvent, compose_multitrack_story
 
 
-def test_multitrack_tracks_present():
-    """Biosignal events yield full multitrack story output."""
+def test_multitrack_track_schemas():
+    """Biosignal events yield full multitrack story output with valid schemas."""
     csv_path = Path("data/biosignals/sample_biosignals.csv")
     events = []
     with csv_path.open(newline="", encoding="utf-8") as f:
@@ -15,26 +16,41 @@ def test_multitrack_tracks_present():
             action = "elevated heart rate" if float(row["heart_rate"]) > 74 else "calm"
             events.append(StoryEvent(actor="subject", action=action))
     result = compose_multitrack_story(events)
+
     assert set(result) == {"prose", "audio", "visual", "usd"}
-    assert result["prose"]
-    for track in ("audio", "visual", "usd"):
-        assert isinstance(result[track], list) and result[track]
+    assert isinstance(result["prose"], str) and result["prose"]
+
+    assert isinstance(result["audio"], list) and result["audio"]
+    assert all(
+        isinstance(a, dict) and set(a) == {"cue"} and isinstance(a["cue"], str)
+        for a in result["audio"]
+    )
+
+    assert isinstance(result["visual"], list) and result["visual"]
+    assert all(
+        isinstance(v, dict)
+        and set(v) == {"directive"}
+        and isinstance(v["directive"], str)
+        for v in result["visual"]
+    )
+
+    assert isinstance(result["usd"], list) and result["usd"]
+    assert all(
+        isinstance(u, dict)
+        and set(u) == {"op", "path", "action"}
+        and all(isinstance(u[k], str) for k in ("op", "path", "action"))
+        for u in result["usd"]
+    )
 
 
-def test_multitrack_story_content():
-    """`compose_multitrack_story` expands events into expected track data."""
+def test_multitrack_story_golden_file():
+    """`compose_multitrack_story` output matches the recorded sample."""
     events = [
         StoryEvent(actor="hero", action="smiles"),
         StoryEvent(actor="villain", action="frowns"),
     ]
     result = compose_multitrack_story(events)
-    assert result["prose"] == "hero smiles. villain frowns."
-    assert result["audio"] == [{"cue": "hero_smiles"}, {"cue": "villain_frowns"}]
-    assert result["visual"] == [
-        {"directive": "frame hero smiles"},
-        {"directive": "frame villain frowns"},
-    ]
-    assert result["usd"] == [
-        {"op": "AddPrim", "path": "/hero", "action": "smiles"},
-        {"op": "AddPrim", "path": "/villain", "action": "frowns"},
-    ]
+    expected_path = Path("tests/data/bana/multitrack_story.json")
+    with expected_path.open(encoding="utf-8") as f:
+        expected = json.load(f)
+    assert result == expected


### PR DESCRIPTION
## Summary
- test Bana multitrack output for schema compliance
- capture multitrack story sample for golden-file comparison
- document how to invoke Bana narrative tests

## Testing
- `pre-commit run --files tests/test_bana_narrative_engine.py tests/data/bana/multitrack_story.json docs/narrative_system.md docs/INDEX.md`
- `pytest tests/test_bana_narrative_engine.py --cov-fail-under=0`

## Change justification
I did expand Bana multitrack narrative tests on compose_multitrack_story to obtain schema validation and golden-file comparisons, expecting deterministic multitrack outputs.

------
https://chatgpt.com/codex/tasks/task_e_68b85b551b9c832e86c7a82efecc0053