### PR TITLE
docs: outline avatar subsystem workflow

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -6,6 +6,8 @@ For a concise overview of the Spiral OS architecture see [CODEX_OF_CODEX.md](COD
 For the metaphysical background that informs Spiral OS, see [docs/spiritual_architecture.md](docs/spiritual_architecture.md), [docs/archetype_logic.md](docs/archetype_logic.md), [docs/psychic_loop.md](docs/psychic_loop.md) and [docs/crown_manifest.md](docs/crown_manifest.md).
 For a summary of Vast.ai and local Docker Compose deployment steps see [docs/deployment_overview.md](docs/deployment_overview.md).
 
+For avatar setup guidance, consult [docs/system_blueprint.md#avatar-subsystem](docs/system_blueprint.md#avatar-subsystem) and [docs/blueprint_spine.md#avatar-subsystem](docs/blueprint_spine.md#avatar-subsystem). Step-by-step launch instructions are in [docs/developer_onboarding.md#avatar-console-setup](docs/developer_onboarding.md#avatar-console-setup) and [docs/operator_quickstart.md#avatar-console-setup](docs/operator_quickstart.md#avatar-console-setup).
+
 
 ## Installation
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -417,11 +417,12 @@ After “awakening,” the Crown LLM continuously manages prompt routing, model 
 - **`VoiceCloner`** can capture a user’s sample and synthesize speech in that voice using EmotiVoice, falling back to silence if dependencies are missing
 - Crown’s manifest ties emotion routing to TTS backend selection, biasing future voice choices based on prior success
 
-## **Avatar Expression**
+## **Avatar Subsystem**
 
-- **`avatar_expression_engine`** streams avatar frames while playing audio; it lip-syncs with SadTalker/Wav2Lip when available or overlays a simple mouth animation otherwise
-- **`expressive_output`** coordinates speech synthesis, audio playback, background music, and frame streaming, enabling external GUIs to register callbacks for live animation
-- The pipeline supports skin swaps per personality layer and can produce GIFs or real‑time frames for rendering in operator interfaces
+- **`avatar_expression_engine`** renders the 3‑D persona and streams frames while playing audio, using SadTalker/Wav2Lip when available or falling back to a simple mouth overlay.
+- **`expressive_output`** coordinates speech synthesis, music, and video streaming so external GUIs can register callbacks for live animation.
+- A WebRTC gateway exposes the stream to browsers and bridges Discord and Telegram chats through connectors documented in [Communication Interfaces](communication_interfaces.md).
+- See the [Avatar Pipeline](avatar_pipeline.md) for configuration, including texture selection via `guides/avatar_config.toml` and optional 3‑D scene support.
 
 ---
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -340,6 +340,21 @@ See [testing.md](testing.md) for detailed instructions.
    The script sets an emotion, composes a short ritual track and logs an
    insight entry to `data/spiral_cortex_memory.jsonl`.
 
+## Avatar Console Setup
+
+1. **Configure the avatar** – adjust textures and colors in [`guides/avatar_config.toml`](../guides/avatar_config.toml) following the hints in [avatar_pipeline.md](avatar_pipeline.md).
+2. **Launch the console and stream** – start Crown services and the WebRTC video gateway:
+   ```bash
+   bash start_avatar_console.sh
+   ```
+3. **Run external connectors** – with tokens defined in `secrets.env`, start chat bridges:
+   ```bash
+   python communication/webrtc_server.py   # WebRTC browser stream
+   python tools/bot_discord.py            # Discord connector
+   python tools/bot_telegram.py           # Telegram connector
+   ```
+   See [communication_interfaces.md](communication_interfaces.md) for authentication details and additional channels.
+
 ## Setup Scripts
 
 - `scripts/check_requirements.sh` – loads `secrets.env`, ensures required commands are present, and verifies essential environment variables.

--- a/docs/operator_quickstart.md
+++ b/docs/operator_quickstart.md
@@ -7,3 +7,18 @@ Before issuing commands or editing code, read [blueprint_spine.md](blueprint_spi
 
 ## Consent Logging
 Record explicit consent for every session. Log the operator, participants, timestamp, and scope in the canonical ledger so actions remain auditable and reversible. Reference the ethical laws in the [nazarick_manifesto.md](nazarick_manifesto.md) when verifying that consent covers all planned interactions.
+
+## Avatar Console Setup
+
+1. **Configure** – edit [`guides/avatar_config.toml`](../guides/avatar_config.toml) to select textures and colors described in [avatar_pipeline.md](avatar_pipeline.md).
+2. **Launch** – start the avatar console and WebRTC stream:
+   ```bash
+   bash start_avatar_console.sh
+   ```
+3. **Connect** – with tokens in `secrets.env`, run external channels:
+   ```bash
+   python communication/webrtc_server.py
+   python tools/bot_discord.py
+   python tools/bot_telegram.py
+   ```
+   See [communication_interfaces.md](communication_interfaces.md) for connector behaviour and authentication.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -688,13 +688,13 @@ Manages audio capture and playback. See [Audio Ingestion](audio_ingestion.md), [
 - **Health Check:** Run an audio loopback test.
 - **Recovery:** Reinitialize the audio backend or fall back to silent mode.
 
-### Avatar
-Renders the musical persona and drives animations. See [Music Avatar Architecture](music_avatar_architecture.md), [Avatar Pipeline](avatar_pipeline.md), [Nazarick Agents](nazarick_agents.md) and [Chakra Architecture](chakra_architecture.md#heart).
+### Avatar Subsystem
+Handles 3‑D persona rendering, streams frames over WebRTC, and exposes external chat connectors such as Discord and Telegram. The pipeline described in [Avatar Pipeline](avatar_pipeline.md) drives the render loop while the [Communication Interfaces](communication_interfaces.md) guide covers WebRTC signalling and chat bridges.
 - **Layer:** Heart
 - **Priority:** 4
 - **Startup:** Launch after the audio device using Nazarick helpers.
-- **Health Check:** Verify avatar frame rendering.
-- **Recovery:** Reload avatar assets or restart the pipeline.
+- **Health Check:** Verify avatar frame rendering and WebRTC session establishment.
+- **Recovery:** Reload avatar assets, restart `video_stream.py`, or re-run connectors.
 
 ### Video
 Streams generative visuals. See [Video Generation](video_generation.md) and [Chakra Architecture](chakra_architecture.md#third_eye).


### PR DESCRIPTION
## Summary
- document Avatar Subsystem with rendering, WebRTC streaming, and connector references
- add avatar console setup steps for developers and operators
- link avatar setup workflow from Operator guide

## Testing
- `pre-commit run --files README_OPERATOR.md docs/system_blueprint.md docs/blueprint_spine.md docs/developer_onboarding.md docs/operator_quickstart.md` *(fails: Missing Python packages: websockets, ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5cfa614c832e86330f520392c475