### PR TITLE
docs: add opencode client backend guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -355,6 +355,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [onboarding_guide.md](onboarding_guide.md) | Onboarding Guide | **Version:** v1.0.0 **Last updated:** 2025-08-28 Diagram: [Onboarding Walkthrough](onboarding_walkthrough.md) – visua... | - |
 | [onboarding_walkthrough.md](onboarding_walkthrough.md) | Onboarding Walkthrough | This text-based walkthrough provides a step-by-step path to set up the repository and rebuild the project from a fres... | - |
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |
+| [opencode_client.md](opencode_client.md) | Opencode Client | - | - |
 | [operations.md](operations.md) | Operations | - | - |
 | [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
 | [operator_nazarick_bridge.md](operator_nazarick_bridge.md) | Operator-Nazarick Bridge | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ abzu-memory-bootstrap
 - [Development Checklist](development_checklist.md)
 - [Documentation Protocol](documentation_protocol.md)
 - [Connector Health Protocol](connector_health_protocol.md)
+- [Opencode Client](opencode_client.md)
 - [Onboarding Guide](onboarding_guide.md) – step-by-step rebuild using docs alone (v1.0.0, updated 2025-08-28)
 - [Feature Specifications](features/README.md)
 - [Example Feature](features/example_feature.md)

--- a/docs/opencode_client.md
+++ b/docs/opencode_client.md
@@ -1,0 +1,36 @@
+# Opencode Client
+
+## Overview
+`tools.opencode_client` provides a unified interface for generating code
+edits with the Opencode servant model. It supports three backends
+selected through environment variables.
+
+## Backends
+### CLI Backend
+- Default when no special configuration is set.
+- Invokes the local `opencode --diff` command.
+- Requires the `opencode` CLI to be installed.
+
+### HTTP Backend
+- Activated when `OPENCODE_URL` is defined and the `requests` package is
+  available.
+- Sends a `POST` request containing the prompt to the specified endpoint
+  and returns the `diff` or `text` field from the JSON response.
+
+### Kimi-K2 Backend
+- Enabled by setting `OPENCODE_BACKEND` to `kimi` or `kimi-k2`.
+- Delegates generation to the Kimi-K2 client for remote execution.
+
+## Decision Flow
+```mermaid
+flowchart TD
+    A["complete(prompt)"] -->|"OPENCODE_BACKEND=kimi or kimi-k2"| B[Kimi-K2 backend]
+    A -->|"OPENCODE_URL is set"| C[HTTP request]
+    C --> D{Response}
+    D -->|"JSON diff/text"| E[Return diff]
+    D -->|"Fallback"| F[Return raw text]
+    A -->|"Otherwise"| G[Invoke opencode CLI]
+```
+
+## Version History
+- v1.0.0 – Initial version.


### PR DESCRIPTION
## Summary
- Document `tools.opencode_client` backends, covering CLI, HTTP, and Kimi-K2 options with a decision flow diagram.
- Link the new Opencode Client guide from the main documentation index.

## Testing
- `pre-commit run --files docs/opencode_client.md docs/index.md docs/INDEX.md` *(fails: verify-versions mismatch, failing tests, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb191b700832eb181670b3d568d73