### PR TITLE
feat: add model and ethics controls to console

### DIFF
--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -8,6 +8,9 @@ Arcade-style web interface for issuing commands through the Operator API.
 - **Ignite** sends `/start_ignition`.
 - **Query Memory** posts to `/query` with a text payload.
 - **Status** retrieves `/status` for component health summaries.
+- **Add Model** posts to `/operator/models` with a model name and builtin.
+- **Remove Model** deletes `/operator/models/{name}`.
+- **Update Ethics** posts to `/ingest-ethics` to reindex the ethics corpus.
 
 ## Environment Variables
 - `OPERATOR_API_URL` – base URL of the Operator API (default `http://localhost:8000`).
@@ -29,26 +32,27 @@ sequenceDiagram
     RAZAR->>CrownKimi: Orchestrate
 ```
 
-## Runtime Model Management
-Operators can hot-swap servant models without restarting the console using the Operator API.
+## Runtime Model & Ethics Management
+Operators can hot-swap servant models and refresh ethics alignment without restarting the console using the Operator API.
 
 - `POST /operator/models` registers a new servant.
 - `DELETE /operator/models/{name}` removes one.
+- `POST /ingest-ethics` reindexes ethics markdown files.
 
 ```mermaid
-sequenceDiagram
-    participant Operator
-    participant API
-    participant Manager
-    Operator->>API: register servant
-    API->>Manager: register_model
-    Operator->>API: remove servant
-    API->>Manager: unregister_model
+flowchart TD
+    Operator --> UI[Arcade UI]
+    UI -->|Add Model| API[Operator API]
+    API --> Manager[Model Manager]
+    UI -->|Remove Model| API
+    UI -->|Update Ethics| API
+    API --> Ethics[Ethics Store]
 ```
 
 ## Version History
 | Version | Date       | Notes                              |
 |---------|------------|------------------------------------|
+| 0.4.0   | 2025-11-08 | Add model, remove model, and ethics update controls |
 | 0.3.0   | 2025-11-07 | Document runtime model management  |
 | 0.2.0   | 2025-11-06 | Added query endpoint and greeting  |
 | 0.1.0   | 2025-11-06 | Initial operator console doc       |

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -595,9 +595,9 @@ Detects objects with YOLOE and streams bounding boxes to the Large World Model f
 ## Non‑Essential Services
 ### Operator Console Service
 Provides a web UI ([operator_console.md](operator_console.md)) that forwards operator
-commands through the Operator API and surfaces memory summaries from the unified
-bundle. Optional for headless deployments where operators issue requests via
-scripts.
+commands through the Operator API, surfaces memory summaries from the unified
+bundle, and exposes runtime model management and ethics ingestion controls. Optional
+for headless deployments where operators issue requests via scripts.
 
 ```mermaid
 flowchart LR

--- a/web_console/arcade.html
+++ b/web_console/arcade.html
@@ -13,7 +13,18 @@
             <button id="ignite-btn">Ignite</button>
             <button id="memory-btn">Memory Query</button>
             <button id="handover-btn">Handover</button>
+            <input id="add-model-name" placeholder="Model name" />
+            <select id="add-model-builtin">
+                <option value="kimi_k2">kimi_k2</option>
+                <option value="opencode">opencode</option>
+            </select>
+            <button id="add-model-btn">Add Model</button>
+            <input id="remove-model-name" placeholder="Model name" />
+            <button id="remove-model-btn">Remove Model</button>
+            <input id="ethics-dir" placeholder="Ethics dir" />
+            <button id="update-ethics-btn">Update Ethics</button>
         </div>
+        <pre id="action-result"></pre>
     </div>
     <script src="main.js"></script>
 </body>

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -470,6 +470,10 @@ function initArcade() {
     const ignite = document.getElementById('ignite-btn');
     const memory = document.getElementById('memory-btn');
     const handover = document.getElementById('handover-btn');
+    const addModel = document.getElementById('add-model-btn');
+    const removeModel = document.getElementById('remove-model-btn');
+    const updateEthics = document.getElementById('update-ethics-btn');
+    const actionResult = document.getElementById('action-result');
     ignite.addEventListener('click', () => {
         fetch(`${BASE_URL}/ignite`, { method: 'POST' });
     });
@@ -478,6 +482,44 @@ function initArcade() {
     });
     handover.addEventListener('click', () => {
         fetch(`${BASE_URL}/handover`, { method: 'POST' });
+    });
+    addModel.addEventListener('click', async () => {
+        const name = document.getElementById('add-model-name').value;
+        const builtin = document.getElementById('add-model-builtin').value;
+        try {
+            const resp = await fetch(`${BASE_URL}/operator/models`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, builtin })
+            });
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Add model error: ' + err;
+        }
+    });
+    removeModel.addEventListener('click', async () => {
+        const name = document.getElementById('remove-model-name').value;
+        try {
+            const resp = await fetch(
+                `${BASE_URL}/operator/models/${encodeURIComponent(name)}`,
+                { method: 'DELETE' }
+            );
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Remove model error: ' + err;
+        }
+    });
+    updateEthics.addEventListener('click', async () => {
+        const dir = document.getElementById('ethics-dir').value;
+        const url = dir
+            ? `${BASE_URL}/ingest-ethics?directory=${encodeURIComponent(dir)}`
+            : `${BASE_URL}/ingest-ethics`;
+        try {
+            const resp = await fetch(url, { method: 'POST' });
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Update ethics error: ' + err;
+        }
     });
     fetchBackendStatus();
 }


### PR DESCRIPTION
## Summary
- add model, remove model, and ethics update buttons to arcade console
- wire up operator API calls for model management and ethics ingestion
- document new console controls and update system blueprint

## Testing
- `pre-commit run --files docs/operator_console.md docs/system_blueprint.md web_console/arcade.html web_console/main.js` *(fails: missing metrics exporters and self-heal data)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6e6dbe54832e9e8fa65b39296189