### PR TITLE
feat: log self-heal narratives

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -1148,7 +1148,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "memory/cortex.py",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": [
         "__future__",
         "aspect_processor",
@@ -2618,7 +2618,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "memory/narrative_engine.py",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": [
         "__future__",
         "chromadb",
@@ -2656,7 +2656,7 @@
       "chakra": "unknown",
       "type": "agent",
       "path": "agents/nazarick/narrative_scribe.py",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": [
         "__future__",
         "aiokafka",

--- a/memory/cortex.py
+++ b/memory/cortex.py
@@ -10,7 +10,7 @@ thread pool helper.
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import json
 import re
@@ -49,6 +49,7 @@ class SpiralNode(Protocol):
 CORTEX_MEMORY_FILE = Path("data/cortex_memory_spiral.jsonl")
 # Inverted index mapping semantic tags to entry identifiers.
 CORTEX_INDEX_FILE = Path("data/cortex_memory_index.json")
+PATCH_LINKS_FILE = Path("data/patch_links.jsonl")
 
 
 class _RWLock:
@@ -241,6 +242,21 @@ def search_index(
     return ids or set()
 
 
+def link_patch_metadata(component: str, patch: str, story: str) -> None:
+    """Record association between a ``component`` patch and its ``story``."""
+
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "component": component,
+        "patch": patch,
+        "story": story,
+    }
+    PATCH_LINKS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with PATCH_LINKS_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False))
+        fh.write("\n")
+
+
 def query_spirals(
     filter: Optional[Dict[str, Any]] | None = None,
     tags: Optional[List[str]] = None,
@@ -364,6 +380,7 @@ def export_spirals(
 __all__ = [
     "record_spiral",
     "search_index",
+    "link_patch_metadata",
     "hash_tag",
     "query_spirals",
     "query_spirals_concurrent",
@@ -371,5 +388,6 @@ __all__ = [
     "export_spirals",
     "CORTEX_MEMORY_FILE",
     "CORTEX_INDEX_FILE",
+    "PATCH_LINKS_FILE",
     "SpiralNode",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "chakra_healing" / "test_third_eye.py"),
     str(ROOT / "tests" / "chakra_healing" / "test_crown.py"),
     str(ROOT / "tests" / "test_metrics_endpoints.py"),
+    str(ROOT / "tests" / "narrative" / "test_self_heal_logging.py"),
 }
 
 

--- a/tests/narrative/test_self_heal_logging.py
+++ b/tests/narrative/test_self_heal_logging.py
@@ -1,0 +1,50 @@
+"""Tests for self-heal narrative logging."""
+
+from __future__ import annotations
+
+import json
+
+from citadel.event_producer import Event
+from agents.nazarick import narrative_scribe as ns
+from memory import narrative_engine, cortex
+
+
+__version__ = "0.1.0"
+
+
+def test_self_heal_event_logged(tmp_path, monkeypatch):
+    log_file = tmp_path / "story.log"
+    db_path = tmp_path / "stories.db"
+    patch_file = tmp_path / "patches.jsonl"
+
+    monkeypatch.setattr(ns, "LOG_FILE", log_file)
+    monkeypatch.setattr(narrative_engine, "DB_PATH", db_path)
+    monkeypatch.setattr(cortex, "PATCH_LINKS_FILE", patch_file)
+
+    def fake_personas():
+        return {
+            "default": {
+                "tone": "hopeful",
+                "self_heal_template": "{agent} restored {component} with patch {patch}",
+            }
+        }
+
+    monkeypatch.setattr(ns, "_load_personas", fake_personas)
+
+    scribe = ns.NarrativeScribe()
+    event = Event(
+        agent_id="a",
+        event_type="self_heal",
+        payload={"component": "core", "patch": "abc"},
+    )
+    scribe.process_event(event)
+
+    text = log_file.read_text().strip()
+    assert text == "a restored core with patch abc"
+    stories = list(narrative_engine.stream_stories())
+    assert stories[-1] == text
+
+    entry = json.loads(patch_file.read_text().splitlines()[-1])
+    assert entry["component"] == "core"
+    assert entry["patch"] == "abc"
+    assert entry["story"] == text


### PR DESCRIPTION
## Summary
- narrate self-heal events with persona-specific templates
- persist self-heal stories and patch metadata in narrative engine and cortex
- test self-heal event to story flow

## Testing
- `pytest --no-cov tests/narrative/test_self_heal_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba922bf230832e8016f82ca6e393a9