### PR TITLE
ci: validate component versions and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,30 @@ jobs:
       - name: Validate dependency registry
         run: python scripts/check_dependency_registry.py
 
+  validate-components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate component versions
+        run: python scripts/validate_components.py
+
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install doc tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install openapi-spec-validator jsonschema
+      - name: Verify documentation freshness
+        run: docs/build_docs.sh
+
   pytest:
     runs-on: ubuntu-latest
     env:

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate documentation artifacts and verify no stale files remain.
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+python tools/doc_indexer.py
+python scripts/component_inventory.py
+python scripts/validate_api_schemas.py
+# Validate links across markdown files
+git ls-files '*.md' | xargs python scripts/validate_links.py
+
+# Ensure indexes are committed
+git diff --exit-code docs/INDEX.md docs/component_index.md docs/component_status.md docs/component_status.json docs/schemas/openapi.json || {
+  echo "Documentation artifacts are out of date. Run build_docs.sh and commit the results." >&2
+  exit 1
+}

--- a/docs/documentation_protocol.md
+++ b/docs/documentation_protocol.md
@@ -11,4 +11,8 @@ Standard workflow for updating documentation and guides.
    directories to avoid indexing generated artifacts.
 6. **Validate changes with** `pre-commit run --files <changed_files>` **before committing.**
 7. **Use traceable commit messages** that capture the rationale for changes and reference affected documents.
+8. **When bumping component or dependency versions:** update the relevant entries in
+   `requirements.txt` and lockfiles, run `python scripts/validate_components.py` to ensure
+   versions align, then execute `docs/build_docs.sh` to regenerate indexes (documentation index,
+   API docs, component status) and verify links.
 

--- a/scripts/validate_components.py
+++ b/scripts/validate_components.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validate registered component versions against requirements files."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict
+
+__version__ = "0.1.0"
+
+COMPONENT_INDEX = Path("component_index.json")
+REQ_TXT = Path("requirements.txt")
+REQ_LOCK = Path("requirements.lock")
+
+PINNED_RE = re.compile(r"^([A-Za-z0-9_.-]+)==([A-Za-z0-9_.-]+)")
+
+
+def parse_requirements(path: Path) -> Dict[str, str]:
+    """Return mapping of package name to pinned version."""
+    deps: Dict[str, str] = {}
+    if not path.exists():
+        return deps
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = PINNED_RE.match(line)
+        if match:
+            deps[match.group(1).lower()] = match.group(2)
+    return deps
+
+
+def load_components(path: Path) -> Dict[str, str]:
+    """Load component versions from component_index.json."""
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {c["id"].lower(): c["version"] for c in data.get("components", [])}
+
+
+def main() -> int:
+    components = load_components(COMPONENT_INDEX)
+    reqs = parse_requirements(REQ_TXT)
+    lock_reqs = parse_requirements(REQ_LOCK)
+
+    mismatches: list[str] = []
+    for name, version in components.items():
+        req_version = reqs.get(name) or lock_reqs.get(name)
+        if req_version and req_version != version:
+            mismatches.append(f"{name}: {version} != {req_version}")
+
+    if mismatches:
+        print("Component version mismatches detected:\n" + "\n".join(mismatches))
+        return 1
+
+    print("Component versions match requirements.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add script to cross-check component versions with requirements
- automate documentation rebuild and validation
- wire up CI jobs for component version and docs freshness checks

## Testing
- `docs/build_docs.sh` *(fails: Missing __version__ declarations; mission_logger mismatch)*
- `python -m pre_commit run --files scripts/validate_components.py docs/build_docs.sh docs/documentation_protocol.md .github/workflows/ci.yml` *(fails: __version__ mismatch; missing websockets; capture failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8c13be30832e87eecb92a7099a03