### PR TITLE
feat: add game dashboard interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `abzu-memory-bootstrap` script initializes memory layers in one step.
 - Chakra watchdog emits `chakra_down` events with NAZARICK resuscitation.
+- React-based game dashboard wrapping avatar stream and mission map actions.
 - Detailed notes describe how the Chakra watchdog coordinates with the Resuscitator
   to restart failing layers and log recovery metrics.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -416,6 +416,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [tools/kimi_integration.md](tools/kimi_integration.md) | Kimi Integration | Opencode can delegate code generation to the Kimi-K2 model when the service is available. | - |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting | This guide addresses frequent setup problems, driver issues, and environment pitfalls. Refer to [installation](instal... | `../download_models.py`, `../env_validation.py`, `../scripts/bootstrap.py` |
 | [ui/README.md](ui/README.md) | Floor Client UI | This React/Tailwind interface renders floors with channel tiles and streams messages over a WebSocket feed. | - |
+| [ui/game_dashboard.md](ui/game_dashboard.md) | Game Dashboard | The game dashboard wraps the avatar video feed and chakra telemetry in a simple mission map. | - |
 | [ui_service.md](ui_service.md) | UI Service | - | - |
 | [updates/2025-08.md](updates/2025-08.md) | August 2025 Roadmap | - | - |
 | [use_cases/ritual_demo.md](use_cases/ritual_demo.md) | Ritual Demo | This walkthrough demonstrates the small ritual sample included with the repository. The `examples/ritual_demo.py` scr... | - |

--- a/docs/ui/game_dashboard.md
+++ b/docs/ui/game_dashboard.md
@@ -1,0 +1,23 @@
+# Game Dashboard
+
+The game dashboard wraps the avatar video feed and chakra telemetry in a simple mission map.
+
+## Launch
+
+1. Ensure the Spiral OS backend is running and reachable.
+2. Open `web_console/game_dashboard/index.html` in a modern browser. React assets load from a CDN; no build step is required.
+3. The page automatically connects to the avatar stream and event feed.
+
+## Mission Map
+
+The home screen shows large buttons for common actions:
+
+- **Ignite** – boot the system.
+- **Memory Query** – request a memory scan.
+- **Handover** – transfer control to the agent.
+
+Use arrow keys or a gamepad's D‑pad to move focus. Activate a button with **Enter**, **Space**, or the gamepad **A** button.
+
+## Telemetry
+
+An event log under the video lists chakra metrics received from the server. Operators can watch the stream and metrics without touching code.

--- a/web_console/arcade.html
+++ b/web_console/arcade.html
@@ -26,6 +26,6 @@
         </div>
         <pre id="action-result"></pre>
     </div>
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -1,0 +1,66 @@
+import React from 'https://esm.sh/react@18';
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+import { BASE_URL, startStream, connectEvents } from '../main.js';
+
+function GameDashboard() {
+  const buttons = [
+    { id: 'ignite', label: 'Ignite', action: () => fetch(`${BASE_URL}/ignite`, { method: 'POST' }) },
+    { id: 'memory', label: 'Memory Query', action: () => fetch(`${BASE_URL}/memory/query`, { method: 'POST' }) },
+    { id: 'handover', label: 'Handover', action: () => fetch(`${BASE_URL}/handover`, { method: 'POST' }) }
+  ];
+  const [focusIndex, setFocusIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    startStream();
+    connectEvents();
+  }, []);
+
+  React.useEffect(() => {
+    const btn = document.getElementById(buttons[focusIndex].id + '-btn');
+    if (btn) btn.focus();
+  }, [focusIndex]);
+
+  React.useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'ArrowRight') setFocusIndex((i) => (i + 1) % buttons.length);
+      if (e.key === 'ArrowLeft') setFocusIndex((i) => (i + buttons.length - 1) % buttons.length);
+      if (e.key === 'Enter' || e.key === ' ') buttons[focusIndex].action();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [focusIndex]);
+
+  React.useEffect(() => {
+    let raf;
+    const poll = () => {
+      const [gp] = navigator.getGamepads ? navigator.getGamepads() : [];
+      if (gp) {
+        if (gp.buttons[14]?.pressed) setFocusIndex((i) => (i + buttons.length - 1) % buttons.length);
+        if (gp.buttons[15]?.pressed) setFocusIndex((i) => (i + 1) % buttons.length);
+        if (gp.buttons[0]?.pressed) buttons[focusIndex].action();
+      }
+      raf = requestAnimationFrame(poll);
+    };
+    window.addEventListener('gamepadconnected', () => poll());
+    return () => cancelAnimationFrame(raf);
+  }, [focusIndex]);
+
+  return (
+    React.createElement('div', null,
+      React.createElement('div', { className: 'mission-map' },
+        buttons.map((btn) =>
+          React.createElement('button', {
+            id: btn.id + '-btn',
+            key: btn.id,
+            onClick: btn.action
+          }, btn.label)
+        )
+      ),
+      React.createElement('video', { id: 'avatar', width: 320, autoPlay: true, muted: true, playsInline: true }),
+      React.createElement('pre', { id: 'event-log', style: { marginTop: '1rem', textAlign: 'left' } })
+    )
+  );
+}
+
+const root = createRoot(document.getElementById('root'));
+root.render(React.createElement(GameDashboard));

--- a/web_console/game_dashboard/index.html
+++ b/web_console/game_dashboard/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Game Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; margin: 2rem; }
+    .mission-map button { font-size: 1.5rem; margin: 1rem; padding: 1rem 2rem; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./dashboard.js"></script>
+</body>
+</html>

--- a/web_console/index.html
+++ b/web_console/index.html
@@ -42,6 +42,6 @@
             <a href="../tests/README.md" target="_blank">Test Index</a>
         </div>
     </div>
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -537,3 +537,5 @@ window.addEventListener('load', () => {
     loadStatus();
     setInterval(loadStatus, 5000);
 });
+
+export { BASE_URL, startStream, connectEvents };


### PR DESCRIPTION
## Summary
- export WebRTC helpers from web console
- add React mission map dashboard with keyboard/gamepad controls
- document game dashboard usage for operators

## Testing
- `pre-commit run --files web_console/main.js web_console/index.html web_console/arcade.html web_console/game_dashboard/index.html web_console/game_dashboard/dashboard.js docs/ui/game_dashboard.md docs/INDEX.md CHANGELOG.md` *(fails: verify-versions, pytest-cov missing opentelemetry, verify-chakra-monitoring, verify-self-healing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd65778f04832e97d2b1d489b0ae4b