### PR TITLE
feat: route openwebui chats to channels

### DIFF
--- a/tests/crown/server/test_openwebui_bridge.py
+++ b/tests/crown/server/test_openwebui_bridge.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import tests.crown.server.test_server as base
+import httpx
+import pytest
+
+server = base.server
+settings = base.settings
+
+
+def _auth_headers() -> dict[str, str]:
+    async def _login() -> str:
+        transport = httpx.ASGITransport(app=server.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/token", data={"username": "user", "password": "pass"}
+            )
+        return resp.json()["access_token"]
+
+    token = asyncio.run(_login())
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_openwebui_defaults_to_crown(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, str] = {}
+
+    def fake_crown(msg: str, _glm) -> dict[str, str]:
+        called["msg"] = msg
+        return {"text": "crown", "model": "stub"}
+
+    def fail(*_a, **_k):  # pragma: no cover - should not route
+        raise AssertionError("nazarick called")
+
+    monkeypatch.setattr(server, "crown_prompt_orchestrator", fake_crown)
+    monkeypatch.setattr(server, "nazarick_chat", fail)
+
+    async def run() -> tuple[int, dict[str, object]]:
+        transport = httpx.ASGITransport(app=server.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/openwebui-chat",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+                headers=_auth_headers(),
+            )
+        return resp.status_code, resp.json()
+
+    status, data = asyncio.run(run())
+    assert status == 200
+    assert called["msg"] == "hi"
+    assert data["choices"][0]["message"]["content"] == "crown"
+
+
+def test_openwebui_routes_to_nazarick(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, str] = {}
+
+    def fake_nazarick(channel: str, text: str) -> dict[str, str]:
+        called["channel"] = channel
+        called["text"] = text
+        return {"text": "nazarick", "model": "stub"}
+
+    def fail(*_a, **_k):  # pragma: no cover - should not route
+        raise AssertionError("crown called")
+
+    monkeypatch.setattr(server, "nazarick_chat", fake_nazarick)
+    monkeypatch.setattr(server, "crown_prompt_orchestrator", fail)
+
+    async def run() -> tuple[int, dict[str, object]]:
+        transport = httpx.ASGITransport(app=server.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/openwebui-chat",
+                params={"channel": "#signal-hall"},
+                json={"messages": [{"role": "user", "content": "hello"}]},
+                headers=_auth_headers(),
+            )
+        return resp.status_code, resp.json()
+
+    status, data = asyncio.run(run())
+    assert status == 200
+    assert called["channel"] == "#signal-hall"
+    assert called["text"] == "hello"
+    assert data["choices"][0]["message"]["content"] == "nazarick"

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -20,6 +20,21 @@ const GLYPHS = {
     neutral: '🌀'
 };
 
+let mode = 'crown';
+const modeSel = document.createElement('select');
+modeSel.id = 'mode-select';
+['Crown', 'Nazarick'].forEach((label) => {
+    const opt = document.createElement('option');
+    opt.value = label.toLowerCase();
+    opt.textContent = label;
+    modeSel.appendChild(opt);
+});
+modeSel.addEventListener('change', (e) => {
+    mode = e.target.value;
+});
+const cmdInput = document.getElementById('command-input');
+cmdInput.insertAdjacentElement('beforebegin', modeSel);
+
 function applyStyle(style) {
     const video = document.getElementById('avatar');
     let overlay = document.getElementById('style-indicator');
@@ -118,15 +133,28 @@ function sendCommand(command, agent) {
             return;
         }
     }
-    const payload = { command: cmd };
-    if (agent) {
-        payload.agent = agent;
+    let url;
+    let options;
+    if (mode === 'nazarick') {
+        url = `${BASE_URL}/openwebui-chat${agent ? `?channel=${encodeURIComponent(agent)}` : ''}`;
+        options = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ messages: [{ role: 'user', content: cmd }] })
+        };
+    } else {
+        const payload = { command: cmd };
+        if (agent) {
+            payload.agent = agent;
+        }
+        url = `${BASE_URL}/glm-command`;
+        options = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        };
     }
-    fetch(API_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-    })
+    fetch(url, options)
         .then((resp) => resp.json())
         .then((data) => {
             document.getElementById('output').textContent = JSON.stringify(data, null, 2);


### PR DESCRIPTION
## Summary
- allow `/openwebui-chat` to accept a `channel` parameter and forward messages to Nazarick agents
- add Crown vs Nazarick selector in web console to toggle API endpoints
- cover new channel routing with tests

## Testing
- `pre-commit run --files server.py web_console/main.js tests/crown/server/test_openwebui_bridge.py` *(fails: Required test coverage of 80% not reached)*
- `pytest tests/crown/server/test_openwebui_bridge.py -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58d946a0832eade85dc0e1f8517f