### PR TITLE
feat: support per-agent webrtc sessions

### DIFF
--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -21,6 +21,19 @@ tracks that were requested. When bandwidth or configuration prohibits video or
 audio streaming the connector falls back to data-channel messages, ensuring that
 text or other payloads can still reach the client.
 
+## Per-Agent Sessions
+
+Multiple agents can negotiate their own WebRTC channels. Clients address the
+desired agent in the signalling endpoint paths:
+
+```text
+POST /{agent}/offer         # negotiate and receive an answer
+POST /{agent}/avatar-audio  # update the agent's lip-sync audio
+```
+
+The server's ``AvatarSessionManager`` keeps tracks isolated per agent so that
+video and audio updates do not interfere across sessions.
+
 ## Signaling Flow
 
 1. **Client connects** – A client creates a WebRTC offer and sends it to the

--- a/guides/avatar_config.toml
+++ b/guides/avatar_config.toml
@@ -1,8 +1,19 @@
+[agents.alpha]
 eye_color = [0, 128, 255]
 sigil = "spiral"
 
-[skins]
-nigredo_layer = "skins/nigredo.png"
-albedo_layer = "skins/albedo.png"
-rubedo_layer = "skins/rubedo.png"
-citrinitas_layer = "skins/citrinitas.png"
+[agents.alpha.skins]
+nigredo_layer = "skins/alpha/nigredo.png"
+albedo_layer = "skins/alpha/albedo.png"
+rubedo_layer = "skins/alpha/rubedo.png"
+citrinitas_layer = "skins/alpha/citrinitas.png"
+
+[agents.beta]
+eye_color = [255, 64, 64]
+sigil = "cube"
+
+[agents.beta.skins]
+nigredo_layer = "skins/beta/nigredo.png"
+albedo_layer = "skins/beta/albedo.png"
+rubedo_layer = "skins/beta/rubedo.png"
+citrinitas_layer = "skins/beta/citrinitas.png"

--- a/server.py
+++ b/server.py
@@ -65,7 +65,7 @@ from memory.mental import record_task_flow
 import corpus_memory_logging
 import music_generation
 import vector_memory
-from communication import webrtc_gateway as video_stream
+import video_stream
 from connectors import webrtc_connector
 from core import feedback_logging, video_engine
 from crown_config import settings

--- a/tests/test_avatar_stream_pipeline.py
+++ b/tests/test_avatar_stream_pipeline.py
@@ -209,5 +209,5 @@ def test_avatar_stream_pipeline(tmp_path, monkeypatch):
 
     monkeypatch.setattr(server.video_stream, "RTCPeerConnection", DummyPC)
     with TestClient(server.app) as client:
-        resp = client.post("/offer", json={"sdp": "x", "type": "offer"})
+        resp = client.post("/agent/offer", json={"sdp": "x", "type": "offer"})
         assert resp.status_code == 200

