### PR TITLE
Add pluggable avatar render modes with 3D support

### DIFF
--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -82,6 +82,20 @@ for _ in stream_avatar_audio(Path("qnl_hex_song.wav")):
     pass
 ```
 
+## 2-D vs 3-D
+
+Avatars can render with either a lightweight 2‑D placeholder or a simple 3‑D
+scene derived from ``LargeWorldModel``. Select the mode per agent via the API:
+
+```bash
+curl -X POST /agents/overlord/avatar-mode -d '{"mode": "3d"}'
+```
+
+When ``mode`` is ``"3d"`` the video engine expects meshes, camera paths and
+optional lip‑sync audio. These assets are loaded by
+``media.avatar.lwm_renderer`` before frames are generated. Omitting the mode or
+setting it to ``"2d"`` keeps the traditional flat rendering path.
+
 ## Object-aware avatar selection
 
 The video engine can adapt the visible avatar based on the current visual

--- a/src/media/avatar/lwm_renderer.py
+++ b/src/media/avatar/lwm_renderer.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Utilities for loading LargeWorldModel rendering assets."""
+
+__version__ = "0.1.0"
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+
+from ...lwm import LargeWorldModel, default_lwm
+
+try:  # pragma: no cover - optional dependency
+    import librosa  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - optional
+    librosa = None  # type: ignore[assignment]
+
+
+class LWMRenderer:
+    """Load meshes, camera paths and lip-sync data for 3-D avatars."""
+
+    def __init__(self, model: LargeWorldModel | None = None) -> None:
+        self.model = model or default_lwm
+        self.meshes: List[np.ndarray] = []
+        self.camera_paths: List[Tuple[float, float, float]] = []
+        self.audio_wave: np.ndarray | None = None
+        self.step: int = 0
+
+    def load_resources(
+        self,
+        mesh_paths: Iterable[Path],
+        camera_paths: Iterable[Tuple[float, float, float]] | None = None,
+        lip_sync_audio: Path | None = None,
+    ) -> None:
+        """Load scene assets for a configured 3-D model."""
+
+        self.meshes = [self._load_mesh(p) for p in mesh_paths]
+        if camera_paths is not None:
+            self.camera_paths = list(camera_paths)
+        else:
+            scene = self.model.inspect_scene()
+            points = scene.get("points") if isinstance(scene, dict) else None
+            if points:
+                self.camera_paths = [
+                    (float(p.get("index", 0)), 0.0, 0.0) for p in points
+                ]
+        if lip_sync_audio is not None and librosa is not None:
+            try:
+                self.audio_wave, sr = librosa.load(
+                    str(lip_sync_audio), sr=16000, mono=True
+                )
+                self.step = sr // 15
+            except Exception:  # pragma: no cover - optional
+                self.audio_wave = None
+                self.step = 0
+
+    @staticmethod
+    def _load_mesh(path: Path) -> np.ndarray:
+        """Read a mesh from ``path`` returning an empty array on failure."""
+
+        try:
+            return np.loadtxt(path)
+        except Exception:  # pragma: no cover - defensive
+            return np.empty((0, 3))
+
+
+__all__ = ["LWMRenderer"]


### PR DESCRIPTION
## Summary
- extend video engine with render_2d_frame/render_3d_frame plug-in points
- load meshes, camera paths, and lip sync data via new LWMRenderer
- expose `/agents/{id}/avatar-mode` API to toggle 2-D vs 3-D per agent
- document switching modes in avatar pipeline guide

## Testing
- `pre-commit run --files docs/avatar_pipeline.md` *(failed: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*
- `python -m py_compile server.py src/core/video_engine.py src/media/avatar/lwm_renderer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9eaf70c8832ea710145fe5e61da6