### PR TITLE
docs: add memory layer broadcast and query diagrams

### DIFF
--- a/docs/figures/layer_init_broadcast.mmd
+++ b/docs/figures/layer_init_broadcast.mmd
@@ -1,0 +1,8 @@
+graph TD
+    MB[MemoryBundle.initialize] --> EB[(EventBus: memory)]
+    EB --> Cortex[Cortex]
+    EB --> Emotional[Emotional]
+    EB --> Mental[Mental]
+    EB --> Spiritual[Spiritual]
+    EB --> Narrative[Narrative]
+

--- a/docs/figures/query_memory_aggregation.mmd
+++ b/docs/figures/query_memory_aggregation.mmd
@@ -1,0 +1,12 @@
+graph TD
+    Caller[Caller] --> MB[MemoryBundle.query]
+    MB --> QM[query_memory]
+    QM --> Cortex[Cortex store]
+    QM --> Vector[Vector store]
+    QM --> Spiral[Spiral store]
+    Cortex --> QM
+    Vector --> QM
+    Spiral --> QM
+    QM --> MB
+    MB --> Caller
+

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -12,26 +12,29 @@ Initialization broadcasts use the `layer_init` event type.
 
 ### Broadcasting layer initialization
 
-`broadcast_layer_event` now emits **one** event containing a mapping for all
-layers, allowing subscribers to process initialization in a single step.
+`MemoryBundle.initialize` wraps `broadcast_layer_event` and emits **one**
+`layer_init` mapping for all layers, allowing subscribers to process
+initialization in a single step:
 
 ```python
-from memory import broadcast_layer_event
+from memory.bundle import MemoryBundle
 
-broadcast_layer_event({
-    "cortex": "seeded",
-    "emotional": "seeded",
-    "mental": "skipped",
-    "spiritual": "seeded",
-    "narrative": "seeded",
-})
+bundle = MemoryBundle()
+statuses = bundle.initialize()
 ```
 
-The payload contains a `layers` object:
+The event payload contains a `layers` object:
 
 ```json
 {"layers": {"cortex": "seeded", "emotional": "seeded", ...}}
 ```
+
+```mermaid
+{{#include figures/layer_init_broadcast.mmd}}
+```
+
+The Mermaid source lives at
+[figures/layer_init_broadcast.mmd](figures/layer_init_broadcast.mmd).
 
 ## Bundle Initialization
 
@@ -55,14 +58,23 @@ continues and emits a consolidated result.
 
 ## Query aggregation
 
-Use `memory.query_memory.query_memory` to retrieve results across cortex,
-vector, and spiral stores:
+Use `MemoryBundle.query` to retrieve results across cortex, vector, and spiral
+stores:
 
 ```python
-from memory import query_memory
+from memory.bundle import MemoryBundle
 
-records = query_memory("omen")
+bundle = MemoryBundle()
+bundle.initialize()
+records = bundle.query("omen")
 ```
+
+```mermaid
+{{#include figures/query_memory_aggregation.mmd}}
+```
+
+The Mermaid source lives at
+[figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd).
 
 ## Search API
 


### PR DESCRIPTION
## Summary
- add Mermaid diagrams illustrating `layer_init` broadcasts and `query_memory` aggregation
- update memory layer examples to use `MemoryBundle`
- link guide sections to blueprint files

## Testing
- `pre-commit run --files docs/memory_layers_GUIDE.md docs/figures/layer_init_broadcast.mmd docs/figures/query_memory_aggregation.mmd docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles; coverage below threshold)*


------
https://chatgpt.com/codex/tasks/task_e_68bb43a88990832e85a7065096f4c730