### PR TITLE
feat: add narrative story adapter for chakra agents

### DIFF
--- a/agents/chakra_healing/crown_agent.py
+++ b/agents/chakra_healing/crown_agent.py
@@ -1,18 +1,34 @@
-"""Monitor crown chakra metrics and perform full restarts."""
+"""Monitor crown chakra metrics and orchestrate full system restart."""
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "crown"
 THRESHOLD = 0.95
 SCRIPT_PATH = Path("scripts/chakra_healing/crown_full_restart.sh")
+AGENT_ID = "crown_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/heart_agent.py
+++ b/agents/chakra_healing/heart_agent.py
@@ -1,18 +1,34 @@
-"""Monitor heart chakra metrics and repair memory."""
+"""Monitor heart chakra metrics and repair memory layers."""
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "heart"
 THRESHOLD = 0.88
 SCRIPT_PATH = Path("scripts/chakra_healing/heart_memory_repair.py")
+AGENT_ID = "heart_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/root_agent.py
+++ b/agents/chakra_healing/root_agent.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "root"
 THRESHOLD = 0.8
 SCRIPT_PATH = Path("scripts/chakra_healing/root_restore_network.sh")
+AGENT_ID = "root_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/sacral_agent.py
+++ b/agents/chakra_healing/sacral_agent.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "sacral"
 THRESHOLD = 0.85
 SCRIPT_PATH = Path("scripts/chakra_healing/sacral_gpu_recover.py")
+AGENT_ID = "sacral_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/solar_agent.py
+++ b/agents/chakra_healing/solar_agent.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "solar"
 THRESHOLD = 0.9
 SCRIPT_PATH = Path("scripts/chakra_healing/solar_cpu_throttle.py")
+AGENT_ID = "solar_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/third_eye_agent.py
+++ b/agents/chakra_healing/third_eye_agent.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "third_eye"
 THRESHOLD = 0.93
 SCRIPT_PATH = Path("scripts/chakra_healing/third_eye_inference_flush.py")
+AGENT_ID = "third_eye_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/chakra_healing/throat_agent.py
+++ b/agents/chakra_healing/throat_agent.py
@@ -1,18 +1,34 @@
-"""Monitor throat chakra metrics and stabilize APIs."""
+"""Monitor throat chakra metrics and stabilize API throughput."""
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pathlib import Path
 
+from agents.utils.story_adapter import get_recent_stories
 from .base import heal
 
 CHAKRA = "throat"
 THRESHOLD = 0.92
 SCRIPT_PATH = Path("scripts/chakra_healing/throat_api_stabilize.sh")
+AGENT_ID = "throat_agent"
 
 
 def heal_if_needed() -> bool:
     return heal(CHAKRA, THRESHOLD, SCRIPT_PATH)
 
 
-__all__ = ["heal_if_needed", "CHAKRA", "THRESHOLD", "SCRIPT_PATH"]
+def recent_stories(limit: int = 50) -> list[str]:
+    """Return recent narrative stories for this agent."""
+    return get_recent_stories(AGENT_ID, limit)
+
+
+__all__ = [
+    "heal_if_needed",
+    "recent_stories",
+    "CHAKRA",
+    "THRESHOLD",
+    "SCRIPT_PATH",
+    "AGENT_ID",
+]

--- a/agents/utils/__init__.py
+++ b/agents/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Utility helpers for agents."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .story_adapter import get_recent_stories, watch_stories
+
+__all__ = ["get_recent_stories", "watch_stories"]

