### PR TITLE
Add GLM startup health check and enforce requests dependency

### DIFF
--- a/docs/crown_manifest.md
+++ b/docs/crown_manifest.md
@@ -62,7 +62,10 @@ The GLM endpoint and credentials are provided through environment variables:
 | `SERVANT_MODELS`| Comma‑separated `name=url` pairs for servants |
 
 `init_crown_agent.initialize_crown()` reads these settings and registers any
-servant endpoints before performing startup checks.
+servant endpoints before performing startup checks. The Crown agent requires the
+`requests` package and aborts immediately if it is missing. During startup the
+GLM endpoint is contacted at `/health`; a failing response stops initialization
+so misconfiguration is detected early.
 
 ## Health check
 

--- a/src/health/boot_diagnostics.py
+++ b/src/health/boot_diagnostics.py
@@ -50,6 +50,10 @@ def run_boot_checks() -> Dict[str, Optional[ModuleType]]:
             continue
         except ImportError as exc:  # module missing
             logger.error("Missing module %s: %s", name, exc)
+            if name == "requests":
+                raise SystemExit(
+                    "Required dependency 'requests' not installed"
+                ) from exc
             if _install_module(name):
                 try:
                     results[name] = importlib.import_module(name)

--- a/src/health/essential_services.py
+++ b/src/health/essential_services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 VITAL_MODULES = [
+    "requests",
     "server",
     "invocation_engine",
     "emotional_state",


### PR DESCRIPTION
## Summary
- require `requests` during boot diagnostics
- check GLM endpoint health on server startup
- document `requests` dependency and GLM health check

## Testing
- `pre-commit run --files src/health/essential_services.py src/health/boot_diagnostics.py server.py docs/crown_manifest.md docs/INDEX.md` *(fails: verify-versions, capture-failing-tests, pytest-cov, verify-chakra-monitoring)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1d164f9c832e95d8686d101b8264