### PR TITLE
docs: index inner memory diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `/operator/status` endpoint reporting component health, recent errors, and memory usage; bumped `operator_api` to 0.3.5.
 
 - Added `environment.gpu.yml` and CPU/GPU Dockerfiles with pinned versions and documented hardware setup.
+- Documented inner memory guide and diagrams in the documentation index and linked cross-references from the Blueprint Spine and System Blueprint.
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -241,6 +241,22 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [archetype_logic.md](archetype_logic.md) | Archetype Logic | This document outlines how Spiral OS interprets alchemical states to shape its responses. The progression through **N... | - |
 | [architecture.md](architecture.md) | Architecture | This guide maps the core packages that shape the ABZU system and how they cooperate. The diagram below highlights the... | `../INANNA_AI/ethical_validator.py`, `../INANNA_AI_AGENT/inanna_ai.py`, `../core/emotion_analyzer.py`, `../core/memory_logger.py`, `../core/model_selector.py`, `../dashboard/app.py` |
 | [architecture_overview.md](architecture_overview.md) | Architecture Overview | For broader project context read [project_overview.md](project_overview.md) and [README_CODE_FUNCTION.md](../README_C... | `../crown_router.py`, `../labs/cortex_sigil.py`, `../memory/cortex.py`, `../memory/emotional.py`, `../memory/mental.py`, `../memory/sacred.py`, `../memory/spiral_cortex.py`, `../memory/spiritual.py`, `../src/core/emotion_analyzer.py`, `../src/core/memory_logger.py`, `../src/core/model_selector.py`, `../tests/crown/test_crown_router_memory.py`, `../tests/test_core_services.py`, `../tests/test_cortex_memory.py`, `../tests/test_cortex_sigil_logic.py`, `../tests/test_memory_emotional.py`, `../tests/test_memory_spiritual.py`, `../tests/test_seven_dimensional_music.py`, `../tests/test_spiral_cortex_memory.py`, `../tests/test_vast_pipeline.py` |
+| [assets/ai_handover_flow.mmd](assets/ai_handover_flow.mmd) | ai_handover_flow.mmd | - | - |
+| [assets/albedo_flow.mmd](assets/albedo_flow.mmd) | albedo_flow.mmd | - | - |
+| [assets/albedo_state_machine.mmd](assets/albedo_state_machine.mmd) | albedo_state_machine.mmd | - | - |
+| [assets/crown_boot.mmd](assets/crown_boot.mmd) | crown_boot.mmd | - | - |
+| [assets/crown_flow.mmd](assets/crown_flow.mmd) | crown_flow.mmd | - | - |
+| [assets/crown_handshake_sequence.mmd](assets/crown_handshake_sequence.mmd) | crown_handshake_sequence.mmd | - | - |
+| [assets/inanna_core.mmd](assets/inanna_core.mmd) | inanna_core.mmd | - | - |
+| [assets/inanna_flow.mmd](assets/inanna_flow.mmd) | inanna_flow.mmd | - | - |
+| [assets/memory_flow.mmd](assets/memory_flow.mmd) | memory_flow.mmd | - | - |
+| [assets/narrative_engine_flow.mmd](assets/narrative_engine_flow.mmd) | Mermaid diagram of narrative engine flow | - | - |
+| [assets/narrative_flow.mmd](assets/narrative_flow.mmd) | narrative_flow.mmd | - | - |
+| [assets/nazarick_flow.mmd](assets/nazarick_flow.mmd) | nazarick_flow.mmd | - | - |
+| [assets/nazarick_web_console.mmd](assets/nazarick_web_console.mmd) | nazarick_web_console.mmd | - | - |
+| [assets/razar_architecture.mmd](assets/razar_architecture.mmd) | razar_architecture.mmd | - | - |
+| [assets/razar_flow.mmd](assets/razar_flow.mmd) | razar_flow.mmd | - | - |
+| [assets/remote_assistance_sequence.mmd](assets/remote_assistance_sequence.mmd) | remote_assistance_sequence.mmd | - | - |
 | [audio_ingestion.md](audio_ingestion.md) | Audio Ingestion | This guide outlines how Spiral OS loads audio files and enriches them with optional features such as tempo and key de... | - |
 | [avatar_animation.md](avatar_animation.md) | Avatar Animation Modules | This document describes the lightweight avatar animation helpers found in `ai_core.avatar`. | - |
 | [avatar_ethics.md](avatar_ethics.md) | Avatar Ethics | The avatar and call features rely on audiovisual data that may reveal personal information. Operators must handle rec... | - |
@@ -298,6 +314,10 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [features/FEATURE_TEMPLATE.md](features/FEATURE_TEMPLATE.md) | Feature Specification Template | - | - |
 | [features/README.md](features/README.md) | Feature Specifications | Guidelines for authoring feature specification files. | - |
 | [features/example_feature.md](features/example_feature.md) | Example Feature | - | - |
+| [figures/layer_init_broadcast.mmd](figures/layer_init_broadcast.mmd) | Layer initialization broadcast diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/memory_bundle.mmd](figures/memory_bundle.mmd) | Memory Bundle diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/memory_layer_flow.mmd](figures/memory_layer_flow.mmd) | Memory layer flow diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd) | Query memory aggregation diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
 | [frontend_dependencies.md](frontend_dependencies.md) | Frontend Dependencies | This page outlines the core libraries used by the `floor_client` interface. Refer to each project's documentation for... | - |
 | [great_tomb_of_nazarick.md](great_tomb_of_nazarick.md) | Great Tomb of Nazarick | The foundational design for ABZU's servant hierarchy. For guiding principles see the [Nazarick Manifesto](nazarick_ma... | - |
 | [hardware_support.md](hardware_support.md) | Hardware Support | - CUDA available: False - ROCm available: False - Intel GPU available: False - Selected device: cpu | - |
