### PR TITLE
feat: add avatar room to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `abzu-memory-bootstrap` script initializes memory layers in one step.
 - Chakra watchdog emits `chakra_down` events with NAZARICK resuscitation.
+- Dashboard Avatar Room with quick avatar commands, mini missions, and per-agent selection.
 - React-based game dashboard wrapping avatar stream and mission map actions.
 - Detailed notes describe how the Chakra watchdog coordinates with the Resuscitator
   to restart failing layers and log recovery metrics.

--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -122,3 +122,18 @@ for frame in video_engine.generate_avatar_stream(camera_paths=paths):
 
 `generate_avatar_stream` highlights each camera position with a red pixel so
 downstream renderers can align motion with the audio segment.
+
+## Avatar Room
+
+The game dashboard includes an **Avatar Room** for rapid operator interaction.
+From the dashboard, select an avatar from the dropdown, toggle between 2‑D
+and 3‑D presentation, and trigger quick commands:
+
+- **Wave** – invokes a simple greeting gesture.
+- **Speak** – sends a short phrase for the avatar to voice.
+- **Show Status** – fetches the avatar's current state and displays it.
+
+Pre-scripted **mini missions** such as "Teach me about the chakras" call the
+avatar's voice and gesture pipelines to deliver short tutorials. Each mission
+fires a POST request to the backend and streams the resulting animation and
+speech through the existing WebRTC connection.

--- a/web_console/game_dashboard/avatarRoom.js
+++ b/web_console/game_dashboard/avatarRoom.js
@@ -1,0 +1,98 @@
+import React from 'https://esm.sh/react@18';
+import { BASE_URL } from '../main.js';
+
+function AvatarRoom() {
+  const [mode, setMode] = React.useState('2d');
+  const [phrase, setPhrase] = React.useState('');
+  const [status, setStatus] = React.useState('');
+  const [avatar, setAvatar] = React.useState('default');
+  const avatars = ['default', 'inanna', 'bana'];
+  const missions = [
+    { id: 'chakras', label: 'Teach me about the chakras' },
+    { id: 'breathing', label: 'Guide a breathing exercise' }
+  ];
+
+  const selectAvatar = async (value) => {
+    setAvatar(value);
+    try {
+      await fetch(`${BASE_URL}/avatar/select`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatar: value })
+      });
+    } catch (err) {
+      console.error('select avatar failed', err);
+    }
+  };
+
+  const wave = () => fetch(`${BASE_URL}/avatar/wave`, { method: 'POST' });
+
+  const speak = async () => {
+    try {
+      await fetch(`${BASE_URL}/avatar/speak`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phrase })
+      });
+      setPhrase('');
+    } catch (err) {
+      console.error('speak failed', err);
+    }
+  };
+
+  const showStatus = async () => {
+    try {
+      const resp = await fetch(`${BASE_URL}/avatar/status`);
+      setStatus(await resp.text());
+    } catch (err) {
+      setStatus('status error: ' + err);
+    }
+  };
+
+  const runMission = (id) => {
+    fetch(`${BASE_URL}/avatar/mission`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mission: id })
+    });
+  };
+
+  return (
+    React.createElement('div', { id: 'avatar-room' },
+      React.createElement('div', { className: 'avatar-controls' },
+        React.createElement('select', {
+          value: avatar,
+          onChange: (e) => selectAvatar(e.target.value)
+        }, avatars.map((a) => React.createElement('option', { key: a, value: a }, a))),
+        React.createElement('button', {
+          onClick: () => setMode(mode === '2d' ? '3d' : '2d')
+        }, `Switch to ${mode === '2d' ? '3D' : '2D'}`),
+        React.createElement('button', { onClick: wave }, 'Wave'),
+        React.createElement('input', {
+          value: phrase,
+          onChange: (e) => setPhrase(e.target.value),
+          placeholder: 'Phrase...'
+        }),
+        React.createElement('button', { onClick: speak }, 'Speak'),
+        React.createElement('button', { onClick: showStatus }, 'Show Status')
+      ),
+      React.createElement('pre', null, status),
+      React.createElement('div', { className: 'mini-missions' },
+        missions.map((m) => React.createElement('button', {
+          key: m.id,
+          onClick: () => runMission(m.id)
+        }, m.label))
+      ),
+      React.createElement('video', {
+        id: 'avatar',
+        width: 320,
+        autoPlay: true,
+        muted: true,
+        playsInline: true,
+        style: mode === '3d' ? { transform: 'rotateY(20deg)' } : {}
+      })
+    )
+  );
+}
+
+export default AvatarRoom;

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -3,6 +3,7 @@ import { createRoot } from 'https://esm.sh/react-dom@18/client';
 import { BASE_URL, startStream, connectEvents } from '../main.js';
 import SetupWizard from './setupWizard.js';
 import ChakraMonitor from './chakraMonitor.js';
+import AvatarRoom from './avatarRoom.js';
 
 function GameDashboard() {
   const buttons = [
@@ -68,7 +69,7 @@ function GameDashboard() {
           }, btn.label)
         )
       ),
-      React.createElement('video', { id: 'avatar', width: 320, autoPlay: true, muted: true, playsInline: true }),
+      React.createElement(AvatarRoom, null),
       React.createElement('pre', { id: 'event-log', style: { marginTop: '1rem', textAlign: 'left' } }),
       React.createElement(ChakraMonitor)
     )


### PR DESCRIPTION
## Summary
- add React AvatarRoom with avatar selection, commands, and mini missions
- integrate AvatarRoom into game dashboard and document usage
- note avatar room in changelog

## Testing
- `pre-commit run --files CHANGELOG.md web_console/game_dashboard/avatarRoom.js web_console/game_dashboard/dashboard.js docs/avatar_pipeline.md docs/INDEX.md` *(fails: verify-versions, pytest-cov, verify-chakra-monitoring, verify-self-healing)*


------
https://chatgpt.com/codex/tasks/task_e_68bd79a6e680832eb4b92de34dfba001