### PR TITLE
Handle partial memory layer failures

### DIFF
--- a/memory/query_memory.py
+++ b/memory/query_memory.py
@@ -1,4 +1,9 @@
-"""Aggregated memory queries across cortex, vector, and spiral stores."""
+"""Aggregated memory queries across cortex, vector, and spiral stores.
+
+Each layer is queried independently so that failures in one layer do not
+prevent returning results from the others. Any exceptions are logged and the
+names of failing layers are collected in the ``failed_layers`` field.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document and reinforce memory query safety by logging exceptions and tracking failed layers
- test memory bus behavior when multiple layers raise errors

## Testing
- `pre-commit run --files memory/query_memory.py tests/test_memory_bus.py` *(fails: Required test coverage of 80% not reached; failing test tests/agents/razar/test_boot_sequence.py::test_boot_sequence_order_and_failure)*
- `pytest --no-cov tests/test_memory_bus.py::test_query_memory_partial_results tests/test_memory_bus.py::test_query_memory_multiple_failures -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb4dd2a724832e92deedd0b8afcfef