### PR TITLE
docs: add avatar setup guide and streaming references

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -702,6 +702,9 @@ the avatar alongside the console. The script calls
 `logs/INANNA_AI.log`. Set the optional `AVATAR_SCALE` environment variable to
 adjust the video size.
 
+See [docs/avatar_setup.md](docs/avatar_setup.md) for `.env` entries such as
+`VIDEO_STREAM_URL` and `WEBRTC_TOKEN` that enable real-time streaming.
+
 Type `appear to me` at the prompt to toggle the avatar stream. This command is
 handled by :mod:`core.task_parser` and switches
 `context_tracker.state.avatar_loaded` so the video engine begins emitting

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -265,6 +264,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [avatar_animation.md](avatar_animation.md) | Avatar Animation Modules | This document describes the lightweight avatar animation helpers found in `ai_core.avatar`. | - |
 | [avatar_ethics.md](avatar_ethics.md) | Avatar Ethics | The avatar and call features rely on audiovisual data that may reveal personal information. Operators must handle rec... | - |
 | [avatar_pipeline.md](avatar_pipeline.md) | Avatar Pipeline | The avatar pipeline synchronises generated speech with visual animation. It reads configuration from `guides/avatar_c... | - |
+| [avatar_setup.md](avatar_setup.md) | Avatar Setup | Configure the avatar pipeline by defining environment variables and adjusting textures. | - |
 | [bana_engine.md](bana_engine.md) | Bana Engine | This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sourc... | - |
 | [blueprint_spine.md](blueprint_spine.md) | **ABZU Project: Deep-Dive Overview** | - | - |
 | [chakra_architecture.md](chakra_architecture.md) | Chakra Architecture | This document summarizes the major modules aligned with each chakra layer, their operational state, current quality l... | - |

--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -12,12 +12,20 @@ Install the Python requirements and optional packages for lip sync:
 pip install -r SPIRAL_OS/requirements.txt
 ```
 
-`SadTalker`, `Wav2Lip` and `ControlNet` are optional but provide advanced
-animation when available.
+Optional packages unlock richer animation and streaming features:
 
-When the optional **SadTalker** package is installed the video engine generates
-frames directly from the speech sample. If not available it falls back to
-**Wav2Lip** when present or a minimal mouth overlay.
+| Package    | Feature unlocked |
+|------------|-----------------|
+| `SadTalker` | Drives facial animation directly from the speech sample |
+| `Wav2Lip`  | Adds high-quality lip sync fallback |
+| `ControlNet` | Enables gesture modulation via diffusion guides |
+| `AnimateDiff` | Generates motion sequences for gestures |
+| `aiortc`   | Provides WebRTC transport for real-time streaming |
+| `ffmpeg`   | Encodes and muxes avatar video output |
+
+When **SadTalker** is available the video engine generates frames directly from
+the speech sample. If not installed it falls back to **Wav2Lip** when present or
+to a minimal mouth overlay.
 
 Gesture control is supported through **ControlNet** or **AnimateDiff** if those
 modules can be imported. The video engine calls `apply_gesture()` from the first
@@ -58,8 +66,7 @@ import soundfile as sf
 sf.write("sample_voice.wav", np.zeros(16000), 16000)
 ```
 
-Any external WAV file can also be used; public domain samples are available at
-[https://people.sc.fsu.edu/~jburkardt/data/wav/](https://people.sc.fsu.edu/~jburkardt/data/wav/).
+Any external WAV file can also be used; public domain samples are widely available online.
 
 Generate a short sovereign voice sample from hexadecimal bytes and animate it:
 

--- a/docs/avatar_setup.md
+++ b/docs/avatar_setup.md
@@ -1,0 +1,32 @@
+# Avatar Setup
+
+Configure the avatar pipeline by defining environment variables and adjusting textures.
+
+## Environment variables
+
+Add the following entries to your `.env` or `secrets.env` file:
+
+```env
+VIDEO_STREAM_URL="webrtc://localhost:9000/stream"
+AVATAR_SCALE="1.0"
+WEBRTC_TOKEN="change-me"
+```
+
+`VIDEO_STREAM_URL` points the client to the WebRTC or HTTP stream. `AVATAR_SCALE` adjusts the rendered frame size, and `WEBRTC_TOKEN` authenticates real-time sessions.
+
+## Texture configuration
+
+Customize avatar textures in `guides/avatar_config.toml`:
+
+```toml
+eye_color = [0, 128, 255]
+sigil = "spiral"
+
+[skins]
+nigredo_layer = "skins/nigredo.png"
+albedo_layer = "skins/albedo.png"
+rubedo_layer = "skins/rubedo.png"
+citrinitas_layer = "skins/citrinitas.png"
+```
+
+See [avatar_pipeline.md](avatar_pipeline.md) for the rendering workflow and optional package table.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -608,7 +608,7 @@ Provides the user messaging interface and routes requests to internal agents. Se
 - **Startup:** Launch after the memory store is available.
 - **Health Check:** Probe `/chat/health` and watch latency.
 - **Recovery:** Restart the gateway or verify network configuration.
-- **WebRTC Connector:** Streams avatar video, audio, and data channels when offered, falling back to data-only mode if media negotiation fails.
+- **WebRTC Connector:** Streams avatar video, audio, and data channels when offered, falling back to data-only mode if media negotiation fails. See [avatar_setup.md](avatar_setup.md) for environment variables that enable real-time avatars.
 
 ### Memory Systems
 Persist conversations and embeddings for retrieval across sessions. See [Memory Architecture](memory_architecture.md), [Vector Memory](vector_memory.md) and [Chakra Architecture](chakra_architecture.md#heart).


### PR DESCRIPTION
## Summary
- document optional avatar packages and the features they unlock
- add avatar setup guide with `.env` examples
- link the setup guide from operator and system blueprint docs for reliable streaming

## Testing
- `pre-commit run --files README_OPERATOR.md docs/avatar_pipeline.md docs/system_blueprint.md docs/avatar_setup.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b0162d8832e94166f74164064ee