--- a/agents/utils/story_adapter.py
+++ b/agents/utils/story_adapter.py
@@ -1,0 +1,32 @@
+"""Adapters for retrieving narrative stories for agents."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Callable
+
+from memory import narrative_engine, story_lookup
+
+
+def get_recent_stories(agent_id: str, limit: int = 50) -> list[str]:
+    """Return the most recent story texts for ``agent_id``.
+
+    Parameters
+    ----------
+    agent_id:
+        Agent identifier to filter stories.
+    limit:
+        Maximum number of stories to return.
+    """
+    records = list(story_lookup.find(agent_id=agent_id))
+    return [r["text"] for r in records][-limit:]
+
+
+def watch_stories(callback: Callable[[str], None]) -> None:
+    """Stream recorded stories and invoke ``callback`` for each."""
+    for story in narrative_engine.stream_stories():
+        callback(story)
+
+
+__all__ = ["get_recent_stories", "watch_stories"]

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -29,6 +29,26 @@ These guardians poll Chakracon metrics and invoke recovery scripts when threshol
 | `crown_agent` | `scripts/chakra_healing/crown_full_restart.sh` | Orchestrate system reboot and operator notification |
 
 
+### Narrative History Adapter
+
+Each chakra agent can retrieve its recent narrative context using the shared
+story adapter:
+
+```python
+from agents.utils.story_adapter import get_recent_stories
+
+stories = get_recent_stories("root_agent", limit=20)
+```
+
+Streaming the full log is also supported:
+
+```python
+from agents.utils.story_adapter import watch_stories
+
+watch_stories(print)
+```
+
+
 ## Launch Commands
 
 Start all servants for development:

--- a/docs/test_index.md
+++ b/docs/test_index.md
@@ -7,5 +7,6 @@ Generated automatically. Catalog of test modules and scenarios.
 | `tests/integration/test_context_rl.py` | Validate RL context environment reset/step and training loop. | `memory.context_env`, `memory.mental` |
 | `tests/razar/test_ai_invoker.py` | Verify opencode CLI patch flow in `ai_invoker.handover`. | `razar.ai_invoker` |
 | `tests/monitoring/test_escalation_notifier.py` | Validate operator escalation when log conditions met. | `monitoring.escalation_notifier` |
+| `tests/agents/test_story_adapter.py` | Validate narrative story retrieval and streaming. | `agents.utils.story_adapter`, `memory.narrative_engine` |
 
 Backlinks: [Component Index](component_index.md) | [Connector Index](connectors/CONNECTOR_INDEX.md) | [Dependency Index](dependency_index.md)

--- a/tests/agents/test_story_adapter.py
+++ b/tests/agents/test_story_adapter.py
@@ -1,0 +1,45 @@
+"""Tests for the narrative story adapter."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import time
+
+from agents.utils.story_adapter import get_recent_stories, watch_stories
+from memory import narrative_engine
+
+
+def _index(agent: str, text: str) -> None:
+    ts = time.time()
+    narrative_engine.index_story(agent, "event", text, timestamp=ts)
+    narrative_engine.log_event(
+        {
+            "time": ts,
+            "agent_id": agent,
+            "event_type": "event",
+            "payload": {},
+        }
+    )
+
+
+def test_get_recent_stories(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "stories.db"
+    monkeypatch.setattr(narrative_engine, "DB_PATH", db_path)
+
+    _index("root_agent", "alpha")
+    _index("root_agent", "beta")
+
+    assert get_recent_stories("root_agent", limit=1) == ["beta"]
+
+
+def test_watch_stories(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "stories.db"
+    monkeypatch.setattr(narrative_engine, "DB_PATH", db_path)
+
+    narrative_engine.log_story("one")
+    narrative_engine.log_story("two")
+
+    collected: list[str] = []
+    watch_stories(collected.append)
+    assert collected == ["one", "two"]


### PR DESCRIPTION
## Summary
- add `agents.utils.story_adapter` with helpers to fetch or stream narratives
- wire narrative history lookup into chakra healing agents
- document story adapter usage and add unit tests

## Testing
- `python scripts/verify_versions.py agents/utils/__init__.py agents/utils/story_adapter.py agents/chakra_healing/root_agent.py agents/chakra_healing/sacral_agent.py agents/chakra_healing/solar_agent.py agents/chakra_healing/heart_agent.py agents/chakra_healing/throat_agent.py agents/chakra_healing/third_eye_agent.py agents/chakra_healing/crown_agent.py tests/agents/test_story_adapter.py`
- `pytest tests/agents/test_story_adapter.py -q --cov=agents/utils/story_adapter.py --cov-fail-under=0` *(fails: module not imported, tests skipped)*
- `pre-commit run --files agents/utils/__init__.py agents/utils/story_adapter.py agents/chakra_healing/root_agent.py agents/chakra_healing/sacral_agent.py agents/chakra_healing/solar_agent.py agents/chakra_healing/heart_agent.py agents/chakra_healing/throat_agent.py agents/chakra_healing/third_eye_agent.py agents/chakra_healing/crown_agent.py docs/nazarick_agents.md docs/test_index.md tests/agents/test_story_adapter.py docs/INDEX.md` *(fails: verify_chakra_monitoring, verify_self_healing, pytest collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9d5f10a4832eae59148c2be9348a