### PR TITLE
Add ignition e2e tests for web operator

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -42,7 +42,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 15f50da5c4976146da69ab1ad9e0b0c08ddc62462aab9e650a90fc6561800f60
+    sha256: 9d56f16a7065a964fc442c25c4523ae7ac154c805cf452beb1a8ed3305833ffa
     summary:
       purpose: Project goals and scope.
       scope: Entire project.

--- a/tests/web_operator/test_ignition_e2e.py
+++ b/tests/web_operator/test_ignition_e2e.py
@@ -1,0 +1,50 @@
+"""End-to-end tests for operator_service ignition route."""
+
+import json
+from typing import Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+
+from operator_service.api import app
+from razar import boot_orchestrator
+
+
+@pytest.fixture
+def client() -> Iterable[TestClient]:
+    """Return TestClient that captures server errors as responses."""
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_ignition_success(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RAZAR ignition streams logs and ends in success."""
+    logs = [
+        json.dumps({"step": "init"}),
+        json.dumps({"status": "success"}),
+    ]
+
+    def fake_start() -> Iterable[str]:
+        for item in logs:
+            yield item
+
+    monkeypatch.setattr(boot_orchestrator, "start", fake_start)
+    resp = client.post("/start_ignition")
+    assert resp.status_code == 200
+    lines = resp.text.strip().splitlines()
+    assert lines == logs
+    assert json.loads(lines[-1])["status"] == "success"
+
+
+def test_ignition_crown_failure(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crown failure propagates as server error."""
+
+    def fail() -> Iterable[str]:  # pragma: no cover - failure path
+        raise RuntimeError("crown offline")
+
+    monkeypatch.setattr(boot_orchestrator, "start", fail)
+    resp = client.post("/start_ignition")
+    assert resp.status_code == 500
+    assert resp.text == "Internal Server Error"


### PR DESCRIPTION
## Summary
- add end-to-end tests for `/start_ignition` success path and Crown failure

## Testing
- `pre-commit run --files tests/web_operator/test_ignition_e2e.py onboarding_confirm.yml` *(fails: Coverage failure: total of 6 is less than fail-under=80)*
- `pytest --override-ini addopts="" tests/web_operator/test_ignition_e2e.py -q -rs` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf85250ac832e99a0d8746d946c43