### PR TITLE
fix: ensure audio module on path

### DIFF
--- a/crown_decider.py
+++ b/crown_decider.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 import crown_config
 import emotional_state
 import servant_model_manager as smm
+import audio  # noqa: F401
 from audio import voice_aura
 from INANNA_AI import emotional_memory
 from task_profiling import classify_task

--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -20,6 +20,22 @@ from datetime import datetime
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, Awaitable
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Ensure local packages like ``audio`` are importable without installation.
+# This mirrors the pytest configuration that adds ``src`` to ``PYTHONPATH``.
+# ---------------------------------------------------------------------------
+_ROOT = Path(__file__).resolve().parent
+_SRC = _ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+_py_path = os.environ.get("PYTHONPATH", "")
+if str(_SRC) not in _py_path.split(os.pathsep):
+    os.environ["PYTHONPATH"] = os.pathsep.join([p for p in (str(_SRC), _py_path) if p])
+
+import audio  # noqa: F401  # Required for crown_decider audio features
 
 import crown_decider
 import emotional_state


### PR DESCRIPTION
## Summary
- add audio package to PYTHONPATH in crown prompt orchestrator
- explicitly import audio where audio voice features are used

## Testing
- `pre-commit run --files crown_prompt_orchestrator.py crown_decider.py`
- `python crown_prompt_orchestrator.py "Hello"` *(fails: NameError: name 'LOADER_DIR' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc20fa40832e895bfe1fecafc665