### PR TITLE
Add RAZAR state validator and tests

### DIFF
--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -36,6 +36,7 @@ from . import (
     health_checks,
     mission_logger,
     quarantine_manager,
+    state_validator,
 )
 from .ignition_builder import DEFAULT_STATUS, parse_system_blueprint
 from razar import crown_handshake
@@ -65,6 +66,8 @@ class BootOrchestrator:
         self.config_path = config or root / "config" / "razar_config.yaml"
         self.ignition_path = ignition or root / "docs" / "Ignition.md"
         self.state_path = state or root / "logs" / "razar_state.json"
+
+        state_validator.validate_state(self.state_path)
 
         self.components = parse_system_blueprint(self.blueprint_path)
         self.statuses: Dict[str, str] = {

--- a/agents/razar/runtime_manager.py
+++ b/agents/razar/runtime_manager.py
@@ -20,7 +20,7 @@ import shlex
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence
 import venv
-from . import checkpoint_manager, health_checks, quarantine_manager
+from . import checkpoint_manager, health_checks, quarantine_manager, state_validator
 from razar.bootstrap_utils import STATE_FILE
 
 # Re-export primary entry points for simpler imports
@@ -48,6 +48,7 @@ class RuntimeManager:
     ) -> None:
         self.config_path = config_path
         self.state_path = state_path or STATE_FILE
+        state_validator.validate_state(self.state_path)
         self.venv_path = venv_path or config_path.parent / ".razar_venv"
         # ``razar_env.yaml`` lives at the repository root and lists dependencies
         # for each component layer.  Allow ``env_path`` to be overridden for

--- a/agents/razar/state_validator.py
+++ b/agents/razar/state_validator.py
@@ -1,0 +1,56 @@
+"""State file validation utilities for RAZAR."""
+
+from __future__ import annotations
+
+__version__ = "0.2.2"
+__all__ = ["validate_state", "DEFAULT_STATE"]
+
+import json
+from pathlib import Path
+
+try:  # pragma: no cover - dependency is handled in tests
+    import jsonschema
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError("jsonschema is required for state validation") from exc
+
+DEFAULT_STATE = {
+    "last_component": "",
+    "capabilities": [],
+    "downtime": {},
+    "launched_models": [],
+    "handshake": {
+        "acknowledgement": "",
+        "capabilities": [],
+        "downtime": {},
+    },
+    "glm4v_present": False,
+    "events": [],
+}
+
+
+def validate_state(path: Path | str) -> None:
+    """Validate the state file at ``path`` against the schema.
+
+    If the file is missing or fails validation, a backup is created and a
+    fresh state file based on ``DEFAULT_STATE`` is written.
+    """
+
+    state_path = Path(path)
+    root = Path(__file__).resolve().parents[2]
+    schema_path = root / "docs" / "schemas" / "razar_state.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    valid = False
+    if state_path.exists():
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+            jsonschema.validate(data, schema)
+            valid = True
+        except (json.JSONDecodeError, jsonschema.ValidationError):
+            backup_path = state_path.with_suffix(state_path.suffix + ".bak")
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            state_path.replace(backup_path)
+
+    if not valid:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(DEFAULT_STATE), encoding="utf-8")

--- a/tests/agents/razar/test_state_validator.py
+++ b/tests/agents/razar/test_state_validator.py
@@ -1,0 +1,33 @@
+import json
+
+from agents.razar.state_validator import DEFAULT_STATE, validate_state
+
+
+def test_validate_state_with_valid_file(tmp_path):
+    path = tmp_path / "razar_state.json"
+    path.write_text(json.dumps(DEFAULT_STATE), encoding="utf-8")
+
+    validate_state(path)
+
+    assert not path.with_suffix(".json.bak").exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == DEFAULT_STATE
+
+
+def test_validate_state_creates_missing_file(tmp_path):
+    path = tmp_path / "missing_state.json"
+    validate_state(path)
+    assert json.loads(path.read_text(encoding="utf-8")) == DEFAULT_STATE
+    assert not path.with_suffix(".json.bak").exists()
+
+
+def test_validate_state_recreates_corrupt_file(tmp_path):
+    path = tmp_path / "corrupt.json"
+    corrupt = DEFAULT_STATE.copy()
+    corrupt.pop("glm4v_present")  # violate schema
+    path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    validate_state(path)
+
+    backup = path.with_suffix(".json.bak")
+    assert backup.exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == DEFAULT_STATE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,6 +273,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "agents" / "razar" / "test_ignition_sequence.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_crown_handshake.py"),
     str(ROOT / "tests" / "agents" / "razar" / "test_mission_brief_rotation.py"),
+    str(ROOT / "tests" / "agents" / "razar" / "test_state_validator.py"),
     str(ROOT / "tests" / "test_operator_api.py"),
     str(ROOT / "tests" / "test_operator_command_route.py"),
     str(ROOT / "tests" / "ignition" / "test_full_stack.py"),


### PR DESCRIPTION
## Summary
- add state_validator to ensure `razar_state.json` matches schema and backup malformed files
- validate state on startup of boot orchestrator and runtime manager
- cover state validator with unit tests

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files agents/razar/state_validator.py agents/razar/boot_orchestrator.py agents/razar/runtime_manager.py tests/agents/razar/test_state_validator.py tests/conftest.py`
- `PYTEST_ADDOPTS="--cov=agents/razar/state_validator.py --cov-fail-under=0" pytest tests/agents/razar/test_state_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_68bccded5934832eb0b1a0f1dd873219