### PR TITLE
refactor: break razar bootstrap circular imports

### DIFF
--- a/agents/guardian.py
+++ b/agents/guardian.py
@@ -7,7 +7,6 @@ __version__ = "0.1.0"
 from typing import Any, Callable
 
 from .event_bus import emit_event
-from .cocytus.prompt_arbiter import arbitrate
 
 
 def run_validated_task(
@@ -34,6 +33,8 @@ def run_validated_task(
     emit_event(actor, "evaluate_entity", entity_result)
 
     if not ethics_result.get("compliant", False):
+        from .cocytus.prompt_arbiter import arbitrate
+
         arbitrate(actor, action, entity_result)
         return None
 

--- a/agents/razar/code_repair.py
+++ b/agents/razar/code_repair.py
@@ -24,12 +24,12 @@ from typing import Iterable, Sequence
 from INANNA_AI.glm_integration import GLMIntegration
 
 from . import doc_sync, quarantine_manager
+from razar.bootstrap_utils import PATCH_LOG_PATH
 
 logger = logging.getLogger(__name__)
 
 # Determine repository root relative to this file
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-PATCH_LOG_PATH = PROJECT_ROOT / "logs" / "razar_ai_patches.json"
 
 
 def _record_patch(component: str, diff: str, tests: str) -> None:

--- a/agents/razar/runtime_manager.py
+++ b/agents/razar/runtime_manager.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Sequence
 import venv
 from . import checkpoint_manager, health_checks, quarantine_manager
+from razar.bootstrap_utils import STATE_FILE
 
 # Re-export primary entry points for simpler imports
 __all__ = ["RuntimeManager", "main"]
@@ -46,7 +47,7 @@ class RuntimeManager:
         env_path: Path | None = None,
     ) -> None:
         self.config_path = config_path
-        self.state_path = state_path or Path("logs/razar_state.json")
+        self.state_path = state_path or STATE_FILE
         self.venv_path = venv_path or config_path.parent / ".razar_venv"
         # ``razar_env.yaml`` lives at the repository root and lists dependencies
         # for each component layer.  Allow ``env_path`` to be overridden for

--- a/razar/ai_invoker.py
+++ b/razar/ai_invoker.py
@@ -14,14 +14,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-from agents.razar import ai_invoker as remote_ai_invoker
-from agents.razar import code_repair
+from .bootstrap_utils import PATCH_LOG_PATH
 
 __version__ = "0.1.1"
 
 LOGGER = logging.getLogger(__name__)
-
-PATCH_LOG_PATH = code_repair.PATCH_LOG_PATH
 
 
 def _append_patch_log(entry: Dict[str, Any]) -> None:
@@ -67,6 +64,9 @@ def handover(
         ``True`` if at least one patch was applied successfully, otherwise
         ``False``.
     """
+    from agents.razar import ai_invoker as remote_ai_invoker
+    from agents.razar import code_repair
+
     ctx: Dict[str, Any] = {"component": component, "error": error}
     if context:
         ctx.update(context)

--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -21,17 +21,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from . import ai_invoker, crown_handshake, doc_sync, health_checks, mission_logger
+from .bootstrap_utils import (
+    HISTORY_FILE,
+    LOGS_DIR,
+    MAX_MISSION_BRIEFS,
+    STATE_FILE,
+)
 from .crown_handshake import CrownResponse
 from .quarantine_manager import is_quarantined, quarantine_component
 from agents.nazarick.service_launcher import launch_required_agents
 
 LOGGER = logging.getLogger("razar.boot_orchestrator")
-
-LOGS_DIR = Path(__file__).resolve().parents[1] / "logs"
-HISTORY_FILE = LOGS_DIR / "razar_boot_history.json"
-STATE_FILE = LOGS_DIR / "razar_state.json"
-# keep a limited number of mission brief archives for auditability
-MAX_MISSION_BRIEFS = 20
 
 
 def load_history() -> Dict[str, Any]:

--- a/razar/bootstrap_utils.py
+++ b/razar/bootstrap_utils.py
@@ -1,0 +1,24 @@
+"""Utility constants shared across RAZAR bootstrap modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Base directory for runtime logs
+LOGS_DIR = Path(__file__).resolve().parents[1] / "logs"
+
+# Frequently used log file locations
+STATE_FILE = LOGS_DIR / "razar_state.json"
+HISTORY_FILE = LOGS_DIR / "razar_boot_history.json"
+PATCH_LOG_PATH = LOGS_DIR / "razar_ai_patches.json"
+
+# Keep a limited number of mission brief archives for auditability
+MAX_MISSION_BRIEFS = 20
+
+__all__ = [
+    "LOGS_DIR",
+    "STATE_FILE",
+    "HISTORY_FILE",
+    "PATCH_LOG_PATH",
+    "MAX_MISSION_BRIEFS",
+]


### PR DESCRIPTION
## Summary
- centralize bootstrapping paths in `razar.bootstrap_utils`
- lazy-load remote agent modules to avoid circular imports
- use shared state paths in runtime manager and repair utilities

## Testing
- `pre-commit run --files razar/bootstrap_utils.py razar/boot_orchestrator.py razar/ai_invoker.py agents/razar/runtime_manager.py agents/razar/code_repair.py agents/guardian.py`
- `CROWN_WS_URL=ws://localhost:8765 python -m razar.boot_orchestrator`

------
https://chatgpt.com/codex/tasks/task_e_68b871234670832ea5c76298ca7d8cb5