### PR TITLE
docs: document heartbeat session flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documented heartbeat propagation, session management, and self-healing in
+  `system_blueprint.md`, `blueprint_spine.md`, `avatar_pipeline.md`, and
+  `operator_onboarding.md`; added cross-links from `GENESIS/README.md` and
+  `README_OPERATOR.md` for quick reference.
 - Track model endpoints and patches in `worlds.config_registry`; added
   `world export`/`world import` utilities and automatic registration of
   model endpoints.

--- a/GENESIS/README.md
+++ b/GENESIS/README.md
@@ -1,3 +1,10 @@
 # GENESIS Doctrine
 
 Refer to the [Doctrine Index](../docs/doctrine_index.md) for canonical files, versions, and update history.
+
+Quick links:
+
+- [System Blueprint](../docs/system_blueprint.md#chakra-cycle-engine)
+- [Blueprint Spine](../docs/blueprint_spine.md#heartbeat-propagation-and-self-healing)
+- [Avatar Pipeline](../docs/avatar_pipeline.md#heartbeat-and-session-management)
+- [Operator Onboarding](../docs/operator_onboarding.md#multi-agent-streams)

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -13,6 +13,12 @@ For heartbeat propagation and recovery design, consult
 and
 [docs/chakra_architecture.md#chakra-cycle-engine](docs/chakra_architecture.md#chakra-cycle-engine).
 
+For session management and avatar stream resilience, see
+[docs/system_blueprint.md#session-management](docs/system_blueprint.md#session-management),
+[docs/blueprint_spine.md#session-management](docs/blueprint_spine.md#session-management),
+[docs/avatar_pipeline.md#heartbeat-and-session-management](docs/avatar_pipeline.md#heartbeat-and-session-management) and
+[docs/operator_onboarding.md#multi-agent-streams](docs/operator_onboarding.md#multi-agent-streams).
+
 For avatar setup guidance, consult [docs/system_blueprint.md#avatar-subsystem](docs/system_blueprint.md#avatar-subsystem) and [docs/blueprint_spine.md#avatar-subsystem](docs/blueprint_spine.md#avatar-subsystem). Step-by-step launch instructions are in [docs/developer_onboarding.md#avatar-console-setup](docs/developer_onboarding.md#avatar-console-setup) and [docs/operator_quickstart.md#avatar-console-setup](docs/operator_quickstart.md#avatar-console-setup).
 
 

--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -4,6 +4,16 @@ The avatar pipeline synchronises generated speech with visual animation. It read
 configuration from `guides/avatar_config.toml` and produces frames via
 `core.video_engine`.
 
+## Heartbeat and Session Management
+
+The video engine listens for the system heartbeat so avatar streams stay in sync
+with the chakra cycle. Each active stream is tied to an operator session and is
+renewed on every beat. If the heartbeat goes missing, the stream is marked
+stalled and the pipeline triggers its self-healing routine to reconnect WebRTC
+channels and reload textures before resuming playback. Session identifiers are
+persisted in memory so multi-agent streams can restart without losing their
+place in the narrative.
+
 ## Setup
 
 Install the Python requirements and optional packages for lip sync:

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -85,6 +85,15 @@ For layer-specific responsibilities, see
 [Nazarick Agents](nazarick_agents.md). The remediation philosophy follows the
 [Self-Healing Manifesto](self_healing_manifesto.md).
 
+### **Session Management**
+
+Operator sessions are anchored to the same heartbeat cadence. RAZAR records a
+session when the first command arrives and renews it with each heartbeat. If a
+layer drops from the cycle, the session is flagged but retained so agents can
+replay context once the self-healing loop restores the path. Session state lives
+in the memory bundle, enabling multi-agent streams to pause and resume without
+losing narrative continuity.
+
 ## **3. Key Components & Modules**
 
 - **RAZAR Suite (`razar/` & top-level scripts)**

--- a/docs/operator_onboarding.md
+++ b/docs/operator_onboarding.md
@@ -10,5 +10,15 @@ The Game Dashboard includes a modal wizard that guides operators through essenti
 ## Progress Persistence
 Current step and completion state are stored in `localStorage` so operators can resume the wizard after closing the browser.
 
+## Multi-Agent Streams
+1. Launch the servant processes with `start_dev_agents.py` or via the dashboard's **Agents** panel.
+2. When prompted, select the agents to stream and confirm the WebRTC session for each.
+3. Use the **Streams** tab to verify audio and video for every agent.
+
+## Monitor Chakra Pulses
+1. Open the **Chakra Monitor** from the dashboard sidebar.
+2. Confirm each layer emits pulses at the expected 1 : 1 ratio.
+3. Pulses that drop or drift trigger alerts; follow the [Recovery Playbook](recovery_playbook.md) to restore alignment.
+
 ## Related Documents
 - [README_OPERATOR.md](../README_OPERATOR.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -103,6 +103,17 @@ and retrieval requests, while `nazarick_agents` subscribe to mission updates and
 state changes. See the [Operations Guide](operations.md#heartbeat-polling-and-event-routing)
 for runtime details.
 
+### Session Management
+
+RAZAR tracks every operator session and binds it to the heartbeat stream. The
+first beat establishes a session record; subsequent beats extend the lifetime
+until the operator disconnects or a timeout elapses. Session metadata is stored
+in the unified memory bundle so agents can recover context after restarts. When
+the cycle engine flags a missing beat, the session is marked **degraded** and
+the self‑healing loop attempts to restore the underlying layer before closing or
+handing off the session. This keeps long‑running missions intact even when
+individual chakras momentarily fail.
+
 ### Mission Logging
 
 `agents.razar.mission_logger` persists each component lifecycle change to

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -21,7 +21,7 @@ documents:
       key_rules: Maintain architectural consistency.
       insight: Align new modules with existing architecture.
   docs/blueprint_spine.md:
-    sha256: 6e5acee87a9c0cdb15035dad24f1a7e955dd72eaf8174b4c96835317d9933641
+    sha256: fd3016da23ac8fcf83976a5e4d376cfe0f4680e6e68f908bc7d1ff165f4401e1
     summary:
       purpose: Deep-dive overview of mission, agents, and memory bundle.
       scope: System structure and narratives.


### PR DESCRIPTION
## Summary
- clarify session management in the system blueprint and blueprint spine
- explain heartbeat-driven stream recovery in the avatar pipeline and operator onboarding
- cross-link heartbeat guides from operator and GENESIS docs

## Testing
- `pre-commit run --files docs/system_blueprint.md docs/blueprint_spine.md docs/avatar_pipeline.md docs/operator_onboarding.md GENESIS/README.md README_OPERATOR.md CHANGELOG.md onboarding_confirm.yml` *(fails: Run tests with coverage error, verify-chakra-monitoring missing module, verify-self-healing no cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bda70fb328832eb154792b4e75bba2