### PR TITLE
feat: add lifecycle remediation support

### DIFF
--- a/agents/razar/recovery_manager.py
+++ b/agents/razar/recovery_manager.py
@@ -78,6 +78,9 @@ class RecoveryManager:
     # ------------------------------------------------------------------
     def recover(self, module: str, state: Dict[str, Any]) -> None:
         """Run the full recovery procedure for ``module``."""
+        # Broadcast the component failure before beginning recovery so that
+        # auxiliary services can react (e.g. Nazarick remediation agents).
+        self.bus.report_issue(module, "component_down")
 
         self.pause_system()
         self.save_state(module, state)

--- a/tests/agents/razar/test_recovery_integration.py
+++ b/tests/agents/razar/test_recovery_integration.py
@@ -1,0 +1,79 @@
+"""Integration test for RecoveryManager and Nazarick ChakraResuscitator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import queue
+from typing import Dict, Iterator, List, Tuple
+
+from agents.nazarick.chakra_resuscitator import ChakraResuscitator
+from agents.razar.lifecycle_bus import Issue
+from agents.razar.recovery_manager import RecoveryManager
+
+
+class DummyBus:
+    """Minimal in-memory lifecycle bus for testing."""
+
+    def __init__(self) -> None:
+        self.statuses: List[Tuple[str, str]] = []
+        self._issues: "queue.Queue[Issue]" = queue.Queue()
+
+    def report_issue(self, component: str, issue: str) -> None:
+        self._issues.put(Issue(component, issue))
+
+    def listen_for_issues(self) -> Iterator[Issue]:
+        while not self._issues.empty():
+            yield self._issues.get()
+
+    def publish_status(self, component: str, status: str) -> None:
+        self.statuses.append((component, status))
+
+    def send_control(
+        self, component: str, action: str
+    ) -> None:  # pragma: no cover - noop
+        pass
+
+
+class DummyRecoveryManager(RecoveryManager):
+    """RecoveryManager variant with side effects disabled."""
+
+    def __init__(self, bus: DummyBus, state_dir: Path) -> None:
+        self.bus = bus
+        self.state_dir = state_dir
+
+    def pause_system(self) -> None:  # pragma: no cover - noop
+        pass
+
+    def resume_system(self) -> None:  # pragma: no cover - noop
+        pass
+
+    def apply_fixes(self, module: str) -> None:  # pragma: no cover - noop
+        pass
+
+    def restart_module(self, module: str) -> None:  # pragma: no cover - noop
+        pass
+
+    def restore_state(
+        self, module: str, state: Dict[str, object]
+    ) -> None:  # pragma: no cover
+        pass
+
+
+def test_component_down_triggers_resuscitation(tmp_path) -> None:
+    bus = DummyBus()
+    called: Dict[str, bool] = {}
+
+    def repair_root() -> bool:
+        called["root"] = True
+        return True
+
+    resuscitator = ChakraResuscitator(
+        {"root": repair_root}, bus=bus, emitter=lambda *_: None
+    )
+    manager = DummyRecoveryManager(bus, tmp_path)
+
+    manager.recover("root", {})
+    resuscitator.run_bus(limit=1)
+
+    assert called.get("root") is True
+    assert ("root", "repaired") in bus.statuses


### PR DESCRIPTION
## Summary
- publish component_down notifications from RecoveryManager
- add ChakraResuscitator hooks for lifecycle bus remediation
- test Nazarick component recovery integration

## Testing
- `pre-commit run --files agents/razar/recovery_manager.py agents/nazarick/chakra_resuscitator.py tests/agents/razar/test_recovery_integration.py` *(fails: Required test coverage of 80% not reached)*
- `pytest --no-cov tests/agents/razar/test_recovery_integration.py tests/monitoring/test_chakra_watchdog.py::test_trigger_resuscitator -q` *(skipped: requires unavailable resources)*


------
https://chatgpt.com/codex/tasks/task_e_68bcd2639d8c832e937f5acc1eaad80e