### PR TITLE
docs: document arcade memory interface

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -62,6 +62,23 @@ The arcade console offers a retro portal for mission control.
 - Maintain readable contrast and avoid flashing sequences over 10 Hz.
 - Align chakra events with their canonical color palette.
 
+#### Arcade Memory Interface
+The console can inspect memory readiness during ignition via `/memory/query`.
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant Console
+    participant RAZAR
+    participant Memory as "Memory Bundle"
+    Operator->>Console: start ignition
+    Console->>RAZAR: /start_ignition
+    RAZAR->>Memory: /memory/query
+    Memory-->>RAZAR: bundle status
+    RAZAR-->>Console: report
+    Console-->>Operator: display readiness
+```
+
 ## Repository Blueprint
 ABZU adheres to a consistent top-level directory layout:
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -86,6 +86,7 @@ sequenceDiagram
 graph TD
     Arcade[Arcade Console]
     RAZAR[RAZAR]
+    Scan[Operator Memory Scan]
     subgraph MemoryBundle
         Cortex
         Emotional
@@ -94,6 +95,8 @@ graph TD
         Narrative
     end
     Arcade --> RAZAR
+    Arcade --> Scan
+    Scan --> MemoryBundle
     RAZAR --> MemoryBundle
     MemoryBundle --> Arcade
 ```

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -630,10 +630,9 @@ Offers a retro-styled portal that narrates boot sequences with Sumerian motifs.
 
 ```mermaid
 flowchart LR
-    Tablet[(Tablet of Destinies)] --> ArcadeUI[Arcade UI]
-    ArcadeUI --> RAZAR
-    RAZAR --> MemoryBundle[(Memory Bundle)]
-    MemoryBundle --> ArcadeUI
+    Console[Arcade Console] --> OperatorAPI[Operator API]
+    OperatorAPI --> MemoryBundle[(Memory Bundle)]
+    MemoryBundle --> Console
 ```
 
 - **Layer:** Throat


### PR DESCRIPTION
## Summary
- add Arcade Memory Interface sequence to The Absolute Protocol
- attach Operator Memory Scan node to the Blueprint Spine memory bundle
- link console, Operator API, and memory layers in the Arcade UI Service

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/blueprint_spine.md docs/system_blueprint.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*
- `pytest` *(fails: 38 errors during collection including missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4ded7d1c832ebcd0490cfcbd6e48