### PR TITLE
Add chakra heartbeat monitoring and gating

### DIFF
--- a/crown_router.py
+++ b/crown_router.py
@@ -19,6 +19,13 @@ from INANNA_AI.ethical_validator import EthicalValidator
 from agents.nazarick.document_registry import DocumentRegistry
 
 try:  # pragma: no cover - optional dependency
+    from monitoring.chakra_heartbeat import ChakraHeartbeat
+
+    heartbeat_monitor = ChakraHeartbeat()
+except Exception:  # pragma: no cover - heartbeat optional
+    heartbeat_monitor = None
+
+try:  # pragma: no cover - optional dependency
     from prometheus_client import Counter, Gauge, Histogram, REGISTRY
 except Exception:  # pragma: no cover - optional dependency
     Counter = Gauge = Histogram = REGISTRY = None  # type: ignore[assignment]
@@ -157,6 +164,8 @@ def route_decision(
         Decision containing ``model``, ``tts_backend``, ``avatar_style`` and
         ``aura``.
     """
+    if heartbeat_monitor is not None and heartbeat_monitor.sync_status() != "aligned":
+        raise RuntimeError("chakras out of sync")
     if THROUGHPUT_COUNTER is not None:
         THROUGHPUT_COUNTER.labels("crown").inc()
     start = time.perf_counter()

--- a/monitoring/chakra_heartbeat.py
+++ b/monitoring/chakra_heartbeat.py
@@ -1,0 +1,63 @@
+"""Record chakra heartbeat timestamps and report synchronization status."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Iterable
+
+from distributed_memory import DistributedMemory
+
+
+class ChakraHeartbeat:
+    """Track last heartbeat per chakra with optional Redis persistence."""
+
+    def __init__(
+        self,
+        chakras: Iterable[str] | None = None,
+        *,
+        window: float = 5.0,
+        memory: DistributedMemory | None = None,
+    ) -> None:
+        try:
+            self._memory = memory or DistributedMemory(key="chakra_heartbeat")
+        except Exception:  # pragma: no cover - redis optional
+            self._memory = None
+        self.window = window
+        self._cache: Dict[str, float] = {}
+        self._chakras = set(chakras or [])
+
+    def beat(self, chakra: str, timestamp: float | None = None) -> None:
+        """Record a heartbeat for ``chakra`` at ``timestamp``."""
+
+        ts = timestamp or time.time()
+        self._chakras.add(chakra)
+        self._cache[chakra] = ts
+        if self._memory is not None:
+            self._memory.client.hset(self._memory.key, chakra, ts)
+
+    def heartbeats(self) -> Dict[str, float]:
+        """Return mapping of chakras to their last seen heartbeat."""
+
+        beats = dict(self._cache)
+        if self._memory is not None:
+            data = self._memory.client.hgetall(self._memory.key)
+            for key, val in data.items():
+                name = key.decode() if hasattr(key, "decode") else key
+                beats[name] = float(val)
+        return beats
+
+    def sync_status(self, *, now: float | None = None) -> str:
+        """Return ``aligned`` when all chakras reported recently."""
+
+        if not self._chakras:
+            return "aligned"
+        current = now or time.time()
+        beats = self.heartbeats()
+        for chakra in self._chakras:
+            ts = beats.get(chakra)
+            if ts is None or current - ts > self.window:
+                return "out_of_sync"
+        return "aligned"
+
+
+__all__ = ["ChakraHeartbeat"]

--- a/tests/monitoring/test_chakra_heartbeat.py
+++ b/tests/monitoring/test_chakra_heartbeat.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+import types
+import time
+
+import pytest
+
+# Stub heavy dependencies before importing crown_router
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+dummy_np = types.ModuleType("numpy")
+dummy_np.asarray = lambda x, dtype=None: x
+dummy_np.linalg = types.SimpleNamespace(norm=lambda x: 1.0)
+sys.modules.setdefault("numpy", dummy_np)
+qlm_mod = types.ModuleType("MUSIC_FOUNDATION.qnl_utils")
+qlm_mod.quantum_embed = lambda t: [0.0]
+sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qlm_mod)
+MF = types.ModuleType("MUSIC_FOUNDATION")
+MF.qnl_utils = qlm_mod
+sys.modules.setdefault("MUSIC_FOUNDATION", MF)
+
+rag_pkg = sys.modules.setdefault("rag", types.ModuleType("rag"))
+orch_mod = types.ModuleType("rag.orchestrator")
+
+
+class DummyOrchestrator:
+    def route(self, *a, **k):
+        return {"model": "glm"}
+
+
+orch_mod.MoGEOrchestrator = DummyOrchestrator
+rag_pkg.orchestrator = orch_mod
+sys.modules["rag.orchestrator"] = orch_mod
+
+doc_mod = types.ModuleType("agents.nazarick.document_registry")
+
+doc_mod.DocumentRegistry = type("DummyRegistry", (), {"get_corpus": lambda self: {}})
+sys.modules["agents.nazarick.document_registry"] = doc_mod
+
+crown_decider_mod = types.ModuleType("crown_decider")
+crown_decider_mod.decide_expression_options = lambda e: {
+    "tts_backend": "",
+    "avatar_style": "",
+    "aura": None,
+}
+sys.modules["crown_decider"] = crown_decider_mod
+
+import crown_router
+from monitoring.chakra_heartbeat import ChakraHeartbeat
+
+
+def test_sync_status_alignment() -> None:
+    hb = ChakraHeartbeat(chakras=["root", "crown"], window=1.0)
+    now = time.time()
+    hb.beat("root", now)
+    hb.beat("crown", now)
+    assert hb.sync_status(now=now + 0.5) == "aligned"
+    assert hb.sync_status(now=now + 2.0) == "out_of_sync"
+
+
+def test_out_of_sync_blocks_crown(monkeypatch) -> None:
+    hb = ChakraHeartbeat(chakras=["root", "crown"], window=0.5)
+    now = time.time()
+    hb.beat("root", now)
+    monkeypatch.setattr(crown_router, "heartbeat_monitor", hb)
+    monkeypatch.setattr(
+        crown_router,
+        "decide_expression_options",
+        lambda e: {"tts_backend": "", "avatar_style": "", "aura": None},
+    )
+    with pytest.raises(RuntimeError):
+        crown_router.route_decision("hi", {"emotion": "joy"})


### PR DESCRIPTION
## Summary
- add ChakraHeartbeat utility to persist chakra heartbeat timestamps and compute sync status
- gate crown routing when chakras fall out of sync
- cover heartbeat sync and routing block via tests

## Testing
- `pre-commit run --files monitoring/chakra_heartbeat.py crown_router.py tests/monitoring/test_chakra_heartbeat.py` *(fails: Required test coverage of 80% not reached / missing metrics exporters)*
- `pytest --no-cov tests/monitoring/test_chakra_heartbeat.py` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbda25b6c832e8194ed718cf2209d