### PR TITLE
feat(operator): enable runtime servant swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Emitted structured health events during RAZAR boot and introduced recovery daemon for automated restarts.
 - Added `/operator/status` endpoint reporting component health, recent errors, and memory usage; bumped `operator_api` to 0.3.5.
+- Runtime servant model registration: `servant_model_manager` now supports
+  unregistering and reloading handlers, and `operator_api` exposes endpoints
+  to add or remove servant models at runtime (v0.3.6).
 
 - Added `environment.gpu.yml` and CPU/GPU Dockerfiles with pinned versions and documented hardware setup.
 - Documented inner memory guide and diagrams in the documentation index and linked cross-references from the Blueprint Spine and System Blueprint.

--- a/component_index.json
+++ b/component_index.json
@@ -3095,7 +3095,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "operator_api.py",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": [
         "__future__",
         "agents",

--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -29,8 +29,26 @@ sequenceDiagram
     RAZAR->>CrownKimi: Orchestrate
 ```
 
+## Runtime Model Management
+Operators can hot-swap servant models without restarting the console using the Operator API.
+
+- `POST /operator/models` registers a new servant.
+- `DELETE /operator/models/{name}` removes one.
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant API
+    participant Manager
+    Operator->>API: register servant
+    API->>Manager: register_model
+    Operator->>API: remove servant
+    API->>Manager: unregister_model
+```
+
 ## Version History
 | Version | Date       | Notes                              |
 |---------|------------|------------------------------------|
+| 0.3.0   | 2025-11-07 | Document runtime model management  |
 | 0.2.0   | 2025-11-06 | Added query endpoint and greeting  |
 | 0.1.0   | 2025-11-06 | Initial operator console doc       |

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -455,7 +455,9 @@ are registered via `init_crown_agent.py` and booted with
 guided by `_EMOTION_MODEL_MATRIX`: joy and excited map to DeepSeek,
 stress, fear and sadness route to Mistral, while calm or neutral tones
 use GLM. See [LLM Models](LLM_MODELS.md) for
-`MoGEOrchestrator` heuristics and further context.
+`MoGEOrchestrator` heuristics and further context. Servant models can
+also be swapped at runtime through Operator API endpoints that
+register or unregister handlers via `servant_model_manager`.
 
 ## Persona Layers
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = true

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -42,7 +42,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: c468df76c3a9862b353c650b603f9dfe88ee4e235e3a1f8da15eae784bbd0a96
+    sha256: 57e42c75981ab1e97b3002cdc741500025bf6ba39f4a8bbd91313613ab30ce3a
     summary:
       purpose: Project goals and scope.
       scope: Entire project.
@@ -169,7 +169,7 @@ documents:
         it succeeds.
       insight: Run the health check to catch connector outages early.
   docs/system_blueprint.md:
-    sha256: 136e125552c0c2079faa0079f4d56763de2440172d279c2685ddf1bcae786ad0
+    sha256: 59c67828c311eb69c6d875e0df69f95cc3757821a385ab6e2344d2805283c8ac
     summary:
       purpose: Architectural blueprint overview.
       scope: System-wide architecture.
@@ -191,7 +191,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: 84a94abb953d959ffe92422729f5a87bb7536a5984f3e7bf6eb30f5b11e1e92d
+    sha256: 75084c1443ea96cb794c62dc1e3cf4403839af3b6fdd786cee025c360f3f03d2
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/servant_model_manager.py
+++ b/servant_model_manager.py
@@ -19,6 +19,18 @@ def register_model(name: str, handler: _Handler) -> None:
         _REGISTRY[name] = handler
 
 
+def unregister_model(name: str) -> None:
+    """Remove ``name`` from the registry if present."""
+    with _LOCK:
+        _REGISTRY.pop(name, None)
+
+
+def reload_model(name: str, handler: _Handler) -> None:
+    """Replace ``name`` with ``handler``, registering if absent."""
+    with _LOCK:
+        _REGISTRY[name] = handler
+
+
 def register_subprocess_model(name: str, command: List[str]) -> None:
     """Register a model invoked via subprocess ``command``."""
 
@@ -77,6 +89,8 @@ def invoke_sync(name: str, prompt: str) -> str:
 
 __all__ = [
     "register_model",
+    "unregister_model",
+    "reload_model",
     "register_subprocess_model",
     "invoke",
     "invoke_sync",

--- a/tests/test_operator_api.py
+++ b/tests/test_operator_api.py
@@ -180,3 +180,18 @@ def test_status_endpoint(client: TestClient, tmp_path: Path) -> None:
     assert "components" in body
     assert body["errors"] == ["error: boom"]
     assert body["memory"]["files"] == 1
+
+
+def test_register_and_unregister_servant_model(client: TestClient) -> None:
+    """Operator can register and remove servant models at runtime."""
+
+    resp = client.post(
+        "/operator/models",
+        json={"name": "echo", "command": ["bash", "-lc", "cat"]},
+    )
+    assert resp.status_code == 200
+    assert "echo" in resp.json()["models"]
+
+    resp = client.delete("/operator/models/echo")
+    assert resp.status_code == 200
+    assert "echo" not in resp.json()["models"]


### PR DESCRIPTION
## Summary
- allow registering or removing servant models at runtime through operator API
- track servant model swaps in operator console docs and system blueprint
- support unregistering and reloading handlers in servant model manager

## Testing
- `pre-commit run --files CHANGELOG.md component_index.json docs/operator_console.md docs/system_blueprint.md onboarding_confirm.yml operator_api.py servant_model_manager.py tests/test_operator_api.py mypy.ini` *(fails: mypy type errors; missing monitoring deps)*
- `pytest tests/test_operator_api.py::test_register_and_unregister_servant_model -q` *(fails: coverage threshold not met)*


------
https://chatgpt.com/codex/tasks/task_e_68bc665a26b4832e83a9c53f8d025243