### PR TITLE
Offload GLM calls and add async API

### DIFF
--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -71,7 +71,7 @@ def _build_context(limit: int = 3) -> str:
 
 
 async def _delegate(prompt: str, glm: GLMIntegration) -> str:
-    return glm.complete(prompt)
+    return await asyncio.to_thread(glm.complete, prompt)
 
 
 def _apply_layer(message: str) -> tuple[str | None, str | None]:


### PR DESCRIPTION
## Summary
- offload blocking GLM calls to thread in crown prompt orchestrator
- ensure orchestrator awaits delegate
- add optional async `complete_async` method to GLMIntegration using aiohttp

## Testing
- `pre-commit run --files crown_prompt_orchestrator.py INANNA_AI/glm_integration.py`
- `pytest tests/crown/test_prompt_orchestrator.py::test_basic_flow --override-ini="addopts=" -q`
- `pytest tests/test_glm_modules.py::test_env_overrides_endpoint --override-ini="addopts=" -q` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b88cc839e0832eace81f597f82f523