### PR TITLE
feat: verify documentation doctrine

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,9 +136,9 @@ repos:
     language: system
     types: [markdown]
     exclude: ^docs/INDEX\.md$
-  - id: verify-doctrine-refs
-    name: Verify doctrine references
-    entry: python scripts/verify_doctrine_refs.py
+  - id: verify-doctrine
+    name: Verify documentation doctrine
+    entry: python scripts/verify_doctrine.py
     language: system
     pass_filenames: false
     files: ^docs/

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,7 +14,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -387,6 +386,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../floor_client/README.md](../floor_client/README.md) | Floor Client | This folder contains the React interface for Floor channels. | - |
 | [../guides/visual_customization.md](../guides/visual_customization.md) | Avatar Visual Customization | This guide outlines how to turn a 2D concept image into the 3D model used by the video engine. | - |
 | [../monitoring/README.md](../monitoring/README.md) | Monitoring | This stack launches Prometheus and Grafana alongside an NVIDIA GPU exporter. Metrics include frames per second (FPS),... | - |
+| [../monitoring/copresence_dashboard.md](../monitoring/copresence_dashboard.md) | Copresence Dashboard | This Grafana dashboard surfaces real‑time copresence signals for operators. It focuses on boot health, narrative flow... | - |
 | [../monitoring/metrics_catalog.md](../monitoring/metrics_catalog.md) | Metrics Catalog | \| Metric \| Type \| Labels \| Description \| Dashboard \| \| --- \| --- \| --- \| --- \| --- \| \| `service_boot_duration_seconds... | - |
 | [../sacred_inputs/00-INVOCATION.md](../sacred_inputs/00-INVOCATION.md) | 00-INVOCATION.md | - | - |
 | [../scripts/install_profiles.md](../scripts/install_profiles.md) | Installation Profiles | This project provides several installation profiles using optional dependencies defined in `pyproject.toml`. | - |

--- a/docs/contributor_checklist.md
+++ b/docs/contributor_checklist.md
@@ -5,6 +5,9 @@ This checklist distills mandatory practices for ABZU contributors.
 ## Triple-Reading Rule
 - Read [blueprint_spine.md](blueprint_spine.md) **three times** before making changes. The repetition ensures deep architectural awareness as required by [The Absolute Protocol](The_Absolute_Protocol.md).
 
+## Documentation Doctrine
+- Run `python scripts/verify_doctrine.py` to confirm key docs exist and doctrine rules remain intact. The pre-commit hook executes this automatically when documentation changes.
+
 ## Error Index Updates
 - Record recurring issues in [error_registry.md](error_registry.md).
 - Update entries whenever new error patterns are resolved or observed.

--- a/scripts/verify_doctrine.py
+++ b/scripts/verify_doctrine.py
@@ -1,35 +1,32 @@
 from __future__ import annotations
 
-"""Verify key documentation references.
+"""Verify core documentation doctrine.
 
 This script enforces three documentation invariants:
 
 * ``docs/The_Absolute_Protocol.md`` mentions the rule to read
   ``blueprint_spine.md`` three times.
-* ``docs/INDEX.md`` contains entries for ``The_Absolute_Protocol.md`` and
-  ``blueprint_spine.md``.
+* ``docs/INDEX.md`` lists ``The_Absolute_Protocol.md`` and ``blueprint_spine.md``.
 * ``docs/error_registry.md`` and ``docs/testing/failure_inventory.md`` exist.
 
-The script exits with a non-zero status and prints the failing checks when any
-invariant is violated. It is intended for use as a pre-commit hook.
+The script exits with a non-zero status and prints failing checks when any
+invariant is violated. Intended for use as a pre-commit hook.
 """
 
 from pathlib import Path
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
-DOCS = ROOT / "docs"
 
 BLUEPRINT_RULE = "read [blueprint_spine.md](blueprint_spine.md) three times"
 
 
-def verify_doctrine_refs(root: Path | None = None) -> None:
-    """Validate documentation references under *root* (defaults to repo root)."""
+def verify_doctrine(root: Path | None = None) -> None:
+    """Validate documentation doctrine under *root* (defaults to repo root)."""
     base = Path(root) if root else ROOT
     docs = base / "docs"
     errors: list[str] = []
 
-    # Check Absolute Protocol rule
     protocol_path = docs / "The_Absolute_Protocol.md"
     if not protocol_path.exists():
         errors.append(f"missing {protocol_path}")
@@ -40,7 +37,6 @@ def verify_doctrine_refs(root: Path | None = None) -> None:
                 "The_Absolute_Protocol.md missing 'read blueprint_spine.md three times' rule"
             )
 
-    # Ensure INDEX includes protocol and blueprint entries
     index_path = docs / "INDEX.md"
     if not index_path.exists():
         errors.append("missing docs/INDEX.md")
@@ -50,7 +46,6 @@ def verify_doctrine_refs(root: Path | None = None) -> None:
             if name not in index_text:
                 errors.append(f"{name} not listed in INDEX.md")
 
-    # Required supporting docs
     for rel in ("error_registry.md", "testing/failure_inventory.md"):
         if not (docs / rel).exists():
             errors.append(f"missing docs/{rel}")
@@ -59,8 +54,8 @@ def verify_doctrine_refs(root: Path | None = None) -> None:
         for err in errors:
             print(err, file=sys.stderr)
         raise SystemExit(1)
-    print("verify_doctrine_refs: all checks passed")
+    print("verify_doctrine: all checks passed")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
-    verify_doctrine_refs()
+    verify_doctrine()

--- a/tests/scripts/test_verify_doctrine.py
+++ b/tests/scripts/test_verify_doctrine.py
@@ -4,7 +4,7 @@ import pathlib
 
 import pytest
 
-from scripts.verify_doctrine_refs import verify_doctrine_refs
+from scripts.verify_doctrine import verify_doctrine
 
 
 def _setup_docs(root: pathlib.Path, protocol_text: str, index_text: str) -> None:
@@ -17,16 +17,16 @@ def _setup_docs(root: pathlib.Path, protocol_text: str, index_text: str) -> None
     (docs / "testing" / "failure_inventory.md").write_text("failures")
 
 
-def test_verify_doctrine_refs_pass(tmp_path: pathlib.Path) -> None:
+def test_verify_doctrine_pass(tmp_path: pathlib.Path) -> None:
     protocol_text = "Before touching any code, read [blueprint_spine.md](blueprint_spine.md) three times."
     index_text = "The_Absolute_Protocol.md\nblueprint_spine.md\n"
     _setup_docs(tmp_path, protocol_text, index_text)
-    verify_doctrine_refs(tmp_path)
+    verify_doctrine(tmp_path)
 
 
-def test_verify_doctrine_refs_fail(tmp_path: pathlib.Path) -> None:
+def test_verify_doctrine_fail(tmp_path: pathlib.Path) -> None:
     protocol_text = "Read blueprint once."
     index_text = "The_Absolute_Protocol.md\n"
     _setup_docs(tmp_path, protocol_text, index_text)
     with pytest.raises(SystemExit):
-        verify_doctrine_refs(tmp_path)
+        verify_doctrine(tmp_path)


### PR DESCRIPTION
## Summary
- add `verify_doctrine.py` to ensure Absolute Protocol, doc index, and error docs stay in sync
- hook verify_doctrine in pre-commit to run on documentation edits
- document doctrine verification in contributor checklist and add tests

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/verify_doctrine.py tests/scripts/test_verify_doctrine.py docs/contributor_checklist.md` *(fails: missing Python packages websockets; later run produced multiple test errors)*
- `pytest -o addopts= tests/scripts/test_verify_doctrine.py` *(skipped due to repo test allow-list)*
- `python scripts/verify_doctrine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b998439254832e82823b9d8fbde6d2