### PR TITLE
feat: add chakra metrics

### DIFF
--- a/agents/nazarick/chakra_resuscitator.py
+++ b/agents/nazarick/chakra_resuscitator.py
@@ -4,12 +4,41 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Callable, Dict
 
 from agents.event_bus import emit_event, subscribe
 from citadel.event_producer import Event
 
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter, Histogram
+    from agents.razar.health_checks import init_metrics as _init_metrics
+
+    _init_metrics()
+except Exception:  # pragma: no cover - metrics are optional
+    Counter = Histogram = None  # type: ignore[assignment]
+
+
 LOGGER = logging.getLogger(__name__)
+
+RESUSCITATION_COUNTER = (
+    Counter(
+        "chakra_resuscitation_attempts_total",
+        "Number of resuscitation attempts",  # total attempts
+        ["chakra", "outcome"],
+    )
+    if Counter
+    else None
+)
+RESUSCITATION_DURATION = (
+    Histogram(
+        "chakra_resuscitation_duration_seconds",
+        "Duration of resuscitation attempts in seconds",
+        ["chakra"],
+    )
+    if Histogram
+    else None
+)
 
 
 class ChakraResuscitator:
@@ -39,11 +68,18 @@ class ChakraResuscitator:
         chakra = str(event.payload.get("chakra"))
         action = self.actions.get(chakra)
         success = False
+        start = time.time()
         if action:
             try:
                 success = action()
             except Exception:  # pragma: no cover - unexpected failure
                 LOGGER.exception("Repair action failed for %s", chakra)
+        duration = time.time() - start
+        if RESUSCITATION_DURATION is not None:
+            RESUSCITATION_DURATION.labels(chakra).observe(duration)
+        outcome = "success" if success else "failure"
+        if RESUSCITATION_COUNTER is not None:
+            RESUSCITATION_COUNTER.labels(chakra, outcome).inc()
         if success:
             LOGGER.info("Resuscitated chakra %s", chakra)
             self.emit("nazarick", "chakra_resuscitated", {"chakra": chakra})


### PR DESCRIPTION
## Summary
- instrument chakra watchdog with Prometheus counters and timers
- track resuscitation attempts and latency for chakras

## Testing
- `pre-commit run --files monitoring/chakra_watchdog.py agents/nazarick/chakra_resuscitator.py` *(fails: Library stubs not installed for "yaml"; Library stubs not installed for "requests"; Item "None" has no attribute "labels"; unrecognized arguments: --cov=src --cov=agents --cov-fail-under=80; ModuleNotFoundError: No module named 'agents')*


------
https://chatgpt.com/codex/tasks/task_e_68bcaba9d670832e9faea8c892a9665a