### PR TITLE
feat: add LWM camera paths for avatar

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -85,3 +85,33 @@ objects to avatar textures. For example, a ``"cat"`` detection selects
 ``avatars/cat.png`` while a ``"dog"`` detection loads ``avatars/dog.png``. When
 no known objects are present the default texture is used. This allows external
 scene objects to dynamically influence the avatar's appearance.
+
+## 3-D mode
+
+`LargeWorldModel` support enables a lightweight three‑dimensional workflow. Pass
+an instance to :func:`src.media.avatar.generate_avatar` alongside captured frame
+paths. The function builds a placeholder scene and returns a list of
+``(x, y, z)`` camera coordinates synchronised with the frames. These coordinates
+can drive simple camera motion during playback.
+
+Required assets:
+
+- a sequence of still frames representing the scene
+- the built‑in ``src.lwm`` module; no external weights are needed
+
+Example:
+
+```python
+from pathlib import Path
+from src.lwm import LargeWorldModel
+from src.media.avatar import generate_avatar
+from core import video_engine
+
+frames = [Path("frame1.png"), Path("frame2.png")]
+audio, paths = generate_avatar(1000, frames, Path("out.mp4"), lwm_model=LargeWorldModel())
+for frame in video_engine.generate_avatar_stream(camera_paths=paths):
+    pass  # render or encode the frame
+```
+
+`generate_avatar_stream` highlights each camera position with a red pixel so
+downstream renderers can align motion with the audio segment.

--- a/src/media/avatar/generation.py
+++ b/src/media/avatar/generation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 __version__ = "0.1.0"
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, List, Tuple
 
 from ...lwm import LargeWorldModel
 from ..audio import generate_waveform
@@ -19,7 +19,7 @@ def generate_avatar(
     images: Iterable[Path],
     video_output: Path,
     lwm_model: LargeWorldModel | None = None,
-) -> Any:
+) -> tuple[Any, List[Tuple[float, float, float]]]:
     """Generate avatar media.
 
     Parameters
@@ -36,9 +36,19 @@ def generate_avatar(
 
     Returns
     -------
-    Any
-        The generated audio segment returned by :func:`generate_waveform`.
+    tuple
+        A tuple ``(audio_segment, camera_paths)`` where ``audio_segment`` is
+        returned by :func:`generate_waveform` and ``camera_paths`` is a list of
+        ``(x, y, z)`` coordinates describing the camera trajectory. When no
+        ``lwm_model`` is supplied the list is empty.
     """
+
+    image_list = list(images)
+    camera_paths: List[Tuple[float, float, float]] = []
+    if lwm_model is not None:
+        lwm_model.from_frames(image_list)
+        camera_paths = [(float(i), 0.0, 0.0) for i in range(len(image_list))]
+
     audio_segment = generate_waveform(audio_duration_ms)
-    generate_video(list(images), video_output, lwm_model=lwm_model)
-    return audio_segment
+    generate_video(image_list, video_output, lwm_model=lwm_model)
+    return audio_segment, camera_paths

--- a/tests/test_media_avatar.py
+++ b/tests/test_media_avatar.py
@@ -18,10 +18,28 @@ def test_generate_avatar_pipeline(monkeypatch) -> None:
     gen_video = mock.Mock()
     monkeypatch.setattr(avatar.generation, "generate_waveform", gen_waveform)
     monkeypatch.setattr(avatar.generation, "generate_video", gen_video)
-    result = avatar.generate_avatar(1000, [], Path("video.mp4"))
+    result, paths = avatar.generate_avatar(1000, [], Path("video.mp4"))
     assert result == "audio"
+    assert paths == []
     gen_waveform.assert_called_once_with(1000)
-    gen_video.assert_called_once_with([], Path("video.mp4"))
+    gen_video.assert_called_once_with([], Path("video.mp4"), lwm_model=None)
+
+
+def test_generate_avatar_with_lwm(monkeypatch) -> None:
+    """Passing an LWM model should return camera paths."""
+    gen_waveform = mock.Mock(return_value="audio")
+    gen_video = mock.Mock()
+    monkeypatch.setattr(avatar.generation, "generate_waveform", gen_waveform)
+    monkeypatch.setattr(avatar.generation, "generate_video", gen_video)
+    model = avatar.generation.LargeWorldModel()
+    images = [Path("a.png"), Path("b.png")]
+    result, paths = avatar.generate_avatar(
+        1000, images, Path("video.mp4"), lwm_model=model
+    )
+    assert result == "audio"
+    assert len(paths) == len(images)
+    gen_waveform.assert_called_once_with(1000)
+    gen_video.assert_called_once_with(images, Path("video.mp4"), lwm_model=model)
 
 
 def test_play_avatar_pipeline(monkeypatch) -> None:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT))
 import emotional_state
 import env_validation
 from core import context_tracker, video_engine
+from types import SimpleNamespace
 
 pytestmark = pytest.mark.skipif(
     not env_validation.check_audio_binaries(require=False),
@@ -60,3 +61,12 @@ def test_upscaled_output(monkeypatch):
     stream = video_engine.start_stream(scale=2)
     frame = next(stream)
     assert frame.shape[0] == 128 and frame.shape[1] == 128
+
+
+def test_camera_paths_highlight_pixel(monkeypatch):
+    """Camera paths from LWM should influence rendered frames."""
+    dummy = SimpleNamespace(inspect_scene=lambda: {"points": [{"index": 0}]})
+    monkeypatch.setattr(video_engine, "default_lwm", dummy)
+    stream = video_engine.generate_avatar_stream()
+    frame = next(stream)
+    assert np.array_equal(frame[0, 0], np.array([255, 0, 0], dtype=np.uint8))


### PR DESCRIPTION
## Summary
- build 3D scenes when an LWM model is provided and expose synchronized camera paths
- render camera markers in video engine when LWM data is available
- document 3-D avatar workflow and assets

## Testing
- `pre-commit run --files docs/avatar_pipeline.md src/core/video_engine.py src/media/avatar/generation.py tests/test_media_avatar.py tests/test_video.py` *(fails: mypy errors, missing dependencies, broken link)*
- `pytest tests/test_media_avatar.py tests/test_video.py --override-ini addopts=""` *(skipped: audio tools not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd58c6eb78832ebcdf18229456834a