### PR TITLE
feat: add conversation timeline and NLQ search to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `training/fine_tune_mistral.py` configuring mythological and project corpora.
 - Extended `scripts/check_requirements.sh` to report missing Python modules.
 - Published memory layer bus events and `query_memory` aggregator.
+- Web console pulls conversation logs per agent with timeline view, NLQ log search, and operator onboarding prompts.
 - Recorded mythology and project material datasets in `component_index.json`.
 - Listed dataset licensing, version history, and evaluation metrics in `docs/bana_engine.md`.
 - Implemented `bana/narrative_api.py` for narrative retrieval and streaming.

--- a/web_console/index.html
+++ b/web_console/index.html
@@ -10,6 +10,11 @@
 </head>
 <body>
     <h1>Spiral OS Web Console</h1>
+    <div id="search-bar">
+        <input id="global-search" type="text" placeholder="Search conversations">
+        <button id="search-btn">Search</button>
+        <div id="search-results" style="margin-top:0.5rem;"></div>
+    </div>
     <input id="command-input" type="text" placeholder="Enter command">
     <button id="send-btn">Send</button>
     <div id="emotion" style="margin-top:1rem;"></div>
@@ -24,6 +29,10 @@
     <div id="agents-section" style="margin-top:1rem;">
         <h2>Agents</h2>
         <ul id="agent-list" style="list-style:none;padding:0;"></ul>
+    </div>
+    <div id="timeline-section" style="margin-top:1rem;">
+        <h2>Conversation Timeline</h2>
+        <div id="conversation-timeline"></div>
     </div>
     <div id="status-panel" style="margin-top:1rem;">
         <h2>Status</h2>


### PR DESCRIPTION
## Summary
- pull per-agent conversation logs via new API and render timeline view
- add natural-language log search bar calling `/nlq/logs` and highlighting matches
- introduce onboarding tooltip for first-time operators

## Testing
- `pre-commit run --files web_console/index.html web_console/main.js CHANGELOG.md` *(fails: module 'feedback_logging' missing and other dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baa59e7e28832e9a84e826ce5660fb