### PR TITLE
Add document registry and integrate with crown router

### DIFF
--- a/agents/nazarick/document_registry.py
+++ b/agents/nazarick/document_registry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Tuple
+
+
+class DocumentRegistry:
+    """Collect documents from configured directories."""
+
+    def __init__(self, roots: Iterable[str | Path]) -> None:
+        self._roots = [Path(r) for r in roots]
+
+    def iter_documents(self) -> Iterator[Tuple[str, str]]:
+        """Yield ``(path, text)`` pairs for markdown files under ``roots``."""
+        for root in self._roots:
+            if not root.exists():
+                continue
+            for path in root.rglob("*.md"):
+                try:
+                    yield str(path), path.read_text(encoding="utf-8")
+                except Exception:  # pragma: no cover - file may be unreadable
+                    continue
+
+    def get_corpus(self) -> Dict[str, str]:
+        """Return mapping of file paths to contents."""
+        return {path: text for path, text in self.iter_documents()}

--- a/rag/orchestrator.py
+++ b/rag/orchestrator.py
@@ -147,6 +147,7 @@ class MoGEOrchestrator:
         text_modality: bool = True,
         voice_modality: bool = False,
         music_modality: bool = False,
+        documents: Dict[str, str] | None = None,
     ) -> Dict[str, Any]:
         """Process ``text`` with models based on ``emotion_data`` and flags."""
         emotion = emotion_data.get("emotion", "neutral")

--- a/tests/agents/nazarick/test_document_registry.py
+++ b/tests/agents/nazarick/test_document_registry.py
@@ -1,0 +1,81 @@
+"""Integration tests for the document registry."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+otel = types.ModuleType("opentelemetry")
+otel.trace = types.SimpleNamespace(get_tracer=lambda *a, **k: None)
+sys.modules.setdefault("opentelemetry", otel)
+
+from agents.nazarick.document_registry import DocumentRegistry
+
+
+def test_registry_collects_expected_files():
+    registry = DocumentRegistry([Path("GENESIS"), Path("IGNITION")])
+    corpus = registry.get_corpus()
+    names = {Path(p).name for p in corpus}
+    assert "GENESIS_.md" in names
+    assert "EA_ENUMA_ELISH_.md" in names
+
+
+def test_crown_router_receives_documents(monkeypatch):
+    sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+    sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+    sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+    dummy_np = types.ModuleType("numpy")
+    dummy_np.asarray = lambda x, dtype=None: x
+    dummy_np.linalg = types.SimpleNamespace(norm=lambda x: 1.0)
+    sys.modules.setdefault("numpy", dummy_np)
+    audio_mod = types.ModuleType("audio")
+    audio_mod.voice_aura = types.SimpleNamespace()
+    sys.modules.setdefault("audio", audio_mod)
+    qnl_utils = types.ModuleType("MUSIC_FOUNDATION.qnl_utils")
+    qnl_utils.quantum_embed = lambda t: [0.0]
+    mf = types.ModuleType("MUSIC_FOUNDATION")
+    mf.qnl_utils = qnl_utils
+    sys.modules.setdefault("MUSIC_FOUNDATION", mf)
+    sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qnl_utils)
+
+    docs_seen: dict[str, dict[str, str] | None] = {}
+
+    class DummyOrchestrator:
+        def route(
+            self,
+            text,
+            emotion_data,
+            *,
+            text_modality=False,
+            voice_modality=False,
+            music_modality=False,
+            documents=None,
+        ):
+            docs_seen["docs"] = documents
+            return {"model": "glm"}
+
+    rag_pkg = sys.modules.setdefault("rag", types.ModuleType("rag"))
+    orch_mod = types.ModuleType("rag.orchestrator")
+    orch_mod.MoGEOrchestrator = DummyOrchestrator
+    rag_pkg.orchestrator = orch_mod
+    sys.modules.setdefault("rag.orchestrator", orch_mod)
+
+    ROOT = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(ROOT))
+
+    import crown_router
+
+    importlib.reload(crown_router)
+
+    registry = DocumentRegistry([Path("GENESIS"), Path("IGNITION")])
+    monkeypatch.setattr(crown_router, "registry", registry)
+    monkeypatch.setattr(
+        crown_router, "vector_memory", types.SimpleNamespace(search=lambda *a, **k: [])
+    )
+    monkeypatch.setattr(crown_router, "decide_expression_options", lambda e: {})
+    monkeypatch.setattr(crown_router.emotional_state, "get_soul_state", lambda: "")
+
+    crown_router.route_decision("hi", {"emotion": "joy"})
+    assert docs_seen["docs"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,6 +256,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_nazarick_messaging.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_ethics_manifesto.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_trust_matrix.py"),
+    str(ROOT / "tests" / "agents" / "nazarick" / "test_document_registry.py"),
     str(ROOT / "tests" / "agents" / "test_razar_cli.py"),
     str(ROOT / "tests" / "agents" / "test_razar_blueprint_synthesizer.py"),
     str(ROOT / "tests" / "test_citadel_event_producer.py"),


### PR DESCRIPTION
## Summary
- implement `DocumentRegistry` to gather markdown documents across configured folders
- initialize registry in `crown_router` and forward document corpus to orchestrator decisions
- expose documents parameter in `MoGEOrchestrator.route`
- verify registry and router integration with dedicated tests

## Testing
- `pytest tests/agents/nazarick/test_document_registry.py -q -p no:cov -o addopts=""`
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files agents/nazarick/document_registry.py crown_router.py rag/orchestrator.py tests/agents/nazarick/test_document_registry.py tests/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc717cd7e8832e947498318e3deb3d