### PR TITLE
test: compare narrative tracks to golden data

### DIFF
--- a/tests/data/bana/audio.json
+++ b/tests/data/bana/audio.json
@@ -1,0 +1,9 @@
+[
+  {
+    "cue": "hero_smiles"
+  },
+  {
+    "cue": "villain_frowns"
+  }
+]
+

--- a/tests/data/bana/prose.json
+++ b/tests/data/bana/prose.json
@@ -1,0 +1,2 @@
+"hero smiles. villain frowns."
+

--- a/tests/data/bana/usd.json
+++ b/tests/data/bana/usd.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "AddPrim",
+    "path": "/hero",
+    "action": "smiles"
+  },
+  {
+    "op": "AddPrim",
+    "path": "/villain",
+    "action": "frowns"
+  }
+]
+

--- a/tests/data/bana/visual.json
+++ b/tests/data/bana/visual.json
@@ -1,0 +1,9 @@
+[
+  {
+    "directive": "frame hero smiles"
+  },
+  {
+    "directive": "frame villain frowns"
+  }
+]
+

--- a/tests/test_bana_narrative_engine.py
+++ b/tests/test_bana_narrative_engine.py
@@ -7,7 +7,7 @@ import json
 from memory.narrative_engine import StoryEvent, compose_multitrack_story
 
 
-def test_multitrack_track_schemas():
+def test_multitrack_track_schemas() -> None:
     """Biosignal events yield full multitrack story output with valid schemas."""
     csv_path = Path("data/biosignals/sample_biosignals.csv")
     events = []
@@ -43,14 +43,15 @@ def test_multitrack_track_schemas():
     )
 
 
-def test_multitrack_story_golden_file():
+def test_multitrack_story_golden_file() -> None:
     """`compose_multitrack_story` output matches the recorded sample."""
     events = [
         StoryEvent(actor="hero", action="smiles"),
         StoryEvent(actor="villain", action="frowns"),
     ]
     result = compose_multitrack_story(events)
-    expected_path = Path("tests/data/bana/multitrack_story.json")
-    with expected_path.open(encoding="utf-8") as f:
-        expected = json.load(f)
-    assert result == expected
+    data_dir = Path("tests/data/bana")
+    for track in ("prose", "audio", "visual", "usd"):
+        with (data_dir / f"{track}.json").open(encoding="utf-8") as f:
+            expected = json.load(f)
+        assert result[track] == expected, f"{track} track mismatch"


### PR DESCRIPTION
## Summary
- test Bana narrative engine `compose_multitrack_story` against per-track golden data
- add individual golden JSON files for prose, audio, visual, and USD tracks

## Testing
- `pytest tests/test_bana_narrative_engine.py::test_multitrack_story_golden_file -q --no-cov`
- `SKIP=confirm-reading,check-env,capture-failing-tests,pytest-cov pre-commit run --files tests/test_bana_narrative_engine.py tests/data/bana/*.json`

------
https://chatgpt.com/codex/tasks/task_e_68babbe1e20c832ea7c160aaf8b5ee41