### PR TITLE
feat: add world service manifest and bootstrap validation

### DIFF
--- a/docs/world_bootstrap.md
+++ b/docs/world_bootstrap.md
@@ -29,3 +29,10 @@ The command:
 - **Mental layer** – uses Neo4j when available, otherwise a JSONL fallback
 - **Servant models** – custom endpoints from `SERVANT_MODELS`
 
+## Updating Models and Tokenizers
+
+Service parameters are declared per world in `worlds/services.yaml`. Adjust the
+`model` and `tokenizer` entries for your world, then rerun
+`abzu-bootstrap-world`. The bootstrap process validates the manifest and warns
+when a configured service is missing.
+

--- a/scripts/bootstrap_world.py
+++ b/scripts/bootstrap_world.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from agents.nazarick.service_launcher import launch_required_agents
 from init_crown_agent import initialize_crown
 from memory.bundle import MemoryBundle
+from worlds.services import load_manifest, warn_missing_services
 
 __version__ = "0.2.0"
 
@@ -40,6 +41,10 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     root = Path(__file__).resolve().parents[1]
     _prepare_file_backed_storage(root)
+
+    manifest = load_manifest(root / "worlds" / "services.yaml")
+    world = os.getenv("WORLD_NAME", "default")
+    warn_missing_services(manifest, world)
 
     bundle = MemoryBundle()
     statuses = bundle.initialize()

--- a/worlds/services.py
+++ b/worlds/services.py
@@ -1,0 +1,54 @@
+"""Service manifest loader for per-world settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class ServiceManifest:
+    """Configuration for services bound to a world."""
+
+    model: str | None = None
+    tokenizer: str | None = None
+    vector_db: Dict[str, Any] | None = None
+    event_bus: Dict[str, Any] | None = None
+
+
+def load_manifest(path: Path) -> Dict[str, ServiceManifest]:
+    """Load service manifest mapping worlds to configurations."""
+
+    if not path.exists():
+        logging.debug("services manifest %s missing", path)
+        return {}
+    data = yaml.safe_load(path.read_text("utf-8")) or {}
+    manifest: Dict[str, ServiceManifest] = {}
+    for world, cfg in data.items():
+        manifest[world] = ServiceManifest(
+            model=cfg.get("model"),
+            tokenizer=cfg.get("tokenizer"),
+            vector_db=cfg.get("vector_db"),
+            event_bus=cfg.get("event_bus"),
+        )
+    return manifest
+
+
+def warn_missing_services(manifest: Dict[str, ServiceManifest], world: str) -> None:
+    """Emit warnings for undefined services for ``world``."""
+
+    services = manifest.get(world)
+    if services is None:
+        logging.warning("world %s has no service manifest", world)
+        return
+    required = ("model", "tokenizer", "vector_db", "event_bus")
+    for name in required:
+        if getattr(services, name) is None:
+            logging.warning("world %s missing %s configuration", world, name)
+
+
+__all__ = ["load_manifest", "warn_missing_services", "ServiceManifest"]

--- a/worlds/services.yaml
+++ b/worlds/services.yaml
@@ -1,0 +1,21 @@
+# Per-world service declarations
+# schema:
+# <world>:
+#   model: <model name>
+#   tokenizer: <tokenizer version>
+#   vector_db:
+#     backend: <backend>
+#     path: <path to database>
+#   event_bus:
+#     transport: <transport>
+#     bootstrap_servers: <servers>
+
+default:
+  model: glm-1
+  tokenizer: glm-tokenizer-v1
+  vector_db:
+    backend: faiss
+    path: data/vector.index
+  event_bus:
+    transport: kafka
+    bootstrap_servers: localhost:9092


### PR DESCRIPTION
## Summary
- define per-world `worlds/services.yaml` schema
- validate service manifest during `abzu-bootstrap-world`
- document updating models and tokenizers

## Testing
- `PYTHONPATH=. pre-commit run --files docs/world_bootstrap.md scripts/bootstrap_world.py worlds/services.py worlds/services.yaml docs/INDEX.md` *(fails: missing metrics exporters, no self-heal cycles)*
- `PYTHONPATH=. python scripts/bootstrap_world.py` *(fails: GLM health check 503)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5612bb98832e9e28d2e7b58b29bb