### PR TITLE
feat: enable opencode kimi backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/operator_quickstart.md` summarizing the triple-reading rule and consent logging.
 - Introduced optional Opencode CLI handover in `razar.ai_invoker` with
   accompanying setup instructions in RAZAR docs.
+- Enabled Opencode to delegate code generation to the Kimi-K2 servant model and documented setup in `docs/tools/kimi_integration.md`.
 
 ### Documentation Audit
 - Expanded RAZAR agent guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -367,6 +367,7 @@ This index excludes `node_modules`, `dist`, and `build` directories.
 | [testing.md](testing.md) | Testing | ```mermaid flowchart LR D[Developer] --> T[pytest] T --> R[Report] ``` | - |
 | [testing_music_pipeline.md](testing_music_pipeline.md) | Testing Music Pipeline | To run the unit tests for the ritual music pipeline: | - |
 | [the_absolute_pytest.md](the_absolute_pytest.md) | The Absolute Pytest | > **Note:** Before writing tests, review [blueprint_spine.md](blueprint_spine.md) and consult the [Module Index](modu... | - |
+| [tools/kimi_integration.md](tools/kimi_integration.md) | Kimi Integration | Opencode can delegate code generation to the Kimi-K2 model when the service is available. | - |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting | This guide addresses frequent setup problems, driver issues, and environment pitfalls. Refer to [installation](instal... | `../download_models.py`, `../env_validation.py`, `../scripts/bootstrap.py` |
 | [ui/README.md](ui/README.md) | Floor Client UI | This React/Tailwind interface renders floors with channel tiles and streams messages over a WebSocket feed. | - |
 | [updates/2025-08.md](updates/2025-08.md) | August 2025 Roadmap | - | - |

--- a/docs/tools/kimi_integration.md
+++ b/docs/tools/kimi_integration.md
@@ -1,0 +1,11 @@
+# Kimi Integration
+
+Opencode can delegate code generation to the Kimi-K2 model when the service is available.
+
+1. Launch a Kimi-K2 service and note its URL.
+2. Set environment variables:
+   - `KIMI_K2_URL` – endpoint for the Kimi-2 service.
+   - `OPENCODE_BACKEND=kimi` – route Opencode requests through Kimi.
+3. Use `tools.opencode_client.complete` for code-generation tasks; it will call Kimi when configured.
+
+Kimi-2 excels at reasoning about code and provides a lightweight backend for Opencode-driven development.

--- a/tools/kimi_k2_client.py
+++ b/tools/kimi_k2_client.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 _ENDPOINT = os.getenv("KIMI_K2_URL", "http://localhost:8004")
 
 
+def endpoint() -> str:
+    """Return the configured Kimi-K2 endpoint."""
+
+    return _ENDPOINT
+
+
 def complete(prompt: str) -> str:
     """Return the completion from Kimi-K2 for ``prompt``."""
 
@@ -35,4 +41,4 @@ def complete(prompt: str) -> str:
         raise RuntimeError("Kimi-K2 request failed") from exc
 
 
-__all__ = ["complete"]
+__all__ = ["complete", "endpoint"]

--- a/tools/opencode_client.py
+++ b/tools/opencode_client.py
@@ -8,6 +8,8 @@ import logging
 import os
 import subprocess
 
+from . import kimi_k2_client
+
 try:  # pragma: no cover - optional dependency
     import requests
 except Exception:  # pragma: no cover - requests optional
@@ -16,16 +18,21 @@ except Exception:  # pragma: no cover - requests optional
 logger = logging.getLogger(__name__)
 
 _ENDPOINT = os.getenv("OPENCODE_URL")
+_BACKEND = os.getenv("OPENCODE_BACKEND", "").lower()
 
 
 def complete(prompt: str) -> str:
     """Return the code diff for ``prompt`` via Opencode.
 
-    If ``OPENCODE_URL`` is set, an HTTP request is issued. Otherwise the local
-    ``opencode`` CLI is invoked. Errors are wrapped in :class:`RuntimeError`.
+    If ``OPENCODE_BACKEND`` is ``"kimi"`` the Kimi-K2 client is used directly.
+    When ``OPENCODE_URL`` is set, an HTTP request is issued. Otherwise the
+    local ``opencode`` CLI is invoked. Errors are wrapped in
+    :class:`RuntimeError`.
     """
 
     try:
+        if _BACKEND in {"kimi", "kimi-k2"}:
+            return kimi_k2_client.complete(prompt)
         if _ENDPOINT and requests is not None:
             resp = requests.post(_ENDPOINT, json={"prompt": prompt}, timeout=30)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary
- expose Kimi-K2 endpoint for service consumers
- allow Opencode client to delegate to Kimi-K2 when configured
- document how to run code generation via Kimi-2

## Testing
- `pre-commit run --files tools/kimi_k2_client.py tools/opencode_client.py docs/tools/kimi_integration.md docs/INDEX.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b96896267c832ea5ad8ec680e5f916