### PR TITLE
Add Chakra monitoring verification script and test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,12 @@ repos:
     language: system
     pass_filenames: false
     files: ^docs/
+  - id: verify-chakra-monitoring
+    name: Verify chakra monitoring
+    entry: python scripts/verify_chakra_monitoring.py
+    language: system
+    pass_filenames: false
+    files: ^(docs/|monitoring/)
 
 - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
   rev: v9.19.0

--- a/scripts/verify_chakra_monitoring.py
+++ b/scripts/verify_chakra_monitoring.py
@@ -1,0 +1,98 @@
+"""Verify chakra monitoring setup and metric emission."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+from agents.razar import health_checks
+
+__version__ = "0.1.0"
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EXPORTERS = [
+    "http://localhost:9101/metrics",  # node exporter
+    "http://localhost:8080/metrics",  # cadvisor
+    "http://localhost:9400/metrics",  # gpu exporter
+]
+
+
+def _fetch(url: str, timeout: float = 2.0) -> bool:
+    """Return ``True`` if ``url`` returns any content."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosec B310
+            if resp.status >= 400:
+                return False
+            body = resp.read()
+    except Exception as exc:  # pragma: no cover - network dependent
+        print(f"failed to query {url}: {exc}", file=sys.stderr)
+        return False
+    return bool(body.strip())
+
+
+def _find_free_port() -> int:
+    s = socket.socket()
+    s.bind(("localhost", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _check_agent_metrics() -> bool:
+    """Run a doc sync check and confirm metrics are exposed."""
+    port = _find_free_port()
+    health_checks.init_metrics(port)
+    # run a cheap check that should succeed
+    health_checks.run("razar_doc_sync_agent")
+    # wait briefly for server thread
+    for _ in range(5):
+        try:
+            with urllib.request.urlopen(
+                f"http://localhost:{port}"
+            ) as resp:  # nosec B310
+                text = resp.read().decode()
+            return "service_health_status" in text
+        except Exception:  # pragma: no cover - network dependent
+            time.sleep(0.1)
+    return False
+
+
+def _check_docs() -> list[str]:
+    docs = ROOT / "docs"
+    errors: list[str] = []
+    if not (docs / "chakra_metrics.md").exists():
+        errors.append("missing docs/chakra_metrics.md")
+    if not (docs / "The_Absolute_Protocol.md").exists():
+        errors.append("missing docs/The_Absolute_Protocol.md")
+    return errors
+
+
+def verify_chakra_monitoring() -> int:
+    """Exit non-zero when monitoring invariants are violated."""
+    urls_env = os.getenv("CHAKRA_EXPORTERS")
+    exporters = (
+        [u.strip() for u in urls_env.split(",")] if urls_env else DEFAULT_EXPORTERS
+    )
+    missing = [url for url in exporters if not _fetch(url)]
+    if missing:
+        for url in missing:
+            print(f"missing metrics from exporter {url}", file=sys.stderr)
+    if not _check_agent_metrics():
+        print("agent metrics not emitted", file=sys.stderr)
+        missing.append("agent metrics")
+    doc_errors = _check_docs()
+    if doc_errors:
+        for err in doc_errors:
+            print(err, file=sys.stderr)
+    if missing or doc_errors:
+        return 1
+    print("verify_chakra_monitoring: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(verify_chakra_monitoring())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "razar" / "test_ai_invoker.py"),
     str(ROOT / "tests" / "integration" / "test_core_regressions.py"),
     str(ROOT / "tests" / "integration" / "test_full_flows.py"),
+    str(ROOT / "tests" / "scripts" / "test_verify_chakra_monitoring.py"),
 }
 
 

--- a/tests/scripts/test_verify_chakra_monitoring.py
+++ b/tests/scripts/test_verify_chakra_monitoring.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from scripts.verify_chakra_monitoring import verify_chakra_monitoring
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # pragma: no cover - simple server
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"test_metric 1\n")
+
+    def log_message(self, format: str, *args: object) -> None:  # pragma: no cover
+        return
+
+
+def _serve(port: int) -> HTTPServer:
+    server = HTTPServer(("localhost", port), _MetricsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+@pytest.fixture
+def exporters(monkeypatch: pytest.MonkeyPatch) -> None:
+    servers: list[HTTPServer] = []
+    urls: list[str] = []
+    for _ in range(3):
+        sock = socket.socket()
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        servers.append(_serve(port))
+        urls.append(f"http://localhost:{port}/metrics")
+    monkeypatch.setenv("CHAKRA_EXPORTERS", ",".join(urls))
+    yield
+    for server in servers:
+        server.shutdown()
+
+
+def test_verify_chakra_monitoring(exporters: None) -> None:
+    assert verify_chakra_monitoring() == 0


### PR DESCRIPTION
## Summary
- add verify_chakra_monitoring script to ensure exporters, agent metrics, and docs exist
- test chakra monitoring script with mock exporters
- run chakra monitoring check on docs/ and monitoring/ changes via pre-commit

## Testing
- `pytest tests/scripts/test_verify_chakra_monitoring.py -q` *(fails: Coverage failure: total of 4 is less than fail-under=80)*
- `pre-commit run --files scripts/verify_chakra_monitoring.py .pre-commit-config.yaml tests/scripts/test_verify_chakra_monitoring.py tests/conftest.py` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e5d59ac832eaba49d0edb4c208f