### PR TITLE
docs: expand operator interface and console service

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -16,6 +16,37 @@ Set up the local environment before running tools or tests:
 1. Copy `secrets.env.template` to `secrets.env` and provide values for `HF_TOKEN`, `GLM_API_URL`, and `GLM_API_KEY`.
 2. Run `scripts/check_requirements.sh` to confirm required binaries, the Python 3.11+ runtime, and necessary Python modules are present.
 
+### Operator Interface
+Operators supervise ignition and runtime behaviour. They issue boot commands,
+review handshake logs, and approve escalations before services become
+operator-facing.
+
+**Responsibilities**
+
+- Initiate boot and authorize service launches.
+- Monitor audit logs and memory summaries for anomalies.
+- Escalate to recovery routines when safeguards trigger.
+
+**Security Notes**
+
+- All console actions require authenticated tokens and are written to
+  append-only logs.
+- Rotate credentials after each mission brief and restrict console access to
+  trusted networks.
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant RAZAR
+    participant "Memory Bundle" as MemoryBundle
+    Operator->>RAZAR: initiate boot
+    RAZAR->>MemoryBundle: load layers
+    MemoryBundle-->>RAZAR: ready
+    RAZAR-->>Operator: request approval
+    Operator-->>RAZAR: authorize launch
+    RAZAR->>Operator: signal online
+```
+
 ## Repository Blueprint
 ABZU adheres to a consistent top-level directory layout:
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -36,7 +36,7 @@ Contributors must pair system enhancements with operator-facing improvements, up
 
 ### **Memory Architecture**
 
-ABZU synchronizes its Cortex, Emotional, Mental, Spiritual, and Narrative stores through a unified memory bundle. `broadcast_layer_event("layer_init")` boots all layers in parallel, and `query_memory` fans out reads across them before combining results into a single response.
+ABZU synchronizes its Cortex, Emotional, Mental, Spiritual, and Narrative stores through a unified memory bundle. `broadcast_layer_event("layer_init")` boots all layers in parallel, and `query_memory` fans out reads across them before combining results into a single response that an Operator Agent can relay to consoles.
 
 ```mermaid
 {{#include figures/layer_init_query_flow.mmd}}
@@ -61,6 +61,8 @@ The Mermaid source lives at [figures/layer_init_query_flow.mmd](figures/layer_in
     - **`spiritual.py`**, **`narrative_engine.py`**, etc., support higher-level symbolism and story logging.
 - **Operator & Interfaces**
     - **`operator_api.py`**, **`operator_interface_GUIDE.md`**: define command channels and upload routes.
+    - [operator_console.md](operator_console.md): arcade-style UI for issuing operator commands.
+    - [RAZAR Agent](RAZAR_AGENT.md): ignition orchestrator that bridges operator directives to services.
     - **`web_console/`**, **`dashboard/`**: front-end consoles consuming the API.
 - **Docs & Blueprints**
     

--- a/docs/figures/layer_init_query_flow.mmd
+++ b/docs/figures/layer_init_query_flow.mmd
@@ -16,3 +16,5 @@ flowchart LR
     Mental --> Aggregate
     Spiritual --> Aggregate
     Narrative --> Aggregate
+
+    Aggregate --> OperatorAgent[Operator Agent]

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -580,6 +580,26 @@ Detects objects with YOLOE and streams bounding boxes to the Large World Model f
 - **Recovery:** Reload YOLOE weights or restart the adapter.
 
 ## Non‑Essential Services
+### Operator Console Service
+Provides a web UI ([operator_console.md](operator_console.md)) that forwards operator
+commands through the Operator API and surfaces memory summaries from the unified
+bundle. Optional for headless deployments where operators issue requests via
+scripts.
+
+```mermaid
+flowchart LR
+    OperatorConsole -->|commands| RAZAR
+    RAZAR -->|status| OperatorConsole
+    RAZAR --> MemoryBundle[(Memory Bundle)]
+    MemoryBundle --> RAZAR
+```
+
+- **Layer:** Throat
+- **Priority:** 3
+- **Startup:** Launch after the chat gateway.
+- **Health Check:** Probe `/operator/health`.
+- **Recovery:** Redeploy static assets or restart the service.
+
 ### Audio Device
 Manages audio capture and playback. See [Audio Ingestion](audio_ingestion.md), [Voice Setup](voice_setup.md) and [Chakra Architecture](chakra_architecture.md#root).
 - **Layer:** Root
@@ -614,10 +634,11 @@ recommended for both local runs and production deployments described in
 0. RAZAR Startup Orchestrator (external, priority 0) – see [RAZAR Agent](RAZAR_AGENT.md)
 1. Memory Store (Heart, priority 1)
 2. Chat Gateway (Throat, priority 2)
-3. CROWN LLM (Crown, priority 2)
-4. Vision Adapter (Third Eye, priority 2)
-5. Audio Device (priority 3)
-6. Avatar (priority 4)
+3. Operator Console Service (Throat, priority 3, optional)
+4. CROWN LLM (Crown, priority 2)
+5. Vision Adapter (Third Eye, priority 2)
+6. Audio Device (priority 3)
+7. Avatar (priority 4)
 7. Video (priority 5)
 
 Each step should report readiness before continuing. After the final service

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -20,6 +20,13 @@ documents:
       scope: Entire platform.
       key_rules: Maintain architectural consistency.
       insight: Align new modules with existing architecture.
+  docs/blueprint_spine.md:
+    sha256: 6e96b0fc804fdb2dbfd8580b4601b22dd3c4dce1751840ae848534e6534689c4
+    summary:
+      purpose: Deep-dive overview of mission, agents, and memory bundle.
+      scope: System structure and narratives.
+      key_rules: Keep cross-links and diagrams synchronized.
+      insight: Highlights triadic stack and operator-first design.
   docs/bana_engine.md:
     sha256: 878ab78976e9d7f39d9d96eabbbc9cb2442e412080fcdb1d62bab9a72a991518
     summary:
@@ -162,7 +169,7 @@ documents:
         it succeeds.
       insight: Run the health check to catch connector outages early.
   docs/system_blueprint.md:
-    sha256: 9411fd238e5aaf5d751c9eb18a48ef47ec3a583aff2a11fde57f9bc6c710bf4f
+    sha256: eeb49c0b4965f7e69417462862ef363405a1617c25b8889fa112ccaf65d23ea0
     summary:
       purpose: Architectural blueprint overview.
       scope: System-wide architecture.
@@ -184,7 +191,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 8bbed5e41825b377d3d3a5a2a55c97690628ce42808f04c3ab82d1cb5d0d2d0d
+    sha256: 1f9b10d1bca899379f2d91b80d4e6dbffc264524d45669f41e21214afd853baf
     summary:
       purpose: Core contribution rules.
       scope: All contributors.


### PR DESCRIPTION
## Summary
- document operator interface duties and security notes
- link Operator Agent and console to system diagrams
- add Operator Console Service with memory-flow diagram

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_hashes.py onboarding_confirm.yml`
- `PYTHONPATH=. pre-commit run --files docs/The_Absolute_Protocol.md docs/figures/layer_init_query_flow.mmd docs/blueprint_spine.md docs/system_blueprint.md onboarding_confirm.yml docs/INDEX.md` *(fails: missing metrics exporters, no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf4ce24f8832e9cfd9389b127d440