### PR TITLE
Handle missing layers in aggregate search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the copresence dashboard and added tests for metrics endpoints.
 
 - Introduced chakra healing scripts and monitoring agents with logging and documentation.
+- Gracefully handle missing memory layers in `aggregate_search` with tests and documentation.
 
 - Emitted structured health events during RAZAR boot and introduced recovery daemon for automated restarts.
 - Added `/operator/status` endpoint reporting component health, recent errors, and memory usage; bumped `operator_api` to 0.3.5.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -53,4 +53,10 @@ from memory.search_api import aggregate_search
 results = aggregate_search("omen", source_weights={"spiritual": 2.0})
 ```
 
+## Handling missing layers
+
+Each memory layer is optional. `aggregate_search` guards against failures by
+skipping any layer that raises during lookup and logging an error. Queries will
+still return results from the remaining layers.
+
 


### PR DESCRIPTION
## Summary
- handle missing layer failures in `aggregate_search`
- test aggregate search resilience when individual layers fail
- document how missing layers are skipped and logged

## Testing
- `pytest tests/test_memory_bus.py::test_aggregate_search_handles_missing_layers -vv --no-cov` *(skipped: requires unavailable resources)*
- `SKIP=capture-failing-tests,pytest-cov pre-commit run --files memory/search_api.py tests/test_memory_bus.py docs/memory_layers_GUIDE.md CHANGELOG.md docs/INDEX.md` *(failed: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*

------
https://chatgpt.com/codex/tasks/task_e_68baddf8601c832ea1ff926480646ff5