### PR TITLE
feat: add self healing verifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,6 +153,12 @@ repos:
     language: system
     pass_filenames: false
     files: ^(docs/|monitoring/)
+  - id: verify-self-healing
+    name: Verify self healing
+    entry: python scripts/verify_self_healing.py
+    language: system
+    pass_filenames: false
+    files: ^(docs/|logs/|quarantine/)
 
 - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
   rev: v9.19.0

--- a/scripts/verify_self_healing.py
+++ b/scripts/verify_self_healing.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Verify self-healing health checks."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DOCS_INDEX = PROJECT_ROOT / "docs" / "INDEX.md"
+MANIFEST = PROJECT_ROOT / "docs" / "self_healing_manifesto.md"
+SELF_HEAL_LOG = PROJECT_ROOT / "logs" / "self_heal.jsonl"
+QUARANTINE_DIR = PROJECT_ROOT / "quarantine"
+
+
+def _manifest_listed(index: Path = DOCS_INDEX, manifest: Path = MANIFEST) -> bool:
+    """Return True if manifest is referenced in docs index."""
+    if not index.exists() or not manifest.exists():
+        return False
+    return manifest.name in index.read_text(encoding="utf-8")
+
+
+def _recent_successful_cycles(
+    log: Path = SELF_HEAL_LOG, *, max_age_hours: int = 24
+) -> bool:
+    """Return True if log contains a recent successful entry."""
+    if not log.exists():
+        return False
+    threshold = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+    for line in log.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        status = data.get("status")
+        ts = data.get("timestamp") or data.get("time") or data.get("ts")
+        if status != "success" or not ts:
+            continue
+        try:
+            when = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when >= threshold:
+            return True
+    return False
+
+
+def _quarantine_fresh(
+    directory: Path = QUARANTINE_DIR, *, max_age_hours: int = 24
+) -> bool:
+    """Return True if no quarantined component exceeds threshold."""
+    now = datetime.now(timezone.utc)
+    threshold = now - timedelta(hours=max_age_hours)
+    for path in directory.glob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        ts = data.get("quarantined_at")
+        if not ts:
+            return False
+        try:
+            when = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if when < threshold:
+            return False
+    return True
+
+
+def verify_self_healing(
+    *, max_quarantine_hours: int = 24, max_cycle_hours: int = 24
+) -> int:
+    """Exit non-zero if self-healing invariants are violated."""
+    errors: list[str] = []
+    if not _manifest_listed():
+        errors.append("docs/self_healing_manifesto.md missing from docs/INDEX.md")
+    if not _recent_successful_cycles(max_age_hours=max_cycle_hours):
+        errors.append(
+            f"no successful self-heal cycles in last {max_cycle_hours}h"
+        )
+    if not _quarantine_fresh(max_age_hours=max_quarantine_hours):
+        errors.append(
+            "quarantined component exceeds age threshold"
+            f" ({max_quarantine_hours}h)"
+        )
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        return 1
+    print("verify_self_healing: all checks passed")
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-quarantine-hours",
+        type=int,
+        default=24,
+        help="Maximum allowed quarantine age in hours",
+    )
+    parser.add_argument(
+        "--max-cycle-hours",
+        type=int,
+        default=24,
+        help="Maximum age of successful self-heal cycle in hours",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    return verify_self_healing(
+        max_quarantine_hours=args.max_quarantine_hours,
+        max_cycle_hours=args.max_cycle_hours,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/scripts/test_verify_self_healing.py
+++ b/tests/scripts/test_verify_self_healing.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import scripts.verify_self_healing as vsh
+
+
+def _setup_env(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "self_healing_manifesto.md").write_text("manifesto")
+    (docs / "INDEX.md").write_text("self_healing_manifesto.md")
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    ts = datetime.now(timezone.utc).isoformat()
+    (logs / "self_heal.jsonl").write_text(
+        json.dumps({"timestamp": ts, "status": "success"}) + "\n"
+    )
+    (tmp_path / "quarantine").mkdir()
+
+
+def test_verify_self_healing_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_env(tmp_path)
+    monkeypatch.setattr(vsh, "DOCS_INDEX", tmp_path / "docs" / "INDEX.md")
+    monkeypatch.setattr(vsh, "MANIFEST", tmp_path / "docs" / "self_healing_manifesto.md")
+    monkeypatch.setattr(vsh, "SELF_HEAL_LOG", tmp_path / "logs" / "self_heal.jsonl")
+    monkeypatch.setattr(vsh, "QUARANTINE_DIR", tmp_path / "quarantine")
+    assert vsh.verify_self_healing() == 0
+
+
+def test_missing_manifest_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_env(tmp_path)
+    (tmp_path / "docs" / "INDEX.md").write_text("other.md")
+    monkeypatch.setattr(vsh, "DOCS_INDEX", tmp_path / "docs" / "INDEX.md")
+    monkeypatch.setattr(vsh, "MANIFEST", tmp_path / "docs" / "self_healing_manifesto.md")
+    monkeypatch.setattr(vsh, "SELF_HEAL_LOG", tmp_path / "logs" / "self_heal.jsonl")
+    monkeypatch.setattr(vsh, "QUARANTINE_DIR", tmp_path / "quarantine")
+    assert vsh.verify_self_healing() == 1
+
+
+def test_stale_quarantine_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_env(tmp_path)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    data = {"quarantined_at": old.isoformat()}
+    qfile = tmp_path / "quarantine" / "comp.json"
+    qfile.write_text(json.dumps(data))
+    monkeypatch.setattr(vsh, "DOCS_INDEX", tmp_path / "docs" / "INDEX.md")
+    monkeypatch.setattr(vsh, "MANIFEST", tmp_path / "docs" / "self_healing_manifesto.md")
+    monkeypatch.setattr(vsh, "SELF_HEAL_LOG", tmp_path / "logs" / "self_heal.jsonl")
+    monkeypatch.setattr(vsh, "QUARANTINE_DIR", tmp_path / "quarantine")
+    assert vsh.verify_self_healing(max_quarantine_hours=24) == 1
+
+
+def test_missing_recent_cycle_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_env(tmp_path)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    (tmp_path / "logs" / "self_heal.jsonl").write_text(
+        json.dumps({"timestamp": old.isoformat(), "status": "success"}) + "\n"
+    )
+    monkeypatch.setattr(vsh, "DOCS_INDEX", tmp_path / "docs" / "INDEX.md")
+    monkeypatch.setattr(vsh, "MANIFEST", tmp_path / "docs" / "self_healing_manifesto.md")
+    monkeypatch.setattr(vsh, "SELF_HEAL_LOG", tmp_path / "logs" / "self_heal.jsonl")
+    monkeypatch.setattr(vsh, "QUARANTINE_DIR", tmp_path / "quarantine")
+    assert vsh.verify_self_healing(max_cycle_hours=24) == 1


### PR DESCRIPTION
## Summary
- add self healing verification script ensuring manifesto listed, recent cycles, and no stale quarantine
- run checks via new tests for success and failure scenarios
- wire verify-self-healing into pre-commit hooks

## Testing
- `pre-commit run --files scripts/verify_self_healing.py tests/scripts/test_verify_self_healing.py .pre-commit-config.yaml` *(fails: command not found: pre-commit)*
- `python3 -m pytest tests/scripts/test_verify_self_healing.py::test_verify_self_healing_pass -q` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_68ba946a60d4832e8467895504c83230