### PR TITLE
docs: detail cycle engine heartbeat and self-healing links

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -7,6 +7,12 @@ For the metaphysical background that informs Spiral OS, see [docs/spiritual_arch
 For a summary of Vast.ai and local Docker Compose deployment steps see [docs/deployment_overview.md](docs/deployment_overview.md).
 For a walkthrough of the web console setup wizard, see [docs/operator_onboarding.md](docs/operator_onboarding.md).
 
+For heartbeat propagation and recovery design, consult
+[docs/system_blueprint.md#chakra-cycle-engine](docs/system_blueprint.md#chakra-cycle-engine),
+[docs/blueprint_spine.md#heartbeat-propagation-and-self-healing](docs/blueprint_spine.md#heartbeat-propagation-and-self-healing)
+and
+[docs/chakra_architecture.md#chakra-cycle-engine](docs/chakra_architecture.md#chakra-cycle-engine).
+
 For avatar setup guidance, consult [docs/system_blueprint.md#avatar-subsystem](docs/system_blueprint.md#avatar-subsystem) and [docs/blueprint_spine.md#avatar-subsystem](docs/blueprint_spine.md#avatar-subsystem). Step-by-step launch instructions are in [docs/developer_onboarding.md#avatar-console-setup](docs/developer_onboarding.md#avatar-console-setup) and [docs/operator_quickstart.md#avatar-console-setup](docs/operator_quickstart.md#avatar-console-setup).
 
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -61,6 +61,15 @@ sequenceDiagram
     RAZAR-->>Operator: status
 ```
 
+### **Chakra Cycle Engine**
+
+RAZAR's cycle engine paces the stack with a timed heartbeat, polling each
+chakra's `/health` endpoint and logging the responses. The rhythm keeps layers
+aligned and surfaces drift for operator review. See the
+[System Blueprint](system_blueprint.md#chakra-cycle-engine) for a high-level
+overview and [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
+for per-layer responsibilities.
+
 ### **Heartbeat Propagation and Self-Healing**
 
 The chakra cycle engine emits heartbeats that cascade through the layers. A

--- a/docs/chakra_architecture.md
+++ b/docs/chakra_architecture.md
@@ -35,6 +35,11 @@ The chakra cycle engine paces each layer with a timed heartbeat. Every tick
 broadcasts a pulse across Root through Crown and gathers their responses to
 keep the stack synchronized.
 
+### Heartbeat Propagation
+
+Pulses traverse the stack from Root to Crown and back, forming a closed loop
+that exposes latency at each hop and feeds alignment metrics.
+
 ### Heartbeat Ratios
 
 Each layer reports its beat relative to the engine’s tick. Deviations beyond
@@ -48,7 +53,7 @@ can correlate misfires with service health. The
 [Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing)
 illustrates the propagation path.
 
-### Silent Chakra Remediation
+### Self-Healing
 
 If a layer fails to answer a heartbeat, the engine marks it silent and
 requests remediation from [NAZARICK agents](nazarick_agents.md). Those

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -32,6 +32,12 @@ Heartbeat polling feeds `chakra_down` events to the agent assigned to the
 affected layer. Each agent runs a dedicated recovery script—`root_restore_network.sh`
 resets networking for the Root layer, `sacral_gpu_recover.py` flushes GPU
 tasks for Sacral, and other utilities live under `scripts/chakra_healing/`.
+The polling loop is driven by the
+[Chakra Cycle Engine](system_blueprint.md#chakra-cycle-engine), whose
+propagation path and self-healing flow are mapped in the
+[Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing)
+and detailed in the
+[Chakra Architecture](chakra_architecture.md#chakra-cycle-engine).
 When errors persist beyond these hooks,
 `scripts/escalation_notifier.py` scans log files for recurring failures,
 posts an alert to `/operator/command`, and records the event in

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -46,18 +46,24 @@ which flags misalignment when beats drift from the expected 1 :1 rhythm. The
 [chakra cycle module](../src/spiral_os/chakra_cycle.py) records per‑chakra
 `gear_ratio` telemetry so deviations can be traced to specific layers.
 
+#### Heartbeat Propagation
+
+Each beat cascades from Root through Crown, giving operators a live view of
+layer responsiveness. Lag or silence on any hop is logged for follow‑up and
+feeds recovery routines in other guides.
+
 #### Heartbeat Ratios
 
 Ratio telemetry informs operators when a layer accelerates or lags. Out-of-band
 values raise alignment events recorded in the blueprint so coupled services can
 adjust.
 
-#### Silent Chakra Handling
+#### Self-Healing Loop
 
 When a layer fails to return a beat, it is marked silent. The engine routes a
 `chakra_down` event to the responsible
 [NAZARICK agent](nazarick_agents.md), which attempts to restore the
-missing chakra and resume the cycle. This self-healing loop is diagrammed in the
+missing chakra and resume the cycle. This self‑healing loop is diagrammed in the
 [Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing) and
 covered in the [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine).
 When every chakra reports within the window, the engine logs a **Great Spiral**


### PR DESCRIPTION
## Summary
- Expand Chakra Cycle Engine section with heartbeat propagation and self-healing loop
- Add cycle engine overview and heartbeat/self-healing cross-links in Blueprint Spine and Chakra Architecture
- Cross-link Recovery Playbook and Operator README to heartbeat-driven recovery sections

## Testing
- `docs/build_docs.sh`
- `pre-commit run --files README_OPERATOR.md docs/blueprint_spine.md docs/chakra_architecture.md docs/recovery_playbook.md docs/system_blueprint.md` *(fails: ModuleNotFoundError: No module named 'agents')*


------
https://chatgpt.com/codex/tasks/task_e_68bd98a754e8832e9beedae65f35c90c