### PR TITLE
feat: expand monitoring with system and GPU metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted narrative engine stories and events to SQLite with optional Chroma search and exposed `narrative_api` in connector registry.
 - Recorded sample biosignal datasets and tests covering ingestion, persistence, and retrieval.
 - Enforced ≥90% coverage in CI workflows; pipelines fail when thresholds are not met.
+- Integrated Node Exporter, cAdvisor, and DCGM GPU exporter into monitoring stack, added network I/O watchdog metrics, and expanded Grafana dashboards.
 - Added GPG-based release signing scripts and documentation for verifying build artifacts.
 - Added `scan_todo_fixme` pre-commit hook to block `TODO`/`FIXME` markers and documented rule in The Absolute Protocol.
 - Added GitHub Actions workflow `dependency-audit.yml` to run `pip-audit` and `npm audit`, failing on high-severity vulnerabilities and uploading reports.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -387,9 +387,11 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [voice_setup.md](voice_setup.md) | Voice Model Setup | This guide explains how to install external text-to-speech models so ABZU can produce spoken output. | - |
 | [../floor_client/README.md](../floor_client/README.md) | Floor Client | This folder contains the React interface for Floor channels. | - |
 | [../guides/visual_customization.md](../guides/visual_customization.md) | Avatar Visual Customization | This guide outlines how to turn a 2D concept image into the 3D model used by the video engine. | - |
-| [../monitoring/README.md](../monitoring/README.md) | Monitoring | This stack launches Prometheus and Grafana alongside an NVIDIA GPU exporter. Metrics include frames per second (FPS),... | - |
+| [../monitoring/README.md](../monitoring/README.md) | Monitoring | This stack launches Prometheus, Grafana, Node Exporter, cAdvisor, and an NVIDIA GPU exporter. Metrics include CPU, me... | - |
 | [../monitoring/copresence_dashboard.md](../monitoring/copresence_dashboard.md) | Copresence Dashboard | This Grafana dashboard surfaces real‑time copresence signals for operators. It focuses on boot health, narrative flow... | - |
 | [../monitoring/metrics_catalog.md](../monitoring/metrics_catalog.md) | Metrics Catalog | \| Metric \| Type \| Labels \| Description \| Dashboard \| \| --- \| --- \| --- \| --- \| --- \| \| `service_boot_duration_seconds... | - |
+| [../patents/recursive_emotion_router_sigil_interpretation.md](../patents/recursive_emotion_router_sigil_interpretation.md) | Recursive Emotion Router with Sigil Interpretation | **Version:** 0.1 **Status:** Draft | - |
+| [../patents/sacred_glyph_vae_pipeline.md](../patents/sacred_glyph_vae_pipeline.md) | Sacred Glyph VAE Pipeline | **Version:** 0.1 **Status:** Draft | - |
 | [../sacred_inputs/00-INVOCATION.md](../sacred_inputs/00-INVOCATION.md) | 00-INVOCATION.md | - | - |
 | [../scripts/install_profiles.md](../scripts/install_profiles.md) | Installation Profiles | This project provides several installation profiles using optional dependencies defined in `pyproject.toml`. | - |
 | [../src/dashboard/OVERVIEW.md](../src/dashboard/OVERVIEW.md) | Dashboard Overview | Streamlit dashboard for monitoring and interacting with Spiral OS components. | - |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -108,6 +108,19 @@ docker compose -f monitoring/docker-compose.yml up
 
 Grafana listens on `http://localhost:3000` and Prometheus on `http://localhost:9090`.
 
+### Resource dashboards
+
+The docker-compose stack also launches resource exporters:
+
+- **Node Exporter** gathers CPU, RAM, disk, and network metrics from the host.
+- **cAdvisor** exposes container-level statistics.
+- **gpu-exporter** (DCGM) publishes GPU utilization and memory data.
+
+Import `monitoring/grafana-dashboard.json` into Grafana to view panels for
+these metrics. CPU, memory, disk, network, and GPU graphs are preconfigured.
+The `monitoring/watchdog.py` script augments these dashboards with system
+network throughput using `psutil.net_io_counters`.
+
 ## Timing metrics
 
 Latency histograms are exported via Prometheus:

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,20 +1,23 @@
 # Monitoring
 
-This stack launches Prometheus and Grafana alongside an NVIDIA GPU exporter.
-Metrics include frames per second (FPS), API latency, and GPU utilization.
+This stack launches Prometheus, Grafana, Node Exporter, cAdvisor, and an
+NVIDIA GPU exporter. Metrics include CPU, memory, disk, network, container
+statistics, frames per second (FPS), API latency, and GPU utilization.
 
 ```bash
 docker compose up
 ```
 
-Prometheus listens on port `9090` and Grafana on `3000`.
+Prometheus listens on port `9090` and Grafana on `3000`. Node Exporter exposes
+metrics on `9101`, cAdvisor on `8080`, and the DCGM GPU exporter on `9400`.
 
 ## Watchdog
 
-`watchdog.py` tracks CPU, memory and file descriptors for configured services.
-Alerts are printed to the console and written as JSON under `alerts/`. When
-a threshold is exceeded, the script optionally exposes metrics for Prometheus
-on port `9100` and attempts service restarts via `os_guardian.action_engine`.
+`watchdog.py` tracks CPU, memory, file descriptors, and system network I/O for
+configured services. Alerts are printed to the console and written as JSON
+under `alerts/`. When a threshold is exceeded, the script optionally exposes
+metrics for Prometheus on port `9100` and attempts service restarts via
+`os_guardian.action_engine`.
 
 Run the watchdog with:
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -14,6 +14,27 @@ services:
       - "3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
+  node-exporter:
+    image: prom/node-exporter
+    ports:
+      - "9101:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /sys:/sys:ro
   gpu-exporter:
     image: nvidia/dcgm-exporter:3.2.6
     runtime: nvidia

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -20,6 +20,60 @@
           "legendFormat": "p95"
         }
       ]
+    },
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        {
+          "expr": "100 - (avg(irate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "cpu"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        {
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100",
+          "legendFormat": "memory"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Disk Usage",
+      "targets": [
+        {
+          "expr": "(1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"}) * 100",
+          "legendFormat": "disk"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Network I/O",
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total[5m])",
+          "legendFormat": "rx"
+        },
+        {
+          "expr": "rate(node_network_transmit_bytes_total[5m])",
+          "legendFormat": "tx"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "GPU Utilization",
+      "targets": [
+        {
+          "expr": "avg(DCGM_FI_DEV_GPU_UTIL)",
+          "legendFormat": "gpu"
+        }
+      ]
     }
   ]
 }

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -10,6 +10,12 @@ scrape_configs:
   - job_name: 'gpu'
     static_configs:
       - targets: ['gpu-exporter:9400']
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
   - job_name: 'watchdog'
     static_configs:
       - targets: ['watchdog:9100']


### PR DESCRIPTION
## Summary
- add node-exporter and cAdvisor to monitoring stack and Prometheus scrape targets
- expose GPU metrics in Grafana alongside CPU, memory, disk, and network panels
- push network I/O from watchdog using psutil

## Testing
- `pre-commit run --files monitoring/docker-compose.yml monitoring/prometheus.yml monitoring/grafana-dashboard.json monitoring/watchdog.py monitoring/README.md docs/monitoring.md CHANGELOG.md docs/INDEX.md` *(fails: 31 errors during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f8f0aa98832eb56edb4ab4b3f4be