### PR TITLE
feat: structured mission lifecycle logging

### DIFF
--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 
 ### Added
+- Mission logger emits structured lifecycle events, including `resolved` and
+  `shutdown` states for recovery tracking.
 - Documented remediation steps for placeholder violations in RAZAR agent
 - Structured health events recorded for each boot step.
 - Added recovery daemon monitoring `razar_state.json` for automatic restarts.

--- a/docs/RAZAR_GUIDE.md
+++ b/docs/RAZAR_GUIDE.md
@@ -24,6 +24,20 @@ Requires `pyyaml`, `prometheus_client`, `websockets`, and a reachable `CROWN_WS_
 python -m razar.crown_handshake path/to/brief.json
 ```
 
+## Monitoring & Recovery
+RAZAR emits lifecycle events to `logs/razar.log` via
+`agents.razar.mission_logger`. Each JSON line records the event, component,
+status, timestamp, and optional details. Use these entries to track recovery
+progress and feed metrics collectors or dashboards.
+
+Count recovery attempts:
+
+```bash
+jq -r 'select(.event=="recovery") | .component' logs/razar.log | wc -l
+```
+
+Review the full remediation flow in the [Recovery Playbook](recovery_playbook.md).
+
 ## Cross-Links
 - [System Blueprint](system_blueprint.md)
 - [Deployment Guide](deployment.md)
@@ -32,5 +46,6 @@ python -m razar.crown_handshake path/to/brief.json
 ## Version History
 | Version | Date | Notes |
 |---------|------|-------|
+| 0.3.0 | 2025-10-17 | Structured lifecycle logging and recovery metrics. |
 | 0.2.2 | 2025-09-21 | Expanded remote assistance workflow and patch logging. |
 | 0.1.0 | 2025-08-30 | Initial release of RAZAR runtime orchestrator. |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -77,6 +77,30 @@ python -m razar.status_dashboard
 The output lists each component with its priority and criticality and provides
 links to the quarantine log and boot history.
 
+## Mission lifecycle metrics
+
+`agents.razar.mission_logger` appends a JSON line for each lifecycle change
+recorded during a mission. These entries can be transformed into metrics for
+alerting and dashboards.
+
+Count how many times components entered recovery mode:
+
+```bash
+jq -r 'select(.event=="recovery") | .component' logs/razar.log | wc -l
+```
+
+Expose per-event counters to Prometheus using the textfile collector:
+
+```bash
+jq -r '.event' logs/razar.log | sort | uniq -c | \
+  awk '{printf "mission_events_total{event=\"%s\"} %s\n", $2,$1}' \
+  > /var/lib/node_exporter/mission.prom
+```
+
+Correlate these metrics with the remediation flow described in the
+[Recovery Playbook](recovery_playbook.md) to verify that failed components are
+patched and resolved in order.
+
 ## Health check metrics
 
 `agents/razar/health_checks.py` performs service probes with per-service latency

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -94,6 +94,14 @@ and retrieval requests, while `nazarick_agents` subscribe to mission updates and
 state changes. See the [Operations Guide](operations.md#heartbeat-polling-and-event-routing)
 for runtime details.
 
+### Mission Logging
+
+`agents.razar.mission_logger` persists each component lifecycle change to
+`logs/razar.log`. These structured events drive the recovery flow in
+the [Recovery Playbook](recovery_playbook.md) and surface states such as
+`start`, `error`, `recovery`, `quarantine`, and `resolved` for every mission
+stage.
+
 ### Agent-Specific Recovery
 
 Each chakra has a dedicated remediation script. When the heartbeat poller

--- a/tests/agents/razar/test_mission_logging.py
+++ b/tests/agents/razar/test_mission_logging.py
@@ -1,0 +1,32 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from agents.razar import mission_logger
+
+
+def test_log_format_and_fields(tmp_path: Path, monkeypatch) -> None:
+    """Mission logger writes structured lifecycle events."""
+
+    log_file = tmp_path / "razar.log"
+    monkeypatch.setattr(mission_logger, "LOG_PATH", log_file)
+
+    mission_logger.log_start("alpha", "success", "booted")
+    mission_logger.log_error("beta", "failure")
+    mission_logger.log_resolved("beta", "restored", "patched")
+    mission_logger.log_event(mission_logger.Lifecycle.SHUTDOWN, "alpha", "ok")
+
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+
+    assert entries[0]["event"] == "start"
+    assert entries[0]["details"] == "booted"
+    assert "details" not in entries[1]
+
+    required = {"event", "component", "status", "timestamp"}
+    for entry in entries:
+        assert required <= entry.keys()
+        # ISO-8601 parse check raises ValueError on invalid format
+        datetime.fromisoformat(entry["timestamp"])
+
+    assert any(e["event"] == "resolved" for e in entries)
+    assert any(e["event"] == "shutdown" for e in entries)


### PR DESCRIPTION
## Summary
- instrument mission logger with a Lifecycle enum and resolved/shutdown helpers
- document new recovery metrics in RAZAR and monitoring guides
- add regression test for mission logger output

## Testing
- `PYTHONPATH=. pre-commit run --files agents/razar/mission_logger.py docs/RAZAR_GUIDE.md docs/monitoring.md docs/system_blueprint.md CHANGELOG_razar.md tests/agents/razar/test_mission_logging.py` *(fails: missing metrics exporters and self-heal cycles)*
- `pytest tests/agents/razar/test_mission_logging.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4af41414832e951e5cb35bc8e4e3