### PR TITLE
Enforce boot component health probes and add boot sequence tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Enforced explicit health probes for RAZAR boot components and added boot
+  sequence tests.
 - Documented operator-first principle and contributor guidance across core docs.
 
 - WebSocket `/operator/events` for command acknowledgements and progress with console subscription.

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added optional Opencode CLI handover path in `ai_invoker.handover` and
   documented setup in RAZAR agent guide and recovery playbook. The CLI output
   feeds into `code_repair.repair_module`.
+- Enforced explicit health probes for boot components and logged probe results
+  in `razar_state.json`.
 
  - Expanded guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.
 - Added schema diagrams for configuration files and a full ignition example with log excerpts and mission-brief archive notes.

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -203,12 +203,12 @@ logs/mission_briefs/
 | 2025-09-21T00:00:01Z | basic_service | dependency | Install missing packages or verify the environment. |
 ```
 
-### Probe Failure Matrix
+### Probe Failure Troubleshooting Matrix
 
-| Probe           | Failure Indicator                         | Remediation                                                  |
-|-----------------|-------------------------------------------|--------------------------------------------------------------|
-| basic_service   | `Health check failed for basic_service`   | Validate dependencies and restart the service.               |
-| complex_service | `Health check failed for complex_service` | Inspect configuration or escalate repair to a remote agent. |
+| Component       | Health Probe                          | Failure Indicator                         | Remediation                                                  |
+|-----------------|---------------------------------------|-------------------------------------------|--------------------------------------------------------------|
+| basic_service   | `http://localhost:8000/healthz`       | `Health check failed for basic_service`   | Validate dependencies and restart the service.               |
+| complex_service | `/var/log/complex_service.log`        | `Health check failed for complex_service` | Inspect configuration or escalate repair to a remote agent. |
 
 ## Cross-links
 - [System Blueprint](system_blueprint.md)

