### PR TITLE
feat: expose memory query endpoint

### DIFF
--- a/operator_service/api.py
+++ b/operator_service/api.py
@@ -56,6 +56,12 @@ async def query(payload: dict) -> dict:
     return query_memory(text)
 
 
+@app.get("/memory/query")
+async def memory_query(prompt: str) -> dict:
+    """Return aggregated memory search results via ``query_memory``."""
+    return query_memory(prompt)
+
+
 @app.get("/status")
 async def status() -> dict:
     """Return component statuses from RAZAR."""

--- a/tests/web_operator/test_api.py
+++ b/tests/web_operator/test_api.py
@@ -54,3 +54,29 @@ def test_query_returns_results(
     resp = client.post("/query", json={"query": "hi"})
     assert resp.status_code == 200
     assert resp.json() == {"res": "ok"}
+
+
+def test_memory_query_success(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = {
+        "cortex": [],
+        "vector": [],
+        "spiral": "",
+        "failed_layers": [],
+    }
+    monkeypatch.setattr(api, "query_memory", lambda q: expected)
+    resp = client.get("/memory/query", params={"prompt": "hi"})
+    assert resp.status_code == 200
+    assert resp.json() == expected
+
+
+def test_memory_query_error(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(_: str) -> dict:
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(api, "query_memory", boom)
+    resp = client.get("/memory/query", params={"prompt": "hi"})
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- add `GET /memory/query` endpoint that invokes `memory.query_memory`
- cover success and error paths for new endpoint

## Testing
- `pre-commit run --files operator_service/api.py tests/web_operator/test_api.py` (fails: Required test coverage of 80% not reached)
- `pytest tests/web_operator/test_api.py::test_memory_query_success tests/web_operator/test_api.py::test_memory_query_error --cov-fail-under=0` (skipped: requires unavailable resources)


------
https://chatgpt.com/codex/tasks/task_e_68bc4899e24c832e9f827ea87f010e62