### PR TITLE
Add audit doctrine enforcement script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,9 +136,9 @@ repos:
     language: system
     types: [markdown]
     exclude: ^docs/INDEX\.md$
-  - id: verify-doctrine
-    name: Verify documentation doctrine
-    entry: python scripts/verify_doctrine.py
+  - id: audit-doctrine
+    name: Audit documentation doctrine
+    entry: python scripts/audit_doctrine.py
     language: system
     pass_filenames: false
     files: ^docs/

--- a/docs/contributor_checklist.md
+++ b/docs/contributor_checklist.md
@@ -6,7 +6,7 @@ This checklist distills mandatory practices for ABZU contributors.
 - Read [blueprint_spine.md](blueprint_spine.md) **three times** before making changes. The repetition ensures deep architectural awareness as required by [The Absolute Protocol](The_Absolute_Protocol.md).
 
 ## Documentation Doctrine
-- Run `python scripts/verify_doctrine.py` to confirm key docs exist and doctrine rules remain intact. The pre-commit hook executes this automatically when documentation changes.
+- Run `python scripts/audit_doctrine.py` to confirm key docs exist, required index entries are present, and doctrine rules remain intact. The pre-commit hook executes this automatically when documentation changes.
 
 ## Error Index Updates
 - Record recurring issues in [error_registry.md](error_registry.md).
@@ -20,3 +20,4 @@ This checklist distills mandatory practices for ABZU contributors.
 | Version | Date | Notes |
 |---------|------|-------|
 | 0.1.0 | 2025-10-25 | Initial checklist. |
+| 0.1.1 | 2025-09-04 | Replace verify_doctrine with audit_doctrine. |

--- a/scripts/audit_doctrine.py
+++ b/scripts/audit_doctrine.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Audit core documentation doctrine.
+
+This script enforces several documentation invariants:
+
+* ``docs/The_Absolute_Protocol.md`` mentions the rule to read
+  ``blueprint_spine.md`` three times.
+* ``docs/INDEX.md`` lists ``The_Absolute_Protocol.md``, ``blueprint_spine.md``,
+  ``error_registry.md`` and ``testing/failure_inventory.md``.
+* ``docs/error_registry.md`` and ``docs/testing/failure_inventory.md`` exist
+  and are non-empty.
+
+The script exits with a non-zero status and prints failing checks when any
+invariant is violated. Intended for use as a pre-commit hook.
+"""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BLUEPRINT_RULE = "read [blueprint_spine.md](blueprint_spine.md) three times"
+
+
+def audit_doctrine(root: Path | None = None) -> None:
+    """Validate documentation doctrine under *root* (defaults to repo root)."""
+    base = Path(root) if root else ROOT
+    docs = base / "docs"
+    errors: list[str] = []
+
+    protocol_path = docs / "The_Absolute_Protocol.md"
+    if not protocol_path.exists():
+        errors.append(f"missing {protocol_path}")
+    else:
+        text = protocol_path.read_text(encoding="utf-8").lower()
+        if BLUEPRINT_RULE.lower() not in text:
+            errors.append(
+                "The_Absolute_Protocol.md missing 'read blueprint_spine.md three times' rule"
+            )
+
+    index_path = docs / "INDEX.md"
+    if not index_path.exists():
+        errors.append("missing docs/INDEX.md")
+    else:
+        index_text = index_path.read_text(encoding="utf-8")
+        for name in (
+            "The_Absolute_Protocol.md",
+            "blueprint_spine.md",
+            "error_registry.md",
+            "testing/failure_inventory.md",
+        ):
+            if name not in index_text:
+                errors.append(f"{name} not listed in INDEX.md")
+
+    for rel in ("error_registry.md", "testing/failure_inventory.md"):
+        path = docs / rel
+        if not path.exists():
+            errors.append(f"missing docs/{rel}")
+        elif not path.read_text(encoding="utf-8").strip():
+            errors.append(f"docs/{rel} is empty")
+
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        raise SystemExit(1)
+    print("audit_doctrine: all checks passed")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    audit_doctrine()

--- a/tests/scripts/test_audit_doctrine.py
+++ b/tests/scripts/test_audit_doctrine.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from scripts.audit_doctrine import audit_doctrine
+
+
+def _setup_docs(
+    root: pathlib.Path,
+    protocol_text: str,
+    index_text: str,
+    error_text: str = "errors",
+    failure_text: str = "failures",
+) -> None:
+    docs = root / "docs"
+    (docs / "testing").mkdir(parents=True)
+    (docs / "The_Absolute_Protocol.md").write_text(protocol_text)
+    (docs / "blueprint_spine.md").write_text("blueprint")
+    (docs / "INDEX.md").write_text(index_text)
+    (docs / "error_registry.md").write_text(error_text)
+    (docs / "testing" / "failure_inventory.md").write_text(failure_text)
+
+
+def test_audit_doctrine_pass(tmp_path: pathlib.Path) -> None:
+    protocol_text = "Before touching any code, read [blueprint_spine.md](blueprint_spine.md) three times."
+    index_text = (
+        "The_Absolute_Protocol.md\n"
+        "blueprint_spine.md\n"
+        "error_registry.md\n"
+        "testing/failure_inventory.md\n"
+    )
+    _setup_docs(tmp_path, protocol_text, index_text)
+    audit_doctrine(tmp_path)
+
+
+def test_audit_doctrine_fail(tmp_path: pathlib.Path) -> None:
+    protocol_text = "Read blueprint once."
+    index_text = "The_Absolute_Protocol.md\n"
+    _setup_docs(tmp_path, protocol_text, index_text, error_text="")
+    with pytest.raises(SystemExit):
+        audit_doctrine(tmp_path)


### PR DESCRIPTION
## Summary
- add `audit_doctrine` script to verify documentation rules and index coverage
- wire script into pre-commit and contributor checklist
- test `audit_doctrine` behavior

## Testing
- `pre-commit run --files scripts/audit_doctrine.py tests/scripts/test_audit_doctrine.py .pre-commit-config.yaml docs/contributor_checklist.md docs/INDEX.md` *(fails: tests fail during collection)*
- `pytest tests/scripts/test_audit_doctrine.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a41d95c4832e993193733a4e9adc