### PR TITLE
feat(razar): add health events and recovery daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Emitted structured health events during RAZAR boot and introduced recovery daemon for automated restarts.
+
 - Added `environment.gpu.yml` and CPU/GPU Dockerfiles with pinned versions and documented hardware setup.
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 - Documented remediation steps for placeholder violations in RAZAR agent
+- Structured health events recorded for each boot step.
+- Added recovery daemon monitoring `razar_state.json` for automatic restarts.
   guide.
 - Added logging requirement for RAZAR ↔ Crown ↔ Operator exchanges in `logs/interaction_log.jsonl`.
 - Persisted CROWN handshake responses to `logs/mission_briefs/` and

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -56,6 +56,29 @@ flowchart TD
     B -->|log| F[logs/razar_ai_invocations.json]
 ```
 
+### Recovery Flow
+```mermaid
+flowchart TD
+    M[Monitor razar_state.json] --> N{Failure event?}
+    N -->|yes| O[request_shutdown]
+    O --> P[ai_invoker.handover]
+    P --> Q{patch applied?}
+    Q -->|yes| R[resume component]
+    Q -->|no| S[operator escalation]
+    N -->|no| M
+```
+
+Example health event from `logs/razar_state.json`:
+```json
+{
+  "step": "launch",
+  "component": "crown_router",
+  "status": "fail",
+  "error": "Health check failed",
+  "timestamp": 0
+}
+```
+
 ## Architecture Diagram
 ```mermaid
 flowchart TD

--- a/scripts/recovery_daemon.py
+++ b/scripts/recovery_daemon.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List
+
+from razar import ai_invoker, recovery_manager
+from razar.bootstrap_utils import STATE_FILE
+
+__version__ = "0.1.0"
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_events() -> List[Dict[str, Any]]:
+    if not STATE_FILE.exists():
+        return []
+    try:
+        data = json.loads(STATE_FILE.read_text())
+    except json.JSONDecodeError:
+        return []
+    return data.get("events", [])
+
+
+def _handle_event(event: Dict[str, Any]) -> None:
+    if event.get("step") != "launch" or event.get("status") != "fail":
+        return
+    component = event.get("component", "")
+    error = event.get("error", "")
+    LOGGER.info("Attempting recovery for %s", component)
+    recovery_manager.request_shutdown(component)
+    patched = ai_invoker.handover(component, error)
+    if patched:
+        recovery_manager.resume(component)
+        LOGGER.info("Component %s recovered", component)
+    else:
+        LOGGER.warning("Automatic recovery failed for %s", component)
+
+
+def monitor(interval: float = 1.0) -> None:
+    logging.basicConfig(level=logging.INFO)
+    last = 0
+    while True:
+        events = _load_events()
+        new_events = events[last:]
+        for event in new_events:
+            _handle_event(event)
+        last = len(events)
+        time.sleep(interval)
+
+
+def main() -> None:
+    monitor()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- emit structured health events throughout RAZAR boot sequence
- monitor `razar_state.json` with recovery daemon for automatic restart attempts
- document recovery flow with diagrams and example logs

## Testing
- `pre-commit run --files CHANGELOG.md CHANGELOG_razar.md docs/RAZAR_AGENT.md razar/boot_orchestrator.py scripts/recovery_daemon.py` *(fails: AttributeError and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b98ce57c14832e85936c095f8f5c83