### PR TITLE
Add Chakracon metric monitors to agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted narrative engine stories and events to SQLite with optional Chroma search and exposed `narrative_api` in connector registry.
 - Recorded sample biosignal datasets and tests covering ingestion, persistence, and retrieval.
 - Enforced ≥90% coverage in CI workflows; pipelines fail when thresholds are not met.
+- Introduced Chakracon metric monitoring with `start_monitoring` hooks for multiple agents.
 - Integrated Node Exporter, cAdvisor, and DCGM GPU exporter into monitoring stack, added network I/O watchdog metrics, and expanded Grafana dashboards.
 - Added GPG-based release signing scripts and documentation for verifying build artifacts.
 - Added `scan_todo_fixme` pre-commit hook to block `TODO`/`FIXME` markers and documented rule in The Absolute Protocol.

--- a/agents/bana/bio_adaptive_narrator.py
+++ b/agents/bana/bio_adaptive_narrator.py
@@ -7,20 +7,52 @@ state. The main entry point is :func:`generate_story`.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Iterable
 
-__version__ = "0.0.2"
-
 import numpy as np
+import requests
 
 try:  # pragma: no cover - optional dependency
     from biosppy.signals import ecg
 except Exception:  # pragma: no cover - dependency may be missing
     ecg = None  # type: ignore
 
+from ..event_bus import emit_event
 from memory import narrative_engine
 from spiral_memory import DEFAULT_MEMORY
 from connectors.primordials_api import send_metrics
