### PR TITLE
feat: add simple web ui service

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Memory UI</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6">
+  <h1 class="text-2xl font-bold mb-4">Memory Query</h1>
+  <div class="mb-4">
+    <input id="query" class="border p-2" placeholder="Enter query" />
+    <button id="search" class="bg-blue-500 text-white px-4 py-2 ml-2">Search</button>
+  </div>
+  <pre id="results" class="bg-gray-100 p-2"></pre>
+  <div class="mt-6">
+    <button id="check-status" class="bg-green-500 text-white px-4 py-2">Check Status</button>
+  </div>
+  <pre id="status" class="bg-gray-100 p-2 mt-2"></pre>
+  <script>
+    document.getElementById('search').onclick = async () => {
+      const q = document.getElementById('query').value;
+      const res = await fetch(`/memory/query?query=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+    };
+    document.getElementById('check-status').onclick = async () => {
+      const res = await fetch('/status');
+      const data = await res.json();
+      document.getElementById('status').textContent = JSON.stringify(data, null, 2);
+    };
+  </script>
+</body>
+</html>

--- a/tests/web_ui/test_memory_query.py
+++ b/tests/web_ui/test_memory_query.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from ui_service import app
+
+
+def test_memory_query_returns_aggregated_results(monkeypatch):
+    client = TestClient(app)
+
+    expected = {
+        "cortex": [1],
+        "vector": [2],
+        "spiral": "s",
+        "failed_layers": [],
+    }
+
+    def fake_query_memory(query: str):  # noqa: ANN001 - simple stub
+        return expected
+
+    monkeypatch.setattr("ui_service.query_memory", fake_query_memory)
+
+    resp = client.get("/memory/query", params={"query": "hello"})
+
+    assert resp.status_code == 200
+    assert resp.json() == expected

--- a/ui_service.py
+++ b/ui_service.py
@@ -1,0 +1,38 @@
+"""Lightweight UI service exposing memory and status endpoints."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, Dict
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from memory.query_memory import query_memory
+
+app = FastAPI(title="UI Service")
+
+templates = Jinja2Templates(directory="templates")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request) -> HTMLResponse:
+    """Serve the home page."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/status")
+async def status() -> Dict[str, str]:
+    """Return a simple status indicator."""
+    return {"status": "ok"}
+
+
+@app.get("/memory/query")
+async def memory_query(query: str) -> Dict[str, Any]:
+    """Return aggregated memory search results."""
+    return query_memory(query)
+
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add FastAPI `ui_service` exposing home, status, and memory query endpoints
- serve minimal Tailwind-based template for interactive queries
- cover memory query endpoint with a unit test

## Testing
- `pre-commit run --files ui_service.py templates/index.html tests/web_ui/test_memory_query.py` *(fails: Required test coverage of 80% not reached)*
- `pytest tests/web_ui/test_memory_query.py --cov=ui_service --cov-fail-under=0` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd5324600832eb10527d6b51f4a08