### PR TITLE
docs: document arcade ui memory scan workflow

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/arcade_ui.md
+++ b/docs/arcade_ui.md
@@ -13,6 +13,14 @@ Operator-facing arcade interface that bridges the Operator API and RAZAR.
 - `OPERATOR_TOKEN` – bearer token used for authenticated requests.
 - `CROWN_URL` – Crown service RAZAR delegates to after approval.
 
+## Quickstart
+```bash
+export OPERATOR_API_URL="http://localhost:8000"
+export OPERATOR_TOKEN="<token>"
+npm start --prefix web_console
+# visit http://localhost:5173 and click Memory Scan
+```
+
 ## Operator Interaction
 The operator uses the Arcade UI to send HTTP commands to the Operator API. Each button forwards a request that RAZAR interprets
 and relays to Crown. Responses bubble back to the arcade, giving the operator real‑time feedback on system state.
@@ -29,6 +37,20 @@ sequenceDiagram
     ArcadeUI->>OperatorAPI: REST call
     OperatorAPI->>RAZAR: delegate
     RAZAR->>Crown: orchestrate
+```
+
+## Memory Scan
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant "Arcade UI" as ArcadeUI
+    participant "/memory/query" as MemoryQuery
+    participant MemoryBundle
+
+    Operator->>ArcadeUI: click Memory Scan
+    ArcadeUI->>MemoryQuery: GET /memory/query
+    MemoryQuery->>MemoryBundle: aggregate layers
 ```
 
 ## Version History

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ abzu-memory-bootstrap
 - [How to Use](how_to_use.md)
 - [UI Service](ui_service.md) – lightweight FastAPI interface for memory queries
 - [Operator Console](operator_console.md) – Arcade UI for Operator API commands
-- [Arcade UI](arcade_ui.md) – features, env vars, and RAZAR interaction
+- [Arcade UI](arcade_ui.md) – features, env vars, quickstart, and memory scan sequence
 - [Operator Interface Guide](operator_interface_GUIDE.md) – REST endpoints for Crown and RAZAR control
 - [Bootstrap World Script](../scripts/bootstrap_world.py) – populate mandatory layers with defaults
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -14,7 +14,7 @@ Follow this reading order before contributing. After reviewing each document, re
    - [Persona API Guide](../persona_api_guide.md)
    - [Spiral Cortex Terminal](../spiral_cortex_terminal.md)
 
-6. [Arcade UI](../arcade_ui.md)
+6. [Arcade UI](../arcade_ui.md) – quickstart workflow and memory scan diagram
 
 Confirm each item before starting code changes.
 

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -44,7 +44,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Crown – Sahasrara** – `start_spiral_os.py` and `init_crown_agent.py` initialise the entire ritual sequence.
 * **UI Service** – FastAPI front-end providing a browser gateway to memory queries. See [ui_service.md](ui_service.md).
 * **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md).
-* **Arcade UI** – features and environment variables for operator commands. See [arcade_ui.md](arcade_ui.md).
+* **Arcade UI** – features, quickstart, and memory scan sequence. See [arcade_ui.md](arcade_ui.md).
 
 When a command arrives, the orchestrator consults the current emotional state and vector memory to select a model. If hex data or ritual text is present, it hands the payload to the QNL engine which returns symbolic notes. The Sonic Core turns those notes into audio and animates the avatar while new vectors are logged for future reference. This flow allows the layers to reinforce one another so the system speaks and remembers with continuity.
 


### PR DESCRIPTION
## Summary
- extend Arcade UI docs with quickstart and Memory Scan sequence diagram
- cross-link Arcade UI from index, project overview, and onboarding checklist

## Testing
- `PYTHONPATH=. pre-commit run --files docs/arcade_ui.md docs/index.md docs/onboarding/README.md docs/project_overview.md docs/INDEX.md` *(failed: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c46ab68832e83c6e4e45022fef3