### PR TITLE
docs: add memory bundle section

### DIFF
--- a/docs/ABZU_SUBSYSTEM_OVERVIEW.md
+++ b/docs/ABZU_SUBSYSTEM_OVERVIEW.md
@@ -60,3 +60,15 @@ graph TD
 - **Bundle initialization** – `MemoryBundle.initialize()` emits a single `layer_init` broadcast, seeding all five layers at once.
 - **Query traversal** – `MemoryBundle.query()` fans requests across every layer and aggregates the responses before returning to the RAG Orchestrator.
 - See [Memory Layers Guide](memory_layers_GUIDE.md) for implementation specifics.
+
+## Memory Bundle Layers
+
+```mermaid
+{{#include figures/memory_bundle.mmd}}
+```
+
+- **Cortex** – surface-level vectors and sensory impressions.
+- **Emotional** – affective cues that color context.
+- **Mental** – task graphs and deliberative state.
+- **Spiritual** – doctrine-aware memory and ritual traces.
+- **Narrative** – long-form stories and summaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,12 +14,15 @@ Initialize every memory layer with a single command:
 abzu-memory-bootstrap
 ```
 
+## Memory Bundle
+- [Subsystem Overview](ABZU_SUBSYSTEM_OVERVIEW.md#memory-bundle-layers) – full five-layer bundle diagram and roles
+- [Memory Layers Guide](memory_layers_GUIDE.md) – bus protocol with diagrams: [Memory Bundle](figures/memory_bundle.mmd), [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd), [Query Memory Aggregation](figures/query_memory_aggregation.mmd)
+
 ## Architecture
 - [Architecture Overview](architecture_overview.md)
 - [Blueprint Export](BLUEPRINT_EXPORT.md) – versioned snapshot of key documents
 - [Detailed Architecture](architecture.md)
 - [Crown Agent Overview](CROWN_OVERVIEW.md)
-- [Inner Memory](memory_layers_GUIDE.md) – layer guide with diagrams: [Memory Bundle](figures/memory_bundle.mmd), [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd), [Memory Layer Flow](figures/memory_layer_flow.mmd), [Query Memory Aggregation](figures/query_memory_aggregation.mmd)
 ## Nazarick
 - [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
 - [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -7,7 +7,7 @@ documents:
       key_rules: Review AGENTS and run pre-commit before committing.
       insight: Check AGENTS.md before committing changes.
   docs/ABZU_SUBSYSTEM_OVERVIEW.md:
-    sha256: e575ff650f076601f2dae9c09ccc3b0658999204f71a22508aab24c98f050445
+    sha256: 8168179d78a4af60a1186bf7a2b35db48f4404613000c47c24081d85d1ab4a8a
     summary:
       purpose: Overview of ABZU subsystems.
       scope: System architecture.
@@ -226,14 +226,14 @@ documents:
       key_rules: Review before altering system protection code.
       insight: Review before modifying system protection code.
   docs/INDEX.md:
-    sha256: c0622f688c8ad9d6fbd8f020e729720fa1eda44aaec23b78d802a6ebae40e6d1
+    sha256: c045c573ed599fd457833bb0cea6d02a7018ce193c065671838d712f3f648b96
     summary:
       purpose: Generated documentation index.
       scope: Repository documentation.
       key_rules: Regenerate index after documentation updates.
       insight: Regenerate with tools/doc_indexer.py after updating docs.
   docs/index.md:
-    sha256: d046489925a9aaedd77e2ee5a2c4daaf882fc64e6399b8d10b3ab3a615ac112e
+    sha256: 096baa9214beb03704e135d9b5d8772f129d05f73fe3174fd2010bccfcee368b
     summary:
       purpose: Curated documentation entry points.
       scope: Top-level docs index.


### PR DESCRIPTION
## Summary
- expand subsystem overview with standalone memory bundle diagram and layer bullets
- add Memory Bundle section to docs index linking to guide and diagrams
- update onboarding confirmations for touched docs

## Testing
- `PYTHONPATH=. pre-commit run --files docs/ABZU_SUBSYSTEM_OVERVIEW.md docs/index.md onboarding_confirm.yml` *(fails: missing metrics exporters and self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdff27964832eabeb201158d69e66