### PR TITLE
docs: add Kimi-powered repair guidance

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -70,6 +70,27 @@ flowchart LR
     C --> D[Relaunch]
 ```
 
+### Kimi-powered repairs
+
+Set the following variables to route handover through the Kimi backend:
+
+- `OPENCODE_BACKEND=kimi`
+- `KIMI_K2_URL=<your K2 endpoint>`
+
+See [Kimi Integration](tools/kimi_integration.md) for step-by-step instructions.
+
+```python
+import os
+from agents.razar import ai_invoker
+
+os.environ["OPENCODE_BACKEND"] = "kimi"
+os.environ["KIMI_K2_URL"] = "https://k2.example/api"
+
+ai_invoker.handover("crown_router", "Health check failed", use_opencode=True)
+```
+
+If Kimi supplies a patch, it is applied and the component relaunches.
+
 ### Recovery Flow
 ```mermaid
 flowchart TD

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -52,3 +52,24 @@ orchestrator repeats this handover and health check cycle until the component
 recovers or the remote attempt limit is reached. Enable long task mode with
 `--long-task` to keep requesting patches indefinitely; abort with `Ctrl+C` to
 halt the loop. Every long task attempt is written to `logs/razar_long_task.json`.
+
+## Kimi-powered repairs
+
+Set these variables to delegate repairs through Kimi:
+
+- `OPENCODE_BACKEND=kimi`
+- `KIMI_K2_URL=<your K2 endpoint>`
+
+See [Kimi Integration](tools/kimi_integration.md) for step-by-step instructions.
+
+```python
+import os
+from agents.razar import ai_invoker
+
+os.environ["OPENCODE_BACKEND"] = "kimi"
+os.environ["KIMI_K2_URL"] = "https://k2.example/api"
+
+ai_invoker.handover("crown_router", "Health check failed", use_opencode=True)
+```
+
+If Kimi returns a patch, it is applied and the boot sequence resumes.


### PR DESCRIPTION
## Summary
- document Kimi-powered repairs in RAZAR agent guide
- outline Kimi env vars and example in recovery playbook

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/recovery_playbook.md docs/INDEX.md` *(fails: agents/razar/mission_logger.py version mismatch; pytest args; missing 'agents' module; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bd501345b4832ebf8509e55ecbd203