### PR TITLE
test: add arcade flow coverage

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -42,7 +42,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 9d56f16a7065a964fc442c25c4523ae7ac154c805cf452beb1a8ed3305833ffa
+    sha256: c468df76c3a9862b353c650b603f9dfe88ee4e235e3a1f8da15eae784bbd0a96
     summary:
       purpose: Project goals and scope.
       scope: Entire project.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_lip_sync.py"),
     str(ROOT / "tests" / "test_memory_search.py"),
     str(ROOT / "tests" / "test_memory_persistence.py"),
+    str(ROOT / "tests" / "web_operator" / "test_arcade_flow.py"),
     str(ROOT / "tests" / "heart" / "memory_emotional" / "test_memory_emotional.py"),
     str(ROOT / "tests" / "test_start_dev_agents_triage.py"),
     str(ROOT / "tests" / "test_gateway.py"),

--- a/tests/web_operator/test_arcade_flow.py
+++ b/tests/web_operator/test_arcade_flow.py
@@ -1,0 +1,75 @@
+"""Arcade flow tests for web operator."""
+
+import json
+from typing import Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+
+from operator_service.api import app
+from razar import ai_invoker, boot_orchestrator, status_dashboard
+from scripts import welcome_banner
+
+
+@pytest.fixture
+def client() -> Iterable[TestClient]:
+    """Return TestClient for operator service."""
+    with TestClient(app) as c:
+        yield c
+
+
+def test_arcade_flow(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Simulate arcade button presses and verify responses and banner."""
+    # Ensure cuneiform banner prints correctly
+    welcome_banner.print_banner()
+    banner_output = capsys.readouterr().out.strip()
+    expected_banner = (
+        "\U0001202D\U00012129\U00012306 "
+        "\U00012120\U0001208A "
+        "\U0001213F\U0001213E\U00012100"
+    )
+    assert banner_output == expected_banner
+
+    # Arcade page loads
+    page_resp = client.get("/")
+    assert page_resp.status_code == 200
+    assert "Arcade Operator" in page_resp.text
+
+    # Mock backend behaviors
+    monkeypatch.setattr(
+        boot_orchestrator,
+        "start",
+        lambda: iter([json.dumps({"ignition": "ok"})]),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        status_dashboard,
+        "_component_statuses",
+        lambda: [{"name": "comp", "status": "up"}],
+    )
+    monkeypatch.setattr(
+        ai_invoker,
+        "handover",
+        lambda component, error: iter([json.dumps({"handover": "done"})]),
+    )
+
+    # Ignite button
+    resp = client.post("/start_ignition")
+    assert resp.status_code == 200
+    ignition_logs = [json.loads(line) for line in resp.text.strip().splitlines()]
+    assert ignition_logs == [{"ignition": "ok"}]
+
+    # Query button
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"components": [{"name": "comp", "status": "up"}]}
+
+    # Handover button
+    resp = client.post("/handover", json={"component": "demo", "error": "boom"})
+    assert resp.status_code == 200
+    handover_logs = [json.loads(line) for line in resp.text.strip().splitlines()]
+    assert handover_logs == [{"handover": "done"}]


### PR DESCRIPTION
## Summary
- exercise arcade operator ignition, status query, and handover interactions
- enable arcade flow test in the suite and refresh onboarding confirmation hash

## Testing
- `pre-commit run --files tests/web_operator/test_arcade_flow.py tests/conftest.py onboarding_confirm.yml` *(fails: Required test coverage of 80% not reached)*
- `pytest tests/web_operator/test_arcade_flow.py --cov=tests/web_operator/test_arcade_flow.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68bc0d574024832eba193bdaadfc9fda