### PR TITLE
Add observability endpoints and event bus spans

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,6 +164,10 @@ collector's UI for correlation with metrics. Memory queries also emit spans for
 each layer, enabling trace-based performance analysis alongside agent event
 emission.
 
+Message flow across agents is traceable as well. The `agents.event_bus`
+module now wraps publish and subscribe operations in spans, allowing you to
+follow events from emission to consumption within your chosen trace viewer.
+
 ### Troubleshooting
 
 - Ensure `psutil` and `prometheus_client` are installed.

--- a/operator_service/api.py
+++ b/operator_service/api.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from memory import query_memory
 from razar import boot_orchestrator, status_dashboard
@@ -26,6 +27,7 @@ BASE_DIR = Path(__file__).resolve().parents[1] / "web_operator"
 TEMPLATE_DIR = BASE_DIR / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 app.mount("/static", StaticFiles(directory=str(BASE_DIR)), name="static")
+Instrumentator().instrument(app).expose(app)
 
 
 def _stream(result: Iterable[str]) -> Iterator[str]:
@@ -59,3 +61,9 @@ async def status() -> dict:
     """Return component statuses from RAZAR."""
     components = status_dashboard._component_statuses()
     return {"components": components}
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    """Basic liveness probe."""
+    return {"status": "ok"}

--- a/ui_service.py
+++ b/ui_service.py
@@ -9,10 +9,12 @@ from typing import Any, Dict
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from memory.query_memory import query_memory
 
 app = FastAPI(title="UI Service")
+Instrumentator().instrument(app).expose(app)
 
 templates = Jinja2Templates(directory="templates")
 
@@ -32,6 +34,12 @@ async def boot(request: Request) -> HTMLResponse:
 @app.get("/status")
 async def status() -> Dict[str, str]:
     """Return a simple status indicator."""
+    return {"status": "ok"}
+
+
+@app.get("/healthz")
+async def healthz() -> Dict[str, str]:
+    """Alias for Kubernetes health probes."""
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- instrument event bus with OpenTelemetry spans for publish and subscribe
- expose `/metrics` and `/healthz` on operator and UI FastAPI services
- document monitoring setup and event bus tracing

## Testing
- `pre-commit run --files agents/event_bus.py operator_service/api.py ui_service.py docs/operations.md`
- `pytest --no-cov tests/agents/test_event_bus.py tests/web_operator/test_api.py tests/web_ui/test_boot_page.py tests/web_ui/test_memory_query.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc44e1d584832e92ef7354232329de