### PR TITLE
feat: add memory scan interface

### DIFF
--- a/web_operator/arcade.css
+++ b/web_operator/arcade.css
@@ -1,6 +1,44 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 body { background: #000; color: #0ff; font-family: 'Press Start 2P', monospace; text-align: center; }
 button { background: #111; color: #0ff; border: 2px solid #0ff; padding: 10px; margin: 10px; cursor: pointer; }
 #log { background: #000; color: #0f0; border: 1px solid #0ff; padding: 10px; margin-top: 20px; height: 200px; overflow: auto; white-space: pre-wrap; }
 .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.8); align-items: center; justify-content: center; }
 .modal-content { background: #111; padding: 20px; border: 2px solid #0ff; }
 .modal.show { display: flex; }
+
+.pixel-font { font-family: 'Press Start 2P', monospace; }
+
+.scanlines {
+  position: relative;
+  overflow: hidden;
+}
+
+.scanlines::after {
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0px,
+    rgba(0, 0, 0, 0) 2px,
+    rgba(0, 0, 0, 0.25) 3px,
+    rgba(0, 0, 0, 0.25) 4px
+  );
+  z-index: 1;
+}
+
+.retro-table {
+  margin: 20px auto;
+  border-collapse: collapse;
+}
+
+.retro-table th,
+.retro-table td {
+  border: 1px solid #0ff;
+  padding: 4px 8px;
+}

--- a/web_operator/main.js
+++ b/web_operator/main.js
@@ -1,0 +1,45 @@
+async function memoryScan() {
+  const query = document.getElementById('memory-query').value;
+  const resp = await fetch('/memory/query', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query })
+  });
+  const data = await resp.json();
+  renderMemoryResults(Array.isArray(data) ? data : []);
+}
+
+function renderMemoryResults(data) {
+  const container = document.getElementById('memory-results');
+  container.innerHTML = '';
+  if (data.length === 0) {
+    container.textContent = 'No results';
+    return;
+  }
+  const table = document.createElement('table');
+  table.className = 'retro-table';
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  const keys = Object.keys(data[0]);
+  keys.forEach(key => {
+    const th = document.createElement('th');
+    th.textContent = key;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  data.forEach(item => {
+    const row = document.createElement('tr');
+    keys.forEach(key => {
+      const cell = document.createElement('td');
+      cell.textContent = item[key];
+      row.appendChild(cell);
+    });
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  container.appendChild(table);
+}
+
+document.getElementById('memory-scan-btn').addEventListener('click', memoryScan);

--- a/web_operator/templates/arcade.html
+++ b/web_operator/templates/arcade.html
@@ -16,6 +16,12 @@
   <button id="ignite">Ignite</button>
   <button id="query">Query Memory</button>
   <button id="status">Status</button>
+  <section id="memory-scan">
+    <h2>Memory Scan</h2>
+    <input type="text" id="memory-query" class="pixel-font" placeholder="Enter query" />
+    <button id="memory-scan-btn">Scan</button>
+    <div id="memory-results" class="scanlines"></div>
+  </section>
   <pre id="log"></pre>
   <script>
     async function streamText(url, options) {
@@ -38,5 +44,6 @@
       document.getElementById('greeting-modal').classList.remove('show');
     };
   </script>
+  <script src="/static/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add memory scan controls to arcade operator template
- render `/memory/query` results via new main.js in retro table
- style memory scanner with pixel fonts and scanline overlay

## Testing
- `pre-commit run --files web_operator/templates/arcade.html web_operator/arcade.css web_operator/main.js` *(fails: Required test coverage of 80% not reached)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4ad8e780832e9d61ae6d403a9178