### PR TITLE
feat: add AI handover retry loop for boot orchestrator

### DIFF
--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   `handshake` in `logs/razar_state.json`.
 - Logged handshake and model-launch events in `logs/razar_state.json` and documented event persistence in the deployment guide.
 - Archived GLM-4.1V launch events to `logs/mission_briefs/` and added tests
+- Boot orchestrator escalates failed components through AI handover with automated patching, health-check retries, and invocation logging.
   for mission-brief archiving and GLM capability detection.
 - Added module coverage and example run sections to the RAZAR agent guide.
 - Rotated mission brief archives and required Crown availability via `CROWN_WS_URL` before boot.

--- a/component_index.json
+++ b/component_index.json
@@ -614,7 +614,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/boot_orchestrator.py",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": [
         "__future__",
         "agents",
@@ -826,7 +826,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/check_memory_layers.py",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": [
         "__future__",
         "memory",
@@ -2113,7 +2113,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/init_memory_layers.py",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": [
         "__future__",
         "memory",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -35,7 +35,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 4f4b07972085bc9341a56b1fb85f37da8354e726a73e10f03613fcc5f83b76b1
+    sha256: 265d674dc79b6554f277cf09d6b432a1ad99c1af840496d92e1361fb3d9a3c3e
     summary:
       purpose: Project goals and scope.
       scope: Entire project.

--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -8,7 +8,7 @@ subsequent runs.
 
 from __future__ import annotations
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 import argparse
 import asyncio
@@ -32,6 +32,9 @@ from .quarantine_manager import is_quarantined, quarantine_component
 from agents.nazarick.service_launcher import launch_required_agents
 
 LOGGER = logging.getLogger("razar.boot_orchestrator")
+
+# Path for recording AI handover attempts
+INVOCATION_LOG_PATH = LOGS_DIR / "razar_ai_invocations.json"
 
 
 def load_history() -> Dict[str, Any]:
@@ -146,6 +149,28 @@ def _record_probe(name: str, ok: bool) -> None:
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
     STATE_FILE.write_text(json.dumps(data, indent=2))
     _emit_event("probe", "ok" if ok else "fail", component=name)
+
+
+def _log_ai_invocation(component: str, attempt: int, error: str, patched: bool) -> None:
+    """Append AI handover attempt details to :data:`INVOCATION_LOG_PATH`."""
+    entry = {
+        "component": component,
+        "attempt": attempt,
+        "error": error,
+        "patched": patched,
+        "timestamp": time.time(),
+    }
+    records: List[Dict[str, Any]] = []
+    if INVOCATION_LOG_PATH.exists():
+        try:
+            records = json.loads(INVOCATION_LOG_PATH.read_text())
+            if not isinstance(records, list):
+                records = []
+        except json.JSONDecodeError:
+            records = []
+    records.append(entry)
+    INVOCATION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    INVOCATION_LOG_PATH.write_text(json.dumps(records, indent=2))
 
 
 def _rotate_mission_briefs(archive_dir: Path, limit: int = MAX_MISSION_BRIEFS) -> None:
@@ -293,7 +318,7 @@ def launch_component(component: Dict[str, Any]) -> subprocess.Popen:
     probe from :mod:`health_checks` is used. When no probe exists, a warning is
     logged and the component is assumed healthy.
     """
-    name = component.get("name")
+    name = str(component.get("name"))
     LOGGER.info("Launching %s", name)
     _emit_event("launch", "start", component=name)
     proc = subprocess.Popen(component["command"])
@@ -334,6 +359,12 @@ def main() -> None:
         default=3,
         help="Quarantine component after N cumulative failures",
     )
+    parser.add_argument(
+        "--remote-attempts",
+        type=int,
+        default=3,
+        help="AI handover attempts after local retries fail",
+    )
     args = parser.parse_args()
 
     log_file = Path(__file__).with_name("boot_orchestrator.log")
@@ -356,7 +387,7 @@ def main() -> None:
 
     try:
         for comp in components:
-            name = comp.get("name", "")
+            name = str(comp.get("name", ""))
             if is_quarantined(name):
                 LOGGER.info("Skipping quarantined component %s", name)
                 continue
@@ -379,24 +410,40 @@ def main() -> None:
                 except Exception as exc:
                     LOGGER.error("Attempt %s failed for %s: %s", attempt, name, exc)
                     if attempt > args.retries:
-                        # escalate to remote agent for potential repair
-                        patched = ai_invoker.handover(name, str(exc))
-                        if patched:
-                            LOGGER.info("Retrying %s after AI patch", name)
+                        error_msg = str(exc)
+                        remote_success = False
+                        for r_attempt in range(1, args.remote_attempts + 1):
+                            patched = ai_invoker.handover(
+                                name, error_msg, use_opencode=True
+                            )
+                            _log_ai_invocation(name, r_attempt, error_msg, patched)
+                            if not patched:
+                                continue
+                            LOGGER.info(
+                                "Retrying %s after AI patch (remote attempt %s)",
+                                name,
+                                r_attempt,
+                            )
                             try:
+                                attempts += 1
                                 proc = launch_component(comp)
                                 processes.append(proc)
                                 success = True
-                                attempts += 1
+                                remote_success = True
                                 break
                             except Exception as exc2:
+                                attempts += 1
+                                error_msg = str(exc2)
                                 LOGGER.error(
-                                    "Retry after AI patch failed for %s: %s",
+                                    "Remote attempt %s failed for %s: %s",
+                                    r_attempt,
                                     name,
                                     exc2,
                                 )
+                        if remote_success:
+                            break
                         failure_counts[name] = failure_counts.get(name, 0) + 1
-                        quarantine_component(comp, str(exc))
+                        quarantine_component(comp, error_msg)
                         run_metrics["components"].append(
                             {"name": name, "attempts": attempts, "success": False}
                         )


### PR DESCRIPTION
## Summary
- escalate exhausted boot retries through `ai_invoker.handover` with Opencode
- re-run health checks until success and log each attempt to `razar_ai_invocations.json`
- document remote recovery flow in Recovery Playbook

## Testing
- `pre-commit run --files razar/boot_orchestrator.py docs/recovery_playbook.md component_index.json onboarding_confirm.yml CHANGELOG_razar.md` *(fails: ValueError in test_boot_sequence_order_and_failure; coverage below threshold; missing 'agents' for verify_chakra_monitoring; no successful self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb7402488832e99b4dfca09a82eb3