### PR TITLE
Add world patch export command

### DIFF
--- a/docs/world_bootstrap.md
+++ b/docs/world_bootstrap.md
@@ -38,9 +38,22 @@ when a configured service is missing.
 
 ## Repair Metadata
 
-Remote repair attempts and the resulting component hashes are tracked in
-`worlds/config_registry`. When exporting world configuration, the
-`remote_attempts` field counts how many AI patches were applied per component
-and `component_hashes` stores each component's final digest. Import these fields
+Remote repair attempts, the patches applied, and the resulting component hashes
+are tracked in `worlds/config_registry`. When exporting world configuration, the
+`remote_attempts` field counts how many AI patches were applied per component,
+`patches` records each patch alongside its final digest, and
+`component_hashes` stores each component's current hash. Import these fields
 into newly cloned worlds to reproduce a repaired state.
+
+## Exporting Configuration
+
+Use the `abzu-world-export` command to capture the current world's metadata for
+bootstrapping elsewhere:
+
+```bash
+abzu-world-export world.json
+```
+
+The command writes `world.json` (or your chosen path) containing layer, agent,
+service, and repair data, including patches and component hashes.
 

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -35,7 +35,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 265d674dc79b6554f277cf09d6b432a1ad99c1af840496d92e1361fb3d9a3c3e
+    sha256: a36305430216498c9cecd98f107edbdb0cc5fca05efa6de5a9bb2cc213df4a03
     summary:
       purpose: Project goals and scope.
       scope: Entire project.
@@ -184,7 +184,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: adb0167929d9e6aeeaa57ef51b4fb22e6f01b14e82d64892ce43ae4b7ee46646
+    sha256: 9f66320a7a5452f48b3cefaa3f3009aae4db5ebb46566ac83b15714904e570f6
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ inanna = "cli:main"
 crown-prompt = "crown_prompt_orchestrator:main"
 abzu-memory-bootstrap = "scripts.bootstrap_memory:main"
 abzu-bootstrap-world = "scripts.bootstrap_world:main"
+abzu-world-export = "scripts.world_export:main"
 
 [tool.poetry.scripts]
 abzu = "cli:main"

--- a/scripts/world_export.py
+++ b/scripts/world_export.py
@@ -1,0 +1,29 @@
+"""Export current world configuration and patch metadata."""
+
+from __future__ import annotations
+
+import argparse
+
+from worlds.config_registry import export_config_file
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Write world configuration to ``path`` (default ``world.json``)."""
+    parser = argparse.ArgumentParser(description="Export world configuration")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="world.json",
+        help="Destination file for the exported configuration",
+    )
+    parser.add_argument(
+        "--world",
+        help="Name of the world to export (default: WORLD_NAME env or 'default')",
+    )
+    args = parser.parse_args(argv)
+    out_path = export_config_file(args.path, world=args.world)
+    print(f"Exported configuration to {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,4 +1,7 @@
 import importlib
+from pathlib import Path
+
+import pytest
 
 from worlds.config_registry import (
     export_config,
@@ -7,11 +10,13 @@ from worlds.config_registry import (
     import_config_file,
     reset_registry,
     register_remote_attempt,
-    register_component_hash,
+    register_patch,
 )
 
 
-def test_registration_and_roundtrip(tmp_path, monkeypatch):
+def test_registration_and_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # start with a clean registry
     reset_registry()
 
@@ -38,7 +43,7 @@ def test_registration_and_roundtrip(tmp_path, monkeypatch):
 
     # Register remote repair metadata
     register_remote_attempt("demo")
-    register_component_hash("demo", "abc123")
+    register_patch("demo", "patch1", "abc123")
 
     cfg = export_config()
 
@@ -48,6 +53,9 @@ def test_registration_and_roundtrip(tmp_path, monkeypatch):
     assert cfg["brokers"]["redis"]["channel"] == "chan"
     assert cfg["remote_attempts"]["demo"] == 1
     assert cfg["component_hashes"]["demo"] == "abc123"
+    assert cfg["patches"] == [
+        {"component": "demo", "patch": "patch1", "hash": "abc123"}
+    ]
 
     # verify round-trip via dictionary
     reset_registry()

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -10,6 +10,7 @@ from .config_registry import (
     register_layer,
     register_remote_attempt,
     register_component_hash,
+    register_patch,
     register_path,
     reset_registry,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "register_layer",
     "register_remote_attempt",
     "register_component_hash",
+    "register_patch",
     "register_path",
     "reset_registry",
 ]


### PR DESCRIPTION
## Summary
- log applied patches in world config registry and track resulting component hashes
- add `abzu-world-export` CLI to capture world configuration
- document repair metadata and export workflow

## Testing
- `pre-commit run --files docs/world_bootstrap.md onboarding_confirm.yml pyproject.toml tests/test_config_registry.py worlds/__init__.py worlds/config_registry.py scripts/world_export.py` *(failed: capture failing pytest cases)*
- `pytest tests/test_config_registry.py` *(failed: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bbce8d11b8832eaf045b6a8753ab3e