### PR TITLE
Chore: remove secrets env and document template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ When bumping versions in
 
 ## Setup
 
+Copy `secrets.env.template` to `secrets.env` and fill in the required tokens and URLs before running any scripts.
+
 Use Python 3.10 or later. Install development dependencies with:
 
 ```bash

--- a/secrets.env
+++ b/secrets.env
@@ -1,3 +1,0 @@
-HF_TOKEN=changeme
-GLM_API_URL=http://localhost:8000/glm41v_9b
-GLM_API_KEY=changeme


### PR DESCRIPTION
## Summary
- remove committed secrets.env and keep it out of version control
- remind contributors to copy secrets.env.template and fill required variables

## Testing
- `pre-commit run --files CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_e_68b89b12b770832e8e0959c07d5f24ad