### PR TITLE
Add mission builder and JSON mission orchestration

### DIFF
--- a/docs/operator_quickstart.md
+++ b/docs/operator_quickstart.md
@@ -22,3 +22,13 @@ Record explicit consent for every session. Log the operator, participants, times
    python tools/bot_telegram.py
    ```
    See [communication_interfaces.md](communication_interfaces.md) for connector behaviour and authentication.
+
+## Mission Builder
+
+1. **Compose** – open `web_console/mission_builder/index.html` in a browser and arrange `event` blocks, specifying an `event` name and `capability`.
+2. **Export** – click **Download Mission JSON** and save the file under the `missions/` directory. Sample templates such as `daily_ignition_check.json` and `avatar_broadcast.json` are provided.
+3. **Run** – dispatch the mission through the task orchestrator:
+   ```bash
+   python -m agents.task_orchestrator missions/daily_ignition_check.json
+   ```
+   Each event emits through the bus and reaches agents advertising the capability.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -658,6 +658,13 @@ flowchart LR
     MemoryBundle --> RAZAR
 ```
 
+### Mission Builder
+
+Offers a Blockly-based editor (`web_console/mission_builder`) for composing mission
+event sequences. The builder exports JSON consumed by
+`agents/task_orchestrator.py`, and starter templates live in the `missions/`
+directory.
+
 - **Layer:** Throat
 - **Priority:** 3
 - **Startup:** Launch after the chat gateway.

--- a/missions/avatar_broadcast.json
+++ b/missions/avatar_broadcast.json
@@ -1,0 +1,9 @@
+[
+  {
+    "event_type": "broadcast",
+    "payload": {
+      "capability": "avatar-message",
+      "message": "hello operators"
+    }
+  }
+]

--- a/missions/daily_ignition_check.json
+++ b/missions/daily_ignition_check.json
@@ -1,0 +1,9 @@
+[
+  {
+    "event_type": "ignition_check",
+    "payload": {
+      "capability": "ignite",
+      "target": "crown"
+    }
+  }
+]

--- a/web_console/mission_builder/index.html
+++ b/web_console/mission_builder/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Mission Builder</title>
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <style>
+    html, body, #blocklyDiv { height: 100%; margin: 0; }
+    #controls { position: absolute; top: 10px; right: 10px; }
+  </style>
+</head>
+<body>
+  <div id="blocklyDiv"></div>
+  <div id="controls">
+    <button onclick="downloadMission()">Download Mission JSON</button>
+  </div>
+  <xml id="toolbox" style="display: none">
+    <block type="mission_event"></block>
+  </xml>
+  <script src="mission_builder.js"></script>
+</body>
+</html>

--- a/web_console/mission_builder/mission_builder.js
+++ b/web_console/mission_builder/mission_builder.js
@@ -1,0 +1,50 @@
+/* global Blockly */
+
+const workspace = Blockly.inject('blocklyDiv', {
+  toolbox: document.getElementById('toolbox')
+});
+
+Blockly.defineBlocksWithJsonArray([
+  {
+    "type": "mission_event",
+    "message0": "event %1 capability %2",
+    "args0": [
+      { "type": "field_input", "name": "EVENT", "text": "event_type" },
+      { "type": "field_input", "name": "CAPABILITY", "text": "capability" }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 230,
+    "tooltip": "Emit an event with a capability",
+    "helpUrl": ""
+  }
+]);
+
+function missionToJson() {
+  const mission = [];
+  const blocks = workspace.getTopBlocks(true);
+  for (const block of blocks) {
+    if (block.type === 'mission_event') {
+      mission.push({
+        event_type: block.getFieldValue('EVENT'),
+        payload: { capability: block.getFieldValue('CAPABILITY') }
+      });
+    }
+  }
+  return mission;
+}
+
+function downloadMission() {
+  const data = JSON.stringify(missionToJson(), null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'mission.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+window.downloadMission = downloadMission;


### PR DESCRIPTION
## Summary
- add Blockly-based mission builder web UI
- support dispatching mission JSON via TaskOrchestrator
- document mission workflow and include sample mission templates

## Testing
- `pre-commit run --files agents/task_orchestrator.py docs/operator_quickstart.md docs/system_blueprint.md missions/daily_ignition_check.json missions/avatar_broadcast.json web_console/mission_builder/index.html web_console/mission_builder/mission_builder.js docs/INDEX.md` *(failed: missing metrics exporters and self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bd781fc578832ea5dde1f7d160b54b