### PR TITLE
feat: log agent communications and expose interaction API

### DIFF
--- a/agents/interaction_log.py
+++ b/agents/interaction_log.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Utilities for recording agent communications."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+_LOG_PATH = Path("logs") / "agent_interactions.jsonl"
+
+
+def log_agent_interaction(entry: Dict[str, Any]) -> None:
+    """Append ``entry`` with timestamp to the interactions log."""
+    entry = dict(entry)
+    entry.setdefault("timestamp", datetime.utcnow().isoformat())
+    _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, default=repr) + "\n")

--- a/glm_shell.py
+++ b/glm_shell.py
@@ -11,6 +11,7 @@ import argparse
 from crown_config import require, settings
 from INANNA_AI.glm_integration import GLMIntegration
 from init_crown_agent import initialize_crown
+from agents.interaction_log import log_agent_interaction
 
 
 def send_command(command: str) -> str:
@@ -27,7 +28,17 @@ def send_command(command: str) -> str:
     else:
         glm = initialize_crown()
     prompt = f"[shell]{command}"
-    return glm.complete(prompt)
+    response = glm.complete(prompt)
+    log_agent_interaction(
+        {
+            "source": "operator",
+            "target": "crown",
+            "command": command,
+            "response": response,
+            "function": "send_command",
+        }
+    )
+    return response
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/operator_api.py
+++ b/operator_api.py
@@ -158,6 +158,29 @@ async def operator_status() -> dict[str, object]:
     }
 
 
+@router.get("/agents/interactions")
+async def agent_interactions(
+    agents: list[str] | None = None, limit: int = 100
+) -> list[dict[str, object]]:
+    """Return recent agent interactions filtered by ``agents``."""
+    path = Path("logs") / "agent_interactions.jsonl"
+    if not path.exists():
+        return []
+    records: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if agents and not (
+                entry.get("source") in agents or entry.get("target") in agents
+            ):
+                continue
+            records.append(entry)
+    return records[-limit:]
+
+
 @router.post("/operator/upload")
 async def upload_file(
     operator: str = Form(...),

--- a/schemas/agent_interactions.sql
+++ b/schemas/agent_interactions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE agent_interactions (
+    timestamp TEXT,
+    source TEXT,
+    target TEXT,
+    function TEXT,
+    action TEXT,
+    command TEXT,
+    response TEXT,
+    metadata TEXT
+);


### PR DESCRIPTION
## Summary
- log `emit_event` and `send_command` calls to `logs/agent_interactions.jsonl`
- expose `/agents/interactions` endpoint for querying recent agent conversations
- train Vanna on `agent_interactions` table schema for NLQ support

## Testing
- `pre-commit run --files agents/interaction_log.py agents/event_bus.py glm_shell.py operator_api.py schemas/agent_interactions.sql` *(fails: error while running tests; missing dependencies such as python-multipart and feedback_logging)*

------
https://chatgpt.com/codex/tasks/task_e_68baa3743298832e9dc2fb12e8914a09