### PR TITLE
feat(worlds): add configuration registry

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,5 +1,26 @@
 """Core agent packages for ABZU."""
 
+from __future__ import annotations
+
+import pkgutil
+from pathlib import Path
+
+from worlds.config_registry import register_agent
 from .event_bus import emit_event, set_event_producer
 
-__all__ = ["emit_event", "set_event_producer"]
+
+def _discover_agents() -> tuple[str, ...]:
+    base = Path(__file__).resolve().parent
+    agents = []
+    for module in pkgutil.iter_modules([str(base)]):
+        if module.ispkg and not module.name.startswith("_"):
+            agents.append(module.name)
+    return tuple(sorted(agents))
+
+
+AGENTS = _discover_agents()
+for _agent in AGENTS:
+    register_agent(_agent)
+
+
+__all__ = ["emit_event", "set_event_producer", "AGENTS"]

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -1,0 +1,25 @@
+"""World configuration utilities."""
+
+from .config_registry import (
+    export_config,
+    export_config_file,
+    import_config,
+    import_config_file,
+    register_agent,
+    register_broker,
+    register_layer,
+    register_path,
+    reset_registry,
+)
+
+__all__ = [
+    "export_config",
+    "export_config_file",
+    "import_config",
+    "import_config_file",
+    "register_agent",
+    "register_broker",
+    "register_layer",
+    "register_path",
+    "reset_registry",
+]


### PR DESCRIPTION
## Summary
- expand world config registry to track agents alongside layers, brokers, and model paths
- auto-register available agents on package import
- support exporting and importing world configs via JSON files

## Testing
- `pre-commit run --files agents/__init__.py tests/test_config_registry.py worlds/__init__.py worlds/config_registry.py` *(fails: RuntimeError: no .dist-info at /root/.local/share/virtualenv/wheel/3.12/image/1/CopyPipInstall/pip-25.2-py3-none-any, has pip)*
- `pytest tests/test_config_registry.py` *(fails: Required test coverage of 80% not reached. Total coverage: 1.12%)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c619298832e88d24d2c222d2df9