### PR TITLE
doc: register nazarick core docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,7 +14,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -51,6 +51,9 @@ graph LR
 | [Test Planning Guide](onboarding/test_planning.md) | Filing "Test Plan" issues defining scope, chakra, and coverage goals | Quarterly |
 | [Bana Engine](bana_engine.md) | Mistral 7B fine-tuning, event processing, and output paths | Quarterly |
 | [Nazarick Narrative System](nazarick_narrative_system.md) | Biosignal→StoryEvent pipeline and memory hooks | Quarterly |
+| [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md) | Observability framework and channel hierarchy | Quarterly |
+| [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md) | Personality, memory, and communication design for agents | Quarterly |
+| [Nazarick Agents](nazarick_agents.md) | Roster and launch commands for Nazarick servant agents | Quarterly |
 | [RAZAR AI agents config](../config/razar_ai_agents.json) | Roster of handover agents and authentication settings | Quarterly |
 | [Environment check script](../scripts/check_env.py) | Verifies required packages and tools are installed | Each commit |
 | [Change Intent Ledger](../logs/change_intent.jsonl) | Records commit intents and observed behavior | Each commit |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -239,6 +239,27 @@ documents:
       scope: Top-level docs index.
       key_rules: Maintain curated documentation entry points.
       insight: Links to Nazarick architecture and memory blueprints.
+  agents/nazarick/nazarick_core_architecture.md:
+    sha256: d30ed1392ff91d4269e644da871f2ed5bb565e5d202a8abf683e10c80845f516
+    summary:
+      purpose: Design real-time observability framework and channel hierarchy for Spiral OS.
+      scope: Nazarick monitoring architecture and operator interface.
+      key_rules: Stream agent events with narrative tags and archive critical logs immutably.
+      insight: Operator commands supersede all agent actions.
+  agents/nazarick/nazarick_memory_blueprint.md:
+    sha256: 45bbde8a01a6531d169f537380e47c54b07a8a97641b611a4d833b1631f5f621
+    summary:
+      purpose: Blueprint for human-like agent personality, memory, planning, and expression.
+      scope: Nazarick agent traits, memory stores, and communication protocols.
+      key_rules: Store memories in vectors, summarize long interactions, and coordinate via defined APIs.
+      insight: Personality fragments from vectors adapt agents to current state.
+  docs/nazarick_agents.md:
+    sha256: 9cfdb5732c777137ca29fe3796729c7a2fd3af751dddf6dca9faedd435c0321f
+    summary:
+      purpose: Roster and launch guide for Nazarick servant agents.
+      scope: Agent roles, channels, and Chakracon telemetry.
+      key_rules: Launch servants with provided scripts and monitor chakra alerts.
+      insight: Chakracon telemetry signals energy anomalies to operators.
   docs/nazarick_narrative_system.md:
     sha256: aa86c1e0e1cf0b4a5a9cfe80b4e1e34af815482d357630827d72994404fd065b
     summary:


### PR DESCRIPTION
## Summary
- track Nazarick Core Architecture, Memory Blueprint, and Nazarick Agents as protected documents
- record hashes and onboarding summaries for the new Nazarick docs
- regenerate documentation index

## Testing
- `pre-commit run --files docs/KEY_DOCUMENTS.md onboarding_confirm.yml docs/INDEX.md` (with SKIP=verify-versions,check-env,capture-failing-tests,pytest-cov)
- `python scripts/verify_doc_hashes.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba0a770248832ebbd8ace44106f99a