### PR TITLE
docs: add ignition blueprint and cross-links

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -324,6 +323,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [great_tomb_of_nazarick.md](great_tomb_of_nazarick.md) | Great Tomb of Nazarick | The foundational design for ABZU's servant hierarchy. For guiding principles see the [Nazarick Manifesto](nazarick_ma... | - |
 | [hardware_support.md](hardware_support.md) | Hardware Support | - CUDA available: False - ROCm available: False - Intel GPU available: False - Selected device: cpu | - |
 | [how_to_use.md](how_to_use.md) | How to Use Spiral OS Avatar | 1. Run `python start_spiral_os.py` to launch the orchestration engine. This loads the core modules, starts a local Fa... | - |
+| [ignition_blueprint.md](ignition_blueprint.md) | Ignition Blueprint | - | - |
 | [ignition_flow.md](ignition_flow.md) | Ignition Flow | This guide traces the activation sequence from **RAZAR** through to the final **operator interface**, linking each st... | `../INANNA_AI_AGENT/inanna_ai.py`, `../agents/bana/bio_adaptive_narrator.py`, `../crown_router.py`, `../operator_api.py`, `../razar/boot_orchestrator.py`, `../scripts/validate_ignition.py` |
 | [ignition_map.md](ignition_map.md) | Ignition Map | Summary of components grouped by ignition stage. See [Ignition](Ignition.md) for boot priorities and [component_index... | - |
 | [ignition_sequence_protocol.md](ignition_sequence_protocol.md) | Ignition Sequence Protocol | Defines the required logging checkpoints and escalation flow during the system boot sequence. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -230,6 +230,7 @@ logs/mission_briefs/
 - [Deployment Guide](deployment.md)
 - [Monitoring Guide](monitoring.md)
 - [Protocol Compliance](protocol_compliance.md)
+- [Ignition Blueprint](ignition_blueprint.md)
 
 ## Component & Link
 - [razar/boot_orchestrator.py](../razar/boot_orchestrator.py)

--- a/docs/ignition_blueprint.md
+++ b/docs/ignition_blueprint.md
@@ -1,0 +1,32 @@
+# Ignition Blueprint
+
+## Overview
+This blueprint outlines adaptive ignition sequences coordinated by RAZAR. When Crown fails to launch or report healthy status, RAZAR can loop back for another attempt or delegate recovery to the Kimi2 assistant before retrying Crown.
+
+## Flexible Recovery Flow
+- **Initial ignition** – RAZAR launches Crown and waits for a healthy status.
+- **Failure loop** – If Crown reports a failure, RAZAR re-enters the ignition cycle.
+- **Delegated patch** – After repeated failures, RAZAR routes context to Kimi2 for a patch and then retries Crown.
+- **Sustained operation** – Successful recovery returns Crown to steady state and ends the loop.
+
+## State Diagram
+```mermaid
+stateDiagram-v2
+    [*] --> RAZAR
+    RAZAR --> Crown: ignite
+    Crown --> RAZAR: failure
+    RAZAR --> Crown: retry
+    RAZAR --> Kimi2: request patch
+    Kimi2 --> Crown: apply fix
+    Crown --> RAZAR: report
+    Crown --> [*]: stable
+```
+
+## Cross-links
+- [Project Overview](project_overview.md)
+- [RAZAR Agent](RAZAR_AGENT.md)
+
+## Version History
+| Version | Date | Notes |
+|---------|------|-------|
+| 0.1.0 | 2025-10-17 | Initial flexible ignition loops and state diagram. |

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -25,6 +25,8 @@ Spiral OS organises its components into seven chakra layers:
 6. **Third Eye – Ajna** – insight and pattern recognition.
 7. **Crown – Sahasrara** – cosmic connection and initialization rites.
 
+For adaptive startup and recovery loops see [Ignition Blueprint](ignition_blueprint.md).
+
 These layers work together to awaken the INANNA system and maintain a ritual flow during use.
 
 For a plain-language diagram of how a request moves through these layers, see [architecture_overview.md](architecture_overview.md).


### PR DESCRIPTION
## Summary
- Document RAZAR fallback loops through new `ignition_blueprint.md`
- Link ignition blueprint from project overview and RAZAR agent docs for easy discovery

## Change Justification
I did create docs/ignition_blueprint.md and link it from project_overview.md and RAZAR_AGENT.md to obtain documented recovery loops, expecting contributors to navigate ignition flows.

## Testing
- `pre-commit run --files docs/ignition_blueprint.md docs/project_overview.md docs/RAZAR_AGENT.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h; pytest: error: unrecognized arguments: --cov=src --cov=agents --cov-fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_68bbccbab608832eaf3a8ceb36a7e1a9