+
+__version__ = "0.0.2"
+
+CHAKRA = "third_eye"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_HEART_RATE = 120.0
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("heart_rate", 0.0)
+        if value > THRESHOLD_HEART_RATE:
+            emit_event("bana", "heart_rate_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
 
 try:  # pragma: no cover - optional dependency
     from transformers import pipeline  # type: ignore
@@ -83,4 +115,4 @@ def generate_story(bio_stream: Iterable[float], sampling_rate: float = 1000.0) -
     return text
 
 
-__all__ = ["generate_story", "__version__"]
+__all__ = ["generate_story", "start_monitoring", "__version__"]

--- a/agents/cocytus/prompt_arbiter.py
+++ b/agents/cocytus/prompt_arbiter.py
@@ -8,11 +8,43 @@ Responsibilities:
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+import threading
+import time
+
+import requests
 
 from typing import Any, Dict
 
 from ..event_bus import emit_event
+
+__version__ = "0.1.0"
+
+CHAKRA = "solar_plexus"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_BIAS = 0.7
+
+
+def fetch_metrics() -> Dict[str, Any]:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = float(data.get("bias", 0.0))
+        if value > THRESHOLD_BIAS:
+            emit_event("cocytus", "bias_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
 
 
 def arbitrate(actor: str, action: str, entity_eval: Dict[str, Any]) -> None:
@@ -25,4 +57,4 @@ def arbitrate(actor: str, action: str, entity_eval: Dict[str, Any]) -> None:
     )
 
 
-__all__ = ["arbitrate"]
+__all__ = ["arbitrate", "start_monitoring"]

--- a/agents/demiurge/strategic_simulator.py
+++ b/agents/demiurge/strategic_simulator.py
@@ -4,4 +4,41 @@
 - scenario stress-testing
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "third_eye"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_RISK = 0.8
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("risk", 0.0)
+        if value > THRESHOLD_RISK:
+            emit_event("demiurge", "risk_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/ecosystem/aura_capture.py
+++ b/agents/ecosystem/aura_capture.py
@@ -4,4 +4,41 @@
 - sensor health checks
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "root"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_TELEMETRY = 75.0
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("telemetry", 0.0)
+        if value > THRESHOLD_TELEMETRY:
+            emit_event("aura_capture", "telemetry_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/ecosystem/mare_gardener.py
+++ b/agents/ecosystem/mare_gardener.py
@@ -4,4 +4,41 @@
 - capacity planning advisories
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "root"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_CAPACITY = 80.0
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("capacity", 0.0)
+        if value > THRESHOLD_CAPACITY:
+            emit_event("mare_gardener", "capacity_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/pandora/persona_emulator.py
+++ b/agents/pandora/persona_emulator.py
@@ -4,4 +4,41 @@
 - identity consistency checks
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "throat"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_DRIFT = 0.6
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("drift", 0.0)
+        if value > THRESHOLD_DRIFT:
+            emit_event("pandora", "drift_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/pleiades/signal_router.py
+++ b/agents/pleiades/signal_router.py
@@ -3,4 +3,41 @@
 - fallback relay strategies
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "throat"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_LATENCY = 200.0
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("latency", 0.0)
+        if value > THRESHOLD_LATENCY:
+            emit_event("pleiades", "latency_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/pleiades/star_map.py
+++ b/agents/pleiades/star_map.py
@@ -3,4 +3,41 @@
 - cosmic alignment calculations
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "crown"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_MISALIGNMENT = 0.4
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("misalignment", 0.0)
+        if value > THRESHOLD_MISALIGNMENT:
+            emit_event("pleiades", "misalignment_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/sebas/compassion_module.py
+++ b/agents/sebas/compassion_module.py
@@ -4,4 +4,41 @@
 - conflict signal resolution
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "heart"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_STRESS = 0.8
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("stress", 0.0)
+        if value > THRESHOLD_STRESS:
+            emit_event("sebas", "stress_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/shalltear/fast_inference_agent.py
+++ b/agents/shalltear/fast_inference_agent.py
@@ -4,4 +4,41 @@
 - monitor API quotas
 """
 
+import threading
+import time
+
+import requests
+
+from ..event_bus import emit_event
+
 __version__ = "0.1.0"
+
+CHAKRA = "root"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_QUOTA = 0.9
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("quota", 0.0)
+        if value > THRESHOLD_QUOTA:
+            emit_event("shalltear", "quota_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitoring"]

--- a/agents/victim/security_canary.py
+++ b/agents/victim/security_canary.py
@@ -9,12 +9,44 @@ from __future__ import annotations
 __version__ = "0.1.0"
 
 import logging
+import threading
+import time
+
+import requests
 from pathlib import Path
 from typing import Callable
 
 from vector_memory import persist_snapshot
+from ..event_bus import emit_event
 
 logger = logging.getLogger(__name__)
+
+CHAKRA = "sacral"
+CHAKRACON_URL = "http://localhost:8080"
+THRESHOLD_THREAT = 0.5
+
+
+def fetch_metrics() -> dict:
+    resp = requests.get(f"{CHAKRACON_URL}/metrics/{CHAKRA}", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_metrics(poll_interval: float = 5.0) -> None:
+    while True:
+        data = fetch_metrics()
+        value = data.get("threat", 0.0)
+        if value > THRESHOLD_THREAT:
+            emit_event("victim", "threat_high", {"value": value})
+        time.sleep(poll_interval)
+
+
+def start_monitoring(poll_interval: float = 5.0) -> threading.Thread:
+    thread = threading.Thread(
+        target=monitor_metrics, args=(poll_interval,), daemon=True
+    )
+    thread.start()
+    return thread
 
 
 def broadcast_alert(message: str) -> None:
@@ -43,4 +75,4 @@ def detect_breach(
     return True
 
 
-__all__ = ["detect_breach", "broadcast_alert"]
+__all__ = ["detect_breach", "broadcast_alert", "start_monitoring"]


### PR DESCRIPTION
## Summary
- monitor Chakracon metrics in agents with thresholds
- export start_monitoring helpers for background polling
- document monitoring addition in changelog

## Testing
- `pre-commit run --files agents/shalltear/fast_inference_agent.py agents/cocytus/prompt_arbiter.py agents/demiurge/strategic_simulator.py agents/ecosystem/aura_capture.py agents/ecosystem/mare_gardener.py agents/sebas/compassion_module.py agents/pandora/persona_emulator.py agents/pleiades/signal_router.py agents/pleiades/star_map.py agents/victim/security_canary.py agents/bana/bio_adaptive_narrator.py CHANGELOG.md` *(fails: AttributeError: 'str' object has no attribute 'dtype' and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0106eec8832e83cc01c71ecd52c4