### PR TITLE
test: cover console logs and streaming

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_adaptive_learning_stub.py"),
     str(ROOT / "tests" / "test_env_validation.py"),
     str(ROOT / "tests" / "crown" / "test_config.py"),
+    str(ROOT / "tests" / "crown" / "test_console_startup.py"),
     str(ROOT / "tests" / "test_download_deepseek.py"),
     str(ROOT / "tests" / "test_dashboard_app.py"),
     str(ROOT / "tests" / "test_dashboard_usage.py"),


### PR DESCRIPTION
## Summary
- extend crown console startup tests to verify log creation and streaming output
- allow console startup tests in test collection

## Testing
- `pre-commit run --files tests/crown/test_console_startup.py tests/conftest.py` (with `SKIP=capture-failing-tests`)
- `pytest --no-cov tests/crown/test_console_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_68b89cfcd9d8832eb8b50439950b520b