### PR TITLE
docs: add RAZAR self-healing overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented inner memory guide and diagrams in the documentation index and linked cross-references from the Blueprint Spine and System Blueprint.
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
+- Documented RAZAR self-healing overview with links to recovery playbook and Kimi integration.
 
 - Documented onboarding triple-reading requirement and Nazarick Web Console access in `docs/operator_interface_GUIDE.md` and updated `docs/INDEX.md`.
 - Web console streams avatar video, audio, and narrative text concurrently and `abzu operator-console --smoke-test` exercises a scripted session.

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
  - Expanded guide with architecture diagram, requirements, deployment workflow, config schemas, cross-links, and example runs.
 - Added schema diagrams for configuration files and a full ignition example with log excerpts and mission-brief archive notes.
+- Introduced self-healing overview linking recovery playbook and Kimi integration.
 
 ### Changed
 - Boot orchestrator now records the full CROWN handshake response under

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -56,6 +56,20 @@ flowchart TD
     B -->|log| F[logs/razar_ai_invocations.json]
 ```
 
+### Self-Healing Overview
+RAZAR blends automated recovery with operator playbooks. When a failure is detected,
+`ai_invoker.handover` delegates the context to external helpers that can generate
+patches through Opencode or the [Kimi Integration](tools/kimi_integration.md). The
+patched component is relaunched following the steps in the
+[Recovery Playbook](recovery_playbook.md).
+
+```mermaid
+flowchart LR
+    A[Failure Detected] --> B[ai_invoker.handover]
+    B --> C[Opencode/Kimi Patch]
+    C --> D[Relaunch]
+```
+
 ### Recovery Flow
 ```mermaid
 flowchart TD

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ abzu-memory-bootstrap
 - [Feature Specifications](features/README.md)
 - [Example Feature](features/example_feature.md)
 - [RAZAR Agent](RAZAR_AGENT.md)
+- [RAZAR Self-Healing Overview](RAZAR_AGENT.md#self-healing-overview)
 
 ## Indices
 - [Component Index](component_index.md)


### PR DESCRIPTION
## Summary
- document self-healing overview for RAZAR with Kimi/Opencode patch loop
- link self-healing section from docs index
- record self-healing docs in project changelogs

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/index.md docs/INDEX.md CHANGELOG.md CHANGELOG_razar.md` *(fails: test_boot_sequence_order_and_failure, coverage under 80, missing metrics exporters, no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbc500e84832e96b0c243b5ac07f0