### PR TITLE
Add world config registry and integrate event bus and memory

### DIFF
--- a/agents/event_bus.py
+++ b/agents/event_bus.py
@@ -21,6 +21,7 @@ from citadel.event_producer import (
     RedisEventProducer,
     KafkaEventProducer,
 )
+from worlds.config_registry import register_broker
 
 _producer: Optional[EventProducer] = None
 
@@ -48,9 +49,11 @@ def _get_producer() -> Optional[EventProducer]:
     if channel:
         url = os.getenv("CITADEL_REDIS_URL", "redis://localhost")
         _producer = RedisEventProducer(channel=channel, url=url)
+        register_broker("redis", {"channel": channel, "url": url})
     elif topic:
         servers = os.getenv("CITADEL_KAFKA_SERVERS", "localhost:9092")
         _producer = KafkaEventProducer(topic=topic, bootstrap_servers=servers)
+        register_broker("kafka", {"topic": topic, "servers": servers})
     return _producer
 
 

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 from typing import Dict
 
 from agents.event_bus import emit_event
+from worlds.config_registry import register_layer
 from .query_memory import query_memory
 
 __version__ = "0.1.3"
 
 LAYERS = ("cortex", "emotional", "mental", "spiritual", "narrative")
+
+for _layer in LAYERS:
+    register_layer(_layer)
 
 
 def broadcast_layer_event(statuses: Dict[str, str]) -> None:

--- a/memory/cortex.py
+++ b/memory/cortex.py
@@ -22,6 +22,8 @@ from pathlib import Path
 from threading import Condition, Lock
 from typing import Any, Dict, Iterable, List, Protocol, Optional, Sequence, Set
 
+from worlds.config_registry import register_path
+
 from aspect_processor import analyze_phonetic, analyze_semantic, analyze_temporal
 
 import hashlib
@@ -50,6 +52,9 @@ CORTEX_MEMORY_FILE = Path("data/cortex_memory_spiral.jsonl")
 # Inverted index mapping semantic tags to entry identifiers.
 CORTEX_INDEX_FILE = Path("data/cortex_memory_index.json")
 PATCH_LINKS_FILE = Path("data/patch_links.jsonl")
+
+register_path("cortex_memory", str(CORTEX_MEMORY_FILE))
+register_path("cortex_index", str(CORTEX_INDEX_FILE))
 
 
 class _RWLock:

--- a/memory/emotional.py
+++ b/memory/emotional.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Sequence
 
+from worlds.config_registry import register_path
+
 from aspect_processor import analyze_emotional
 
 try:  # Optional dependency
@@ -75,6 +77,7 @@ def get_connection(db_path: Path | str | None = None) -> sqlite3.Connection:
 
     path = Path(db_path or os.getenv(DB_ENV_VAR, DB_PATH))
     path.parent.mkdir(parents=True, exist_ok=True)
+    register_path("emotional", str(path))
     conn = sqlite3.connect(path)
     _ensure_schema(conn)
     return conn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,6 +291,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "chakra_healing" / "test_crown.py"),
     str(ROOT / "tests" / "test_metrics_endpoints.py"),
     str(ROOT / "tests" / "narrative" / "test_self_heal_logging.py"),
+    str(ROOT / "tests" / "test_config_registry.py"),
 }
 
 

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,0 +1,38 @@
+import importlib
+
+from worlds.config_registry import export_config, import_config, reset_registry
+
+
+def test_registration_and_roundtrip(tmp_path, monkeypatch):
+    # start with a clean registry
+    reset_registry()
+
+    # Reload memory to trigger layer registration
+    import memory
+
+    importlib.reload(memory)
+
+    # Register a path via emotional layer initialiser
+    from memory.emotional import get_connection
+
+    emo_path = tmp_path / "emotions.db"
+    get_connection(emo_path)
+
+    # Register a broker via event bus
+    import agents.event_bus as eb
+
+    eb.set_event_producer(None)
+    monkeypatch.setenv("CITADEL_REDIS_CHANNEL", "chan")
+    monkeypatch.setenv("CITADEL_REDIS_URL", "redis://localhost")
+    eb._get_producer()
+
+    cfg = export_config()
+
+    assert set(cfg["layers"]) == set(memory.LAYERS)
+    assert cfg["paths"]["emotional"] == str(emo_path)
+    assert cfg["brokers"]["redis"]["channel"] == "chan"
+
+    # verify round-trip
+    reset_registry()
+    import_config(cfg)
+    assert export_config() == cfg

--- a/worlds/config_registry.py
+++ b/worlds/config_registry.py
@@ -1,0 +1,79 @@
+"""Central registry for per-world configuration metadata."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import Any, Dict, DefaultDict
+
+# Internal structure:
+# {_world: {"layers": set(), "brokers": {}, "paths": {}}}
+_registry: DefaultDict[str, Dict[str, Any]] = defaultdict(
+    lambda: {"layers": set(), "brokers": {}, "paths": {}}
+)
+
+
+def _world_name(world: str | None = None) -> str:
+    """Return normalised world name.
+
+    When ``world`` is ``None`` the ``WORLD_NAME`` environment variable is used
+    falling back to ``"default"``.
+    """
+
+    return world or os.getenv("WORLD_NAME", "default")
+
+
+def register_layer(layer: str, world: str | None = None) -> None:
+    """Record availability of ``layer`` for ``world``."""
+
+    _registry[_world_name(world)]["layers"].add(layer)
+
+
+def register_broker(
+    broker: str, config: Dict[str, Any], world: str | None = None
+) -> None:
+    """Record ``broker`` configuration for ``world``."""
+
+    _registry[_world_name(world)]["brokers"][broker] = config
+
+
+def register_path(name: str, path: str, world: str | None = None) -> None:
+    """Record filesystem ``path`` identified by ``name`` for ``world``."""
+
+    _registry[_world_name(world)]["paths"][name] = path
+
+
+def export_config(world: str | None = None) -> Dict[str, Any]:
+    """Return a JSON-serialisable mapping for ``world``."""
+
+    data = _registry[_world_name(world)]
+    return {
+        "layers": sorted(data["layers"]),
+        "brokers": dict(data["brokers"]),
+        "paths": dict(data["paths"]),
+    }
+
+
+def import_config(config: Dict[str, Any], world: str | None = None) -> None:
+    """Merge ``config`` into the registry for ``world``."""
+
+    data = _registry[_world_name(world)]
+    data["layers"].update(config.get("layers", []))
+    data["brokers"].update(config.get("brokers", {}))
+    data["paths"].update(config.get("paths", {}))
+
+
+def reset_registry() -> None:
+    """Clear all stored world configuration (primarily for tests)."""
+
+    _registry.clear()
+
+
+__all__ = [
+    "register_layer",
+    "register_broker",
+    "register_path",
+    "export_config",
+    "import_config",
+    "reset_registry",
+]


### PR DESCRIPTION
## Summary
- add `worlds.config_registry` to track per-world layers, brokers, and paths
- register event bus producers and memory initializers with the registry
- test registration and configuration round-trip

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files agents/event_bus.py memory/__init__.py memory/cortex.py memory/emotional.py worlds/config_registry.py worlds/__init__.py tests/test_config_registry.py tests/conftest.py`
- `pytest --no-cov tests/test_config_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae39cde64832e981dd99df79cec24