@@ -315,7 +335,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | This guide describes the event bus protocol and query flow connecting the Cortex, Emotional, Mental, Spiritual, and N... | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -123,7 +123,7 @@ Modules are organized by chakra (Root through Crown), with additional Nazarick a
 
 ## **4. Memory Architecture**
 
-ABZU layers five memory stores—Cortex, Emotional, Mental, Spiritual, and Narrative—each switchable between file-based JSON/SQLite and vector-DB back ends via environment variables.
+ABZU layers five memory stores—Cortex, Emotional, Mental, Spiritual, and Narrative—each switchable between file-based JSON/SQLite and vector-DB back ends via environment variables. See [Memory Layers Guide](memory_layers_GUIDE.md) and diagrams like [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd) and [Memory Layer Flow](figures/memory_layer_flow.mmd) for event sequencing and query aggregation.
 
 Once these stores ignite, RAZAR activates the Bana engine to narrate state transitions across layers.
 

--- a/docs/figures/layer_init_broadcast.mmd
+++ b/docs/figures/layer_init_broadcast.mmd
@@ -1,3 +1,6 @@
+%% Layer initialization broadcast diagram
+%% Version: v1.0.0
+%% Last updated: 2025-09-05
 graph TD
     MB[MemoryBundle.initialize] --> EB[(EventBus: memory)]
     EB --> Cortex[Cortex]

--- a/docs/figures/memory_bundle.mmd
+++ b/docs/figures/memory_bundle.mmd
@@ -1,3 +1,6 @@
+%% Memory Bundle diagram
+%% Version: v1.0.0
+%% Last updated: 2025-09-05
 flowchart LR
     bundle[MemoryBundle] --> cortex[Cortex]
     bundle --> emotional[Emotional]

--- a/docs/figures/memory_layer_flow.mmd
+++ b/docs/figures/memory_layer_flow.mmd
@@ -1,3 +1,6 @@
+%% Memory layer flow diagram
+%% Version: v1.0.0
+%% Last updated: 2025-09-05
 graph TD
     MB[MemoryBundle.initialize] --> Cortex[Cortex]
     MB --> Emotional[Emotional]

--- a/docs/figures/query_memory_aggregation.mmd
+++ b/docs/figures/query_memory_aggregation.mmd
@@ -1,3 +1,6 @@
+%% Query memory aggregation diagram
+%% Version: v1.0.0
+%% Last updated: 2025-09-05
 graph TD
     Caller[Caller] --> MB[MemoryBundle.query]
     MB --> QM[query_memory]

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ abzu-memory-bootstrap
 - [Blueprint Export](BLUEPRINT_EXPORT.md) – versioned snapshot of key documents
 - [Detailed Architecture](architecture.md)
 - [Crown Agent Overview](CROWN_OVERVIEW.md)
+- [Inner Memory](memory_layers_GUIDE.md) – layer guide with diagrams: [Memory Bundle](figures/memory_bundle.mmd), [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd), [Memory Layer Flow](figures/memory_layer_flow.mmd), [Query Memory Aggregation](figures/query_memory_aggregation.mmd)
 ## Nazarick
 - [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
 - [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,5 +1,8 @@
 # Memory Layers Guide
 
+**Version:** v1.0.0
+**Last updated:** 2025-09-05
+
 This guide describes the event bus protocol and query flow connecting the
 Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
 
@@ -114,3 +117,7 @@ Extras can be combined, for example
 `pip install "spiral-os[mental,emotional]"` to enable multiple layers.
 
 
+
+---
+
+Backlinks: [Blueprint Spine](blueprint_spine.md) | [System Blueprint](system_blueprint.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -39,8 +39,7 @@ feedback.
 
 ABZU groups its Cortex, Emotional, Mental, Spiritual, and Narrative layers into a unified memory bundle, enabling cross-layer
 reasoning. Each layer receives a `layer_init` broadcast on startup, and incoming queries fan out across all layers before being
-aggregated into a single response. See [Memory Layers Guide](memory_layers_GUIDE.md) and [Blueprint Spine](blueprint_spine.md)
-for implementation details and schema references.
+aggregated into a single response. See [Memory Layers Guide](memory_layers_GUIDE.md), [Blueprint Spine](blueprint_spine.md), and diagrams such as [Memory Bundle](figures/memory_bundle.mmd), [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd), [Memory Layer Flow](figures/memory_layer_flow.mmd), and [Query Memory Aggregation](figures/query_memory_aggregation.mmd) for implementation details and schema references.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary
- add Inner Memory entry and memory guide versioning
- cross-link diagrams from blueprint and system blueprints
- extend doc indexer to capture mermaid diagrams

## Testing
- `pre-commit run --files tools/doc_indexer.py docs/index.md docs/memory_layers_GUIDE.md docs/blueprint_spine.md docs/system_blueprint.md docs/figures/memory_bundle.mmd docs/figures/layer_init_broadcast.mmd docs/figures/memory_layer_flow.mmd docs/figures/query_memory_aggregation.mmd CHANGELOG.md docs/INDEX.md` *(fails: missing metrics exporters and self-heal cycles)*
- `python tools/doc_indexer.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb45dc18a8832ead2773476ca89325