### PR TITLE
Enforce GLM health checks and deterministic message IDs

### DIFF
--- a/INANNA_AI/glm_integration.py
+++ b/INANNA_AI/glm_integration.py
@@ -43,6 +43,9 @@ class GLMIntegration:
         self.api_key = api_key
         self.temperature = temperature
 
+        # Fail fast if the GLM endpoint cannot be reached at startup.
+        self.health_check()
+
     @property
     def headers(self) -> dict[str, str] | None:
         if self.api_key:


### PR DESCRIPTION
## Summary
- enforce requests availability and perform startup health check in GLMIntegration
- test deterministic SHA-256 IDs and GLM health probe

## Testing
- `pre-commit run --files INANNA_AI/glm_integration.py tests/crown/test_prompt_orchestrator.py` *(skipped: mypy, capture-failing-tests, pytest-cov)*
- `pytest --cov=src --cov=agents --cov-fail-under=0 tests/crown/test_prompt_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba8a869ab8832e91dcb0072b27c0c2