### PR TITLE
docs: add chat connector instructions

### DIFF
--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -1,9 +1,9 @@
 # Communication Interfaces
 
 This document outlines how external clients interact with the avatar through
-various communication channels. The current implementation exposes WebRTC and
-Telegram interfaces, with additional channels pluggable through the gateway
-layer.
+various communication channels. The current implementation exposes WebRTC,
+Discord, and Telegram interfaces, with additional channels pluggable through the
+gateway layer.
 
 Each connector includes a ``__version__`` field for traceability and is tracked
 in the [Connector Index](connectors/CONNECTOR_INDEX.md).
@@ -58,6 +58,23 @@ environment variables:
 
 Additional channels should expose a token and use ``verify_token`` prior to
 calling the ``Gateway``.
+
+## Chat Connectors
+
+Two reference chat connectors bridge external text platforms to the avatar:
+
+- ``tools/bot_discord.py`` – posts messages from Discord channels to the
+  ``/glm-command`` endpoint and returns both text and optional synthesized voice
+  clips. Configure a bot token via ``DISCORD_BOT_TOKEN`` and launch with
+  ``python tools/bot_discord.py``.
+- ``communication/telegram_bot.py`` – forwards Telegram chats through the
+  ``Gateway``. Set ``TELEGRAM_BOT_TOKEN`` and run
+  ``python communication/telegram_bot.py``.
+
+Both connectors expect the tokens to be defined in the environment (or
+``secrets.env``) before startup. When running alongside the avatar console they
+relay responses back to their respective channels, enabling remote control of
+the agent.
 
 ## Adding New Channels
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -351,9 +351,13 @@ See [testing.md](testing.md) for detailed instructions.
    ```bash
    python communication/webrtc_server.py   # WebRTC browser stream
    python tools/bot_discord.py            # Discord connector
-   python tools/bot_telegram.py           # Telegram connector
+   python communication/telegram_bot.py   # Telegram connector
    ```
-   See [communication_interfaces.md](communication_interfaces.md) for authentication details and additional channels.
+   These connectors relay avatar replies back to their chat channels. Discord
+   attaches a synthesized audio clip when `core.expressive_output` is available;
+   Telegram forwards text through the `Gateway`. See
+   [communication_interfaces.md](communication_interfaces.md) for authentication
+   details and additional channels.
 
 ## Setup Scripts
 
@@ -372,6 +376,7 @@ Common mistakes and their resolutions:
 | `start_avatar_console.sh` shows permission error | Run `chmod +x start_crown_console.sh` or invoke it with `bash` |
 | Tokens absent in `secrets.env` | Ensure `HF_TOKEN`, `GLM_API_URL`, and `GLM_API_KEY` are set |
 | Model download fails | Check network connectivity and token permissions |
+| Discord/Telegram connector not forwarding avatar replies | Verify `DISCORD_BOT_TOKEN` or `TELEGRAM_BOT_TOKEN` is configured, start the connector after the avatar console, and ensure `ffmpeg` is installed for audio clips |
 
 ## Glossary
 


### PR DESCRIPTION
## Summary
- document Discord and Telegram chat connectors, including tokens and run commands
- guide developers on forwarding avatar responses via chat bridges

## Testing
- `pre-commit run --files docs/communication_interfaces.md docs/developer_onboarding.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bd62208468832e9341be50e8edb4a1