### PR TITLE
docs: detail heartbeat polling and agent recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `environment.gpu.yml` and CPU/GPU Dockerfiles with pinned versions and documented hardware setup.
 - Documented inner memory guide and diagrams in the documentation index and linked cross-references from the Blueprint Spine and System Blueprint.
 - Added `docs/SOCIAL_INVESTOR_ONE_PAGER.md` summarizing the project for prospective social investors.
+- Clarified heartbeat polling, event routing, and agent-specific recovery in core documentation.
 - Added `docs/component_maturity.md` tracking documentation completeness, coverage, and open issues.
 - Documented RAZAR self-healing overview with links to recovery playbook and Kimi integration.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,6 +39,15 @@ python -m razar.status_dashboard
 
 The dashboard also links to quarantine logs and the boot history.
 
+## Heartbeat polling and event routing
+
+`agents.razar.runtime_manager` polls each registered service for a heartbeat.
+Responses and misses are published on the lifecycle bus as
+`component_ready`, `chakra_down`, and `recovered` events. Operator commands and
+mission updates share the same channel so agents can react in real time.
+Refer to the [System Blueprint](system_blueprint.md#event-routing) for an
+architectural overview.
+
 For protocol details of the lifecycle bus and automated recovery flow, see
 the [RAZAR Agent guide](RAZAR_AGENT.md#lifecycle-bus-and-recovery-protocol).
 

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -26,15 +26,16 @@ Recurring problems and their fixes are cataloged in the
 
 `agents.razar.health_checks` exposes Prometheus metrics when `prometheus_client` is installed. These probes allow external systems to track service readiness and latency during recovery.
 
-## Escalation and Chakra self-healing
+## Agent-specific recovery
 
-Chakra agents attempt automatic recovery when health metrics rise above
-defined thresholds. The Root agent triggers `scripts/chakra_healing/root_restore_network.sh`
-to reset networking, while the Sacral agent runs
-`scripts/chakra_healing/sacral_gpu_recover.py` to flush GPU tasks. When
-errors persist, `scripts/escalation_notifier.py` scans log files for
-recurring failures, posts an alert to `/operator/command` and records the
-event in `logs/operator_escalations.jsonl`.
+Heartbeat polling feeds `chakra_down` events to the agent assigned to the
+affected layer. Each agent runs a dedicated recovery script—`root_restore_network.sh`
+resets networking for the Root layer, `sacral_gpu_recover.py` flushes GPU
+tasks for Sacral, and other utilities live under `scripts/chakra_healing/`.
+When errors persist beyond these hooks,
+`scripts/escalation_notifier.py` scans log files for recurring failures,
+posts an alert to `/operator/command`, and records the event in
+`logs/operator_escalations.jsonl`.
 
 ## Opencode Integration
 


### PR DESCRIPTION
## Summary
- expand chakra cycle engine section to cover heartbeat polling and lifecycle events
- document event routing and agent-specific recovery procedures
- note documentation updates in changelog

## Testing
- `pre-commit run --files docs/system_blueprint.md` *(fails: pytest-cov arguments, missing agents modules)*
- `pre-commit run --files docs/operations.md docs/recovery_playbook.md CHANGELOG.md` *(fails: pytest-cov arguments, missing agents modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9fe2fb18832e961b90a422fbd335