### PR TITLE
feat: route repair tasks to opencode

### DIFF
--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -268,7 +268,10 @@ async def crown_prompt_orchestrator_async(
         current = await emotional_state.get_last_emotion_async()
         logger.debug("processing with last emotion %s", current)
         task_type = classify_task(message)
-        model = crown_decider.recommend_llm(task_type, emotion)
+        if task_type in {"repair", "refactor"}:
+            model = "opencode"
+        else:
+            model = crown_decider.recommend_llm(task_type, emotion)
         success = True
         invoke_error: str | None = None
         try:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,6 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/crown_servant_models.md
+++ b/docs/crown_servant_models.md
@@ -2,9 +2,9 @@
 
 Servant models provide auxiliary language capabilities alongside the primary GLM. Registration follows a simple sequence:
 
-1. **Download weights** with `download_models.py` for each servant (DeepSeek, Mistral, Kimi-K2).
-2. **Expose endpoints** by setting environment variables such as `DEEPSEEK_URL`, `MISTRAL_URL`, and `KIMI_K2_URL` or by using the aggregated `SERVANT_MODELS` variable.
+1. **Download weights** with `download_models.py` for each servant (DeepSeek, Mistral, Kimi-K2, Opencode).
+2. **Expose endpoints** by setting environment variables such as `DEEPSEEK_URL`, `MISTRAL_URL`, `KIMI_K2_URL`, and `OPENCODE_URL` or by using the aggregated `SERVANT_MODELS` variable. When `OPENCODE_URL` is unset, the local `opencode` CLI is used.
 3. **Initialize Crown** via `init_crown_agent.initialize_crown()`. During startup the script reads the environment and registers each servant with `servant_model_manager.register_model`.
-4. **Invoke through the orchestrator**. Once registered, `crown_prompt_orchestrator` can delegate requests to these servants based on `crown_decider.recommend_llm`; failures fall back to GLM.
+4. **Invoke through the orchestrator**. Once registered, `crown_prompt_orchestrator` routes prompts tagged with “repair” or “refactor” intents to Opencode and delegates other requests based on `crown_decider.recommend_llm`; failures fall back to GLM.
 
-This flow keeps servant availability explicit and enables health-based routing across DeepSeek, Mistral, and Kimi-K2.
+This flow keeps servant availability explicit and enables health-based routing across DeepSeek, Mistral, Kimi-K2, and Opencode.

--- a/init_crown_agent.py
+++ b/init_crown_agent.py
@@ -146,9 +146,15 @@ def _register_http_servant(name: str, url: str) -> None:
 def _init_servants(cfg: dict) -> None:
     servants = dict(cfg.get("servant_models") or {})
     kimi_url = servants.pop("kimi_k2", None) or os.getenv("KIMI_K2_URL")
+    opencode_present = "opencode" in servants or os.getenv("OPENCODE_URL")
+    opencode_url = servants.pop("opencode", None) or os.getenv("OPENCODE_URL")
     if kimi_url:
         os.environ.setdefault("KIMI_K2_URL", kimi_url)
         smm.register_kimi_k2()
+    if opencode_present:
+        if opencode_url:
+            os.environ.setdefault("OPENCODE_URL", opencode_url)
+        smm.register_opencode()
     for name, url in servants.items():
         _register_http_servant(name, url)
 

--- a/servant_model_manager.py
+++ b/servant_model_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import threading
 from typing import Awaitable, Callable, Dict, List, cast
 
-from tools import kimi_k2_client
+from tools import kimi_k2_client, opencode_client
 
 _Handler = Callable[[str], Awaitable[str] | str]
 _REGISTRY: Dict[str, _Handler] = {}
@@ -39,6 +39,11 @@ def register_subprocess_model(name: str, command: List[str]) -> None:
 def register_kimi_k2() -> None:
     """Register the Kimi-K2 servant model."""
     register_model("kimi_k2", kimi_k2_client.complete)
+
+
+def register_opencode() -> None:
+    """Register the Opencode servant model."""
+    register_model("opencode", opencode_client.complete)
 
 
 def has_model(name: str) -> bool:
@@ -78,4 +83,5 @@ __all__ = [
     "list_models",
     "has_model",
     "register_kimi_k2",
+    "register_opencode",
 ]

--- a/tests/crown/test_servant_routing.py
+++ b/tests/crown/test_servant_routing.py
@@ -1,0 +1,51 @@
+import asyncio
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+dummy_np = types.ModuleType("numpy")
+dummy_np.clip = lambda val, lo, hi: lo if val < lo else hi if val > hi else val
+dummy_np.mean = lambda arr: sum(arr) / len(arr) if arr else 0
+sys.modules.setdefault("numpy", dummy_np)
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+
+import crown_prompt_orchestrator as cpo
+import crown_decider
+import servant_model_manager as smm
+
+
+class DummyGLM:
+    def complete(self, prompt: str, quantum_context: str | None = None) -> str:
+        return f"glm:{prompt}"
+
+
+def _run(message: str, task_type: str, monkeypatch) -> dict:
+    smm._REGISTRY.clear()
+    smm.register_model("opencode", lambda p: f"oc:{p}")
+    monkeypatch.setattr(cpo, "load_interactions", lambda limit=3: [])
+    monkeypatch.setattr(cpo, "classify_task", lambda msg: task_type)
+    monkeypatch.setattr(
+        crown_decider,
+        "recommend_llm",
+        lambda t, e: (_ for _ in ()).throw(AssertionError("decider used")),
+    )
+    glm = DummyGLM()
+    return asyncio.run(cpo.crown_prompt_orchestrator_async(message, glm))
+
+
+def test_repair_routes_to_opencode(monkeypatch):
+    result = _run("fix bug", "repair", monkeypatch)
+    assert result["model"] == "opencode"
+    assert result["text"] == "oc:fix bug"
+
+
+def test_refactor_routes_to_opencode(monkeypatch):
+    result = _run("clean code", "refactor", monkeypatch)
+    assert result["model"] == "opencode"
+    assert result["text"] == "oc:clean code"

--- a/tools/opencode_client.py
+++ b/tools/opencode_client.py
@@ -1,0 +1,52 @@
+"""Client for interacting with the Opencode servant model."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import logging
+import os
+import subprocess
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - requests optional
+    requests = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = os.getenv("OPENCODE_URL")
+
+
+def complete(prompt: str) -> str:
+    """Return the code diff for ``prompt`` via Opencode.
+
+    If ``OPENCODE_URL`` is set, an HTTP request is issued. Otherwise the local
+    ``opencode`` CLI is invoked. Errors are wrapped in :class:`RuntimeError`.
+    """
+
+    try:
+        if _ENDPOINT and requests is not None:
+            resp = requests.post(_ENDPOINT, json={"prompt": prompt}, timeout=30)
+            resp.raise_for_status()
+            try:
+                data = resp.json()
+                return data.get("diff", data.get("text", ""))
+            except Exception:
+                return resp.text
+        cmd = ["opencode", "--diff"]
+        proc = subprocess.run(
+            cmd,
+            input=prompt.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            timeout=30,
+        )
+        return proc.stdout.decode().strip()
+    except Exception as exc:  # pragma: no cover - external failures
+        logger.error("Opencode request failed: %s", exc)
+        raise RuntimeError("Opencode request failed") from exc
+
+
+__all__ = ["complete"]


### PR DESCRIPTION
## Summary
- add Opencode client wrapper and register servant model
- route repair/refactor intents to Opencode
- document Opencode servant and cover routing logic

## Testing
- `pre-commit run --files tools/opencode_client.py servant_model_manager.py crown_prompt_orchestrator.py docs/crown_servant_models.md init_crown_agent.py tests/crown/test_servant_routing.py docs/INDEX.md`
- `pytest tests/crown/test_servant_routing.py --cov=src --cov=agents --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b9656adc88832e995a687a6f99d28e