### PR TITLE
feat: bootstrap memory layers with optional fallbacks

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -339,7 +339,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.1 **Last updated:** 2025-09-05 | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.2 **Last updated:** 2025-09-06 | `../scripts/bootstrap_memory.py` |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,7 +1,7 @@
 # Memory Layers Guide
 
-**Version:** v1.0.1
-**Last updated:** 2025-09-05
+**Version:** v1.0.2
+**Last updated:** 2025-09-06
 
 This guide describes the event bus protocol and query flow connecting the
 Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
@@ -58,6 +58,17 @@ or its dependencies are missing, the bundle substitutes the no-op
 implementation from `memory.optional` and marks the status as `defaulted`.
 Any other import error is reported as `error`, but initialization continues
 and emits a consolidated result.
+
+### Command-line bootstrap
+
+The script [`scripts/bootstrap_memory.py`](../scripts/bootstrap_memory.py)
+initializes the bundle from the command line and logs layer statuses:
+
+```bash
+python scripts/bootstrap_memory.py
+```
+
+Use this during development to verify all layers import correctly.
 
 ## Query aggregation
 

--- a/memory/optional/__init__.py
+++ b/memory/optional/__init__.py
@@ -1,6 +1,7 @@
 """Fallback implementations for optional memory layers."""
 
 __all__ = [
+    "cortex",
     "mental",
     "emotional",
     "spiritual",

--- a/memory/optional/cortex.py
+++ b/memory/optional/cortex.py
@@ -1,0 +1,15 @@
+"""No-op cortex layer used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, List
+
+
+def query_spirals(*args: Any, **kwargs: Any) -> List[Any]:
+    """Return an empty list as no cortex records are stored."""
+    return []
+
+
+__all__ = ["query_spirals"]

--- a/memory/query_memory.py
+++ b/memory/query_memory.py
@@ -13,10 +13,13 @@ from typing import Any, Dict, List
 try:  # pragma: no cover - cortex may be unavailable
     from .cortex import query_spirals
 except Exception:  # pragma: no cover - logged lazily
+    try:
+        from .optional.cortex import query_spirals
+    except Exception:
 
-    def query_spirals(*args: Any, **kwargs: Any) -> list[Any]:
-        """Fallback returning no cortex results."""
-        return []
+        def query_spirals(*args: Any, **kwargs: Any) -> list[Any]:
+            """Fallback returning no cortex results."""
+            return []
 
 
 try:  # pragma: no cover - optional dependency
@@ -82,6 +85,9 @@ def query_memory(query: str) -> Dict[str, Any]:
         logger.exception("spiral recall failed")
         spiral_res = ""
         failed_layers.append("spiral")
+
+    if failed_layers:
+        logger.warning("query_memory partial failure: %s", ", ".join(failed_layers))
 
     return {
         "cortex": cortex_res,


### PR DESCRIPTION
## Summary
- load memory layers with optional fallbacks and emit status event
- log partial query failures and provide cortex no-op
- document bootstrap script for verifying memory layers

## Testing
- `SKIP=verify-chakra-monitoring,verify-self-healing,verify-doctrine,pytest-cov pre-commit run --files memory/bundle.py memory/optional/cortex.py memory/optional/__init__.py memory/query_memory.py docs/memory_layers_GUIDE.md docs/INDEX.md`
- `PYTHONPATH=. python scripts/bootstrap_memory.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*


------
https://chatgpt.com/codex/tasks/task_e_68bc120eff2c832eaaff124c9b01fead