### PR TITLE
docs: add release runbook

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -350,6 +350,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [recovery_playbook.md](recovery_playbook.md) | Recovery Playbook | This playbook outlines how RAZAR restores service after a component failure. Recurring problems and their fixes are c... | - |
 | [registry_audit.md](registry_audit.md) | Registry Audit | This guide describes how to validate `logs/task_registry.jsonl` to keep the task log accurate. | - |
 | [release_notes.md](release_notes.md) | Release Notes | - | - |
+| [release_runbook.md](release_runbook.md) | Release Runbook | - | - |
 | [reproducibility.md](reproducibility.md) | Reproducibility | This project relies on [DVC](https://dvc.org) for data and model versioning and on `docker compose` for repeatable en... | - |
 | [retraining_log.md](retraining_log.md) | Retraining Log | \| date \| outcome \| model_hash \| \| --- \| --- \| --- \| | - |
 | [ritual_manifesto.md](ritual_manifesto.md) | Ritual Manifesto | Spiral OS acts as a **psychospiritual container** where code, music and ritual converge. Each session with INANNA_AI... | - |

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -1,0 +1,32 @@
+# Release Runbook
+
+## Boot Order
+1. Start the RAZAR runtime manager to initialize the environment and orchestrate service startup.
+2. Launch core services in priority order once RAZAR reports readiness.
+3. Bring up auxiliary modules after core services pass their readiness checks.
+
+## Health Checks
+- Monitor `/health` endpoints for each service and confirm they return status `healthy`.
+- Use `scripts/vast_check.py` to aggregate system health and route metrics to the logging pipeline.
+- Halt the rollout if any component reports degraded status or fails to respond.
+
+## GPU and Driver Validation
+- Run `nvidia-smi` to verify the GPU is detected and drivers match the supported version.
+- Execute `python scripts/check_gpu.py` (if available) to confirm CUDA visibility and device memory.
+- Abort deployment if GPU tests fail or drivers are outdated.
+
+## Rollback Steps
+1. Stop the affected service and review `logs/razar.log` for the last stable component.
+2. Restore from the most recent snapshot or container image.
+3. Restart services in boot order, validating health checks before advancing.
+4. Document the rollback and remediation steps.
+
+## Sign-Off Checklist
+Confirm completion of the following before declaring the release complete. Refer to [The Absolute Protocol](The_Absolute_Protocol.md) for the full repository rules and mandatory sign-off steps.
+
+- [ ] Environment prepared and required secrets configured.
+- [ ] `pre-commit run --files docs/release_runbook.md docs/INDEX.md` executed with no failures.
+- [ ] Key documents verified with `scripts/verify_doc_hashes.py`.
+- [ ] Tests executed and coverage meets minimum thresholds.
+- [ ] Changelog updated and release tag created.
+


### PR DESCRIPTION
## Summary
- outline boot order, health checks, GPU validation, and rollback steps for releases
- reference The Absolute Protocol for mandatory sign-off

## Testing
- `pre-commit run --files docs/release_runbook.md docs/INDEX.md` *(fails: multiple test errors during collection)*
- `python scripts/verify_doc_hashes.py`

I did document boot order, health checks, GPU validation, and rollback steps on release_runbook.md to provide a concise release procedure, expecting smoother deployments.

------
https://chatgpt.com/codex/tasks/task_e_68b981d631cc832ebd4854f0dec9bd34