--- a/tests/test_vast_pipeline.py
+++ b/tests/test_vast_pipeline.py
@@ -94,7 +94,7 @@ def test_offer_returns_json_answer(monkeypatch):
                 offer = await pc.createOffer()
                 await pc.setLocalDescription(offer)
                 resp = await client.post(
-                    "/offer",
+                    "/agent/offer",
                     json={
                         "sdp": pc.localDescription.sdp,
                         "type": pc.localDescription.type,

--- a/tests/test_video_stream_audio.py
+++ b/tests/test_video_stream_audio.py
@@ -102,7 +102,7 @@ def test_offer_adds_audio_track(monkeypatch):
                 transport=transport, base_url="http://testserver"
             ) as client:
                 resp = await client.post(
-                    "/offer",
+                    "/agent/offer",
                     json={"sdp": "x", "type": "offer"},
                 )
                 return resp.status_code
@@ -131,12 +131,12 @@ def test_avatar_audio_endpoint_updates_track(monkeypatch, tmp_path):
     monkeypatch.setattr(
         video_stream.avatar_expression_engine, "stream_avatar_audio", fake_stream
     )
-    video_stream._active_track = None  # type: ignore[attr-defined]
-    _ = video_stream.AvatarVideoTrack()
+    video_stream.session_manager.remove("agent")
+    video_stream.session_manager.get_tracks("agent")
     audio_file = tmp_path / "a.wav"
     audio_file.touch()
     with TestClient(server.app) as client:
-        resp = client.post("/avatar-audio", json={"path": str(audio_file)})
+        resp = client.post("/agent/avatar-audio", json={"path": str(audio_file)})
     assert resp.status_code == 200
     assert calls["path"] == audio_file
 

--- a/video_stream.py
+++ b/video_stream.py
@@ -1,3 +1,76 @@
-"""Compatibility layer for deprecated ``video_stream`` module."""
+"""WebRTC video/audio stream management with per-agent sessions."""
 
-from communication.webrtc_gateway import *  # noqa: F401,F403
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from communication.webrtc_gateway import (
+    AvatarAudioTrack,
+    AvatarVideoTrack,
+    WebRTCGateway,
+    WebRTCServer,
+    configure_tracks,
+    enable_audio_track,
+    enable_video_track,
+)
+
+
+class AvatarSessionManager:
+    """Maintain avatar tracks keyed by agent identifier."""
+
+    def __init__(self) -> None:
+        self.video: Dict[str, AvatarVideoTrack] = {}
+        self.audio: Dict[str, AvatarAudioTrack] = {}
+
+    def get_tracks(
+        self, agent: str, audio_path: Optional[Path] = None
+    ) -> Tuple[AvatarVideoTrack | None, AvatarAudioTrack | None]:
+        """Return (video, audio) tracks for ``agent`` creating them if needed."""
+
+        vtrack = self.video.get(agent)
+        if vtrack is None and enable_video_track:
+            vtrack = AvatarVideoTrack(audio_path)
+            self.video[agent] = vtrack
+
+        atrack = self.audio.get(agent)
+        if atrack is None and enable_audio_track:
+            atrack = AvatarAudioTrack(audio_path)
+            self.audio[agent] = atrack
+
+        return vtrack, atrack
+
+    def update_audio(self, agent: str, path: Path) -> None:
+        """Update the lip-sync audio for ``agent``."""
+
+        track = self.video.get(agent)
+        if track is None:
+            raise KeyError(agent)
+        track.update_audio(path)
+
+    def remove(self, agent: str) -> None:
+        """Remove any tracks associated with ``agent``."""
+
+        self.video.pop(agent, None)
+        self.audio.pop(agent, None)
+
+
+session_manager = AvatarSessionManager()
+
+processor = WebRTCGateway(session_manager)
+router = processor.router
+close_peers = processor.close_peers
+
+__all__ = [
+    "AvatarAudioTrack",
+    "AvatarVideoTrack",
+    "AvatarSessionManager",
+    "WebRTCGateway",
+    "WebRTCServer",
+    "configure_tracks",
+    "enable_audio_track",
+    "enable_video_track",
+    "session_manager",
+    "router",
+    "close_peers",
+]


### PR DESCRIPTION
## Summary
- add AvatarSessionManager to manage media tracks per agent
- expose per-agent WebRTC endpoints and session-based audio updates
- document per-agent avatars and configuration example

## Testing
- `pre-commit run --files video_stream.py communication/webrtc_gateway.py server.py guides/avatar_config.toml docs/communication_interfaces.md tests/test_video_stream.py tests/test_video_stream_audio.py tests/web_console/test_webrtc_gateway.py tests/test_avatar_stream_pipeline.py tests/test_vast_pipeline.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; verify-chakra-monitoring; verify-self-healing)*


------
https://chatgpt.com/codex/tasks/task_e_68bd5ed5c8d0832e8e3c0b51b6a63747