### PR TITLE
fix: improve test stability and plotting

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -48,3 +48,42 @@ Failures from `pytest` runs are appended via [`scripts/capture_failing_tests.py`
 - 2025-09-04: ERROR tests/test_voice_cloner_cli.py
 
 - 2025-09-04: AttributeError: module "feedback_logging" has no attribute "NOVELTY_THRESHOLD" (tests/crown/test_orchestrator_music.py)
+
+- 2025-09-05: ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
+
+- 2025-09-05: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/log_schema.sql
+- 2025-09-05: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/channel_schema.sql
+- 2025-09-05: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/timescaledb_agent_events.sql
+- 2025-09-05: ERROR tests/crown/test_orchestrator_music.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/integration/test_core_regressions.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/narrative_engine/test_biosignal_transformation.py
+- 2025-09-05: ERROR tests/narrative_engine/test_dataset_hashes.py
+- 2025-09-05: ERROR tests/narrative_engine/test_event_storage.py
+- 2025-09-05: ERROR tests/narrative_engine/test_ingest_persist_retrieve.py
+- 2025-09-05: ERROR tests/narrative_engine/test_ingestion_to_mistral_output.py
+- 2025-09-05: ERROR tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py
+- 2025-09-05: ERROR tests/razar/test_ai_invoker.py
+- 2025-09-05: ERROR tests/root/test_metrics_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_auto_retrain.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_autoretrain_full.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_avatar_state_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_boot_sequence.py
+- 2025-09-05: ERROR tests/test_dashboard_app.py - AttributeError: 'str' object has no attribute 'dtype'
+- 2025-09-05: ERROR tests/test_dashboard_qnl_mixer.py - AttributeError: 'str' object has no attribute 'dtype'
+- 2025-09-05: ERROR tests/test_emotion_classifier.py - AttributeError: 'types.SimpleNamespace' object has no attribute 'RandomState'
+- 2025-09-05: ERROR tests/test_initial_listen.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_interconnectivity.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_mix_tracks.py
+- 2025-09-05: ERROR tests/test_openwebui_state_updates.py
+- 2025-09-05: ERROR tests/test_quarantine_manager.py
+- 2025-09-05: ERROR tests/test_retrain_and_deploy.py
+- 2025-09-05: ERROR tests/test_retrain_model.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_spiral_cortex_memory.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-05: ERROR tests/test_transformers_generate.py - ValueError: cv2.__spec__ is None
+- 2025-09-05: ERROR tests/test_vector_memory.py
+- 2025-09-05: ERROR tests/test_voice_cloner_cli.py
+
+- 2025-09-05: ERROR    __main__:app.py:30 Failed to fetch benchmarks: db down
+- 2025-09-05: ERROR    __main__:app.py:49 Failed to predict best model: boom
+
+- 2025-09-05: No failures detected.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -32,6 +32,9 @@ except Exception as exc:  # pragma: no cover - external service failure
 
 if metrics:
     df = pd.DataFrame(metrics)
+    # Ensure timestamps are parsed for stable plotting with libraries like Plotly
+    # or Altair which expect datetime types instead of raw strings.
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
     st.write(df)
     st.line_chart(
         df.set_index("timestamp")[["response_time", "coherence", "relevance"]]

--- a/src/feedback_logging.py
+++ b/src/feedback_logging.py
@@ -1,0 +1,25 @@
+"""Compatibility wrapper for :mod:`core.feedback_logging`.
+
+Provides legacy import support while exposing key constants and functions
+from :mod:`core.feedback_logging` at the top level.  Older modules import
+``feedback_logging`` directly; this shim forwards those imports to the
+modern location.
+"""
+
+from __future__ import annotations
+
+from core.feedback_logging import (
+    COHERENCE_THRESHOLD,
+    LOG_FILE,
+    NOVELTY_THRESHOLD,
+    append_feedback,
+    load_feedback,
+)
+
+__all__ = [
+    "append_feedback",
+    "load_feedback",
+    "LOG_FILE",
+    "NOVELTY_THRESHOLD",
+    "COHERENCE_THRESHOLD",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "crown" / "test_config.py"),
     str(ROOT / "tests" / "test_download_deepseek.py"),
     str(ROOT / "tests" / "test_dashboard_app.py"),
+    str(ROOT / "tests" / "test_feedback_logging_import.py"),
     str(ROOT / "tests" / "test_dashboard_usage.py"),
     str(ROOT / "tests" / "test_virtual_env_manager.py"),
     str(ROOT / "tests" / "test_sandbox_session.py"),

--- a/tests/test_feedback_logging_import.py
+++ b/tests/test_feedback_logging_import.py
@@ -1,0 +1,19 @@
+"""Regression tests for the feedback_logging compatibility wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import importlib
+
+import feedback_logging as fl
+from pytest import MonkeyPatch
+
+
+def test_feedback_logging_shim(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(fl, "LOG_FILE", tmp_path / "log.json")
+    mod = importlib.reload(fl)
+    assert isinstance(mod.NOVELTY_THRESHOLD, float)
+    mod.append_feedback({"foo": "bar"})
+    data = mod.load_feedback()
+    assert data and data[0]["foo"] == "bar"


### PR DESCRIPTION
## Summary
- add compatibility wrapper for `feedback_logging`
- parse timestamps for stable dashboard charts
- add regression tests for feedback logging import

## Testing
- `python scripts/capture_failing_tests.py --cov-fail-under=0 --log-cli-level=CRITICAL tests/test_feedback_logging_import.py tests/test_dashboard_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba832d3b34832eb35194e7a655db1c