### PR TITLE
docs: add unified memory bundle diagram

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -227,7 +227,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.91 **Last updated:** 2025-09-05 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.92 **Last updated:** 2025-09-05 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,6 +1,6 @@
 # The Absolute Protocol
 
-**Version:** v1.0.91
+**Version:** v1.0.92
 **Last updated:** 2025-09-05
 
 ## How to Use This Protocol
@@ -31,6 +31,16 @@ ABZU adheres to a consistent top-level directory layout:
 Consult the [Code Index](code_index.md) for an overview of modules, classes, and functions within the repository.
 
 See [docs/REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) for detailed guidance on the repository layout.
+
+### Unified Memory Bundle
+
+The repository's memory layers are orchestrated through a unified `MemoryBundle`. During startup, `bundle.initialize()` emits a single `layer_init` event on the `memory` bus, reporting the status of the Cortex, Emotional, Mental, Spiritual, and Narrative layers in one payload.
+
+```mermaid
+{{#include figures/memory_bundle.mmd}}
+```
+
+The Mermaid source lives at [figures/memory_bundle.mmd](figures/memory_bundle.mmd). See [memory_layers_GUIDE.md](memory_layers_GUIDE.md) for implementation details. Any change to a memory layer must update this diagram and all related visuals across the repository to keep documentation synchronized.
 
 ## Repository Layout Protocol
 Repositories must keep these directories at the root:

--- a/docs/figures/memory_bundle.mmd
+++ b/docs/figures/memory_bundle.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+    bundle[MemoryBundle] --> cortex[Cortex]
+    bundle --> emotional[Emotional]
+    bundle --> mental[Mental]
+    bundle --> spiritual[Spiritual]
+    bundle --> narrative[Narrative]

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -3,6 +3,8 @@
 This guide describes the event bus protocol and query flow connecting the
 Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
 
+Refer to the [Unified Memory Bundle](The_Absolute_Protocol.md#unified-memory-bundle) section of the protocol for repository-wide conventions. Any update to memory layers must be mirrored across all referenced diagrams, including [figures/memory_bundle.mmd](figures/memory_bundle.mmd).
+
 ## Bus protocol
 
 The layers communicate via the `agents.event_bus` channel named `memory`.


### PR DESCRIPTION
## Summary
- document unified MemoryBundle initialization and event in The_Absolute_Protocol
- cross-link memory_layers_GUIDE and add Mermaid memory bundle diagram
- note that memory-layer changes require updating all related diagrams

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/memory_layers_GUIDE.md docs/figures/memory_bundle.mmd docs/INDEX.md` *(failed: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d421ab0832e9500fe96f590b9a1