### PR TITLE
feat(operator-service): add ignition and handover web endpoints

### DIFF
--- a/operator_service/__init__.py
+++ b/operator_service/__init__.py
@@ -1,0 +1,3 @@
+"""Operator service exposing ignition, status, and handover APIs."""
+
+__all__ = ["app"]

--- a/operator_service/api.py
+++ b/operator_service/api.py
@@ -1,0 +1,59 @@
+"""FastAPI app exposing ignition, status and handover controls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+
+from razar import boot_orchestrator, ai_invoker, status_dashboard
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "web_operator" / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+
+def _stream(result: Iterable[str]) -> Iterator[str]:
+    """Yield items from ``result`` as strings."""
+    for item in result:
+        yield item if item.endswith("\n") else f"{item}\n"
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Serve arcade operator interface."""
+    return templates.TemplateResponse("arcade.html", {"request": request})
+
+
+@app.post("/start_ignition")
+async def start_ignition() -> StreamingResponse:
+    """Kick off ignition via ``boot_orchestrator.start`` and stream logs."""
+    logs = boot_orchestrator.start()  # type: ignore[attr-defined]
+    return StreamingResponse(_stream(logs), media_type="text/plain")
+
+
+@app.get("/status")
+async def status() -> dict:
+    """Return component statuses from RAZAR."""
+    components = status_dashboard._component_statuses()
+    return {"components": components}
+
+
+@app.post("/handover")
+async def handover(payload: dict) -> StreamingResponse:
+    """Delegate failure via ``ai_invoker.handover`` and stream logs."""
+    component = payload.get("component", "")
+    error = payload.get("error", "")
+    logs = ai_invoker.handover(component, error)
+    return StreamingResponse(_stream(logs), media_type="text/plain")

--- a/tests/web_operator/test_api.py
+++ b/tests/web_operator/test_api.py
@@ -1,0 +1,60 @@
+"""Tests for operator_service.api."""
+
+import json
+from typing import Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+
+from operator_service.api import app
+from razar import boot_orchestrator, ai_invoker, status_dashboard
+
+
+@pytest.fixture
+def client() -> Iterable[TestClient]:
+    """Return TestClient for operator service."""
+    with TestClient(app) as c:
+        yield c
+
+
+def test_start_ignition_streams(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called: list[str] = []
+
+    def fake_start() -> Iterable[str]:
+        called.append("yes")
+        yield json.dumps({"boot": "ok"})
+
+    monkeypatch.setattr(boot_orchestrator, "start", fake_start)
+    resp = client.post("/start_ignition")
+    assert resp.status_code == 200
+    assert called == ["yes"]
+    assert json.loads(resp.text) == {"boot": "ok"}
+
+
+def test_status_returns_components(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        status_dashboard,
+        "_component_statuses",
+        lambda: [{"name": "comp", "status": "up"}],
+    )
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"components": [{"name": "comp", "status": "up"}]}
+
+
+def test_handover_streams(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, tuple[str, str]] = {}
+
+    def fake_handover(component: str, error: str) -> Iterable[str]:
+        captured["args"] = (component, error)
+        yield json.dumps({"patched": True})
+
+    monkeypatch.setattr(ai_invoker, "handover", fake_handover)
+    resp = client.post("/handover", json={"component": "x", "error": "boom"})
+    assert resp.status_code == 200
+    assert captured["args"] == ("x", "boom")
+    assert json.loads(resp.text) == {"patched": True}

--- a/web_operator/templates/arcade.html
+++ b/web_operator/templates/arcade.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Arcade Operator</title>
+  <style>
+    body { background: black; color: #0ff; font-family: 'Press Start 2P', monospace; text-align:center; }
+    button { background:#f0f; color:#0ff; border:2px solid #0ff; padding:10px; margin:10px; cursor:pointer; }
+    #log { background:#000; color:#0f0; border:1px solid #0ff; padding:10px; margin-top:20px; height:200px; overflow:auto; white-space:pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>Arcade Operator</h1>
+  <button id="ignite">Ignite</button>
+  <button id="handover">Handover</button>
+  <button id="query">Query Memory</button>
+  <pre id="log"></pre>
+  <script>
+    async function streamText(url, options) {
+      const resp = await fetch(url, options);
+      const text = await resp.text();
+      document.getElementById('log').textContent = text;
+    }
+    document.getElementById('ignite').onclick = () => streamText('/start_ignition', {method:'POST'});
+    document.getElementById('handover').onclick = () => streamText('/handover', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({component:'demo', error:'boom'})});
+    document.getElementById('query').onclick = async () => {
+      const resp = await fetch('/status');
+      const data = await resp.json();
+      document.getElementById('log').textContent = JSON.stringify(data, null, 2);
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose /start_ignition, /status, /handover FastAPI endpoints under operator_service
- add 90's arcade-style web interface invoking those endpoints
- cover new API with unit tests

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files operator_service/__init__.py operator_service/api.py web_operator/templates/arcade.html tests/web_operator/test_api.py`
- `pytest --no-cov tests/web_operator/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbf1848988832eb82934f4eb9b4f18