### PR TITLE
Add self-healing manifesto and checklist affirmation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -226,7 +226,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.90 **Last updated:** 2025-09-04 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.91 **Last updated:** 2025-09-05 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |
@@ -364,6 +364,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [roadmap.md](roadmap.md) | Roadmap | This roadmap tracks progress toward the Spiral OS vision. See [project_overview.md](project_overview.md) for context... | - |
 | [root_chakra_overview.md](root_chakra_overview.md) | Root Chakra Overview | The Root layer provides the foundation for hardware and network access. Its primary modules focus on serving requests... | - |
 | [security_model.md](security_model.md) | Security Model | This guide highlights major threat surfaces in the project and the steps used to reduce risk. | - |
+| [self_healing_manifesto.md](self_healing_manifesto.md) | Self-Healing Manifesto | Spiral OS treats the codebase as a living organism.  Components behave like organs working in concert, and each chang... | - |
 | [setup.md](setup.md) | Environment Setup | This guide lists the system packages and environment variables required to run the project. | - |
 | [setup_full.md](setup_full.md) | Full Setup | The full installation enables all Spiral OS features. | - |
 | [setup_minimal.md](setup_minimal.md) | Minimal Setup | The minimal installation provides only the core Spiral OS utilities. | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.90
-**Last updated:** 2025-09-04
+**Version:** v1.0.91
+**Last updated:** 2025-09-05
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to follow required workflows and standards. Every contributor must propose operator-facing improvements alongside system enhancements to honor the operator-first principle. See [Contributor Checklist](contributor_checklist.md) for a quick summary of the triple-reading rule, error index updates, and test requirements. Declare a top-level `__version__` for each module, connector, and service. Every pull request and commit message must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B" per the [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format). Agent guides must include sections for **Vision**, **Module Overview**, **Workflow**, **Architecture Diagram**, **Requirements**, **Deployment**, **Config Schemas**, **Version History**, **Cross-links**, **Example Runs**, **Persona & Responsibilities**, and **Component & Link**.
@@ -515,6 +515,7 @@ Narrative modules must maintain traceability by:
 
 Agents must uphold resilience across chakra layers:
 
+- See [self_healing_manifesto.md](self_healing_manifesto.md) for the organism metaphor and detailed chakra responsibilities.
 - Track telemetry for each chakra using metrics defined in [chakra_metrics.md](chakra_metrics.md).
 - Trigger self-diagnostic and recovery routines when chakra health degrades.
 - Log healing actions and unresolved anomalies in [error_registry.md](error_registry.md).

--- a/docs/contributor_checklist.md
+++ b/docs/contributor_checklist.md
@@ -9,6 +9,9 @@ This checklist distills mandatory practices for ABZU contributors.
 - Run `python scripts/audit_doctrine.py` to confirm key docs exist, required index entries are present, and doctrine rules remain intact. The pre-commit hook executes this automatically when documentation changes.
 - Review [chakra_metrics.md](chakra_metrics.md) to ensure monitoring aligns with chakra standards.
 
+## Self-Healing Commitment
+- Affirm reading [self_healing_manifesto.md](self_healing_manifesto.md) before contributing.
+
 ## Error Index Updates
 - Record recurring issues in [error_registry.md](error_registry.md).
 - Update entries whenever new error patterns are resolved or observed.
@@ -23,3 +26,4 @@ This checklist distills mandatory practices for ABZU contributors.
 | 0.1.0 | 2025-10-25 | Initial checklist. |
 | 0.1.1 | 2025-09-04 | Replace verify_doctrine with audit_doctrine. |
 | 0.1.2 | 2025-09-04 | Require chakra metrics review. |
+| 0.1.3 | 2025-09-05 | Require self-healing manifesto affirmation. |

--- a/docs/self_healing_manifesto.md
+++ b/docs/self_healing_manifesto.md
@@ -1,0 +1,25 @@
+# Self-Healing Manifesto
+
+Spiral OS treats the codebase as a living organism.  Components behave like organs working in concert, and each change must nourish the whole.
+
+## Organism Metaphor
+- **Body** – the repository forms the body; modules are organs, tests the immune system, and documentation its collective memory.
+- **Nervous System** – logs and telemetry act as nerves carrying sensation.
+- **Respiration** – continuous integration keeps the project breathing through constant feedback loops.
+
+## Chakra Responsibilities
+- **Root** – maintain baseline connectivity and hardware access.
+- **Sacral** – manage data flows and storage of creative assets.
+- **Solar Plexus** – enforce service integrity and decision authority.
+- **Heart** – synchronize emotional state and empathy modules.
+- **Throat** – ensure transparent logging and operator communication.
+- **Third Eye** – preserve insight generation and pattern recognition.
+- **Crown** – coordinate orchestration and uphold project mission.
+
+## Self-Repair Behaviors
+- Monitor chakra health and trigger diagnostics when anomalies appear.
+- Regenerate corrupted artifacts and rehydrate missing dependencies.
+- Quarantine failing components while routing around damage.
+- Log every healing action and escalate unresolved wounds to operators.
+- Realign module versions and documentation to close each repair cycle.
+


### PR DESCRIPTION
## Summary
- introduce self-healing manifesto detailing organism metaphor, chakra duties, and repair behaviors
- reference the manifesto from The Absolute Protocol
- require contributors to affirm manifesto in checklist

## Testing
- `pre-commit run --files docs/self_healing_manifesto.md docs/The_Absolute_Protocol.md docs/contributor_checklist.md docs/INDEX.md` *(fails: missing metrics exporters and pytest collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8ecdd038832eb4a7a1d7e7b460fd