### PR TITLE
feat: stable identifiers and crown CLI

### DIFF
--- a/INANNA_AI/speaking_engine.py
+++ b/INANNA_AI/speaking_engine.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Iterable, Tuple
 
+import hashlib
 import numpy as np
 
 from core.utils.optional_deps import lazy_import
@@ -95,7 +96,8 @@ def _synthesize_gtts(
         }
     )
     archetype = emotion_to_archetype(emotion)
-    out_path = Path(tempfile.gettempdir()) / f"gtts_{abs(hash(text))}.wav"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    out_path = Path(tempfile.gettempdir()) / f"gtts_{digest}.wav"
 
     if gTTS is None:
         wave, sr = _sine_placeholder(f"{archetype} {text}")

--- a/INANNA_AI/tts_bark.py
+++ b/INANNA_AI/tts_bark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import hashlib
 import numpy as np
 
 from .utils import save_wav
@@ -30,7 +31,8 @@ def _sine_placeholder(text: str, path: Path, pitch: float) -> None:
 def synthesize(text: str, emotion: str) -> str:
     """Return a WAV path containing ``text`` spoken in ``emotion`` style."""
     style = get_voice_params(emotion)
-    out_path = Path(tempfile.gettempdir()) / f"bark_{abs(hash(text))}.wav"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    out_path = Path(tempfile.gettempdir()) / f"bark_{digest}.wav"
 
     if generate_audio is not None:
         try:  # pragma: no cover - external library

--- a/INANNA_AI/tts_coqui.py
+++ b/INANNA_AI/tts_coqui.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Dict
 
+import hashlib
 import numpy as np
 
 from .utils import save_wav
