### PR TITLE
Integrate Nazarick ethics manifesto checks

### DIFF
--- a/INANNA_AI/ethical_validator.py
+++ b/INANNA_AI/ethical_validator.py
@@ -15,6 +15,7 @@ from typing import Dict, Iterable, List
 import numpy as np
 
 from . import adaptive_learning
+from agents.nazarick.ethics_manifesto import Manifesto
 
 try:
     from sentence_transformers import SentenceTransformer
@@ -48,13 +49,19 @@ class EthicalValidator:
         *,
         banned_keywords: Iterable[str] | None = None,
         banned_categories: Dict[str, List[str]] | None = None,
+        manifesto: Manifesto | None = None,
         log_dir: str | Path = "audit_logs",
         threshold: float = 0.7,
         model_name: str = "all-MiniLM-L6-v2",
     ) -> None:
         self.allowed = set(allowed_users or [])
         self.banned = [kw.lower() for kw in (banned_keywords or [])]
-        self.categories = banned_categories or DEFAULT_CATEGORIES
+        self.manifesto = manifesto or Manifesto()
+        self.ethos = self.manifesto.ethos
+        manifest_cats = {
+            law.name: list(law.keywords) for law in self.manifesto._laws.values()
+        }
+        self.categories = {**manifest_cats, **(banned_categories or {})}
         self.threshold = threshold
         self.log_dir = Path(log_dir)
 
@@ -111,6 +118,10 @@ class EthicalValidator:
         if user not in self.allowed:
             raise PermissionError("unauthorized")
         return True
+
+    def validate_action(self, actor: str, action: str) -> Dict[str, object]:
+        """Delegate to the underlying ethics manifesto."""
+        return self.manifesto.validate_action(actor, action)
 
     def apply_feedback(
         self,

--- a/tests/agents/nazarick/test_ethics_manifesto_integration.py
+++ b/tests/agents/nazarick/test_ethics_manifesto_integration.py
@@ -1,0 +1,73 @@
+"""Integration tests for manifesto-based validation."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+otel = types.ModuleType("opentelemetry")
+otel.trace = types.SimpleNamespace(get_tracer=lambda *a, **k: None)
+sys.modules.setdefault("opentelemetry", otel)
+
+from agents.nazarick.ethics_manifesto import LAWS
+from INANNA_AI.ethical_validator import EthicalValidator
+
+
+def test_validator_uses_manifesto_laws():
+    validator = EthicalValidator()
+    first = LAWS[0]
+    result = validator.validate_action(
+        "Ainz", f"prepare to {first.keywords[0]} the village"
+    )
+    assert not result["compliant"]
+    assert first.name in result["violated_laws"]
+
+
+def test_crown_router_blocks_violations(monkeypatch):
+    sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+    sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+    sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+    dummy_np = types.ModuleType("numpy")
+    dummy_np.asarray = lambda x, dtype=None: x
+    dummy_np.linalg = types.SimpleNamespace(norm=lambda x: 1.0)
+    sys.modules.setdefault("numpy", dummy_np)
+    qnl_utils = types.ModuleType("MUSIC_FOUNDATION.qnl_utils")
+    qnl_utils.quantum_embed = lambda t: [0.0]
+    mf = types.ModuleType("MUSIC_FOUNDATION")
+    mf.qnl_utils = qnl_utils
+    sys.modules.setdefault("MUSIC_FOUNDATION", mf)
+    sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qnl_utils)
+
+    rag_pkg = sys.modules.setdefault("rag", types.ModuleType("rag"))
+    orch_mod = types.ModuleType("rag.orchestrator")
+
+    class DummyOrchestrator:
+        def route(self, *a, **k):
+            return {"model": "glm"}
+
+    orch_mod.MoGEOrchestrator = DummyOrchestrator
+    rag_pkg.orchestrator = orch_mod
+    sys.modules.setdefault("rag.orchestrator", orch_mod)
+
+    ROOT = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(ROOT))
+
+    import crown_router
+
+    importlib.reload(crown_router)
+
+    monkeypatch.setattr(
+        crown_router, "vector_memory", types.SimpleNamespace(search=lambda *a, **k: [])
+    )
+    monkeypatch.setattr(crown_router, "decide_expression_options", lambda e: {})
+    monkeypatch.setattr(crown_router.emotional_state, "get_soul_state", lambda: "")
+
+    validator = EthicalValidator()
+    with pytest.raises(ValueError):
+        crown_router.route_decision(
+            "prepare to attack the village", {"emotion": "neutral"}, validator=validator
+        )


### PR DESCRIPTION
## Summary
- load laws and ethos from Nazarick manifesto into `EthicalValidator`
- validate Crown requests against the manifesto before routing
- add integration tests ensuring manifesto violations are caught

## Testing
- `pre-commit run ruff --files INANNA_AI/ethical_validator.py crown_router.py tests/agents/nazarick/test_ethics_manifesto_integration.py`
- `pre-commit run black --files INANNA_AI/ethical_validator.py crown_router.py tests/agents/nazarick/test_ethics_manifesto_integration.py`
- `pre-commit run flake8 --files INANNA_AI/ethical_validator.py crown_router.py tests/agents/nazarick/test_ethics_manifesto_integration.py`
- `pytest tests/agents/nazarick/test_ethics_manifesto_integration.py` *(fails: coverage 3% < 80%)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6ba953ac832eb267b3dd41281064