### PR TITLE
feat: add module checks and populate secrets env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configured CI to archive `htmlcov/` and log coverage metrics even when tests fail.
 
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.
+- Extended `scripts/check_requirements.sh` to report missing Python modules.
 - Published memory layer bus events and `query_memory` aggregator.
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.

--- a/scripts/check_requirements.sh
+++ b/scripts/check_requirements.sh
@@ -31,6 +31,14 @@ for cmd in docker nc sox ffmpeg curl jq wget aria2c; do
     fi
 done
 
+# Check for required Python modules
+for module in core audio; do
+    if ! python -c "import $module" >/dev/null 2>&1; then
+        echo "Python module '$module' is missing. Install it or ensure it's on PYTHONPATH." >&2
+        missing=1
+    fi
+done
+
 if [ "$missing" -ne 0 ]; then
     exit 1
 fi

--- a/secrets.env
+++ b/secrets.env
@@ -1,0 +1,3 @@
+HF_TOKEN=changeme
+GLM_API_URL=http://localhost:8000/glm41v_9b
+GLM_API_KEY=changeme


### PR DESCRIPTION
## Summary
- add Python module check to `scripts/check_requirements.sh`
- add sample `secrets.env` with GLM and HF tokens
- document requirement script enhancement in changelog

## Testing
- `which docker ffmpeg sox aria2c`
- `bash scripts/check_requirements.sh`
- `bash start_crown_console.sh` *(fails: curl: (22) The requested URL returned error: 401)*

------
https://chatgpt.com/codex/tasks/task_e_68b87a697678832ea0c525068bcf1230