### PR TITLE
Target specific exceptions in crown orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `crown_handshake` to 0.2.4 and `operator_api`/`webrtc_connector` to 0.3.3 and recorded versions in connector registry.
 - Added mission brief and operator chat examples with connector checklist cross-links in Crown and operator docs.
 - Removed unused `boot_sequence` placeholder from `orchestration_master.py`.
+- Hardened Crown prompt orchestrator to target known exceptions and surface unexpected failures.
 
 ### Chakra Versions
 


### PR DESCRIPTION
## Summary
- refine crown prompt orchestrator to catch ImportError and type errors in personality layer handling
- surface failures from auxiliary integrations and model invocation by logging and re-raising unexpected issues
- document improved error handling

## Testing
- `pre-commit run --files crown_prompt_orchestrator.py CHANGELOG.md`
- `pytest tests/crown/test_prompt_orchestrator.py` *(fails: NameError: LOADER_DIR not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e48bc24832e934e6765eadb0c63