### PR TITLE
Refactor memory event broadcast and query aggregator

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -315,7 +315,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | This guide describes the event bus protocol connecting the Cortex, Emotional, Mental, Spiritual, and Narrative memory... | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | This guide describes the event bus protocol and query flow connecting the Cortex, Emotional, Mental, Spiritual, and N... | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,7 +1,7 @@
 # Memory Layers Guide
 
-This guide describes the event bus protocol connecting the Cortex, Emotional,
-Mental, Spiritual, and Narrative memory layers.
+This guide describes the event bus protocol and query flow connecting the
+Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
 
 ## Bus protocol
 
@@ -9,6 +9,9 @@ The layers communicate via the `agents.event_bus` channel named `memory`.
 Initialization broadcasts use the `layer_init` event type.
 
 ### Broadcasting layer initialization
+
+`broadcast_layer_event` now emits **one** event containing a mapping for all
+layers, allowing subscribers to process initialization in a single step.
 
 ```python
 from memory import broadcast_layer_event
@@ -22,20 +25,27 @@ broadcast_layer_event({
 })
 ```
 
-Each emitted event carries a payload:
+The payload contains a `layers` object:
 
 ```json
-{"layer": "<layer_name>", "status": "<status>"}
+{"layers": {"cortex": "seeded", "emotional": "seeded", ...}}
 ```
 
-Subscribers listen on the `memory` channel to react when individual layers
-initialize or change state.
+## Query aggregation
+
+Use `memory.query_memory.query_memory` to retrieve results across cortex,
+vector, and spiral stores:
+
+```python
+from memory import query_memory
+
+records = query_memory("omen")
+```
 
 ## Search API
 
-Use `memory.search_api.aggregate_search` to query across these layers. Results
-are ranked by exponential recency decay and can be weighted per source through
-`source_weights`.
+`memory.search_api.aggregate_search` combines ranked signals from the layers.
+Results are weighted by exponential recency decay and optional `source_weights`.
 
 ```python
 from memory.search_api import aggregate_search

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -3,12 +3,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 from agents.event_bus import emit_event
-from memory.cortex import query_spirals
-from spiral_memory import spiral_recall
-from vector_memory import query_vectors
+from .query_memory import query_memory
 
 __version__ = "0.1.3"
 
@@ -16,28 +14,17 @@ LAYERS = ("cortex", "emotional", "mental", "spiritual", "narrative")
 
 
 def broadcast_layer_event(statuses: Dict[str, str]) -> None:
-    """Emit initialization ``statuses`` for all memory layers via the event bus.
+    """Emit a single initialization event for all memory layers.
 
-    ``statuses`` maps layer names to their corresponding status strings.
-    Layers missing from the mapping default to ``"unknown"``.
+    ``statuses`` maps layer names to their corresponding status strings. Layers
+    missing from the mapping default to ``"unknown"``.
     """
 
-    for layer in LAYERS:
-        emit_event(
-            "memory",
-            "layer_init",
-            {"layer": layer, "status": statuses.get(layer, "unknown")},
-        )
-
-
-def query_memory(query: str) -> Dict[str, Any]:
-    """Return aggregated results across cortex, vector, and spiral memory."""
-
-    return {
-        "cortex": query_spirals(text=query),
-        "vector": query_vectors(filter={"text": query}),
-        "spiral": spiral_recall(query),
-    }
+    emit_event(
+        "memory",
+        "layer_init",
+        {"layers": {layer: statuses.get(layer, "unknown") for layer in LAYERS}},
+    )
 
 
 __all__ = ["broadcast_layer_event", "query_memory", "LAYERS"]

--- a/memory/query_memory.py
+++ b/memory/query_memory.py
@@ -1,0 +1,22 @@
+"""Aggregated memory queries across cortex, vector, and spiral stores."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .cortex import query_spirals
+from spiral_memory import spiral_recall
+from vector_memory import query_vectors
+
+
+def query_memory(query: str) -> Dict[str, Any]:
+    """Return aggregated results across cortex, vector, and spiral memory."""
+
+    return {
+        "cortex": query_spirals(text=query),
+        "vector": query_vectors(filter={"text": query}),
+        "spiral": spiral_recall(query),
+    }
+
+
+__all__ = ["query_memory"]


### PR DESCRIPTION
## Summary
- emit memory layer statuses as a single event for all layers
- add `query_memory` module aggregating cortex, vector, and spiral stores
- document memory flow and adjust tests for unified broadcast

## Testing
- `PYTHONPATH=. SKIP=verify-chakra-monitoring,verify-self-healing,pytest-cov,capture-failing-tests pre-commit run --files memory/__init__.py memory/query_memory.py tests/test_memory_bus.py docs/memory_layers_GUIDE.md docs/index.md docs/INDEX.md`
- `PYTHONPATH=. pytest tests/test_memory_bus.py::test_broadcast_layer_event_emits tests/test_memory_bus.py::test_query_memory_aggregates -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68bab4d74044832eb50c0fcc02663771