### PR TITLE
feat: add experience replay for agents

### DIFF
--- a/agents/experience_replay.py
+++ b/agents/experience_replay.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Lightweight experience replay using :mod:`vector_memory`.
+
+Agent interactions are logged via :mod:`agents.interaction_log` and, when
+available, stored in the vector database for later retrieval. The
+:func:`replay` function provides similarity search over an agent's past
+interactions so callers can supply contextual lessons before responding.
+"""
+
+from typing import List
+
+from .interaction_log import log_agent_interaction
+
+try:  # pragma: no cover - optional dependency
+    import vector_memory as _vector_memory
+except Exception:  # pragma: no cover - optional dependency
+    _vector_memory = None  # type: ignore[assignment]
+
+vector_memory = _vector_memory
+
+
+def store_event(agent_id: str, text: str) -> None:
+    """Record ``text`` for ``agent_id`` in logs and vector memory."""
+    entry = {
+        "agent_id": agent_id,
+        "text": text,
+        "function": "experience_replay.store_event",
+    }
+    log_agent_interaction(entry)
+    if vector_memory is None:
+        return
+    try:  # pragma: no cover - best effort
+        vector_memory.add_vector(text, {"agent_id": agent_id})
+    except Exception:  # pragma: no cover - ignore storage failures
+        pass
+
+
+def replay(agent_id: str, query: str, *, k: int = 5) -> List[str]:
+    """Return up to ``k`` past events for ``agent_id`` similar to ``query``."""
+    if vector_memory is None:
+        return []
+    try:  # pragma: no cover - best effort
+        hits = vector_memory.search(
+            query, filter={"agent_id": agent_id}, k=k, scoring="similarity"
+        )
+    except Exception:  # pragma: no cover - ignore search failures
+        return []
+    return [hit.get("text", "") for hit in hits]
+
+
+__all__ = ["store_event", "replay"]

--- a/tests/agents/nazarick/test_experience_replay.py
+++ b/tests/agents/nazarick/test_experience_replay.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from agents import experience_replay
+
+
+def test_store_and_replay_similarity_order(monkeypatch):
+    stored = []
+
+    class DummyVM:
+        def add_vector(self, text, meta):  # pragma: no cover - simple
+            stored.append({"text": text, **meta})
+
+        def search(self, query, filter=None, k=5, scoring="similarity"):
+            def score(t: str) -> int:
+                return len(set(query.split()) & set(t.split()))
+
+            results = []
+            for item in stored:
+                if filter and item.get("agent_id") != filter.get("agent_id"):
+                    continue
+                results.append({"text": item["text"], "score": score(item["text"])})
+            results.sort(key=lambda r: r["score"], reverse=True)
+            return results[:k]
+
+    dummy = DummyVM()
+    monkeypatch.setattr(experience_replay, "vector_memory", dummy)
+
+    logs = []
+    monkeypatch.setattr(experience_replay, "log_agent_interaction", logs.append)
+
+    experience_replay.store_event("a", "hello world")
+    experience_replay.store_event("a", "hello there")
+    experience_replay.store_event("a", "goodbye moon")
+
+    hits = experience_replay.replay("a", "hello world")
+
+    assert hits[:2] == ["hello world", "hello there"]
+    assert len(logs) == 3

--- a/tests/agents/test_narrative_scribe.py
+++ b/tests/agents/test_narrative_scribe.py
@@ -13,6 +13,8 @@ __version__ = "0.1.0"
 def test_process_event_writes_log_and_memory(tmp_path, monkeypatch):
     monkeypatch.setattr(ns, "LOG_FILE", tmp_path / "story.log")
     monkeypatch.setattr(narrative_engine, "DB_PATH", tmp_path / "stories.db")
+    monkeypatch.setattr(ns.experience_replay, "replay", lambda *a, **k: [])
+    monkeypatch.setattr(ns.experience_replay, "store_event", lambda *a, **k: None)
 
     def fake_personas():
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "nazarick" / "test_ethics_manifesto.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_trust_matrix.py"),
     str(ROOT / "tests" / "agents" / "nazarick" / "test_document_registry.py"),
+    str(ROOT / "tests" / "agents" / "nazarick" / "test_experience_replay.py"),
     str(ROOT / "tests" / "agents" / "test_razar_cli.py"),
     str(ROOT / "tests" / "agents" / "test_razar_blueprint_synthesizer.py"),
     str(ROOT / "tests" / "test_citadel_event_producer.py"),

--- a/tests/narrative/test_self_heal_logging.py
+++ b/tests/narrative/test_self_heal_logging.py
@@ -20,6 +20,8 @@ def test_self_heal_event_logged(tmp_path, monkeypatch):
     monkeypatch.setattr(ns, "LOG_FILE", log_file)
     monkeypatch.setattr(narrative_engine, "DB_PATH", db_path)
     monkeypatch.setattr(cortex, "PATCH_LINKS_FILE", patch_file)
+    monkeypatch.setattr(ns.experience_replay, "replay", lambda *a, **k: [])
+    monkeypatch.setattr(ns.experience_replay, "store_event", lambda *a, **k: None)
 
     def fake_personas():
         return {
@@ -39,7 +41,7 @@ def test_self_heal_event_logged(tmp_path, monkeypatch):
     )
     scribe.process_event(event)
 
-    text = log_file.read_text().strip()
+    text = log_file.read_text().splitlines()[0]
     assert text == "a restored core with patch abc"
     stories = list(narrative_engine.stream_stories())
     assert stories[-1] == text


### PR DESCRIPTION
## Summary
- add `experience_replay` module to log and vectorize agent events
- teach `narrative_scribe` to retrieve and store lessons before responding
- test experience replay storage and similarity ranking

## Testing
- `pre-commit run --files agents/experience_replay.py agents/nazarick/narrative_scribe.py tests/agents/nazarick/test_experience_replay.py tests/agents/test_narrative_scribe.py tests/narrative/test_self_heal_logging.py tests/conftest.py` *(fails: mypy errors and coverage requirements in unrelated files)*
- `pytest --no-cov tests/agents/nazarick/test_experience_replay.py`
- `pytest --no-cov tests/agents/test_narrative_scribe.py tests/narrative/test_self_heal_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcbfdec4b0832eaeefc1846c11c244