### PR TITLE
docs: expand Nazarick agent roster with chakra telemetry

### DIFF
--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -4,14 +4,15 @@ Nazarick hosts specialized servant agents aligned to chakra layers and coordinat
 
 ## Agent Roster
 
-| Agent ID | Role | Launch Command | Channel |
-| --- | --- | --- | --- |
-| orchestration_master | Boot order and pipeline supervision | `./launch_servants.sh orchestration_master` | `#throne-room` |
-| prompt_orchestrator | Route prompts and recall context | `./launch_servants.sh crown_prompt_orchestrator` | `#signal-hall` |
-| qnl_engine | Process QNL sequences and insights | `./launch_servants.sh qnl_engine` | `#insight-observatory` |
-| memory_scribe | Persist transcripts and embeddings | `./launch_servants.sh memory_scribe` | `#memory-vault` |
+| Agent ID | Role | Chakra Layer | Launch Command | Channel | Chakracon Telemetry |
+| --- | --- | --- | --- | --- | --- |
+| orchestration_master | Boot order and pipeline supervision | Crown | `./launch_servants.sh orchestration_master` | `#throne-room` | Prometheus `chakra_energy{chakra="crown"}` → `crown_overload` → notify `#throne-room` |
+| prompt_orchestrator | Route prompts and recall context | Throat | `./launch_servants.sh crown_prompt_orchestrator` | `#signal-hall` | Prometheus `chakra_energy{chakra="throat"}` → `signal_hall_blockage` → page orchestration_master |
+| qnl_engine | Process QNL sequences and insights | Third Eye | `./launch_servants.sh qnl_engine` | `#insight-observatory` | Prometheus `chakra_energy{chakra="third_eye"}` → `insight_drought` → route to `#throne-room` |
+| memory_scribe | Persist transcripts and embeddings | Heart | `./launch_servants.sh memory_scribe` | `#memory-vault` | Prometheus `chakra_energy{chakra="heart"}` → `memory_backlog` → alert prompt_orchestrator |
+| narrative_scribe | Render event bus stories | Throat | `./launch_servants.sh narrative_scribe` | `#story-forge` | Prometheus `narrative_rate` → `narrative_lag` → escalate to memory_scribe |
 
-The registry lives at [agents/nazarick/agent_registry.json](../agents/nazarick/agent_registry.json).
+The registry lives at [agents/nazarick/agent_registry.json](../agents/nazarick/agent_registry.json). For the full channel hierarchy see [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md).
 
 ## Launch Commands
 
@@ -40,4 +41,4 @@ Use the [Nazarick Web Console](nazarick_web_console.md) to monitor agents, open 
 
 | Version | Date | Notes |
 | --- | --- | --- |
-| [Unreleased](../CHANGELOG.md#documentation-audit) | - | Added agent roles, launch commands, channel mappings, and UI setup. |
+| [Unreleased](../CHANGELOG.md#documentation-audit) | - | Added agent roles, launch commands, channel mappings, chakra layers, and Chakracon telemetry. |


### PR DESCRIPTION
## Summary
- add chakra layer and Chakracon telemetry details to Nazarick agent roster
- document narrative_scribe and link to core architecture for full channel map

## Testing
- `pre-commit run --files docs/nazarick_agents.md docs/INDEX.md` *(fails: tests require missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04628a88832ebe95813db5ec1e2a