### PR TITLE
Add long task mode to boot orchestrator

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -614,7 +614,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/boot_orchestrator.py",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": [
         "__future__",
         "agents",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "integration" / "test_mix_and_store.py"),
     str(ROOT / "tests" / "test_transformers_generate.py"),
     str(ROOT / "tests" / "razar" / "test_ai_invoker.py"),
+    str(ROOT / "tests" / "razar" / "test_long_task.py"),
     str(ROOT / "tests" / "integration" / "test_core_regressions.py"),
     str(ROOT / "tests" / "integration" / "test_full_flows.py"),
     str(ROOT / "tests" / "scripts" / "test_verify_chakra_monitoring.py"),

--- a/tests/razar/test_long_task.py
+++ b/tests/razar/test_long_task.py
@@ -1,0 +1,84 @@
+__version__ = "0.1.0"
+
+import json
+import sys
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+import razar.boot_orchestrator as bo
+import razar.ai_invoker as ai_invoker
+
+
+class DummyProc:
+    returncode = 0
+
+    def terminate(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def wait(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def test_long_task_retries_until_success(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Long task mode keeps invoking handover until a patch succeeds."""
+    handover_calls = {"count": 0}
+
+    def fake_handover(component: str, error: str, use_opencode: bool = False) -> bool:
+        handover_calls["count"] += 1
+        return handover_calls["count"] == 2
+
+    monkeypatch.setattr(ai_invoker, "handover", fake_handover)
+
+    launch_attempts = {"count": 0}
+
+    def fake_launch(comp):
+        launch_attempts["count"] += 1
+        if launch_attempts["count"] == 1:
+            raise RuntimeError("boom")
+        return DummyProc()
+
+    monkeypatch.setattr(bo, "launch_component", fake_launch)
+
+    # Redirect file paths used by boot orchestrator
+    monkeypatch.setattr(bo, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(bo, "HISTORY_FILE", tmp_path / "history.json")
+    monkeypatch.setattr(bo, "INVOCATION_LOG_PATH", tmp_path / "invocations.json")
+    monkeypatch.setattr(bo, "LONG_TASK_LOG_PATH", tmp_path / "long_task.json")
+    monkeypatch.setattr(bo, "LOGS_DIR", tmp_path)
+    monkeypatch.setattr(bo, "_perform_handshake", lambda comps: None)
+    monkeypatch.setattr(bo, "launch_required_agents", lambda: None)
+    monkeypatch.setattr(bo.doc_sync, "sync_docs", lambda: None)
+    monkeypatch.setattr(bo, "_log_ai_invocation", lambda *a, **k: None)
+    monkeypatch.setattr(bo.time, "sleep", lambda *a, **k: None)
+
+    config = {
+        "components": [
+            {"name": "demo", "command": ["echo", "hi"], "health_check": ["true"]}
+        ]
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(config))
+
+    argv = [
+        "bo",
+        "--config",
+        str(cfg_path),
+        "--retries",
+        "0",
+        "--long-task",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    bo.main()
+
+    entries = json.loads((tmp_path / "long_task.json").read_text())
+    assert len(entries) == 2
+    assert entries[0]["patched"] is False
+    assert entries[1]["patched"] is True
+    assert handover_calls["count"] == 2
+    history = json.loads((tmp_path / "history.json").read_text())
+    comp = history["history"][0]["components"][0]
+    assert comp["success"] is True
+    assert comp["attempts"] == 2


### PR DESCRIPTION
## Summary
- extend boot orchestrator with optional `--long-task` retries that log each attempt
- capture long task events in `logs/razar_long_task.json`
- document operator controls for long tasks in the recovery playbook

## Testing
- `pytest --cov=razar --cov-fail-under=0 tests/razar/test_ai_invoker.py tests/razar/test_long_task.py`
- `PYTHONPATH=$PWD pre-commit run --files razar/boot_orchestrator.py component_index.json docs/recovery_playbook.md docs/INDEX.md tests/razar/test_long_task.py tests/conftest.py` *(fails: missing metrics exporters, no self-heal cycles)*

## Change justification
I did implement long-task retries on `boot_orchestrator` to obtain resilient handover loops, expecting components to keep patching until success or operator abort.


------
https://chatgpt.com/codex/tasks/task_e_68bbc61c57fc832eba80e671f77a0ceb