### PR TITLE
Add setup wizard to game dashboard

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -5,6 +5,7 @@ For a short project overview summarizing the vision, chakra layers, key modules 
 For a concise overview of the Spiral OS architecture see [CODEX_OF_CODEX.md](CODEX_OF_CODEX.md).
 For the metaphysical background that informs Spiral OS, see [docs/spiritual_architecture.md](docs/spiritual_architecture.md), [docs/archetype_logic.md](docs/archetype_logic.md), [docs/psychic_loop.md](docs/psychic_loop.md) and [docs/crown_manifest.md](docs/crown_manifest.md).
 For a summary of Vast.ai and local Docker Compose deployment steps see [docs/deployment_overview.md](docs/deployment_overview.md).
+For a walkthrough of the web console setup wizard, see [docs/operator_onboarding.md](docs/operator_onboarding.md).
 
 For avatar setup guidance, consult [docs/system_blueprint.md#avatar-subsystem](docs/system_blueprint.md#avatar-subsystem) and [docs/blueprint_spine.md#avatar-subsystem](docs/blueprint_spine.md#avatar-subsystem). Step-by-step launch instructions are in [docs/developer_onboarding.md#avatar-console-setup](docs/developer_onboarding.md#avatar-console-setup) and [docs/operator_quickstart.md#avatar-console-setup](docs/operator_quickstart.md#avatar-console-setup).
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -367,6 +367,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [operator_console.md](operator_console.md) | Operator Console | Arcade-style web interface for issuing commands through the Operator API. | - |
 | [operator_interface_GUIDE.md](operator_interface_GUIDE.md) | Operator Interface Guide | Instructions for operator API usage, onboarding requirements, and Nazarick Web Console chat rooms. | - |
 | [operator_nazarick_bridge.md](operator_nazarick_bridge.md) | Operator-Nazarick Bridge | **Version:** v1.0.0 **Last updated:** 2025-09-05 | - |
+| [operator_onboarding.md](operator_onboarding.md) | Operator Onboarding Wizard | The Game Dashboard includes a modal wizard that guides operators through essential setup tasks. | - |
 | [operator_protocol.md](operator_protocol.md) | Operator Protocol | Operator actions dispatched via the API include a unique `command_id` UUID. The identifier is returned in responses,... | - |
 | [operator_quickstart.md](operator_quickstart.md) | Operator Quickstart | A concise orientation for operators interacting with ABZU. | - |
 | [os_guardian.md](os_guardian.md) | OS Guardian | Sources: [`../os_guardian/perception.py`](../os_guardian/perception.py), [`../os_guardian/planning.py`](../os_guardia... | `../os_guardian/action_engine.py`, `../os_guardian/perception.py`, `../os_guardian/planning.py`, `../os_guardian/safety.py` |

--- a/docs/operator_onboarding.md
+++ b/docs/operator_onboarding.md
@@ -1,0 +1,14 @@
+# Operator Onboarding Wizard
+
+The Game Dashboard includes a modal wizard that guides operators through essential setup tasks.
+
+## Wizard Flow
+1. **Avatar Config** – The wizard checks for `avatar_config.toml`. If not found, it prompts the operator to place the file on the server.
+2. **API Tokens** – Verifies required API tokens via the `/token-status` endpoint. Missing tokens trigger a reminder to update `secrets.env`.
+3. **Completion** – When both checks pass, the wizard records completion in `localStorage` and unlocks the dashboard.
+
+## Progress Persistence
+Current step and completion state are stored in `localStorage` so operators can resume the wizard after closing the browser.
+
+## Related Documents
+- [README_OPERATOR.md](../README_OPERATOR.md)

--- a/web_console/game_dashboard/index.html
+++ b/web_console/game_dashboard/index.html
@@ -6,6 +6,10 @@
   <style>
     body { font-family: Arial, sans-serif; text-align: center; margin: 2rem; }
     .mission-map button { font-size: 1.5rem; margin: 1rem; padding: 1rem 2rem; }
+    .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; }
+    .modal { background: #fff; padding: 1.5rem; border-radius: 8px; max-width: 420px; width: 100%; text-align: left; }
+    .progress { height: 8px; background: #ddd; border-radius: 4px; overflow: hidden; margin-bottom: 1rem; }
+    .progress-bar { height: 100%; background: #4caf50; }
   </style>
 </head>
 <body>

--- a/web_console/game_dashboard/setupWizard.js
+++ b/web_console/game_dashboard/setupWizard.js
@@ -1,0 +1,107 @@
+import React from 'https://esm.sh/react@18';
+import { BASE_URL } from '../main.js';
+
+export default function SetupWizard({ onComplete }) {
+  const [status, setStatus] = React.useState({ avatar: false, tokens: false });
+  const [step, setStep] = React.useState(() => Number(localStorage.getItem('wizardStep') || 0));
+
+  const steps = [
+    {
+      id: 'avatar',
+      title: 'Avatar Config',
+      tip: 'Ensure avatar_config.toml is available on the server.',
+      check: status.avatar,
+    },
+    {
+      id: 'tokens',
+      title: 'API Tokens',
+      tip: 'Define required API tokens in secrets.env.',
+      check: status.tokens,
+    },
+    {
+      id: 'done',
+      title: 'All Set',
+      tip: 'Setup complete.',
+      check: true,
+    },
+  ];
+
+  async function check() {
+    const avatar = await fetch('/avatar_config.toml', { method: 'HEAD' })
+      .then((r) => r.ok)
+      .catch(() => false);
+    const tokens = await fetch(`${BASE_URL}/token-status`)
+      .then((r) => r.ok)
+      .catch(() => false);
+    setStatus({ avatar, tokens });
+    if (avatar && tokens) {
+      localStorage.setItem('setupWizardCompleted', 'true');
+      onComplete();
+    }
+  }
+
+  React.useEffect(() => {
+    check();
+  }, []);
+
+  const total = steps.length - 1; // exclude final done step for progress
+  const progress = Math.min((step / total) * 100, 100);
+
+  function next() {
+    const nextStep = Math.min(step + 1, steps.length - 1);
+    setStep(nextStep);
+    localStorage.setItem('wizardStep', nextStep);
+    if (nextStep === steps.length - 1) {
+      localStorage.setItem('setupWizardCompleted', 'true');
+      onComplete();
+    }
+  }
+
+  function back() {
+    const prev = Math.max(step - 1, 0);
+    setStep(prev);
+    localStorage.setItem('wizardStep', prev);
+  }
+
+  const current = steps[step];
+
+  return React.createElement(
+    'div',
+    { className: 'modal-overlay' },
+    React.createElement(
+      'div',
+      { className: 'modal' },
+      React.createElement(
+        'div',
+        { className: 'progress' },
+        React.createElement('div', {
+          className: 'progress-bar',
+          style: { width: `${progress}%` },
+        })
+      ),
+      React.createElement('h2', { title: current.tip }, current.title),
+      !current.check && step < steps.length - 1
+        ? React.createElement('p', null, 'Not detected. ', current.tip)
+        : null,
+      step > 0
+        ? React.createElement(
+            'button',
+            { onClick: back, style: { marginRight: '0.5rem' } },
+            'Back'
+          )
+        : null,
+      step < steps.length - 1
+        ? React.createElement(
+            React.Fragment,
+            null,
+            React.createElement(
+              'button',
+              { onClick: check, style: { marginRight: '0.5rem' } },
+              'Re-check'
+            ),
+            React.createElement('button', { onClick: next }, 'Next')
+          )
+        : React.createElement('button', { onClick: next }, 'Finish')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- Add modal-driven setup wizard to the web console game dashboard that checks for avatar config and API tokens before enabling controls
- Persist wizard progress in browser localStorage and provide progress feedback
- Document operator setup wizard flow and link from operator README

## Testing
- `pre-commit run --files README_OPERATOR.md web_console/game_dashboard/dashboard.js web_console/game_dashboard/index.html web_console/game_dashboard/setupWizard.js docs/operator_onboarding.md` *(fails: verify-versions mismatch, capture-failing-tests, pytest-cov argument error, verify-chakra-monitoring, verify-self-healing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd72f4e5a4832e9a8d786918406550