### PR TITLE
docs: outline Crown vs. Nazarick console modes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ abzu-memory-bootstrap
 - [Nazarick Narrative System](nazarick_narrative_system.md) – maps story events to agents and memory layers
 - [Nazarick Manifesto](nazarick_manifesto.md)
 - [Nazarick Web Console](nazarick_web_console.md)
+- [Crown vs. Nazarick Modes](nazarick_web_console.md#crown-vs-nazarick-modes) – choose the right interface
 - [Operator Protocol](operator_protocol.md)
 - [Nazarick Guide](Nazarick_GUIDE.md) – servant orchestration and configuration
 - [Albedo Guide](Albedo_GUIDE.md) – personality layer shaping responses

--- a/docs/nazarick_web_console.md
+++ b/docs/nazarick_web_console.md
@@ -6,6 +6,23 @@ The Nazarick Web Console provides a browser-based interface for issuing commands
 
 The console includes a status panel that polls `/operator/status` for component health, recent errors, and memory usage.
 
+## Crown vs. Nazarick Modes
+
+Operators can route actions through the Crown API or a Nazarick channel.
+Choose the Crown path for system‑wide commands and initialization rites.
+Switch to a Nazarick channel when collaborating with a specific servant or
+following a narrative thread.
+
+- **Crown API** – direct control of services and debugging hooks.
+- **Nazarick Channel** – chat-oriented flows for individual agents.
+
+```mermaid
+flowchart LR
+    O[Operator] --> M{Mode Selector}
+    M --> C[Crown API]
+    M --> N[Nazarick Channel]
+```
+
 ## Interaction Diagram
 
 ```mermaid

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -44,6 +44,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Crown – Sahasrara** – `start_spiral_os.py` and `init_crown_agent.py` initialise the entire ritual sequence.
 * **UI Service** – FastAPI front-end providing a browser gateway to memory queries. See [ui_service.md](ui_service.md).
 * **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md).
+* **Nazarick Web Console** – developer dashboard bridging Crown and Nazarick interfaces. See [Crown vs. Nazarick Modes](nazarick_web_console.md#crown-vs-nazarick-modes).
 * **Arcade UI** – features, quickstart, and memory scan sequence. See [arcade_ui.md](arcade_ui.md).
 
 When a command arrives, the orchestrator consults the current emotional state and vector memory to select a model. If hex data or ritual text is present, it hands the payload to the QNL engine which returns symbolic notes. The Sonic Core turns those notes into audio and animates the avatar while new vectors are logged for future reference. This flow allows the layers to reinforce one another so the system speaks and remembers with continuity.


### PR DESCRIPTION
## Summary
- document Crown vs. Nazarick modes for the Nazarick web console, including a diagram.
- cross-link new guidance from the project overview and documentation index.

## Testing
- `pre-commit run --files docs/nazarick_web_console.md docs/project_overview.md docs/index.md` *(failed: missing metrics exporters and self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b4a4884832e8ac3288fb26f754a