### PR TITLE
feat(memory): add bundle facade

### DIFF
--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -31,6 +31,26 @@ The payload contains a `layers` object:
 {"layers": {"cortex": "seeded", "emotional": "seeded", ...}}
 ```
 
+## Bundle Initialization
+
+`MemoryBundle` wraps the layer modules behind a single interface and reports
+their startup state in one event.
+
+```python
+from memory.bundle import MemoryBundle
+
+bundle = MemoryBundle()
+statuses = bundle.initialize()
+records = bundle.query("omen")
+```
+
+`initialize()` imports each layer and immediately calls
+`broadcast_layer_event()` with the resulting status mapping. When the optional
+mental layer or its dependencies are missing, the bundle substitutes the
+no-op implementation from `memory.optional.mental` and marks the status as
+`defaulted`. Any other import error is reported as `error`, but initialization
+continues and emits a consolidated result.
+
 ## Query aggregation
 
 Use `memory.query_memory.query_memory` to retrieve results across cortex,

--- a/memory/bundle.py
+++ b/memory/bundle.py
@@ -1,0 +1,78 @@
+"""Facade for coordinated memory layer initialization and querying."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from . import broadcast_layer_event, query_memory
+
+
+@dataclass
+class MemoryBundle:
+    """Bundle that instantiates memory layers and aggregates queries."""
+
+    cortex: Any | None = None
+    emotional: Any | None = None
+    mental: Any | None = None
+    spiritual: Any | None = None
+    narrative: Any | None = None
+    statuses: Dict[str, str] = field(default_factory=dict)
+
+    def initialize(self) -> Dict[str, str]:
+        """Instantiate memory layers and emit a consolidated status event."""
+        statuses: Dict[str, str] = {}
+
+        try:
+            from . import cortex as cortex_layer
+
+            self.cortex = cortex_layer
+            statuses["cortex"] = "ready"
+        except Exception:  # pragma: no cover - import failure logged elsewhere
+            statuses["cortex"] = "error"
+
+        try:
+            from . import emotional as emotional_layer
+
+            self.emotional = emotional_layer
+            statuses["emotional"] = "ready"
+        except Exception:  # pragma: no cover
+            statuses["emotional"] = "error"
+
+        try:
+            from . import mental as mental_layer
+
+            self.mental = mental_layer
+            statuses["mental"] = "ready"
+        except Exception:  # mental layer optional
+            from .optional import mental as mental_layer
+
+            self.mental = mental_layer
+            statuses["mental"] = "defaulted"
+
+        try:
+            from . import spiritual as spiritual_layer
+
+            self.spiritual = spiritual_layer
+            statuses["spiritual"] = "ready"
+        except Exception:  # pragma: no cover
+            statuses["spiritual"] = "error"
+
+        try:
+            from . import narrative_engine as narrative_layer
+
+            self.narrative = narrative_layer
+            statuses["narrative"] = "ready"
+        except Exception:  # pragma: no cover
+            statuses["narrative"] = "error"
+
+        broadcast_layer_event(statuses)
+        self.statuses = statuses
+        return statuses
+
+    def query(self, text: str) -> Dict[str, Any]:
+        """Delegate to :func:`query_memory` to aggregate layer results."""
+        return query_memory(text)
+
+
+__all__ = ["MemoryBundle"]


### PR DESCRIPTION
## Summary
- add `MemoryBundle` to coordinate layer initialization and querying
- document bundle usage and failure modes in memory layers guide

## Testing
- `pre-commit run --files memory/bundle.py docs/memory_layers_GUIDE.md` *(fails: verify-versions, pytest-cov, verify-chakra-monitoring, verify-self-healing)*
- `pytest tests/test_memory_bus.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68baf329302c832e9ed71be3b790d1eb