### PR TITLE
feat: expose resource metrics for core layers

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -125,6 +125,21 @@ these metrics. CPU, memory, disk, network, and GPU graphs are preconfigured.
 The `monitoring/watchdog.py` script augments these dashboards with system
 network throughput using `psutil.net_io_counters`.
 
+### Service metrics
+
+Core layers now expose Prometheus gauges for CPU, memory, GPU, and latency.
+`crown_router`, `agents.razar.health_checks`, `agents.bana.bio_adaptive_narrator`,
+and `memory.narrative_engine` publish:
+
+- `service_cpu_usage_percent`
+- `service_memory_usage_bytes`
+- `service_gpu_memory_usage_bytes`
+- `service_request_latency_seconds`
+
+Each metric is labelled by `service` so Grafana panels can display resource
+usage and latency for Crown, RAZAR, Bana, and Memory side by side. Import
+`monitoring/grafana-dashboard.json` to visualize these metrics.
+
 ## Timing metrics
 
 Latency histograms are exported via Prometheus:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -2,6 +2,11 @@ version: '3.8'
 services:
   prometheus:
     image: prom/prometheus
+    # Ensure resource exporters are available before Prometheus starts
+    depends_on:
+      - node-exporter
+      - cadvisor
+      - gpu-exporter
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
@@ -17,6 +22,7 @@ services:
   node-exporter:
     image: prom/node-exporter
     container_name: node-exporter
+    # Exposes host-level CPU, memory, and disk metrics
     restart: unless-stopped
     ports:
       - "9101:9100"
@@ -31,6 +37,7 @@ services:
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
     container_name: cadvisor
+    # Publishes container-level metrics for Prometheus scraping
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -42,6 +49,7 @@ services:
   gpu-exporter:
     image: nvidia/dcgm-exporter:3.2.6
     container_name: gpu-exporter
+    # Reports GPU utilization and memory statistics via DCGM
     restart: unless-stopped
     runtime: nvidia
     ports:

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -74,6 +74,46 @@
           "legendFormat": "gpu"
         }
       ]
+    },
+    {
+      "type": "graph",
+      "title": "Service CPU Usage",
+      "targets": [
+        {
+          "expr": "service_cpu_usage_percent",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Service Memory Usage",
+      "targets": [
+        {
+          "expr": "service_memory_usage_bytes",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Service GPU Memory",
+      "targets": [
+        {
+          "expr": "service_gpu_memory_usage_bytes",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Service Request Latency",
+      "targets": [
+        {
+          "expr": "service_request_latency_seconds",
+          "legendFormat": "{{service}}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- integrate resource exporters in monitoring stack
- export CPU, memory, GPU, and latency metrics from Crown, RAZAR, Bana, and memory
- add Grafana panels and document monitoring setup

## Testing
- `PYTHONPATH=. pre-commit run --files agents/bana/bio_adaptive_narrator.py agents/razar/health_checks.py crown_router.py docs/monitoring.md memory/narrative_engine.py monitoring/docker-compose.yml monitoring/grafana-dashboard.json docs/INDEX.md` *(fails: missing metrics exporters, tests not runnable in env)*
- `pytest tests/test_prometheus_metrics.py tests/test_metrics_endpoints.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68ba858ade94832eba45aff9800788b5