### PR TITLE
Add persistent chakra cycle scheduler

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "integration" / "test_full_flows.py"),
     str(ROOT / "tests" / "scripts" / "test_verify_chakra_monitoring.py"),
     str(ROOT / "tests" / "scripts" / "test_verify_doctrine_refs.py"),
+    str(ROOT / "tests" / "spiral_os" / "test_chakra_cycle.py"),
     str(ROOT / "tests" / "chakra_healing" / "test_root.py"),
     str(ROOT / "tests" / "chakra_healing" / "test_sacral.py"),
     str(ROOT / "tests" / "chakra_healing" / "test_solar.py"),

--- a/tests/spiral_os/test_chakra_cycle.py
+++ b/tests/spiral_os/test_chakra_cycle.py
@@ -1,0 +1,26 @@
+"""Tests for chakra cycle persistence."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import time
+
+from distributed_memory import CycleCounterStore
+from spiral_os.chakra_cycle import ChakraCycle, GEAR_RATIOS
+
+
+def test_cycle_continuity_after_restart(tmp_path):
+    path = tmp_path / "cycles.json"
+    store = CycleCounterStore(path=path)
+    cycle = ChakraCycle(store=store)
+    events = cycle.emit_heartbeat()
+    root_event = next(e for e in events if e.chakra == "root")
+    assert root_event.cycle_count == GEAR_RATIOS["root"]
+    assert root_event.timestamp <= time.time()
+
+    # Restart with same store
+    new_cycle = ChakraCycle(store=CycleCounterStore(path=path))
+    assert new_cycle.get_cycle("root") == root_event.cycle_count
+    new_cycle.emit_heartbeat()
+    assert new_cycle.get_cycle("root") == root_event.cycle_count + GEAR_RATIOS["root"]


### PR DESCRIPTION
## Summary
- add CycleCounterStore for chakra cycle persistence via Redis or JSON
- implement ChakraCycle scheduler with heartbeat APIs
- test cycle continuity across restarts

## Testing
- `pre-commit run --files distributed_memory.py src/spiral_os/chakra_cycle.py tests/spiral_os/test_chakra_cycle.py tests/conftest.py` (fails: Required test coverage of 80% not reached)
- `pytest --no-cov tests/spiral_os/test_chakra_cycle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8ec4a61c832e80be5e7eefda33f3