### PR TITLE
Add escalation notifier for operator alerts

### DIFF
--- a/docs/test_index.md
+++ b/docs/test_index.md
@@ -6,5 +6,6 @@ Generated automatically. Catalog of test modules and scenarios.
 | --- | --- | --- |
 | `tests/integration/test_context_rl.py` | Validate RL context environment reset/step and training loop. | `memory.context_env`, `memory.mental` |
 | `tests/razar/test_ai_invoker.py` | Verify opencode CLI patch flow in `ai_invoker.handover`. | `razar.ai_invoker` |
+| `tests/monitoring/test_escalation_notifier.py` | Validate operator escalation when log conditions met. | `monitoring.escalation_notifier` |
 
 Backlinks: [Component Index](component_index.md) | [Connector Index](connectors/CONNECTOR_INDEX.md) | [Dependency Index](dependency_index.md)

--- a/monitoring/escalation_notifier.py
+++ b/monitoring/escalation_notifier.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from operator_api import broadcast_event
+
+__version__ = "0.1.0"
+
+ESCALATION_LOG = Path("logs") / "operator_escalations.jsonl"
+
+REQUEST_RE = re.compile(r"(?P<ts>\S+)\s+(?P<component>\S+)\s+request", re.I)
+OFFLINE_RE = re.compile(r"(?P<ts>\S+)\s+(?P<component>\S+)\s+offline", re.I)
+
+
+def _parse_ts(text: str) -> datetime:
+    """Return ``datetime`` parsed from ISO-8601 ``text``."""
+    return datetime.fromisoformat(text.replace("Z", "+00:00"))
+
+
+def _notify(event: dict[str, object]) -> None:
+    """Send ``event`` via ``broadcast_event`` and append to escalation log."""
+    asyncio.run(broadcast_event({"event": "escalation", **event}))
+    ESCALATION_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with ESCALATION_LOG.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, default=str) + "\n")
+
+
+def scan_logs(
+    razar_log: Path, crown_log: Path, now: datetime | None = None
+) -> list[dict[str, object]]:
+    """Scan ``razar_log`` and ``crown_log`` for escalation conditions.
+
+    Returns a list of escalation events that were emitted.
+    """
+    now = now or datetime.utcnow()
+    events: list[dict[str, object]] = []
+
+    if razar_log.exists():
+        requests: dict[str, list[datetime]] = {}
+        for line in razar_log.read_text().splitlines():
+            match = REQUEST_RE.search(line)
+            if not match:
+                continue
+            ts = _parse_ts(match.group("ts"))
+            comp = match.group("component")
+            requests.setdefault(comp, []).append(ts)
+        for comp, times in requests.items():
+            times.sort()
+            for i in range(len(times) - 2):
+                if times[i + 2] - times[i] <= timedelta(minutes=10):
+                    event = {
+                        "component": comp,
+                        "reason": "repeated_requests",
+                        "timestamp": now.isoformat() + "Z",
+                    }
+                    _notify(event)
+                    events.append(event)
+                    break
+
+    if crown_log.exists():
+        for line in crown_log.read_text().splitlines():
+            match = OFFLINE_RE.search(line)
+            if not match:
+                continue
+            ts = _parse_ts(match.group("ts"))
+            if now - ts > timedelta(minutes=5):
+                comp = match.group("component")
+                event = {
+                    "component": comp,
+                    "reason": "service_offline",
+                    "timestamp": now.isoformat() + "Z",
+                }
+                _notify(event)
+                events.append(event)
+
+    return events
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Monitor RAZAR and Crown logs for escalation conditions."
+    )
+    parser.add_argument(
+        "--razar-log", type=Path, default=Path("logs/razar.log"), help="RAZAR log path"
+    )
+    parser.add_argument(
+        "--crown-log",
+        type=Path,
+        default=Path("logs/operator.log"),
+        help="Crown log path",
+    )
+    args = parser.parse_args()
+    scan_logs(args.razar_log, args.crown_log)

--- a/tests/monitoring/test_escalation_notifier.py
+++ b/tests/monitoring/test_escalation_notifier.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import json
+import pytest
+
+from monitoring import escalation_notifier
+
+
+def _make_logs(tmp_path: Path, razar: str = "", crown: str = "") -> tuple[Path, Path]:
+    r_path = tmp_path / "razar.log"
+    c_path = tmp_path / "crown.log"
+    r_path.write_text(razar)
+    c_path.write_text(crown)
+    return r_path, c_path
+
+
+def test_repeated_requests_trigger_escalation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    razar_lines = """
+2025-01-01T00:00:00Z db request
+2025-01-01T00:05:00Z db request
+2025-01-01T00:09:00Z db request
+""".strip()
+    r_log, c_log = _make_logs(tmp_path, razar=razar_lines)
+
+    events: list[dict[str, object]] = []
+
+    async def fake_broadcast(
+        event: dict[str, object]
+    ) -> None:  # pragma: no cover - patch
+        events.append(event)
+
+    monkeypatch.setattr(escalation_notifier, "broadcast_event", fake_broadcast)
+    monkeypatch.setattr(
+        escalation_notifier, "ESCALATION_LOG", tmp_path / "operator_escalations.jsonl"
+    )
+
+    now = datetime.fromisoformat("2025-01-01T00:10:00")
+    result = escalation_notifier.scan_logs(r_log, c_log, now=now)
+
+    assert result and result[0]["component"] == "db"
+    stored = json.loads(
+        (tmp_path / "operator_escalations.jsonl").read_text().splitlines()[0]
+    )
+    assert stored["reason"] == "repeated_requests"
+    assert events[0]["component"] == "db"
+
+
+def test_service_offline_triggers_escalation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    crown_lines = "2025-01-01T00:00:00Z api offline"
+    r_log, c_log = _make_logs(tmp_path, crown=crown_lines)
+
+    events: list[dict[str, object]] = []
+
+    async def fake_broadcast(
+        event: dict[str, object]
+    ) -> None:  # pragma: no cover - patch
+        events.append(event)
+
+    monkeypatch.setattr(escalation_notifier, "broadcast_event", fake_broadcast)
+    monkeypatch.setattr(
+        escalation_notifier, "ESCALATION_LOG", tmp_path / "operator_escalations.jsonl"
+    )
+
+    now = datetime.fromisoformat("2025-01-01T00:06:00")
+    result = escalation_notifier.scan_logs(r_log, c_log, now=now)
+
+    assert result and result[0]["component"] == "api"
+    stored = json.loads(
+        (tmp_path / "operator_escalations.jsonl").read_text().splitlines()[0]
+    )
+    assert stored["reason"] == "service_offline"
+    assert events[0]["reason"] == "service_offline"


### PR DESCRIPTION
## Summary
- add monitoring script to scan RAZAR and Crown logs for escalation thresholds
- notify operator via `operator_api.broadcast_event` and log to `logs/operator_escalations.jsonl`
- cover repeated request and offline service scenarios with unit tests

## Testing
- `pre-commit run --files monitoring/escalation_notifier.py tests/monitoring/test_escalation_notifier.py docs/test_index.md docs/INDEX.md` (failed: missing metrics endpoints and test collection errors)
- `pytest tests/monitoring/test_escalation_notifier.py` (failed: coverage threshold and unavailable resources)


------
https://chatgpt.com/codex/tasks/task_e_68ba7c3556f0832eba8011b4901cfefd