### PR TITLE
docs: add operator console guide and links

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -358,6 +358,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [open_web_ui.md](open_web_ui.md) | Open Web UI Integration Guide | This guide describes how the Open Web UI front end connects to the ABZU server, the dependencies required, and the ev... | `../server.py` |
 | [opencode_client.md](opencode_client.md) | Opencode Client | - | - |
 | [operations.md](operations.md) | Operations | - | - |
+| [operator_console.md](operator_console.md) | Operator Console | Arcade-style web interface for issuing commands through the Operator API. | - |
 | [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
 | [operator_nazarick_bridge.md](operator_nazarick_bridge.md) | Operator-Nazarick Bridge | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |
 | [operator_protocol.md](operator_protocol.md) | Operator Protocol | Operator actions dispatched via the API include a unique `command_id` UUID. The identifier is returned in responses,... | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ abzu-memory-bootstrap
 ## Usage
 - [How to Use](how_to_use.md)
 - [UI Service](ui_service.md) – lightweight FastAPI interface for memory queries
+- [Operator Console](operator_console.md) – Arcade UI for Operator API commands
 - [Bootstrap World Script](../scripts/bootstrap_world.py) – populate mandatory layers with defaults
 
 ## Data

--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -1,0 +1,34 @@
+# Operator Console
+
+Arcade-style web interface for issuing commands through the Operator API.
+
+## UI Usage
+- Start the Operator API and serve `web_operator/templates/arcade.html`.
+- **Ignite** sends `/start_ignition`.
+- **Handover** posts to `/handover` with component and error payload.
+- **Query Memory** retrieves `/status` for component health and memory summaries.
+
+## Environment Variables
+- `OPERATOR_API_URL` – base URL of the Operator API (default `http://localhost:8000`).
+- `OPERATOR_TOKEN` – Bearer token for secured endpoints.
+- `CROWN_URL` – location of Crown/Kimi invoked by RAZAR.
+
+## Integration Flow
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant "Arcade UI" as ArcadeUI
+    participant "Operator API" as OperatorAPI
+    participant RAZAR
+    participant "Crown/Kimi" as CrownKimi
+
+    Operator->>ArcadeUI: Click action
+    ArcadeUI->>OperatorAPI: HTTP request
+    OperatorAPI->>RAZAR: Forward command
+    RAZAR->>CrownKimi: Orchestrate
+```
+
+## Version History
+| Version | Date       | Notes                       |
+|---------|------------|-----------------------------|
+| 0.1.0   | 2025-11-06 | Initial operator console doc |

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -43,6 +43,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Third Eye – Ajna** – `qnl_engine.py` interprets hexadecimal strings into musical glyphs and passes them back to the orchestrator; `scripts/data_validate.py` checks training data and `scripts/quality_score.py` evaluates component health.
 * **Crown – Sahasrara** – `start_spiral_os.py` and `init_crown_agent.py` initialise the entire ritual sequence.
 * **UI Service** – FastAPI front-end providing a browser gateway to memory queries. See [ui_service.md](ui_service.md).
+* **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md).
 
 When a command arrives, the orchestrator consults the current emotional state and vector memory to select a model. If hex data or ritual text is present, it hands the payload to the QNL engine which returns symbolic notes. The Sonic Core turns those notes into audio and animates the avatar while new vectors are logged for future reference. This flow allows the layers to reinforce one another so the system speaks and remembers with continuity.
 


### PR DESCRIPTION
## Summary
- add `docs/operator_console.md` to describe Arcade UI usage, required env vars, and flow from Operator to Crown
- link operator console from `docs/index.md` and `docs/project_overview.md`

## Testing
- `pre-commit run --files docs/operator_console.md docs/index.md docs/project_overview.md docs/INDEX.md` *(fails: missing agents module for chakra monitoring, no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3a3c3e0832ea0af0fde3fca703c