### PR TITLE
feat: add chakra-labeled monitoring exporters

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -103,8 +103,12 @@ Add the endpoint to the Prometheus configuration:
 Start the bundled monitoring stack to explore dashboards in Grafana:
 
 ```bash
-docker compose -f monitoring/docker-compose.yml up
+docker compose -f monitoring/docker-compose.yml up -d
 ```
+
+The stack launches Prometheus, Grafana, Node Exporter, cAdvisor, and the DCGM
+GPU exporter. Prometheus labels each target with its chakra layer as defined in
+`monitoring/prometheus.yml` so metrics are grouped by `chakra=<layer>`.
 
 Grafana listens on `http://localhost:3000` and Prometheus on `http://localhost:9090`.
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - grafana-data:/var/lib/grafana
   node-exporter:
     image: prom/node-exporter
+    container_name: node-exporter
+    restart: unless-stopped
     ports:
       - "9101:9100"
     volumes:
@@ -28,6 +30,8 @@ services:
       - '--path.rootfs=/rootfs'
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
@@ -37,6 +41,8 @@ services:
       - /sys:/sys:ro
   gpu-exporter:
     image: nvidia/dcgm-exporter:3.2.6
+    container_name: gpu-exporter
+    restart: unless-stopped
     runtime: nvidia
     ports:
       - "9400:9400"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,21 +4,35 @@ scrape_configs:
   - job_name: 'api'
     static_configs:
       - targets: ['api:8000']
+        labels:
+          chakra: throat
   - job_name: 'mediasoup'
     static_configs:
       - targets: ['mediasoup:3000']
+        labels:
+          chakra: third_eye
   - job_name: 'gpu'
     static_configs:
       - targets: ['gpu-exporter:9400']
+        labels:
+          chakra: sacral
   - job_name: 'node'
     static_configs:
       - targets: ['node-exporter:9100']
+        labels:
+          chakra: root
   - job_name: 'cadvisor'
     static_configs:
       - targets: ['cadvisor:8080']
+        labels:
+          chakra: solar_plexus
   - job_name: 'watchdog'
     static_configs:
       - targets: ['watchdog:9100']
+        labels:
+          chakra: root
   - job_name: 'razar-health'
     static_configs:
       - targets: ['razar-health:9350']
+        labels:
+          chakra: crown


### PR DESCRIPTION
## Summary
- run node-exporter, cAdvisor, and DCGM GPU exporter in monitoring compose stack
- label Prometheus scrape targets with `chakra=<layer>`
- document monitoring stack startup and chakra labels

## Testing
- `pre-commit run --files monitoring/docker-compose.yml monitoring/prometheus.yml docs/monitoring.md` *(fails: scripts/init_memory_layers.py: __version__ 0.1.2 != 0.1.1 in component_index.json, memory/__init__.py: __version__ 0.1.3 != 0.1.2 in component_index.json, pytest: error: unrecognized arguments: --cov=src --cov=agents --cov-fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb5c733c832ea03fe7e497834480