### PR TITLE
feat: add narrative search endpoint

### DIFF
--- a/memory/story_lookup.py
+++ b/memory/story_lookup.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utilities for retrieving stories with event context."""
+
+__version__ = "0.1.0"
+
+import json
+from typing import Any, Dict, Iterator, Optional
+
+from . import narrative_engine
+
+
+def find(
+    agent_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+    text: Optional[str] = None,
+) -> Iterator[Dict[str, Any]]:
+    """Yield joined stories and event metadata.
+
+    Results come from joining ``story_index`` and ``events`` tables. Optional
+    filters by ``agent_id``, ``event_type`` and substring ``text`` are applied
+    to the narrative text.
+    """
+
+    sql = (
+        "SELECT s.time, s.agent_id, s.event_type, s.text, e.id, e.payload "
+        "FROM story_index AS s JOIN events AS e "
+        "ON s.time = e.time AND s.agent_id = e.agent_id "
+        "AND s.event_type = e.event_type"
+    )
+    clauses: list[str] = []
+    params: list[Any] = []
+    if agent_id:
+        clauses.append("s.agent_id = ?")
+        params.append(agent_id)
+    if event_type:
+        clauses.append("s.event_type = ?")
+        params.append(event_type)
+    if text:
+        clauses.append("s.text LIKE ?")
+        params.append(f"%{text}%")
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY s.time"
+    with narrative_engine._get_conn() as conn:  # type: ignore[attr-defined]
+        for ts, ag, et, story_text, event_id, payload in conn.execute(sql, params):
+            yield {
+                "time": ts,
+                "agent_id": ag,
+                "event_type": et,
+                "text": story_text,
+                "event_id": event_id,
+                "payload": json.loads(payload),
+            }
+
+
+__all__ = ["find"]

--- a/tests/narrative/test_story_lookup.py
+++ b/tests/narrative/test_story_lookup.py
@@ -1,0 +1,49 @@
+"""Verify joining of stories and events with filtering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memory import narrative_engine, story_lookup
+
+__version__ = "0.1.0"
+
+
+@pytest.fixture
+def setup_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Populate temporary narrative database with sample data."""
+
+    db_path = tmp_path / "narrative.db"
+    monkeypatch.setattr(narrative_engine, "DB_PATH", db_path)
+    monkeypatch.setattr(narrative_engine, "CHROMA_DIR", tmp_path)
+    records = [
+        (1.0, "agent1", "alpha", "first story", {"n": 1}),
+        (2.0, "agent2", "beta", "second tale", {"n": 2}),
+    ]
+    for ts, agent, etype, text, payload in records:
+        narrative_engine.log_event(
+            {"time": ts, "agent_id": agent, "event_type": etype, "payload": payload}
+        )
+        narrative_engine.index_story(agent, etype, text, ts)
+
+
+def test_find_returns_joined_entries(setup_db: None) -> None:
+    """All results include narrative text and event payload."""
+
+    results = list(story_lookup.find())
+    assert {r["text"] for r in results} == {"first story", "second tale"}
+    payloads = {r["payload"]["n"] for r in results}
+    assert payloads == {1, 2}
+
+
+def test_find_filters(setup_db: None) -> None:
+    """Filters narrow results by agent, event type, and text."""
+
+    by_agent = list(story_lookup.find(agent_id="agent1"))
+    assert len(by_agent) == 1 and by_agent[0]["text"] == "first story"
+    by_type = list(story_lookup.find(event_type="beta"))
+    assert len(by_type) == 1 and by_type[0]["agent_id"] == "agent2"
+    by_text = list(story_lookup.find(text="tale"))
+    assert len(by_text) == 1 and by_text[0]["event_type"] == "beta"


### PR DESCRIPTION
## Summary
- join stories with events via `memory.story_lookup.find`
- expose `/narrative/search` endpoint for indexed stories
- cover lookup filtering and event metadata in tests

## Testing
- `pytest tests/narrative/test_story_lookup.py -q` *(fails: Coverage failure: total of 1 is less than fail-under=80)*
- `pre-commit run --files memory/story_lookup.py narrative_api.py tests/narrative/test_story_lookup.py` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a6d5de8832e9869b326e7841634