### PR TITLE
Link chakras to agents in watchdog events

### DIFF
--- a/monitoring/chakra_watchdog.py
+++ b/monitoring/chakra_watchdog.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
+from pathlib import Path
 from typing import Callable, Dict, Mapping
 
 from agents.event_bus import emit_event
 
 LOGGER = logging.getLogger(__name__)
+
+_registry_path = (
+    Path(__file__).resolve().parents[1] / "agents" / "nazarick" / "agent_registry.json"
+)
+
+try:
+    _registry_data = json.loads(_registry_path.read_text())
+    CHAKRA_TO_AGENT = {
+        entry["chakra"]: entry["id"] for entry in _registry_data.get("agents", [])
+    }
+except FileNotFoundError:
+    LOGGER.warning("Agent registry not found at %s", _registry_path)
+    CHAKRA_TO_AGENT = {}
+except Exception as exc:  # pragma: no cover - unexpected errors
+    LOGGER.warning("Failed to load agent registry from %s: %s", _registry_path, exc)
+    CHAKRA_TO_AGENT = {}
 
 
 class ChakraWatchdog:
@@ -35,11 +53,13 @@ class ChakraWatchdog:
             delay = current - hb
             if delay > self.threshold:
                 LOGGER.warning("Chakra %s missed heartbeat by %.2fs", name, delay)
-                self.emit(
-                    "chakra_watchdog",
-                    "chakra_down",
-                    {"chakra": name, "delay": delay},
-                )
+                payload: Dict[str, float | str] = {"chakra": name, "delay": delay}
+                agent_id = CHAKRA_TO_AGENT.get(name)
+                if agent_id:
+                    payload["target_agent"] = agent_id
+                else:
+                    LOGGER.warning("No agent mapping found for chakra %s", name)
+                self.emit("chakra_watchdog", "chakra_down", payload)
 
     def run(self) -> None:
         """Continuously poll for heartbeat delays."""


### PR DESCRIPTION
## Summary
- load chakra-to-agent mapping from `agents/nazarick/agent_registry.json`
- include mapped `target_agent` in watchdog payloads
- warn when registry entry is missing

## Testing
- `PYTHONPATH=. pre-commit run --files monitoring/chakra_watchdog.py` *(fails: required test coverage 80% not reached; missing metrics exporters)*


------
https://chatgpt.com/codex/tasks/task_e_68bc9472486c832ebc4a0747d577e280