### PR TITLE
feat: add task orchestrator

### DIFF
--- a/agents/nazarick/agent_registry.json
+++ b/agents/nazarick/agent_registry.json
@@ -7,7 +7,9 @@
       "channel": "#throne-room",
       "persona_traits": ["disciplined", "calm"],
       "responsibilities": "Boot order and pipeline supervision.",
-      "code_path": "orchestration_master.py"
+      "code_path": "orchestration_master.py",
+      "capabilities": ["orchestration"],
+      "triggers": ["launch"]
     },
     {
       "id": "prompt_orchestrator",
@@ -16,7 +18,9 @@
       "channel": "#signal-hall",
       "persona_traits": ["focused", "efficient"],
       "responsibilities": "Route prompts and recall context.",
-      "code_path": "crown_prompt_orchestrator.py"
+      "code_path": "crown_prompt_orchestrator.py",
+      "capabilities": ["prompt_routing"],
+      "triggers": ["prompt"]
     },
     {
       "id": "qnl_engine",
@@ -25,7 +29,9 @@
       "channel": "#insight-observatory",
       "persona_traits": ["introspective", "analytic"],
       "responsibilities": "Process QNL sequences and insights.",
-      "code_path": "SPIRAL_OS/qnl_engine.py"
+      "code_path": "SPIRAL_OS/qnl_engine.py",
+      "capabilities": ["qnl_processing"],
+      "triggers": ["insight"]
     },
     {
       "id": "memory_scribe",
@@ -34,7 +40,9 @@
       "channel": "#memory-vault",
       "persona_traits": ["diligent", "archival"],
       "responsibilities": "Persist transcripts and embeddings.",
-      "code_path": "memory_scribe.py"
+      "code_path": "memory_scribe.py",
+      "capabilities": ["memory_persistence"],
+      "triggers": ["persist"]
     }
   ]
 }

--- a/agents/task_orchestrator.py
+++ b/agents/task_orchestrator.py
@@ -1,0 +1,65 @@
+"""Dispatch tasks to agents based on capabilities and triggers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from citadel.event_producer import Event
+
+from .event_bus import emit_event, subscribe
+
+
+REGISTRY_FILE = Path(__file__).parent / "nazarick" / "agent_registry.json"
+
+
+class TaskOrchestrator:
+    """Route events to agents advertising matching capabilities and triggers."""
+
+    def __init__(self, registry_path: Path | None = None) -> None:
+        self.registry_path = registry_path or REGISTRY_FILE
+        self.capability_map: Dict[str, List[str]] = {}
+        self.trigger_map: Dict[str, List[str]] = {}
+        self._load_registry()
+
+    # ------------------------------------------------------------------
+    # Registry handling
+    def _load_registry(self) -> None:
+        data = json.loads(Path(self.registry_path).read_text())
+        for entry in data.get("agents", []):
+            agent_id = entry.get("id")
+            for capability in entry.get("capabilities", []):
+                self.capability_map.setdefault(capability, []).append(agent_id)
+            for trigger in entry.get("triggers", []):
+                self.trigger_map.setdefault(trigger, []).append(agent_id)
+
+    # ------------------------------------------------------------------
+    async def handle_event(self, event: Event) -> None:
+        """Forward ``event`` to matching agents via the event bus."""
+
+        capability = event.payload.get("capability")
+        if capability is None:
+            return
+
+        candidates = self.capability_map.get(capability, [])
+        triggered = self.trigger_map.get(event.event_type, [])
+        for agent_id in [a for a in candidates if a in triggered]:
+            emit_event(
+                "task_orchestrator",
+                "dispatch",
+                {
+                    "target_agent": agent_id,
+                    "capability": capability,
+                    "payload": event.payload,
+                },
+            )
+
+    # ------------------------------------------------------------------
+    async def run(self) -> None:
+        """Continuously consume events from the bus."""
+
+        await subscribe(self.handle_event)
+
+
+__all__ = ["TaskOrchestrator"]

--- a/tests/agents/nazarick/test_task_orchestrator.py
+++ b/tests/agents/nazarick/test_task_orchestrator.py
@@ -1,0 +1,81 @@
+"""Tests for :mod:`agents.task_orchestrator`."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from citadel.event_producer import Event, EventProducer
+
+from agents.event_bus import set_event_producer
+from agents.task_orchestrator import TaskOrchestrator
+
+
+class DummyProducer(EventProducer):
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        self.events: list[Event] = []
+
+    async def emit(self, event: Event) -> None:  # pragma: no cover - trivial
+        self.events.append(event)
+
+
+def _write_registry(tmp_path: Path) -> Path:
+    registry = {
+        "agents": [
+            {
+                "id": "a1",
+                "launch": "",
+                "capabilities": ["compute"],
+                "triggers": ["process"],
+            },
+            {
+                "id": "a2",
+                "launch": "",
+                "capabilities": ["compute"],
+                "triggers": ["process"],
+            },
+            {
+                "id": "b1",
+                "launch": "",
+                "capabilities": ["store"],
+                "triggers": ["save"],
+            },
+        ]
+    }
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps(registry))
+    return path
+
+
+def test_dispatches_to_all_agents_with_capability(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    orchestrator = TaskOrchestrator(registry_path)
+    producer = DummyProducer()
+    set_event_producer(producer)
+
+    event = Event(
+        agent_id="tester", event_type="process", payload={"capability": "compute"}
+    )
+    asyncio.run(orchestrator.handle_event(event))
+
+    targets = {evt.payload["target_agent"] for evt in producer.events}
+    assert targets == {"a1", "a2"}
+
+    set_event_producer(None)
+
+
+def test_no_dispatch_when_capability_unknown(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    orchestrator = TaskOrchestrator(registry_path)
+    producer = DummyProducer()
+    set_event_producer(producer)
+
+    event = Event(
+        agent_id="tester", event_type="process", payload={"capability": "unknown"}
+    )
+    asyncio.run(orchestrator.handle_event(event))
+
+    assert producer.events == []
+
+    set_event_producer(None)


### PR DESCRIPTION
## Summary
- expose agent capabilities and triggers in registry and service launch events
- implement task orchestrator to dispatch events based on capabilities
- cover orchestrator dispatch logic with tests

## Testing
- `SKIP=mypy,pytest-cov pre-commit run --files agents/nazarick/agent_registry.json agents/nazarick/service_launcher.py agents/task_orchestrator.py tests/agents/nazarick/test_task_orchestrator.py`
- `pytest --no-cov tests/agents/nazarick/test_task_orchestrator.py` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bcba8697b8832e8b458d5c5eb5ef78