### PR TITLE
docs: add arcade UI quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
 For deeper background, consult the [CRYSTAL CODEX](CRYSTAL_CODEX.md) and the [documentation inventory](docs/INDEX.md).
 
+## Quick Start – Arcade UI
+
+Set up the Arcade UI and run a sample memory query:
+
+```bash
+pip install -r requirements.lock
+bash scripts/start_local.sh
+```
+
+When the browser opens, click **Memory Scan** to query the memory bus.
+
+Verify the stack and docs:
+
+```bash
+pytest tests/test_memory_bus.py -q
+mkdocs build
+```
+
 ## Requirements
 - Python 3.11 or newer. Use [`pyenv`](https://github.com/pyenv/pyenv) if available to manage multiple versions.
 - Core dependencies are pinned in `requirements.txt` and `dev-requirements.txt`.


### PR DESCRIPTION
## Summary
- document Arcade UI quick start steps and sample memory scan in README
- note commands for verifying memory bus and rebuilding documentation

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files README.md`
- `pytest tests/test_memory_bus.py -q` *(fails: assert ready == seeded; missing narrative layer; service unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4fcb3a80832e8623d6f53896ca2d