### PR TITLE
feat: index nazarick agents

### DIFF
--- a/agents/nazarick/agent_registry.json
+++ b/agents/nazarick/agent_registry.json
@@ -2,46 +2,46 @@
   "agents": [
     {
       "id": "orchestration_master",
-      "launch": "./launch_servants.sh orchestration_master",
       "chakra": "crown",
+      "capabilities": ["orchestration"],
+      "launch": "./launch_servants.sh orchestration_master",
       "channel": "#throne-room",
       "persona_traits": ["disciplined", "calm"],
       "responsibilities": "Boot order and pipeline supervision.",
       "code_path": "orchestration_master.py",
-      "capabilities": ["orchestration"],
       "triggers": ["launch"]
     },
     {
       "id": "prompt_orchestrator",
-      "launch": "./launch_servants.sh crown_prompt_orchestrator",
       "chakra": "throat",
+      "capabilities": ["prompt_routing"],
+      "launch": "./launch_servants.sh crown_prompt_orchestrator",
       "channel": "#signal-hall",
       "persona_traits": ["focused", "efficient"],
       "responsibilities": "Route prompts and recall context.",
       "code_path": "crown_prompt_orchestrator.py",
-      "capabilities": ["prompt_routing"],
       "triggers": ["prompt"]
     },
     {
       "id": "qnl_engine",
-      "launch": "./launch_servants.sh qnl_engine",
       "chakra": "third_eye",
+      "capabilities": ["qnl_processing"],
+      "launch": "./launch_servants.sh qnl_engine",
       "channel": "#insight-observatory",
       "persona_traits": ["introspective", "analytic"],
       "responsibilities": "Process QNL sequences and insights.",
       "code_path": "SPIRAL_OS/qnl_engine.py",
-      "capabilities": ["qnl_processing"],
       "triggers": ["insight"]
     },
     {
       "id": "memory_scribe",
-      "launch": "./launch_servants.sh memory_scribe",
       "chakra": "heart",
+      "capabilities": ["memory_persistence"],
+      "launch": "./launch_servants.sh memory_scribe",
       "channel": "#memory-vault",
       "persona_traits": ["diligent", "archival"],
       "responsibilities": "Persist transcripts and embeddings.",
       "code_path": "memory_scribe.py",
-      "capabilities": ["memory_persistence"],
       "triggers": ["persist"]
     }
   ]

--- a/agents/nazarick/service_launcher.py
+++ b/agents/nazarick/service_launcher.py
@@ -10,16 +10,50 @@ import subprocess
 import threading
 import time
 from pathlib import Path
+from typing import Dict, List, Optional
 
 from .chakra_observer import NazarickChakraObserver
 from agents.event_bus import emit_event
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 LOGGER = logging.getLogger(__name__)
 
 REGISTRY_FILE = Path(__file__).with_name("agent_registry.json")
 LOG_FILE = Path("logs") / "nazarick_startup.json"
+
+
+class AgentDirectory:
+    """In-memory index of Nazarick agents."""
+
+    def __init__(self, agents: List[Dict]):
+        self.agents = agents
+        self.by_id: Dict[str, Dict] = {a.get("id", ""): a for a in agents}
+        self.by_chakra: Dict[str, List[Dict]] = {}
+        self.by_capability: Dict[str, List[Dict]] = {}
+        for agent in agents:
+            chakra = agent.get("chakra")
+            if chakra:
+                self.by_chakra.setdefault(chakra, []).append(agent)
+            for cap in agent.get("capabilities", []):
+                self.by_capability.setdefault(cap, []).append(agent)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "AgentDirectory":
+        data = json.loads(Path(path).read_text()) or {}
+        return cls(data.get("agents", []))
+
+    def get(self, agent_id: str) -> Optional[Dict]:
+        return self.by_id.get(agent_id)
+
+    def get_by_chakra(self, chakra: str) -> List[Dict]:
+        return self.by_chakra.get(chakra, [])
+
+    def get_by_capability(self, capability: str) -> List[Dict]:
+        return self.by_capability.get(capability, [])
+
+
+AGENT_DIRECTORY: AgentDirectory | None = None
 
 
 def launch_required_agents(registry_path: Path | None = None) -> list[dict[str, str]]:
@@ -45,11 +79,13 @@ def launch_required_agents(registry_path: Path | None = None) -> list[dict[str, 
         existing = []
 
     registry_file = Path(registry_path) if registry_path else REGISTRY_FILE
+    global AGENT_DIRECTORY
     try:
-        registry = json.loads(registry_file.read_text()) or {}
-        entries = registry.get("agents", [])
+        AGENT_DIRECTORY = AgentDirectory.from_file(registry_file)
+        entries = AGENT_DIRECTORY.agents
     except FileNotFoundError:  # pragma: no cover - missing registry
         LOGGER.error("Agent registry not found: %s", registry_file)
+        AGENT_DIRECTORY = AgentDirectory([])
         entries = []
 
     events: list[dict[str, str]] = []
@@ -109,4 +145,4 @@ def launch_required_agents(registry_path: Path | None = None) -> list[dict[str, 
     return events
 
 
-__all__ = ["launch_required_agents"]
+__all__ = ["launch_required_agents", "AgentDirectory", "AGENT_DIRECTORY"]

--- a/tests/agents/nazarick/test_agent_directory.py
+++ b/tests/agents/nazarick/test_agent_directory.py
@@ -1,0 +1,15 @@
+from agents.nazarick.service_launcher import AgentDirectory, REGISTRY_FILE
+
+
+def test_lookup_by_chakra():
+    directory = AgentDirectory.from_file(REGISTRY_FILE)
+    agents = directory.get_by_chakra("heart")
+    ids = [a["id"] for a in agents]
+    assert ids == ["memory_scribe"]
+
+
+def test_lookup_by_capability():
+    directory = AgentDirectory.from_file(REGISTRY_FILE)
+    agents = directory.get_by_capability("prompt_routing")
+    ids = [a["id"] for a in agents]
+    assert ids == ["prompt_orchestrator"]


### PR DESCRIPTION
## Summary
- expose chakras and capabilities for every Nazarick agent
- index registry entries in a new `AgentDirectory`
- test lookups by chakra and capability

## Testing
- `pre-commit run --files agents/nazarick/agent_registry.json agents/nazarick/service_launcher.py tests/agents/nazarick/test_agent_directory.py` *(fails: Required test coverage of 80% not reached)*
- `pytest --no-cov tests/agents/nazarick/test_agent_directory.py` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bda8ce9784832eacf5d56cde0972c4