### PR TITLE
docs: add Chat2DB flowchart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced in-memory story log with SQLite-backed persistence and documented schema.
 
 ### Changed
+- Replaced Chat2DB ASCII pipeline with a Mermaid flowchart and linked storage layers.
 - Operator onboarding steps now use Mermaid diagrams for voice selection and agent roster review instead of screenshots in `docs/operator_interface_GUIDE.md`.
 - Assigned unique component IDs for avatar/audio generation modules and RAZAR health checks to avoid collisions, ensuring component lookups remain unambiguous.
 - Bumped `crown_handshake` to 0.2.4 and `operator_api`/`webrtc_connector` to 0.3.3 and recorded versions in connector registry.

--- a/docs/chat2db.md
+++ b/docs/chat2db.md
@@ -9,9 +9,17 @@ the [Heart chakra](chakra_overview.md#heart) via the [Memory Vault](system_bluep
 
 ## Architecture
 
+```mermaid
+flowchart LR
+    Agents --> ChatGateway --> Chat2DB
+    Chat2DB --> SQLite
+    Chat2DB --> VectorStore
+
+    click SQLite "../INANNA_AI/db_storage.py"
+    click VectorStore "../spiral_vector_db/__init__.py"
 ```
-Agents → Chat Gateway → Chat2DB → {SQLite, Vector Store}
-```
+
+SQLite and Vector Store nodes link directly to their implementations.
 
 - **Relational Layer:** [INANNA_AI/db_storage.py](../INANNA_AI/db_storage.py)
   initializes tables for interactions, feedback and benchmarks and exposes


### PR DESCRIPTION
## Summary
- replace Chat2DB ASCII pipeline with a Mermaid flowchart
- link diagram nodes to db_storage.py and spiral_vector_db for quick reference
- note change in changelog

## Testing
- `pre-commit run --files docs/chat2db.md CHANGELOG.md docs/INDEX.md` *(fails: scripts/check_memory_layers.py __version__ 0.1.1 != 0.1.0 in component_index.json; scripts/init_memory_layers.py __version__ 0.1.3 != 0.1.2 in component_index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbae495958832ea1fa4f95ade9cbc9