### PR TITLE
Add world bootstrap script and quickstart guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Introduced `bootstrap_world.py` and a setup quickstart for minimal world configuration.
 - Enforced explicit health probes for RAZAR boot components and added boot
   sequence tests.
 - Documented operator-first principle and contributor guidance across core docs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -306,7 +305,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ignition_flow.md](ignition_flow.md) | Ignition Flow | This guide traces the activation sequence from **RAZAR** through to the final **operator interface**, linking each st... | `../INANNA_AI_AGENT/inanna_ai.py`, `../agents/bana/bio_adaptive_narrator.py`, `../crown_router.py`, `../operator_api.py`, `../razar/boot_orchestrator.py`, `../scripts/validate_ignition.py` |
 | [ignition_map.md](ignition_map.md) | Ignition Map | Summary of components grouped by ignition stage. See [Ignition](Ignition.md) for boot priorities and [component_index... | - |
 | [ignition_sequence_protocol.md](ignition_sequence_protocol.md) | Ignition Sequence Protocol | Defines the required logging checkpoints and escalation flow during the system boot sequence. | - |
-| [index.md](index.md) | Documentation Index | Curated starting points for understanding and operating the project. For an exhaustive, auto-generated inventory of a... | - |
+| [index.md](index.md) | Documentation Index | Curated starting points for understanding and operating the project. For an exhaustive, auto-generated inventory of a... | `../scripts/bootstrap_world.py` |
 | [insight_system.md](insight_system.md) | Insight System | The insight system aggregates interaction logs into structured matrices used by reflection and adaptive learning comp... | - |
 | [installation.md](installation.md) | Installation | Set up the project either with Conda or Docker. Both methods run the bootstrap script, which verifies the Python vers... | - |
 | [ip_registry.md](ip_registry.md) | IP Registry | The following modules are tagged with `@ip-sensitive` and require tracking in this registry. | - |
@@ -371,6 +370,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [setup.md](setup.md) | Environment Setup | This guide lists the system packages and environment variables required to run the project. | - |
 | [setup_full.md](setup_full.md) | Full Setup | The full installation enables all Spiral OS features. | - |
 | [setup_minimal.md](setup_minimal.md) | Minimal Setup | The minimal installation provides only the core Spiral OS utilities. | - |
+| [setup_quickstart.md](setup_quickstart.md) | Setup Quickstart | Spin up a minimal world configuration using file-backed memory layers. | - |
 | [sonic_core_harmonics.md](sonic_core_harmonics.md) | Sonic Core Harmonics | The Sonic Core layers audio synthesis and expression modules on top of Spiral OS. It transforms QNL phrases into audi... | - |
 | [spiral_cortex_terminal.md](spiral_cortex_terminal.md) | Spiral Cortex Terminal | `spiral_cortex_terminal.py` provides a small command line interface for exploring `data/cortex_memory_spiral.jsonl`.... | - |
 | [spiritual_architecture.md](spiritual_architecture.md) | Spiritual Architecture | Spiral OS organizes its components into seven chakra layers, mirroring the energetic centers of the body. Each layer... | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,10 @@ Curated starting points for understanding and operating the project. For an exha
 ## Setup
 - [Setup Guide](setup.md)
 - [Environment Setup](environment_setup.md)
+- [Quickstart Setup](setup_quickstart.md) – minimal world configuration
 ## Usage
 - [How to Use](how_to_use.md)
+- [Bootstrap World Script](../scripts/bootstrap_world.py) – populate mandatory layers with defaults
 
 ## Data
 - [Data Manifest](data_manifest.md)

--- a/docs/setup_quickstart.md
+++ b/docs/setup_quickstart.md
@@ -1,0 +1,20 @@
+# Setup Quickstart
+
+Spin up a minimal world configuration using file-backed memory layers.
+
+## Minimal World
+
+1. Install the core dependencies:
+   ```bash
+   pip install -e .[minimal]
+   ```
+2. Populate mandatory layers with default records:
+   ```bash
+   python scripts/bootstrap_world.py
+   ```
+   The script reports progress as each layer is initialized.
+
+## Next Steps
+
+- Inspect generated data under `data/` to review the seeded layers.
+- Run `scripts/list_layers.py` to verify active memory layers.

--- a/scripts/bootstrap_world.py
+++ b/scripts/bootstrap_world.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Populate mandatory memory layers with default records."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from memory.cortex import record_spiral
+from memory.emotional import log_emotion, get_connection as emotion_conn
+from memory.spiritual import map_to_symbol, get_connection as spirit_conn
+from memory.narrative_engine import log_story
+
+__version__ = "0.1.0"
+
+
+def main() -> None:
+    """Bootstrap core layers using file-backed stores and report progress."""
+    root = Path(__file__).resolve().parents[1]
+    data = root / "data"
+    data.mkdir(parents=True, exist_ok=True)
+
+    os.environ.setdefault("CORTEX_BACKEND", "file")
+    os.environ.setdefault("CORTEX_PATH", str(data / "cortex_memory_spiral.jsonl"))
+    os.environ.setdefault("EMOTION_BACKEND", "file")
+    os.environ.setdefault("EMOTION_DB_PATH", str(data / "emotions.db"))
+    os.environ.setdefault("SPIRIT_BACKEND", "file")
+    os.environ.setdefault("SPIRITUAL_DB_PATH", str(data / "ontology.db"))
+    os.environ.setdefault("NARRATIVE_BACKEND", "file")
+    os.environ.setdefault("NARRATIVE_LOG_PATH", str(data / "story.log"))
+
+    class Node:
+        children = []
+
+    print("Bootstrapping world layers...")
+
+    record_spiral(Node(), {"result": "init"})
+    print("- Cortex layer initialized")
+
+    log_emotion([0.0], conn=emotion_conn())
+    print("- Emotional layer initialized")
+
+    map_to_symbol(("origin", "O"), conn=spirit_conn())
+    print("- Spiritual layer initialized")
+
+    log_story("world initialized")
+    print("- Narrative layer initialized")
+
+    print("World bootstrap complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `bootstrap_world.py` to seed mandatory memory layers with defaults
- document minimal world setup in `setup_quickstart.md`
- link quickstart and script examples from documentation index and update changelog

## Testing
- `pre-commit run --files docs/setup_quickstart.md docs/index.md scripts/bootstrap_world.py CHANGELOG.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python scripts/bootstrap_world.py` *(fails: ModuleNotFoundError: No module named 'memory')*

------
https://chatgpt.com/codex/tasks/task_e_68bae2112a38832e90ed5dddc3515781