### PR TITLE
feat: add optional memory layer fallbacks

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -336,7 +336,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.1 **Last updated:** 2025-09-05 | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,6 +1,6 @@
 # Memory Layers Guide
 
-**Version:** v1.0.0
+**Version:** v1.0.1
 **Last updated:** 2025-09-05
 
 This guide describes the event bus protocol and query flow connecting the
@@ -53,11 +53,11 @@ records = bundle.query("omen")
 ```
 
 `initialize()` imports each layer and immediately calls
-`broadcast_layer_event()` with the resulting status mapping. When the optional
-mental layer or its dependencies are missing, the bundle substitutes the
-no-op implementation from `memory.optional.mental` and marks the status as
-`defaulted`. Any other import error is reported as `error`, but initialization
-continues and emits a consolidated result.
+`broadcast_layer_event()` with the resulting status mapping. When a layer
+or its dependencies are missing, the bundle substitutes the no-op
+implementation from `memory.optional` and marks the status as `defaulted`.
+Any other import error is reported as `error`, but initialization continues
+and emits a consolidated result.
 
 ## Query aggregation
 
@@ -93,11 +93,11 @@ results = aggregate_search("omen", source_weights={"spiritual": 2.0})
 ## Optional Layers
 
 Some memory layers rely on external services and may be absent. When a layer
-fails to import, the system substitutes a no-op implementation from
-`memory/optional/` with the same public API. Initialization marks these
-substituted layers as `defaulted`, and calls such as `aggregate_search` simply
-yield empty results for them while logging any underlying errors. Queries still
-return data from the remaining active layers.
+fails to import, `broadcast_layer_event` and `query_memory` attempt to load a
+no-op implementation from `memory/optional/` that exposes the same public API.
+Substituted layers are reported as `defaulted`, and calls such as
+`aggregate_search` simply yield empty results for them while logging any
+underlying errors. Queries still return data from the remaining active layers.
 
 ## Installation Options
 

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import Dict
 
 from agents.event_bus import emit_event
@@ -13,22 +14,48 @@ __version__ = "0.1.3"
 
 LAYERS = ("cortex", "emotional", "mental", "spiritual", "narrative")
 
+_LAYER_IMPORTS = {
+    "cortex": "memory.cortex",
+    "emotional": "memory.emotional",
+    "mental": "memory.mental",
+    "spiritual": "memory.spiritual",
+    "narrative": "memory.narrative_engine",
+}
+
 for _layer in LAYERS:
     register_layer(_layer)
 
 
-def broadcast_layer_event(statuses: Dict[str, str]) -> None:
+def broadcast_layer_event(statuses: Dict[str, str]) -> Dict[str, str]:
     """Emit a single initialization event for all memory layers.
 
-    ``statuses`` maps layer names to their corresponding status strings. Layers
-    missing from the mapping default to ``"unknown"``.
+    ``statuses`` maps layer names to their corresponding status strings.
+    Missing entries trigger an import attempt. When importing a layer fails,
+    a no-op fallback from ``memory.optional`` is substituted and the status is
+    updated to ``"defaulted"``. If both imports fail the status becomes
+    ``"error"``.
     """
+
+    for layer, module_path in _LAYER_IMPORTS.items():
+        if statuses.get(layer) == "ready":
+            continue
+        try:  # pragma: no cover - import may fail
+            importlib.import_module(module_path)
+            statuses[layer] = "ready"
+        except Exception:  # pragma: no cover - logged elsewhere
+            optional_path = f"memory.optional.{module_path.rsplit('.', 1)[-1]}"
+            try:
+                importlib.import_module(optional_path)
+                statuses[layer] = "defaulted"
+            except Exception:
+                statuses[layer] = "error"
 
     emit_event(
         "memory",
         "layer_init",
         {"layers": {layer: statuses.get(layer, "unknown") for layer in LAYERS}},
     )
+    return statuses
 
 
 __all__ = ["broadcast_layer_event", "query_memory", "LAYERS"]

--- a/memory/optional/__init__.py
+++ b/memory/optional/__init__.py
@@ -1,3 +1,10 @@
 """Fallback implementations for optional memory layers."""
 
-__all__ = ["mental"]
+__all__ = [
+    "mental",
+    "emotional",
+    "spiritual",
+    "narrative_engine",
+    "vector_memory",
+    "spiral_memory",
+]

--- a/memory/optional/emotional.py
+++ b/memory/optional/emotional.py
@@ -1,0 +1,26 @@
+"""No-op emotional layer used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, List, Sequence
+
+EmotionFeatures = Sequence[float]
+
+
+def log_emotion(features: EmotionFeatures, *args: Any, **kwargs: Any) -> None:
+    """Discard emotion features."""
+
+
+def fetch_emotion_history(*args: Any, **kwargs: Any) -> List[Any]:
+    """Return an empty history."""
+    return []
+
+
+def get_connection(*args: Any, **kwargs: Any) -> None:
+    """Return ``None`` to indicate no database connection."""
+    return None
+
+
+__all__ = ["log_emotion", "fetch_emotion_history", "get_connection", "EmotionFeatures"]

--- a/memory/optional/narrative_engine.py
+++ b/memory/optional/narrative_engine.py
@@ -1,0 +1,36 @@
+"""No-op narrative layer used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator
+
+
+@dataclass
+class StoryEvent:
+    """Placeholder story event."""
+
+    actor: str
+    action: str
+    symbolism: str | None = None
+
+
+def log_event(event: Dict[str, Any]) -> None:  # pragma: no cover - no side effects
+    """Discard narrative events."""
+
+
+def query_events(*args: Any, **kwargs: Any) -> Iterator[Dict[str, Any]]:
+    """Yield nothing as no events are stored."""
+    if False:
+        yield {}
+
+
+def search_events(*args: Any, **kwargs: Any) -> Iterator[Dict[str, Any]]:
+    """Yield nothing as no events are stored."""
+    if False:
+        yield {}
+
+
+__all__ = ["StoryEvent", "log_event", "query_events", "search_events"]

--- a/memory/optional/spiral_memory.py
+++ b/memory/optional/spiral_memory.py
@@ -1,0 +1,16 @@
+"""No-op spiral memory used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+
+from typing import Any
+
+
+def spiral_recall(*args: Any, **kwargs: Any) -> str:
+    """Return an empty string as no spiral data are stored."""
+    return ""
+
+
+__all__ = ["spiral_recall"]

--- a/memory/optional/spiritual.py
+++ b/memory/optional/spiritual.py
@@ -1,0 +1,39 @@
+"""No-op spiritual layer used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, List, Optional
+
+
+def set_event_symbol(event: str, symbol: str, *args: Any, **kwargs: Any) -> None:
+    """Discard event-symbol mappings."""
+
+
+def map_to_symbol(event_metadata: Any, *args: Any, **kwargs: Any) -> None:
+    """Discard mappings passed via specification-aligned interface."""
+
+
+def get_event_symbol(event: str, *args: Any, **kwargs: Any) -> Optional[str]:
+    """Return ``None`` as no mappings are stored."""
+    return None
+
+
+def lookup_symbol_history(symbol: str, *args: Any, **kwargs: Any) -> List[str]:
+    """Return an empty list as no mappings are stored."""
+    return []
+
+
+def get_connection(*args: Any, **kwargs: Any) -> None:
+    """Return ``None`` to indicate no database connection."""
+    return None
+
+
+__all__ = [
+    "set_event_symbol",
+    "map_to_symbol",
+    "get_event_symbol",
+    "lookup_symbol_history",
+    "get_connection",
+]

--- a/memory/optional/vector_memory.py
+++ b/memory/optional/vector_memory.py
@@ -1,0 +1,24 @@
+"""No-op vector memory used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, Dict, List
+
+
+def query_vectors(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+    """Return an empty list as no vectors are stored."""
+    return []
+
+
+def search(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+    """Return an empty list for search requests."""
+    return []
+
+
+def add_vector(*args: Any, **kwargs: Any) -> None:
+    """Discard vectors instead of persisting them."""
+
+
+__all__ = ["query_vectors", "search", "add_vector"]

--- a/memory/query_memory.py
+++ b/memory/query_memory.py
@@ -7,12 +7,51 @@ names of failing layers are collected in the ``failed_layers`` field.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
 import logging
+from typing import Any, Dict, List
 
-from .cortex import query_spirals
-from spiral_memory import spiral_recall
-from vector_memory import query_vectors
+try:  # pragma: no cover - cortex may be unavailable
+    from .cortex import query_spirals
+except Exception:  # pragma: no cover - logged lazily
+
+    def query_spirals(*args: Any, **kwargs: Any) -> list[Any]:
+        """Fallback returning no cortex results."""
+        return []
+
+
+try:  # pragma: no cover - optional dependency
+    from vector_memory import query_vectors as _query_vectors
+except Exception:  # pragma: no cover - dependency may be missing
+    try:
+        from .optional import vector_memory as _vector_memory
+
+        def _query_vectors(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+            return _vector_memory.query_vectors(*args, **kwargs)
+
+    except Exception:  # pragma: no cover - fallback missing
+
+        def _query_vectors(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+            return []
+
+
+query_vectors = _query_vectors
+
+try:  # pragma: no cover - optional dependency
+    from spiral_memory import spiral_recall as _spiral_recall
+except Exception:  # pragma: no cover - dependency may be missing
+    try:
+        from .optional import spiral_memory as _spiral_memory
+
+        def _spiral_recall(*args: Any, **kwargs: Any) -> str:
+            return _spiral_memory.spiral_recall(*args, **kwargs)
+
+    except Exception:  # pragma: no cover - fallback missing
+
+        def _spiral_recall(*args: Any, **kwargs: Any) -> str:
+            return ""
+
+
+spiral_recall = _spiral_recall
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add no-op implementations for optional memory layers
- fall back to optional layers when imports fail
- document fallback behavior in Memory Layers Guide

## Testing
- `pre-commit run --files docs/memory_layers_GUIDE.md docs/INDEX.md memory/__init__.py memory/query_memory.py memory/optional/__init__.py memory/optional/emotional.py memory/optional/narrative_engine.py memory/optional/spiral_memory.py memory/optional/spiritual.py memory/optional/vector_memory.py` *(verify-versions, capture-failing-tests, pytest-cov, verify-chakra-monitoring, verify-self-healing: failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb529cad0c832e8907085f5699145e