### PR TITLE
docs: add UI service guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -408,6 +408,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [tools/kimi_integration.md](tools/kimi_integration.md) | Kimi Integration | Opencode can delegate code generation to the Kimi-K2 model when the service is available. | - |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting | This guide addresses frequent setup problems, driver issues, and environment pitfalls. Refer to [installation](instal... | `../download_models.py`, `../env_validation.py`, `../scripts/bootstrap.py` |
 | [ui/README.md](ui/README.md) | Floor Client UI | This React/Tailwind interface renders floors with channel tiles and streams messages over a WebSocket feed. | - |
+| [ui_service.md](ui_service.md) | UI Service | - | - |
 | [updates/2025-08.md](updates/2025-08.md) | August 2025 Roadmap | - | - |
 | [use_cases/ritual_demo.md](use_cases/ritual_demo.md) | Ritual Demo | This walkthrough demonstrates the small ritual sample included with the repository. The `examples/ritual_demo.py` scr... | - |
 | [vanna_usage.md](vanna_usage.md) | Vanna Data Agent Usage | The `vanna_data` agent translates natural language prompts into SQL queries using the [Vanna](https://github.com/vann... | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ abzu-memory-bootstrap
 - [Quickstart Setup](setup_quickstart.md) – minimal world configuration
 ## Usage
 - [How to Use](how_to_use.md)
+- [UI Service](ui_service.md) – lightweight FastAPI interface for memory queries
 - [Bootstrap World Script](../scripts/bootstrap_world.py) – populate mandatory layers with defaults
 
 ## Data

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -42,6 +42,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Throat – Vishuddha** – `orchestrator.py` routes text to the models and the Sonic Core (`audio_engine.py`, `core/avatar_expression_engine.py`) voices the response.
 * **Third Eye – Ajna** – `qnl_engine.py` interprets hexadecimal strings into musical glyphs and passes them back to the orchestrator; `scripts/data_validate.py` checks training data and `scripts/quality_score.py` evaluates component health.
 * **Crown – Sahasrara** – `start_spiral_os.py` and `init_crown_agent.py` initialise the entire ritual sequence.
+* **UI Service** – FastAPI front-end providing a browser gateway to memory queries. See [ui_service.md](ui_service.md).
 
 When a command arrives, the orchestrator consults the current emotional state and vector memory to select a model. If hex data or ritual text is present, it hands the payload to the QNL engine which returns symbolic notes. The Sonic Core turns those notes into audio and animates the avatar while new vectors are logged for future reference. This flow allows the layers to reinforce one another so the system speaks and remembers with continuity.
 

--- a/docs/ui_service.md
+++ b/docs/ui_service.md
@@ -1,0 +1,26 @@
+# UI Service
+
+## Overview
+The UI Service is a lightweight FastAPI application that renders a browser page and proxies memory queries.
+Requests to `/memory/query` are routed through the core `query_memory` helper to aggregate results across memory layers.
+
+## Environment Variables
+- `UI_SERVICE_HOST` – network interface to bind (default `0.0.0.0`).
+- `UI_SERVICE_PORT` – port that serves HTTP traffic (default `9000`).
+
+## Workflow
+1. Export the required environment variables.
+2. Launch the server:
+   ```bash
+   uvicorn ui_service:app --host $UI_SERVICE_HOST --port $UI_SERVICE_PORT
+   ```
+3. Open a browser to `http://$UI_SERVICE_HOST:$UI_SERVICE_PORT`.
+4. Enter a search term; the service returns merged results from the memory layers.
+
+```mermaid
+sequenceDiagram
+    Browser->>FastAPI: request /memory/query
+    FastAPI->>query_memory: dispatch
+    query_memory-->>FastAPI: results
+    FastAPI-->>Browser: response
+```


### PR DESCRIPTION
## Summary
- document lightweight FastAPI UI service and its workflow
- cross-link UI guide from docs index and project overview

## Testing
- `pre-commit run --files docs/ui_service.md docs/index.md docs/project_overview.md` *(fails: coverage < 80%, missing agents module)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6c1898c832e944812dfb5af5bad