### PR TITLE
chore: bump version to 0.1.1 and expand chakra watchdog notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `abzu-memory-bootstrap` script initializes memory layers in one step.
 - Chakra watchdog emits `chakra_down` events with NAZARICK resuscitation.
+- Detailed notes describe how the Chakra watchdog coordinates with the Resuscitator
+  to restart failing layers and log recovery metrics.
 
 - WebSocket `/operator/events` for command acknowledgements and progress with console subscription.
 - Nazarick Web Console docs explain viewing agent interactions, NLQ log search, and live chat streams; added tests for paginated conversation logs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spiral-os
-version = 0.1.0
+version = 0.1.1
 description = Spiral OS command line tools and agents
 
 [options]


### PR DESCRIPTION
## Summary
- bump project version to 0.1.1
- document chakra watchdog and resuscitator coordination in changelog

## Testing
- `pre-commit run --files setup.cfg CHANGELOG.md` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68bca9afd840832ea60ac1e9e525c776