--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -87,3 +87,18 @@ Failures from `pytest` runs are appended via [`scripts/capture_failing_tests.py`
 - 2025-09-05: ERROR    __main__:app.py:49 Failed to predict best model: boom
 
 - 2025-09-05: No failures detected.
+
+- 2025-09-05: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/agent_interactions.sql
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/agents/razar/test_crown_link.py
+- 2025-09-05: ERROR tests/crown/server/test_server.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/monitoring/test_escalation_notifier.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/test_operator_api.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/test_operator_audit.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/test_operator_command_route.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-05: ERROR tests/web_console/test_conversation_timeline.py - RuntimeError: Form data requires "python-multipart" to be installed.

--- a/logs/test_report.txt
+++ b/logs/test_report.txt
@@ -1,6 +1,835 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0 -- /root/.pyenv/versions/3.12.10/bin/python
+cachedir: .pytest_cache
+rootdir: /workspace/ABZU
+configfile: pytest.ini
+plugins: langsmith-0.4.25, cov-6.2.1, anyio-4.10.0, requests-mock-1.12.1
+collecting ... 
+----------------------------------------------------- live log collection ------------------------------------------------------
+ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/timescaledb_agent_events.sql
+Traceback (most recent call last):
+  File "/workspace/ABZU/nlq_api.py", line 33, in _train_vanna
+    vanna.train(ddl=sql_file.read_text())
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 283, in train
+    error_deprecation()
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 47, in error_deprecation
+    raise Exception("""
+Exception: 
+Please switch to the following method for initializing Vanna:
 
-ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
-pytest: error: unrecognized arguments: --cov=src --cov=agents --cov-fail-under=90
-  inifile: /workspace/ABZU/pytest.ini
-  rootdir: /workspace/ABZU
+from vanna.remote import VannaDefault
+
+api_key = # Your API key from https://vanna.ai/account/profile 
+vanna_model_name = # Your model name from https://vanna.ai/account/profile
+                    
+vn = VannaDefault(model=vanna_model_name, api_key=api_key)
+
+ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/channel_schema.sql
+Traceback (most recent call last):
+  File "/workspace/ABZU/nlq_api.py", line 33, in _train_vanna
+    vanna.train(ddl=sql_file.read_text())
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 283, in train
+    error_deprecation()
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 47, in error_deprecation
+    raise Exception("""
+Exception: 
+Please switch to the following method for initializing Vanna:
+
+from vanna.remote import VannaDefault
+
+api_key = # Your API key from https://vanna.ai/account/profile 
+vanna_model_name = # Your model name from https://vanna.ai/account/profile
+                    
+vn = VannaDefault(model=vanna_model_name, api_key=api_key)
+
+ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/agent_interactions.sql
+Traceback (most recent call last):
+  File "/workspace/ABZU/nlq_api.py", line 33, in _train_vanna
+    vanna.train(ddl=sql_file.read_text())
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 283, in train
+    error_deprecation()
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 47, in error_deprecation
+    raise Exception("""
+Exception: 
+Please switch to the following method for initializing Vanna:
+
+from vanna.remote import VannaDefault
+
+api_key = # Your API key from https://vanna.ai/account/profile 
+vanna_model_name = # Your model name from https://vanna.ai/account/profile
+                    
+vn = VannaDefault(model=vanna_model_name, api_key=api_key)
+
+ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/log_schema.sql
+Traceback (most recent call last):
+  File "/workspace/ABZU/nlq_api.py", line 33, in _train_vanna
+    vanna.train(ddl=sql_file.read_text())
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 283, in train
+    error_deprecation()
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/vanna/__init__.py", line 47, in error_deprecation
+    raise Exception("""
+Exception: 
+Please switch to the following method for initializing Vanna:
+
+from vanna.remote import VannaDefault
+
+api_key = # Your API key from https://vanna.ai/account/profile 
+vanna_model_name = # Your model name from https://vanna.ai/account/profile
+                    
+vn = VannaDefault(model=vanna_model_name, api_key=api_key)
+
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:40 Optional package scapy not available: No module named 'scapy'
+WARNING  env_validation:env_validation.py:40 Optional package scapy not available: No module named 'scapy'
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+WARNING  env_validation:env_validation.py:74 Missing optional audio binaries: ffmpeg, sox
+ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+
+collected 805 items / 35 errors / 19 skipped
+
+============================================================ ERRORS ============================================================
+____________________________________ ERROR collecting tests/agents/razar/test_crown_link.py ____________________________________
+ImportError while importing test module '/workspace/ABZU/tests/agents/razar/test_crown_link.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/agents/razar/test_crown_link.py:7: in <module>
+    import websockets
+E   ModuleNotFoundError: No module named 'websockets'
+______________________________________ ERROR collecting tests/crown/server/test_server.py ______________________________________
+tests/crown/server/test_server.py:98: in <module>
+    import server
+server.py:75: in <module>
+    from operator_api import router as operator_router
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+___________________________________ ERROR collecting tests/crown/test_orchestrator_music.py ____________________________________
+tests/crown/test_orchestrator_music.py:49: in <module>
+    from rag import orchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_________________________________ ERROR collecting tests/integration/test_core_regressions.py __________________________________
+tests/integration/test_core_regressions.py:10: in <module>
+    from rag.orchestrator import MoGEOrchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+________________________________ ERROR collecting tests/monitoring/test_escalation_notifier.py _________________________________
+tests/monitoring/test_escalation_notifier.py:9: in <module>
+    from monitoring import escalation_notifier
+monitoring/escalation_notifier.py:9: in <module>
+    from operator_api import broadcast_event
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+___________________________ ERROR collecting tests/narrative_engine/test_biosignal_transformation.py ___________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_biosignal_transformation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_biosignal_transformation.py:11: in <module>
+    from scripts.ingest_biosignals import ingest_directory, ingest_file
+scripts/ingest_biosignals.py:9: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+________________________________ ERROR collecting tests/narrative_engine/test_dataset_hashes.py ________________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_dataset_hashes.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_dataset_hashes.py:9: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+________________________________ ERROR collecting tests/narrative_engine/test_event_storage.py _________________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_event_storage.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_event_storage.py:8: in <module>
+    from scripts.ingest_biosignal_events import ingest_file
+scripts/ingest_biosignal_events.py:8: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+___________________________ ERROR collecting tests/narrative_engine/test_ingest_persist_retrieve.py ____________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_ingest_persist_retrieve.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_ingest_persist_retrieve.py:11: in <module>
+    from scripts.ingest_biosignals import ingest_file
+scripts/ingest_biosignals.py:9: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+_________________________ ERROR collecting tests/narrative_engine/test_ingestion_to_mistral_output.py __________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_ingestion_to_mistral_output.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_ingestion_to_mistral_output.py:10: in <module>
+    from scripts.ingest_biosignals import ingest_file
+scripts/ingest_biosignals.py:9: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+________________________ ERROR collecting tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py _________________________
+ImportError while importing test module '/workspace/ABZU/tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py:6: in <module>
+    from scripts.ingest_biosignals_jsonl import ingest_file
+scripts/ingest_biosignals_jsonl.py:8: in <module>
+    from data.biosignals import DATASET_HASHES, hash_file
+E   ModuleNotFoundError: No module named 'data.biosignals'
+_______________________________________ ERROR collecting tests/razar/test_ai_invoker.py ________________________________________
+import file mismatch:
+imported module 'test_ai_invoker' has this __file__ attribute:
+  /workspace/ABZU/tests/agents/razar/test_ai_invoker.py
+which is not the same as the test file we want to collect:
+  /workspace/ABZU/tests/razar/test_ai_invoker.py
+HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+_____________________________________ ERROR collecting tests/root/test_metrics_logging.py ______________________________________
+tests/root/test_metrics_logging.py:80: in <module>
+    loader.exec_module(start_spiral_os)
+<frozen importlib._bootstrap_external>:999: in exec_module
+    ???
+<frozen importlib._bootstrap>:488: in _call_with_frames_removed
+    ???
+start_spiral_os.py:32: in <module>
+    from rag.orchestrator import MoGEOrchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_________________________________________ ERROR collecting tests/test_auto_retrain.py __________________________________________
+tests/test_auto_retrain.py:25: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_______________________________________ ERROR collecting tests/test_autoretrain_full.py ________________________________________
+tests/test_autoretrain_full.py:21: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_____________________________________ ERROR collecting tests/test_avatar_state_logging.py ______________________________________
+tests/test_avatar_state_logging.py:68: in <module>
+    from rag import orchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_________________________________________ ERROR collecting tests/test_boot_sequence.py _________________________________________
+import file mismatch:
+imported module 'test_boot_sequence' has this __file__ attribute:
+  /workspace/ABZU/tests/agents/razar/test_boot_sequence.py
+which is not the same as the test file we want to collect:
+  /workspace/ABZU/tests/test_boot_sequence.py
+HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+_________________________________________ ERROR collecting tests/test_dashboard_app.py _________________________________________
+tests/test_dashboard_app.py:10: in <module>
+    from streamlit.testing.v1 import AppTest
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/__init__.py:78: in <module>
+    from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/delta_generator.py:75: in <module>
+    from streamlit.elements.plotly_chart import PlotlyMixin
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/elements/plotly_chart.py:59: in <module>
+    configure_streamlit_plotly_theme()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/elements/lib/streamlit_plotly_theme.py:130: in configure_streamlit_plotly_theme
+    textfont=go.icicle.Textfont(color="white")
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/graph_objs/icicle/_textfont.py:568: in __init__
+    self._set_property("color", arg, color)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:4403: in _set_property
+    _set_property_provided_value(self, name, arg, provided)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:398: in _set_property_provided_value
+    obj[name] = val
+    ^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:4932: in __setitem__
+    self._set_prop(prop, value)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:5271: in _set_prop
+    val = validator.validate_coerce(val)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_plotly_utils/basevalidators.py:1343: in validate_coerce
+    v = copy_to_readonly_numpy_array(v)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_plotly_utils/basevalidators.py:130: in copy_to_readonly_numpy_array
+    elif v.dtype.kind in numeric_kinds:
+         ^^^^^^^
+E   AttributeError: 'str' object has no attribute 'dtype'
+______________________________________ ERROR collecting tests/test_dashboard_qnl_mixer.py ______________________________________
+tests/test_dashboard_qnl_mixer.py:10: in <module>
+    from streamlit.testing.v1 import AppTest
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/__init__.py:78: in <module>
+    from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/delta_generator.py:75: in <module>
+    from streamlit.elements.plotly_chart import PlotlyMixin
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/elements/plotly_chart.py:59: in <module>
+    configure_streamlit_plotly_theme()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/streamlit/elements/lib/streamlit_plotly_theme.py:130: in configure_streamlit_plotly_theme
+    textfont=go.icicle.Textfont(color="white")
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/graph_objs/icicle/_textfont.py:568: in __init__
+    self._set_property("color", arg, color)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:4403: in _set_property
+    _set_property_provided_value(self, name, arg, provided)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:398: in _set_property_provided_value
+    obj[name] = val
+    ^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:4932: in __setitem__
+    self._set_prop(prop, value)
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/plotly/basedatatypes.py:5271: in _set_prop
+    val = validator.validate_coerce(val)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_plotly_utils/basevalidators.py:1343: in validate_coerce
+    v = copy_to_readonly_numpy_array(v)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_plotly_utils/basevalidators.py:130: in copy_to_readonly_numpy_array
+    elif v.dtype.kind in numeric_kinds:
+         ^^^^^^^
+E   AttributeError: 'str' object has no attribute 'dtype'
+______________________________________ ERROR collecting tests/test_emotion_classifier.py _______________________________________
+tests/test_emotion_classifier.py:22: in <module>
+    from ml import emotion_classifier as ec
+ml/emotion_classifier.py:11: in <module>
+    from sklearn.ensemble import RandomForestClassifier
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/ensemble/__init__.py:16: in <module>
+    from ._hist_gradient_boosting.gradient_boosting import (
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py:54: in <module>
+    from .grower import TreeGrower
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/ensemble/_hist_gradient_boosting/grower.py:27: in <module>
+    from .splitting import Splitter
+sklearn/ensemble/_hist_gradient_boosting/splitting.pyx:203: in init sklearn.ensemble._hist_gradient_boosting.splitting
+    ???
+E   AttributeError: 'types.SimpleNamespace' object has no attribute 'RandomState'
+________________________________________ ERROR collecting tests/test_initial_listen.py _________________________________________
+tests/test_initial_listen.py:103: in <module>
+    loader.exec_module(start_spiral_os)
+<frozen importlib._bootstrap_external>:999: in exec_module
+    ???
+<frozen importlib._bootstrap>:488: in _call_with_frames_removed
+    ???
+start_spiral_os.py:32: in <module>
+    from rag.orchestrator import MoGEOrchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_______________________________________ ERROR collecting tests/test_interconnectivity.py _______________________________________
+tests/test_interconnectivity.py:22: in <module>
+    from rag import orchestrator
+rag/orchestrator.py:45: in <module>
+    import training_guide
+training_guide.py:20: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+__________________________________________ ERROR collecting tests/test_mix_tracks.py ___________________________________________
+import file mismatch:
+imported module 'test_mix_tracks' has this __file__ attribute:
+  /workspace/ABZU/tests/audio/test_mix_tracks.py
+which is not the same as the test file we want to collect:
+  /workspace/ABZU/tests/test_mix_tracks.py
+HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+____________________________________ ERROR collecting tests/test_openwebui_state_updates.py ____________________________________
+ImportError while importing test module '/workspace/ABZU/tests/test_openwebui_state_updates.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_openwebui_state_updates.py:9: in <module>
+    import tests.test_server as srvtest
+E   ModuleNotFoundError: No module named 'tests.test_server'
+_________________________________________ ERROR collecting tests/test_operator_api.py __________________________________________
+tests/test_operator_api.py:11: in <module>
+    import operator_api
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+________________________________________ ERROR collecting tests/test_operator_audit.py _________________________________________
+tests/test_operator_audit.py:12: in <module>
+    import operator_api
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+____________________________________ ERROR collecting tests/test_operator_command_route.py _____________________________________
+tests/test_operator_command_route.py:10: in <module>
+    import operator_api
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+______________________________________ ERROR collecting tests/test_quarantine_manager.py _______________________________________
+import file mismatch:
+imported module 'test_quarantine_manager' has this __file__ attribute:
+  /workspace/ABZU/tests/agents/razar/test_quarantine_manager.py
+which is not the same as the test file we want to collect:
+  /workspace/ABZU/tests/test_quarantine_manager.py
+HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+______________________________________ ERROR collecting tests/test_retrain_and_deploy.py _______________________________________
+ImportError while importing test module '/workspace/ABZU/tests/test_retrain_and_deploy.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_retrain_and_deploy.py:52: in <module>
+    from INANNA_AI import retrain_and_deploy, train_soul
+INANNA_AI/retrain_and_deploy.py:16: in <module>
+    from .corpus_memory import CHROMA_DIR
+E   ImportError: cannot import name 'CHROMA_DIR' from 'corpus_memory' (unknown location)
+_________________________________________ ERROR collecting tests/test_retrain_model.py _________________________________________
+tests/test_retrain_model.py:8: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_____________________________________ ERROR collecting tests/test_spiral_cortex_memory.py ______________________________________
+tests/test_spiral_cortex_memory.py:45: in <module>
+    import auto_retrain
+auto_retrain.py:44: in <module>
+    NOVELTY_THRESHOLD = feedback_logging.NOVELTY_THRESHOLD
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+_____________________________________ ERROR collecting tests/test_transformers_generate.py _____________________________________
+tests/test_transformers_generate.py:17: in <module>
+    from transformers import AutoTokenizer, GPT2LMHeadModel
+transformers/__init__.py:18: in <module>
+    hf = importlib.import_module("transformers")
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/__init__.py:27: in <module>
+    from . import dependency_versions_check
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/dependency_versions_check.py:16: in <module>
+    from .utils.versions import require_version, require_version_core
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/utils/__init__.py:24: in <module>
+    from .auto_docstring import (
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/utils/auto_docstring.py:30: in <module>
+    from .generic import ModelOutput
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/utils/generic.py:34: in <module>
+    from .import_utils import (
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/transformers/utils/import_utils.py:147: in <module>
+    _cv2_available = importlib.util.find_spec("cv2") is not None
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib.util>:111: in find_spec
+    ???
+E   ValueError: cv2.__spec__ is None
+_________________________________________ ERROR collecting tests/test_vector_memory.py _________________________________________
+import file mismatch:
+imported module 'test_vector_memory' has this __file__ attribute:
+  /workspace/ABZU/tests/memory/test_vector_memory.py
+which is not the same as the test file we want to collect:
+  /workspace/ABZU/tests/test_vector_memory.py
+HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+_______________________________________ ERROR collecting tests/test_voice_cloner_cli.py ________________________________________
+ImportError while importing test module '/workspace/ABZU/tests/test_voice_cloner_cli.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_voice_cloner_cli.py:54: in <module>
+    from src.cli.voice_clone import main as cli_main
+src/cli/__init__.py:14: in <module>
+    from .voice import main as voice_main
+src/cli/voice.py:12: in <module>
+    from core import avatar_expression_engine, load_config
+E   ImportError: cannot import name 'load_config' from 'core' (unknown location)
+_______________________________ ERROR collecting tests/web_console/test_conversation_timeline.py _______________________________
+tests/web_console/test_conversation_timeline.py:11: in <module>
+    import operator_api
+operator_api.py:252: in <module>
+    @router.post("/operator/upload")
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:995: in decorator
+    self.add_api_route(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:934: in add_api_route
+    route = route_class(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/routing.py:555: in __init__
+    self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:285: in get_dependant
+    param_details = analyze_param(
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:482: in analyze_param
+    ensure_multipart_is_installed()
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/fastapi/dependencies/utils.py:115: in ensure_multipart_is_installed
+    raise RuntimeError(multipart_not_installed_error) from None
+E   RuntimeError: Form data requires "python-multipart" to be installed. 
+E   You can install "python-multipart" with: 
+E   
+E   pip install python-multipart
+======================================================= warnings summary =======================================================
+tests/integration/test_context_rl.py:4
+  /workspace/ABZU/tests/integration/test_context_rl.py:4: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    @pytest.mark.integration
+
+tests/test_model.py:14
+  /workspace/ABZU/tests/test_model.py:14: PytestDeprecationWarning: 
+  Module 'transformers' was found, but when imported by pytest it raised:
+      ImportError("cannot import name 'get_full_repo_name' from 'spiral_os._hf_stub' (/workspace/ABZU/src/spiral_os/_hf_stub.py)")
+  In pytest 9.1 this warning will become an error by default.
+  You can fix the underlying problem, or alternatively overwrite this behavior and silence this warning by passing exc_type=ImportError explicitly.
+  See https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror
+    pytest.importorskip("transformers")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=================================================== short test summary info ====================================================
+ERROR tests/agents/razar/test_crown_link.py
+ERROR tests/crown/server/test_server.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+ERROR tests/crown/test_orchestrator_music.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/integration/test_core_regressions.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/monitoring/test_escalation_notifier.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+ERROR tests/narrative_engine/test_biosignal_transformation.py
+ERROR tests/narrative_engine/test_dataset_hashes.py
+ERROR tests/narrative_engine/test_event_storage.py
+ERROR tests/narrative_engine/test_ingest_persist_retrieve.py
+ERROR tests/narrative_engine/test_ingestion_to_mistral_output.py
+ERROR tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py
+ERROR tests/razar/test_ai_invoker.py
+ERROR tests/root/test_metrics_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_auto_retrain.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_autoretrain_full.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_avatar_state_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_boot_sequence.py
+ERROR tests/test_dashboard_app.py - AttributeError: 'str' object has no attribute 'dtype'
+ERROR tests/test_dashboard_qnl_mixer.py - AttributeError: 'str' object has no attribute 'dtype'
+ERROR tests/test_emotion_classifier.py - AttributeError: 'types.SimpleNamespace' object has no attribute 'RandomState'
+ERROR tests/test_initial_listen.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_interconnectivity.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_mix_tracks.py
+ERROR tests/test_openwebui_state_updates.py
+ERROR tests/test_operator_api.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+ERROR tests/test_operator_audit.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+ERROR tests/test_operator_command_route.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+ERROR tests/test_quarantine_manager.py
+ERROR tests/test_retrain_and_deploy.py
+ERROR tests/test_retrain_model.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_spiral_cortex_memory.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+ERROR tests/test_transformers_generate.py - ValueError: cv2.__spec__ is None
+ERROR tests/test_vector_memory.py
+ERROR tests/test_voice_cloner_cli.py
+ERROR tests/web_console/test_conversation_timeline.py - RuntimeError: Form data requires "python-multipart" to be installed. 
+You can install "python-multipart" with: 
+
+pip install python-multipart
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 35 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+========================================= 19 skipped, 2 warnings, 35 errors in 17.87s ==========================================
 

--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -282,7 +282,7 @@ def load_config(path: Path) -> List[Dict[str, Any]]:
         name = comp.get("name", "")
         has_probe = comp.get("health_check") or name in health_checks.CHECKS
         if not has_probe:
-            LOGGER.warning("Component %s lacks a health probe", name)
+            raise ValueError(f"Component {name} lacks a health probe")
     return components
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_dependency_installer.py"),
     str(ROOT / "tests" / "test_bootstrap.py"),
     str(ROOT / "tests" / "test_avatar_lipsync.py"),
+    str(ROOT / "tests" / "test_boot_sequence.py"),
     str(ROOT / "tests" / "test_lip_sync.py"),
     str(ROOT / "tests" / "test_memory_search.py"),
     str(ROOT / "tests" / "test_memory_persistence.py"),

--- a/tests/test_boot_sequence.py
+++ b/tests/test_boot_sequence.py
@@ -1,84 +1,37 @@
 import json
-import sys
-import types
 from pathlib import Path
 
 import pytest
 
-
-class CrownResponse:
-    def __init__(self, acknowledgement="", capabilities=None, downtime=None):
-        self.acknowledgement = acknowledgement
-        self.capabilities = capabilities or []
-        self.downtime = downtime or {}
-
-
-sys.modules["razar.crown_handshake"] = types.SimpleNamespace(
-    perform=lambda path: CrownResponse(),
-    CrownResponse=CrownResponse,
-)
-sys.modules["razar.ai_invoker"] = types.SimpleNamespace(
-    handover=lambda name, msg: False
-)
-sys.modules["razar.doc_sync"] = types.SimpleNamespace(sync_docs=lambda: None)
-sys.modules["razar.mission_logger"] = types.SimpleNamespace(
-    log_event=lambda *args: None
-)
-sys.modules["razar.health_checks"] = types.SimpleNamespace(
-    run=lambda name: True, CHECKS={}
-)
-sys.modules["razar.quarantine_manager"] = types.SimpleNamespace(
-    is_quarantined=lambda name: False,
-    quarantine_component=lambda comp, reason: None,
-)
-sys.modules["agents.nazarick.service_launcher"] = types.SimpleNamespace(
-    launch_required_agents=lambda: None
-)
-
-import tests.conftest as conftest_module
-
-conftest_module.ALLOWED_TESTS.add(str(Path(__file__).resolve()))
-
 from razar import boot_orchestrator
+from razar.bootstrap_utils import STATE_FILE
 
 
-def _setup_logs(monkeypatch, tmp_path: Path) -> Path:
-    log_dir = tmp_path / "logs"
-    monkeypatch.setattr(boot_orchestrator, "LOGS_DIR", log_dir)
-    monkeypatch.setattr(boot_orchestrator, "STATE_FILE", log_dir / "razar_state.json")
-    monkeypatch.setattr(
-        boot_orchestrator, "HISTORY_FILE", log_dir / "razar_boot_history.json"
-    )
-    return log_dir
+def _clear_state():
+    if STATE_FILE.exists():
+        STATE_FILE.unlink()
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 
-def test_boot_sequence_success(monkeypatch, tmp_path):
-    log_dir = _setup_logs(monkeypatch, tmp_path)
-    config = tmp_path / "boot.json"
-    comp = {
-        "name": "good_service",
-        "command": ["python", "-c", "import time; time.sleep(0.1)"],
-        "health_check": ["python", "-c", "import sys; sys.exit(0)"],
-    }
-    config.write_text(json.dumps({"components": [comp]}))
-    components = boot_orchestrator.load_config(config)
-    proc = boot_orchestrator.launch_component(components[0])
-    proc.wait()
-    state = json.loads((log_dir / "razar_state.json").read_text())
-    assert state["probes"]["good_service"]["status"] == "ok"
+def test_boot_sequence_success():
+    _clear_state()
+    components = boot_orchestrator.load_config(Path("razar/boot_config.json"))
+    procs = [boot_orchestrator.launch_component(c) for c in components]
+    for proc in procs:
+        proc.wait()
+    data = json.loads(STATE_FILE.read_text())
+    assert data["probes"]["basic_service"]["status"] == "ok"
+    assert data["probes"]["complex_service"]["status"] == "ok"
 
 
-def test_boot_sequence_failure(monkeypatch, tmp_path):
-    log_dir = _setup_logs(monkeypatch, tmp_path)
-    config = tmp_path / "boot.json"
-    comp = {
+def test_boot_sequence_failure():
+    _clear_state()
+    bad = {
         "name": "bad_service",
-        "command": ["python", "-c", "import time; time.sleep(1)"],
+        "command": ["python", "-c", "print('bad service')"],
         "health_check": ["python", "-c", "import sys; sys.exit(1)"],
     }
-    config.write_text(json.dumps({"components": [comp]}))
-    components = boot_orchestrator.load_config(config)
     with pytest.raises(RuntimeError):
-        boot_orchestrator.launch_component(components[0])
-    state = json.loads((log_dir / "razar_state.json").read_text())
-    assert state["probes"]["bad_service"]["status"] == "fail"
+        boot_orchestrator.launch_component(bad)
+    data = json.loads(STATE_FILE.read_text())
+    assert data["probes"]["bad_service"]["status"] == "fail"


### PR DESCRIPTION
## Summary
- require explicit health probes for each boot component
- test boot sequence success and failure scenarios
- document probe failures in RAZAR agent guide

## Testing
- `PYTHONPATH=$PWD pre-commit run --files CHANGELOG.md CHANGELOG_razar.md docs/RAZAR_AGENT.md razar/boot_orchestrator.py tests/test_boot_sequence.py tests/conftest.py` *(fails: failed to query http://localhost:9101/metrics: <urlopen error [Errno 111] Connection refused>, failed to query http://localhost:8080/metrics: <urlopen error [Errno 111] Connection refused>, failed to query http://localhost:9400/metrics: <urlopen error [Errno 111] Connection refused>, missing metrics from exporter http://localhost:9101/metrics, missing metrics from exporter http://localhost:8080/metrics, missing metrics from exporter http://localhost:9400/metrics, no successful self-heal cycles in last 24h)*
- `pytest -o addopts='' tests/test_boot_sequence.py`

------
https://chatgpt.com/codex/tasks/task_e_68bab4e231e4832e9774e8e3064624aa