### PR TITLE
feat: broadcast memory events and cross-layer search

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -309,7 +309,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | - | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | This guide describes the event bus protocol connecting the Cortex, Emotional, Mental, Spiritual, and Narrative memory... | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -10,13 +10,24 @@ from memory.cortex import query_spirals
 from spiral_memory import spiral_recall
 from vector_memory import query_vectors
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
+
+LAYERS = ("cortex", "emotional", "mental", "spiritual", "narrative")
 
 
-def publish_layer_event(layer: str, status: str) -> None:
-    """Emit initialization ``status`` for memory ``layer`` via the event bus."""
+def broadcast_layer_event(statuses: Dict[str, str]) -> None:
+    """Emit initialization ``statuses`` for all memory layers via the event bus.
 
-    emit_event("memory", "layer_init", {"layer": layer, "status": status})
+    ``statuses`` maps layer names to their corresponding status strings.
+    Layers missing from the mapping default to ``"unknown"``.
+    """
+
+    for layer in LAYERS:
+        emit_event(
+            "memory",
+            "layer_init",
+            {"layer": layer, "status": statuses.get(layer, "unknown")},
+        )
 
 
 def query_memory(query: str) -> Dict[str, Any]:
@@ -29,4 +40,4 @@ def query_memory(query: str) -> Dict[str, Any]:
     }
 
 
-__all__ = ["publish_layer_event", "query_memory"]
+__all__ = ["broadcast_layer_event", "query_memory", "LAYERS"]

--- a/memory/search_api.py
+++ b/memory/search_api.py
@@ -1,0 +1,80 @@
+"""Aggregate memory queries across layers with recency and source ranking."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import math
+from typing import Any, Dict, List
+
+from memory.cortex import query_spirals
+from memory.emotional import fetch_emotion_history
+from memory.narrative_engine import stream_stories
+from memory.spiritual import lookup_symbol_history
+
+try:  # mental layer optional
+    from memory.mental import query_related_tasks
+except Exception:  # pragma: no cover - dependency may be missing
+    query_related_tasks = None
+
+_DECAY_SECONDS = 86_400.0
+
+
+def _recency_weight(ts: str) -> float:
+    """Return exponential decay weight for ``ts``."""
+    try:
+        t = datetime.fromisoformat(ts)
+    except Exception:
+        return 1.0
+    age = (datetime.utcnow() - t).total_seconds()
+    return math.exp(-age / _DECAY_SECONDS)
+
+
+def aggregate_search(
+    query: str, *, source_weights: Dict[str, float] | None = None
+) -> List[Dict[str, Any]]:
+    """Return ranked matches from cortex, emotional, mental, spiritual and narrative layers."""
+
+    q = query.lower()
+    source_weights = source_weights or {}
+    results: List[Dict[str, Any]] = []
+
+    for entry in query_spirals(text=query):
+        results.append(
+            {
+                "source": "cortex",
+                "text": entry.get("decision", {}).get("result", ""),
+                "timestamp": entry.get("timestamp", ""),
+            }
+        )
+
+    for emo in fetch_emotion_history(100):
+        if q in str(emo.vector):
+            results.append(
+                {
+                    "source": "emotional",
+                    "text": str(emo.vector),
+                    "timestamp": emo.timestamp.isoformat(),
+                }
+            )
+
+    if query_related_tasks:
+        for task in query_related_tasks(query):
+            results.append({"source": "mental", "text": task, "timestamp": ""})
+
+    for sym in lookup_symbol_history(query):
+        results.append({"source": "spiritual", "text": sym, "timestamp": ""})
+
+    for story in stream_stories():
+        if q in story.lower():
+            results.append({"source": "narrative", "text": story, "timestamp": ""})
+
+    for res in results:
+        res["score"] = _recency_weight(res.get("timestamp", "")) * source_weights.get(
+            res["source"], 1.0
+        )
+
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return results
+
+
+__all__ = ["aggregate_search"]

--- a/scripts/init_memory_layers.py
+++ b/scripts/init_memory_layers.py
@@ -7,12 +7,12 @@ is skipped if Neo4j or its dependencies are unavailable.
 """
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import os
 from pathlib import Path
 
-from memory import publish_layer_event
+from memory import broadcast_layer_event
 from memory.cortex import record_spiral, query_spirals
 from memory.emotional import (
     log_emotion,
@@ -52,24 +52,28 @@ def main() -> None:
     class Node:
         children = []
 
+    statuses = {}
+
     record_spiral(Node(), {"result": "demo", "tags": ["example"]})
-    publish_layer_event("cortex", "seeded")
+    statuses["cortex"] = "seeded"
 
     log_emotion([0.8], conn=emotion_conn())
-    publish_layer_event("emotional", "seeded")
+    statuses["emotional"] = "seeded"
 
     if record_task_flow and query_related_tasks:
         record_task_flow("taskA", {"step": 1})
-        publish_layer_event("mental", "seeded")
+        statuses["mental"] = "seeded"
     else:
-        publish_layer_event("mental", "skipped")
+        statuses["mental"] = "skipped"
 
     spirit = spirit_conn()
     map_to_symbol(("eclipse", "\u263E"), conn=spirit)
-    publish_layer_event("spiritual", "seeded")
+    statuses["spiritual"] = "seeded"
 
     log_story("hero meets guide")
-    publish_layer_event("narrative", "seeded")
+    statuses["narrative"] = "seeded"
+
+    broadcast_layer_event(statuses)
 
     print("Cortex:", query_spirals(tags=["example"]))
     print("Emotional:", fetch_emotion_history(60, conn=emotion_conn()))


### PR DESCRIPTION
## Summary
- broadcast initialization statuses to all memory layers at once
- add search_api for recency-weighted, multi-layer queries
- document memory bus protocol

## Testing
- `pre-commit run --files memory/__init__.py memory/search_api.py scripts/init_memory_layers.py tests/test_memory_bus.py docs/memory_layers_GUIDE.md docs/INDEX.md` (fails: tests require unavailable dependencies)
- `pytest tests/test_memory_bus.py --cov-fail-under=0` (skipped: tests require unavailable resources)


------
https://chatgpt.com/codex/tasks/task_e_68b98ef73b84832eac41c058a049f1af