### PR TITLE
Add lifecycle heartbeat monitoring

### DIFF
--- a/monitoring/agent_heartbeat.py
+++ b/monitoring/agent_heartbeat.py
@@ -1,0 +1,67 @@
+"""Track agent heartbeat events and detect outages."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Iterable, List
+
+from agents.razar import lifecycle_bus
+
+__version__ = "0.1.0"
+
+
+class AgentHeartbeat:
+    """Track last heartbeat per agent with optional alerting."""
+
+    def __init__(
+        self, agents: Iterable[str] | None = None, *, window: float = 5.0
+    ) -> None:
+        self.window = window
+        self._agents = set(agents or [])
+        self._beats: Dict[str, float] = {}
+
+    async def listen(self) -> None:
+        """Subscribe to lifecycle events and update timestamps."""
+
+        async for event in lifecycle_bus.subscribe():
+            if event.get("event") != "agent_beat":
+                continue
+            agent = event.get("agent")
+            if agent:
+                ts = float(event.get("timestamp", time.time()))
+                self.beat(str(agent), ts)
+
+    def beat(self, agent: str, timestamp: float | None = None) -> None:
+        """Record a heartbeat for ``agent`` at ``timestamp``."""
+
+        ts = timestamp or time.time()
+        self._agents.add(agent)
+        self._beats[agent] = ts
+
+    def heartbeats(self) -> Dict[str, float]:
+        """Return mapping of agents to their last heartbeat."""
+
+        return dict(self._beats)
+
+    def pending(self, *, now: float | None = None) -> List[str]:
+        """Return agents missing a beat beyond the window."""
+
+        current = now or time.time()
+        missing: List[str] = []
+        for agent in self._agents:
+            ts = self._beats.get(agent, 0.0)
+            if current - ts > self.window:
+                missing.append(agent)
+        return missing
+
+    def check_alerts(self, *, now: float | None = None) -> None:
+        """Emit ``agent_down`` events for agents missing beats."""
+
+        missing = self.pending(now=now)
+        for agent in missing:
+            lifecycle_bus.publish({"event": "agent_down", "agent": agent})
+        if missing:
+            raise RuntimeError(f"Missing heartbeats: {', '.join(missing)}")
+
+
+__all__ = ["AgentHeartbeat"]

--- a/tests/agents/razar/test_agent_heartbeat.py
+++ b/tests/agents/razar/test_agent_heartbeat.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from monitoring.agent_heartbeat import AgentHeartbeat
+from agents.razar import lifecycle_bus
+
+
+def test_missing_beat_emits_agent_down(monkeypatch) -> None:
+    hb = AgentHeartbeat(agents=["alpha"], window=0.1)
+    hb.beat("alpha", timestamp=0.0)
+    events: list[dict[str, object]] = []
+
+    def capture(event: dict[str, object]) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(lifecycle_bus, "publish", capture)
+    with pytest.raises(RuntimeError):
+        hb.check_alerts(now=1.0)
+    assert {"event": "agent_down", "agent": "alpha"} in events
+
+
+def test_event_subscription(monkeypatch) -> None:
+    hb = AgentHeartbeat(window=1.0)
+
+    async def fake_stream():
+        yield {"event": "agent_beat", "agent": "beta", "timestamp": 0.0}
+
+    monkeypatch.setattr(lifecycle_bus, "subscribe", lambda: fake_stream())
+    asyncio.run(hb.listen())
+    assert "beta" in hb.heartbeats()


### PR DESCRIPTION
## Summary
- extend razar lifecycle bus with generic publish/subscribe APIs backed by Redis, Kafka, or in-memory queue
- emit agent lifecycle events (start, beat, stop) from service launcher
- monitor agent heartbeats and flag missing pulses
- add tests for heartbeat monitoring

## Testing
- `pre-commit run --files agents/razar/lifecycle_bus.py agents/nazarick/service_launcher.py monitoring/agent_heartbeat.py tests/agents/razar/test_agent_heartbeat.py` *(fails: Required test coverage of 80% not reached; Verify chakra monitoring fails: ModuleNotFoundError: No module named 'agents')*
- `pytest --override-ini="addopts=" -vv tests/agents/razar/test_agent_heartbeat.py` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaaf94bb8832e8dabb4ac16e7f184