### PR TITLE
docs: cross-link Nazarick architecture and memory blueprints

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -106,6 +106,8 @@ The Tomb establishes a chakra-aligned command hierarchy—from Crown to Root—w
 
 Events emitted by agents flow through an “emit_event → Redis/Kafka → FastAPI processor” pipeline and persist in TimescaleDB (temporal) and Neo4j (relational) stores, enabling reconstruction of Nazarick’s activity history.
 
+For deeper architectural detail, see [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md) and [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md).
+
 ## **2. Nazarick Agents and Ethics**
 
 The agent roster includes orchestration_master, prompt_orchestrator, qnl_engine, and memory_scribe—each mapped to a specific channel and launch command, enabling structured supervision and context-aware routing.

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -18,6 +18,11 @@ The codebase is organized across seven chakra‑themed module directories (curre
 - `third_eye/` – insight and pattern analysis modules (v1.0.0).
 - `crown/` – high‑level orchestration and launch scripts (v1.0.1).
 
+After mapping these layers, review the Nazarick system documents:
+[Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md),
+[Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md), and
+[Nazarick Agents](nazarick_agents.md). These are mandatory reading for all contributors.
+
 This guide introduces the ABZU codebase, highlights core entry points, and covers environment setup, chakra architecture overview, CLI usage, and troubleshooting tips. For a guided CLI quick‑start run the [onboarding wizard](onboarding/wizard.py). Additional architecture diagrams are available in [architecture.md](architecture.md).
 
 ## Prerequisites

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ Curated starting points for understanding and operating the project. For an exha
 - [Crown Agent Overview](CROWN_OVERVIEW.md)
 ## Nazarick
 - [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
+- [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)
+- [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md)
 - [Nazarick Agents](nazarick_agents.md)
 - [Nazarick Narrative System](nazarick_narrative_system.md) – maps story events to agents and memory layers
 - [Nazarick Manifesto](nazarick_manifesto.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -52,6 +52,8 @@ feedback.
 - **Agent ecosystem**
   - [RAZAR Agent](RAZAR_AGENT.md) – pre‑creation igniter, virtual‑environment manager, and recovery coordinator
   - [Nazarick Agents](nazarick_agents.md) – roster of specialized servants
+  - [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md) – channel hierarchy and servant topology
+  - [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md) – memory layers and flows
   - [ALBEDO Layer](ALBEDO_LAYER.md) – persona modules and archetypal behavior hooks
   - [Persona API Guide](persona_api_guide.md) – conventions for persona profiles and hooks
   - [Nazarick Manifesto](nazarick_manifesto.md) – narrative charter governing personas

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -162,12 +162,12 @@ documents:
         it succeeds.
       insight: Run the health check to catch connector outages early.
   docs/system_blueprint.md:
-    sha256: 829f695e39205bfc9e698e44fc6b159cb290aef6209df27bf79f63f63e32865b
+    sha256: 92badfba3843ada084139df166b23c05aee24f1998a97770b094d626b44168d7
     summary:
       purpose: Architectural blueprint overview.
       scope: System-wide architecture.
       key_rules: Align changes with blueprint structure.
-      insight: Align changes with blueprint structure.
+      insight: References Nazarick architecture and memory blueprints.
   docs/KEY_DOCUMENTS.md:
     sha256: 740cf6675a3180ebad0b83b3dd5ad63ad782149538ce1667ef5a9a1b9eeb002c
     summary:
@@ -233,12 +233,12 @@ documents:
       key_rules: Regenerate index after documentation updates.
       insight: Regenerate with tools/doc_indexer.py after updating docs.
   docs/index.md:
-    sha256: 2acebbe3802143e395727844880430a286ae76dce858936ecaf23c46366937c3
+    sha256: d046489925a9aaedd77e2ee5a2c4daaf882fc64e6399b8d10b3ab3a615ac112e
     summary:
       purpose: Curated documentation entry points.
       scope: Top-level docs index.
       key_rules: Maintain curated documentation entry points.
-      insight: Add Crown overview to architecture section.
+      insight: Links to Nazarick architecture and memory blueprints.
   docs/nazarick_narrative_system.md:
     sha256: aa86c1e0e1cf0b4a5a9cfe80b4e1e34af815482d357630827d72994404fd065b
     summary:


### PR DESCRIPTION
## Summary
- require reading of Nazarick core architecture and memory blueprint during developer onboarding
- reference architecture and memory blueprints from Great Tomb of Nazarick section and system document map
- list Nazarick architecture and memory blueprints in Nazarick docs index and update onboarding confirmation

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/blueprint_spine.md docs/developer_onboarding.md docs/index.md docs/system_blueprint.md onboarding_confirm.yml` *(fails: verify-versions mismatched in unrelated modules; tests interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ba088dea1c832eab583ef2f9d6b39b