### PR TITLE
feat(worlds): track remote repairs for world exports

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/world_bootstrap.md
+++ b/docs/world_bootstrap.md
@@ -36,3 +36,11 @@ Service parameters are declared per world in `worlds/services.yaml`. Adjust the
 `abzu-bootstrap-world`. The bootstrap process validates the manifest and warns
 when a configured service is missing.
 
+## Repair Metadata
+
+Remote repair attempts and the resulting component hashes are tracked in
+`worlds/config_registry`. When exporting world configuration, the
+`remote_attempts` field counts how many AI patches were applied per component
+and `component_hashes` stores each component's final digest. Import these fields
+into newly cloned worlds to reproduce a repaired state.
+

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -6,6 +6,8 @@ from worlds.config_registry import (
     import_config,
     import_config_file,
     reset_registry,
+    register_remote_attempt,
+    register_component_hash,
 )
 
 
@@ -34,12 +36,18 @@ def test_registration_and_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setenv("CITADEL_REDIS_URL", "redis://localhost")
     eb._get_producer()
 
+    # Register remote repair metadata
+    register_remote_attempt("demo")
+    register_component_hash("demo", "abc123")
+
     cfg = export_config()
 
     assert set(cfg["layers"]) == set(memory.LAYERS)
     assert set(cfg["agents"]) == set(agents.AGENTS)
     assert cfg["paths"]["emotional"] == str(emo_path)
     assert cfg["brokers"]["redis"]["channel"] == "chan"
+    assert cfg["remote_attempts"]["demo"] == 1
+    assert cfg["component_hashes"]["demo"] == "abc123"
 
     # verify round-trip via dictionary
     reset_registry()

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -8,6 +8,8 @@ from .config_registry import (
     register_agent,
     register_broker,
     register_layer,
+    register_remote_attempt,
+    register_component_hash,
     register_path,
     reset_registry,
 )
@@ -20,6 +22,8 @@ __all__ = [
     "register_agent",
     "register_broker",
     "register_layer",
+    "register_remote_attempt",
+    "register_component_hash",
     "register_path",
     "reset_registry",
 ]


### PR DESCRIPTION
## Summary
- record remote repair attempts and final component hashes in world config registry
- export new world metadata and document fields for repaired clones

## Testing
- `pytest --no-cov tests/test_config_registry.py`
- `SKIP=check-env,capture-failing-tests,pytest-cov,verify-chakra-monitoring,verify-self-healing PYTHONPATH=. pre-commit run --files worlds/config_registry.py worlds/__init__.py tests/test_config_registry.py docs/world_bootstrap.md docs/INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_68bbbf13ce68832ead3e99218a28f7bb