### PR TITLE
docs: add Operator-Nazarick bridge overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 
 - Documented onboarding triple-reading requirement and Nazarick Web Console access in `docs/operator_interface_GUIDE.md` and updated `docs/INDEX.md`.
+- Added `docs/operator_nazarick_bridge.md` detailing Vanna data flow, agent channels, and console usage; cross-referenced from onboarding and system docs.
 - Expanded `docs/component_status.md` with detailed alpha/beta/stable criteria.
 - Added `scripts/verify_component_maturity.py` and enforced its check in CI.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -335,6 +336,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |
 | [operations.md](operations.md) | Operations | - | - |
 | [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
+| [operator_nazarick_bridge.md](operator_nazarick_bridge.md) | Operator-Nazarick Bridge | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |
 | [operator_protocol.md](operator_protocol.md) | Operator Protocol | Operator actions dispatched via the API include a unique `command_id` UUID. The identifier is returned in responses,... | - |
 | [operator_quickstart.md](operator_quickstart.md) | Operator Quickstart | A concise orientation for operators interacting with ABZU. | - |
 | [os_guardian.md](os_guardian.md) | OS Guardian | Sources: [`../os_guardian/perception.py`](../os_guardian/perception.py), [`../os_guardian/planning.py`](../os_guardia... | `../os_guardian/action_engine.py`, `../os_guardian/perception.py`, `../os_guardian/planning.py`, `../os_guardian/safety.py` |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -87,6 +87,7 @@ Confirm these items before submitting a pull request:
  - [ ] Environment prepared per [Environment Preparation](#environment-preparation)
  - [ ] Key-document summaries verified with `scripts/verify_doc_hashes.py`
  - [ ] [blueprint_spine.md](blueprint_spine.md) read and acknowledged
+ - [ ] [operator_nazarick_bridge.md](operator_nazarick_bridge.md) reviewed for agent-channel workflow
  - [ ] Version bumps applied and synchronized in `component_index.json`
  - [ ] If any component or connector changes, rebuild `component_index.json` and confirm registry updates
  - [ ] Connector registry updated for added or modified connectors ([docs/connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md))

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -378,7 +378,7 @@ Communication is organized through a chakra-inspired channel hierarchy: Crown Co
 
 ## **4. Operator Interaction**
 
-The Nazarick Web Console exposes a browser-based interface for operators to issue commands, stream media, and chat with individual agents. It reads the agent registry and startup logs to populate an agent panel with chat-room links and direct command buttons. Additionally, the Nazarick Agents guide encourages monitoring agents and issuing commands through this console, which leverages the same FastAPI services used by the agents themselves.
+The Nazarick Web Console exposes a browser-based interface for operators to issue commands, stream media, and chat with individual agents. It reads the agent registry and startup logs to populate an agent panel with chat-room links and direct command buttons. Additionally, the Nazarick Agents guide encourages monitoring agents and issuing commands through this console, which leverages the same FastAPI services used by the agents themselves. See the [Operator-Nazarick Bridge](operator_nazarick_bridge.md) for a walkthrough of Vanna’s data flow, channel personalities, and web console usage.
 
 ## **5. Summary**
 

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -20,6 +20,7 @@ Study the system design materials to grasp component responsibilities and data f
 - [System Blueprint](system_blueprint.md)
 - [Architecture Overview](architecture_overview.md)
 - [Data Flow](data_flow.md)
+- [Operator-Nazarick Bridge](operator_nazarick_bridge.md)
 
 ## 4. Follow the Development Workflow
 Use the process documents to build and modify modules:

--- a/docs/operator_interface_GUIDE.md
+++ b/docs/operator_interface_GUIDE.md
@@ -6,8 +6,10 @@ Defines REST endpoints that let operators control Crown and RAZAR.
 
 ## Onboarding
 The [The Absolute Protocol](The_Absolute_Protocol.md) requires triple-reading the
-[Blueprint Spine](blueprint_spine.md) before contributing. Confirm this review
-before operating the interface. See the [Contributor Checklist](contributor_checklist.md)
+[Blueprint Spine](blueprint_spine.md) before contributing. Review the
+[Operator-Nazarick Bridge](operator_nazarick_bridge.md) to understand Vanna’s
+query pipeline and agent channel personalities. Confirm this review before
+operating the interface. See the [Contributor Checklist](contributor_checklist.md)
 for error index updates and test requirements.
 
 ### Step 1: Select a Voice

--- a/docs/operator_nazarick_bridge.md
+++ b/docs/operator_nazarick_bridge.md
@@ -1,0 +1,29 @@
+# Operator-Nazarick Bridge
+
+**Version:** v1.0.0
+**Last updated:** 2025-09-05
+
+This overview explains how operators converse with Nazarick servants and how those
+conversations flow into data and narrative layers.
+
+## Vanna Data Agent Workflow
+- Operators ask questions in natural language.
+- The `vanna_data` agent converts the prompt into SQL and executes the query.
+- Raw rows are persisted in mental memory while a narrative summary is appended to
+  `data/narrative.log` for later storytelling.
+
+## Nazarick Channels & Personas
+- Servant agents occupy chakra-aligned channels such as the Orchestration Master,
+  Prompt Orchestrator, QNL Engine, and Memory Scribe.
+- Each agent maintains a defined personality that colors its responses and
+  responsibilities.
+- Channel hierarchy ensures messages travel through the proper layers before
+  reaching the operator.
+
+## Operator Web Console
+- The Nazarick Web Console lists active agents and opens dedicated chat rooms.
+- Operators can issue commands, review responses, and stream media from each
+  servant.
+- Narrative logs written by Bana and Vanna are available in the console for
+  review alongside real-time dialogue.
+

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -60,6 +60,7 @@ feedback.
   - [Persona API Guide](persona_api_guide.md) – conventions for persona profiles and hooks
   - [Nazarick Manifesto](nazarick_manifesto.md) – narrative charter governing personas
   - [Chat2DB Interface](chat2db.md) – bridge between the relational log and vector store
+  - [Operator-Nazarick Bridge](operator_nazarick_bridge.md) – Vanna workflow, channel personas, and web console chat
   - [Primordials Service](primordials_service.md) – DeepSeek-V3 orchestration service
 - **Operational guides**
   - [Operations Guide](operations.md) – runbooks for deployment and maintenance


### PR DESCRIPTION
## Summary
- add Operator-Nazarick bridge overview describing Vanna data flow, agent channels, and web console
- cross-link the new overview from blueprint spine, onboarding, and protocol docs
- update operator and onboarding guides to point to the bridge

## Testing
- `SKIP=pytest-cov,capture-failing-tests,verify-chakra-monitoring,verify-self-healing pre-commit run --files docs/operator_nazarick_bridge.md docs/blueprint_spine.md docs/The_Absolute_Protocol.md docs/system_blueprint.md docs/onboarding_guide.md docs/operator_interface_GUIDE.md docs/INDEX.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68baad5c02f4832e98e1d1b352ec8d90