@@ -45,7 +46,8 @@ def synthesize_speech(text: str, emotion: str) -> str:
     The resulting WAV file path is returned.
     """
     style = get_voice_params(emotion)
-    out_path = Path(tempfile.gettempdir()) / f"tts_{abs(hash(text))}.wav"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    out_path = Path(tempfile.gettempdir()) / f"tts_{digest}.wav"
 
     if CoquiTTS is not None:
         tts = _get_tts()

--- a/INANNA_AI/tts_tortoise.py
+++ b/INANNA_AI/tts_tortoise.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import hashlib
 import numpy as np
 
 from .utils import save_wav
@@ -41,7 +42,8 @@ def _sine_placeholder(text: str, path: Path, pitch: float) -> None:
 def synthesize(text: str, emotion: str) -> str:
     """Return a WAV path containing ``text`` spoken in ``emotion`` style."""
     style = get_voice_params(emotion)
-    out_path = Path(tempfile.gettempdir()) / f"tortoise_{abs(hash(text))}.wav"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    out_path = Path(tempfile.gettempdir()) / f"tortoise_{digest}.wav"
 
     if TextToSpeech is not None:
         try:  # pragma: no cover - external library

--- a/INANNA_AI/tts_xtts.py
+++ b/INANNA_AI/tts_xtts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import hashlib
 import numpy as np
 
 from .utils import save_wav
@@ -40,7 +41,8 @@ def _sine_placeholder(text: str, path: Path, pitch: float) -> None:
 def synthesize(text: str, emotion: str) -> str:
     """Return a WAV path containing ``text`` spoken in ``emotion`` style."""
     style = get_voice_params(emotion)
-    out_path = Path(tempfile.gettempdir()) / f"xtts_{abs(hash(text))}.wav"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    out_path = Path(tempfile.gettempdir()) / f"xtts_{digest}.wav"
 
     if TTS is not None:
         try:  # pragma: no cover - external library

--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -400,5 +400,5 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
 __all__ = ["crown_prompt_orchestrator", "crown_prompt_orchestrator_async", "main"]
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI entry
+if __name__ == "__main__":  # pragma: no cover - module CLI
     main()

--- a/docs/crown_manifest.md
+++ b/docs/crown_manifest.md
@@ -12,6 +12,20 @@ Commands typed into the Crown Console reach the agent through `crown_prompt_orch
 
 Memory mutations happen through `vector_memory.py` and are authorised only when the CROWN is active. This ensures a single authority controls persistent memories and the rituals that can reshape them.
 
+### Command-line usage
+
+`crown_prompt_orchestrator.py` exposes a CLI that processes a single message with optional model configuration. After installing the package it can be invoked via the `crown-prompt` command:
+
+```bash
+crown-prompt "hello world" --model path.to.CustomModel
+```
+
+Without installation the module may be executed directly:
+
+```bash
+python -m crown_prompt_orchestrator "hello world"
+```
+
 ## Emotion model mapping
 
 The orchestrator exposes a lookup table called `_EMOTION_MODEL_MATRIX` which matches a detected emotion to the LLM best suited to respond. This mapping is tested to guarantee consistent routing behaviour.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ voice-cli = "cli.voice:main"
 spiral-os = "spiral_os.__main__:main"
 # Unified developer helper
 inanna = "cli:main"
+crown-prompt = "crown_prompt_orchestrator:main"
 
 [tool.poetry.scripts]
 abzu = "cli:main"

--- a/rag/orchestrator.py
+++ b/rag/orchestrator.py
@@ -22,6 +22,8 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Callable, Deque, Dict, List
 
+import hashlib
+
 try:
     import soundfile as sf  # pragma: no cover
 except Exception:
@@ -251,7 +253,8 @@ class MoGEOrchestrator:
         if music_modality and np is not None:
             hex_input = text.encode("utf-8").hex()
             phrases, wave = qnl_engine.hex_to_song(hex_input, duration_per_byte=0.05)
-            wav_path = Path(tempfile.gettempdir()) / f"qnl_{abs(hash(hex_input))}.wav"
+            digest = hashlib.sha256(hex_input.encode("utf-8")).hexdigest()[:8]
+            wav_path = Path(tempfile.gettempdir()) / f"qnl_{digest}.wav"
             if sf is None:
                 wav_data = np.clip(wave, -1.0, 1.0)
                 wav_data = (wav_data * 32767).astype(np.int16)

--- a/src/core/video_engine.py
+++ b/src/core/video_engine.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
+import hashlib
 import numpy as np
 import tomllib
 
@@ -150,7 +151,8 @@ def _upscale(frame: np.ndarray, scale: int) -> np.ndarray:
 
 def _skin_color(name: str) -> np.ndarray:
     """Return a deterministic RGB colour derived from ``name``."""
-    value = abs(hash(name)) & 0xFFFFFF
+    digest = hashlib.sha256(name.encode("utf-8")).digest()
+    value = int.from_bytes(digest[:3], "big")
     return np.array(
         [(value >> 16) & 255, (value >> 8) & 255, value & 255], dtype=np.uint8
     )

--- a/video_stream.py
+++ b/video_stream.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Optional, Set, cast
 
 import numpy as np
+import hashlib
 from fastapi import APIRouter, HTTPException, Request
 from numpy.typing import NDArray
 
@@ -136,7 +137,8 @@ class AvatarVideoTrack(VideoStreamTrack):  # type: ignore[misc]
         self._frames = avatar_expression_engine.stream_avatar_audio(audio_path)
 
     def _cue_colour(self, text: str) -> NDArray[np.uint8]:
-        value = abs(hash(text)) & 0xFFFFFF
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        value = int.from_bytes(digest[:3], "big")
         return np.array(
             [(value >> 16) & 255, (value >> 8) & 255, value & 255],
             dtype=np.uint8,


### PR DESCRIPTION
## Summary
- replace salted `hash()` usage with `hashlib.sha256` for deterministic IDs and colors
- expose `crown_prompt_orchestrator` as `crown-prompt` CLI and document usage
- note: pre-commit hook fails due to missing optional modules

## Testing
- `pytest tests/crown/test_prompt_orchestrator.py::test_deterministic_ids tests/crown/test_prompt_orchestrator.py::test_cli_entry tests/test_video_stream_helpers.py::test_cue_colour_deterministic tests/test_video_stream.py::test_avatar_video_track_applies_cue tests/test_tts_backends.py::test_backend_selection --cov=src --cov=agents --cov-fail-under=0`
- `pre-commit run --files INANNA_AI/speaking_engine.py INANNA_AI/tts_bark.py INANNA_AI/tts_coqui.py INANNA_AI/tts_tortoise.py INANNA_AI/tts_xtts.py crown_prompt_orchestrator.py pyproject.toml rag/orchestrator.py src/core/video_engine.py video_stream.py docs/crown_manifest.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_68ba190eda2c832ea8b8c2be7e0c87f3