### PR TITLE
feat: add world bootstrap entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Introduced `bootstrap_world.py` and a setup quickstart for minimal world configuration.
+- Expanded `bootstrap_world.py` to initialize memory layers, start Crown, and load agent profiles; exposed as `abzu-bootstrap-world`.
 - Enforced explicit health probes for RAZAR boot components and added boot
   sequence tests.
 - Documented operator-first principle and contributor guidance across core docs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -415,6 +415,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [voice_aura.md](voice_aura.md) | Voice Aura FX | `audio/voice_aura.py` applies subtle reverb and delay based on the current emotion. Each emotion maps to a simple pre... | - |
 | [voice_cloner.md](voice_cloner.md) | Voice Cloner | The `VoiceCloner` utility records a short sample of a speaker and synthesises new speech in the captured voice. It ex... | - |
 | [voice_setup.md](voice_setup.md) | Voice Model Setup | This guide explains how to install external text-to-speech models so ABZU can produce spoken output. | - |
+| [world_bootstrap.md](world_bootstrap.md) | World Bootstrap | Initialize ABZU's world by preparing memory layers, starting Crown services, and loading agent profiles. | - |
 | [../floor_client/README.md](../floor_client/README.md) | Floor Client | This folder contains the React interface for Floor channels. | - |
 | [../guides/visual_customization.md](../guides/visual_customization.md) | Avatar Visual Customization | This guide outlines how to turn a 2D concept image into the 3D model used by the video engine. | - |
 | [../monitoring/README.md](../monitoring/README.md) | Monitoring | This stack launches Prometheus, Grafana, Node Exporter, cAdvisor, and an NVIDIA GPU exporter. Metrics include CPU, me... | - |

--- a/docs/world_bootstrap.md
+++ b/docs/world_bootstrap.md
@@ -1,0 +1,31 @@
+# World Bootstrap
+
+Initialize ABZU's world by preparing memory layers, starting Crown services, and
+loading agent profiles.
+
+## Prerequisites
+
+- Python 3.10+
+- Environment tokens:
+  - `HF_TOKEN` for model downloads and tokenizer access
+  - `GLM_API_KEY` for Crown language model endpoints
+- Optional `SERVANT_MODELS` for additional servant URLs
+
+## Usage
+
+```bash
+abzu-bootstrap-world
+```
+
+The command:
+
+1. Seeds file-backed cortex, emotional, mental, spiritual, and narrative layers
+2. Initializes Crown using `config/crown.yml`
+3. Launches agents listed in `agents/nazarick/agent_registry.json`
+
+## Optional Services
+
+- **Vector memory** – requires the `faiss` package; skipped if absent
+- **Mental layer** – uses Neo4j when available, otherwise a JSONL fallback
+- **Servant models** – custom endpoints from `SERVANT_MODELS`
+

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: b374f813859a35725a3af62797ae298b10c8dca35733347ff79c9325f8713314
+    sha256: adb0167929d9e6aeeaa57ef51b4fb22e6f01b14e82d64892ce43ae4b7ee46646
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ spiral-os = "spiral_os.__main__:main"
 inanna = "cli:main"
 crown-prompt = "crown_prompt_orchestrator:main"
 abzu-memory-bootstrap = "scripts.bootstrap_memory:main"
+abzu-bootstrap-world = "scripts.bootstrap_world:main"
 
 [tool.poetry.scripts]
 abzu = "cli:main"

--- a/scripts/bootstrap_world.py
+++ b/scripts/bootstrap_world.py
@@ -1,51 +1,58 @@
 #!/usr/bin/env python3
-"""Populate mandatory memory layers with default records."""
+"""Initialize memory layers, start Crown, and load agent profiles."""
+
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
-from memory.cortex import record_spiral
-from memory.emotional import log_emotion, get_connection as emotion_conn
-from memory.spiritual import map_to_symbol, get_connection as spirit_conn
-from memory.narrative_engine import log_story
+from agents.nazarick.service_launcher import launch_required_agents
+from init_crown_agent import initialize_crown
+from memory.bundle import MemoryBundle
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
-def main() -> None:
-    """Bootstrap core layers using file-backed stores and report progress."""
-    root = Path(__file__).resolve().parents[1]
+def _prepare_file_backed_storage(root: Path) -> None:
+    """Ensure file-backed paths exist and environment defaults are set."""
     data = root / "data"
     data.mkdir(parents=True, exist_ok=True)
 
-    os.environ.setdefault("CORTEX_BACKEND", "file")
-    os.environ.setdefault("CORTEX_PATH", str(data / "cortex_memory_spiral.jsonl"))
-    os.environ.setdefault("EMOTION_BACKEND", "file")
-    os.environ.setdefault("EMOTION_DB_PATH", str(data / "emotions.db"))
-    os.environ.setdefault("SPIRIT_BACKEND", "file")
-    os.environ.setdefault("SPIRITUAL_DB_PATH", str(data / "ontology.db"))
-    os.environ.setdefault("NARRATIVE_BACKEND", "file")
-    os.environ.setdefault("NARRATIVE_LOG_PATH", str(data / "story.log"))
+    env_defaults = {
+        "CORTEX_BACKEND": "file",
+        "CORTEX_PATH": str(data / "cortex_memory_spiral.jsonl"),
+        "EMOTION_BACKEND": "file",
+        "EMOTION_DB_PATH": str(data / "emotions.db"),
+        "MENTAL_BACKEND": "file",
+        "MENTAL_JSON_PATH": str(data / "tasks.jsonl"),
+        "SPIRIT_BACKEND": "file",
+        "SPIRITUAL_DB_PATH": str(data / "ontology.db"),
+        "NARRATIVE_BACKEND": "file",
+        "NARRATIVE_LOG_PATH": str(data / "story.log"),
+    }
+    for key, value in env_defaults.items():
+        os.environ.setdefault(key, value)
 
-    class Node:
-        children = []
 
-    print("Bootstrapping world layers...")
+def main() -> None:
+    """Bootstrap world services and report their status."""
+    logging.basicConfig(level=logging.INFO)
+    root = Path(__file__).resolve().parents[1]
+    _prepare_file_backed_storage(root)
 
-    record_spiral(Node(), {"result": "init"})
-    print("- Cortex layer initialized")
+    bundle = MemoryBundle()
+    statuses = bundle.initialize()
+    for layer, status in statuses.items():
+        logging.info("memory %s: %s", layer, status)
 
-    log_emotion([0.0], conn=emotion_conn())
-    print("- Emotional layer initialized")
+    logging.info("Starting Crown services...")
+    initialize_crown()
 
-    map_to_symbol(("origin", "O"), conn=spirit_conn())
-    print("- Spiritual layer initialized")
-
-    log_story("world initialized")
-    print("- Narrative layer initialized")
-
-    print("World bootstrap complete.")
+    logging.info("Launching agent profiles...")
+    events = launch_required_agents()
+    for event in events:
+        logging.info("agent %s: %s", event.get("agent"), event.get("status"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand `bootstrap_world.py` to initialise memory layers, start Crown, and launch agent profiles
- expose `abzu-bootstrap-world` console command
- document world bootstrap prerequisites and optional services

## Testing
- `pre-commit run --files scripts/bootstrap_world.py pyproject.toml docs/world_bootstrap.md CHANGELOG.md docs/INDEX.md onboarding_confirm.yml` *(fails: Missing Python packages: websockets)*

------
https://chatgpt.com/codex/tasks/task_e_68bb50a7eec0832ead6912e556a5049b