### PR TITLE
Add resuscitator agent and recovery confirmation

### DIFF
--- a/agents/nazarick/resuscitator.py
+++ b/agents/nazarick/resuscitator.py
@@ -1,0 +1,63 @@
+"""NAZARICK agent restarting failed peers via lifecycle events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict
+
+from agents.event_bus import emit_event
+from agents.razar import lifecycle_bus
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Resuscitator:
+    """Listen for ``agent_down`` events and attempt recovery."""
+
+    def __init__(
+        self,
+        actions: Dict[str, Callable[[], bool]],
+        emitter: Callable[[Dict[str, Any]], None] = lifecycle_bus.publish,
+    ) -> None:
+        self.actions = actions
+        self.emit = emitter
+
+    # ------------------------------------------------------------------
+    def resuscitate(self, agent: str) -> bool:
+        """Run the restart or patch routine for ``agent``."""
+
+        action = self.actions.get(agent)
+        success = bool(action and action())
+        event = "agent_resuscitated" if success else "agent_resuscitation_failed"
+        payload = {"event": event, "agent": agent}
+        self.emit(payload)
+        emit_event("nazarick", event, {"agent": agent})
+        level = logging.INFO if success else logging.ERROR
+        LOGGER.log(
+            level,
+            "%s agent %s",
+            "Resuscitated" if success else "Failed to resuscitate",
+            agent,
+        )
+        return success
+
+    # ------------------------------------------------------------------
+    async def handle_event(self, event: Dict[str, Any]) -> None:
+        """Process an ``agent_down`` event from the lifecycle bus."""
+
+        if event.get("event") != "agent_down":
+            return
+        agent = str(event.get("agent"))
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.resuscitate, agent)
+
+    # ------------------------------------------------------------------
+    async def run(self) -> None:
+        """Subscribe to the lifecycle bus and remediate failures."""
+
+        async for evt in lifecycle_bus.subscribe():
+            await self.handle_event(evt)
+
+
+__all__ = ["Resuscitator"]

--- a/tests/agents/nazarick/test_resuscitator_flow.py
+++ b/tests/agents/nazarick/test_resuscitator_flow.py
@@ -1,0 +1,109 @@
+"""Integration tests for :mod:`agents.nazarick.resuscitator`."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import queue
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
+
+from agents.nazarick.resuscitator import Resuscitator
+from agents.razar import lifecycle_bus
+from agents.razar.recovery_manager import RecoveryManager
+from agents.razar.lifecycle_bus import Issue
+
+
+def test_restart_attempt_emits_success() -> None:
+    """``agent_down`` events trigger restart attempts and callbacks."""
+
+    events: List[Dict[str, object]] = []
+
+    def emitter(event: Dict[str, object]) -> None:
+        events.append(event)
+
+    called = False
+
+    def restart() -> bool:
+        nonlocal called
+        called = True
+        return True
+
+    resuscitator = Resuscitator({"alpha": restart}, emitter=emitter)
+    asyncio.run(resuscitator.handle_event({"event": "agent_down", "agent": "alpha"}))
+
+    assert called
+    assert {"event": "agent_resuscitated", "agent": "alpha"} in events
+
+
+class DummyBus:
+    """Minimal in-memory lifecycle bus for testing."""
+
+    def __init__(self) -> None:
+        self.statuses: List[Tuple[str, str]] = []
+        self._issues: "queue.Queue[Issue]" = queue.Queue()
+
+    def report_issue(self, component: str, issue: str) -> None:
+        self._issues.put(Issue(component, issue))
+
+    def listen_for_issues(self) -> Iterator[Issue]:
+        while not self._issues.empty():
+            yield self._issues.get()
+
+    def publish_status(self, component: str, status: str) -> None:
+        self.statuses.append((component, status))
+
+    def send_control(
+        self, component: str, action: str
+    ) -> None:  # pragma: no cover - noop
+        pass
+
+
+class DummyRecoveryManager(RecoveryManager):
+    """RecoveryManager variant with side effects disabled."""
+
+    def __init__(self, bus: DummyBus, state_dir: Path) -> None:
+        self.bus = bus  # type: ignore[assignment]
+        self.state_dir = state_dir
+
+    def pause_system(self) -> None:  # pragma: no cover - noop
+        pass
+
+    def resume_system(self) -> None:  # pragma: no cover - noop
+        pass
+
+    def apply_fixes(self, module: str) -> None:  # pragma: no cover - noop
+        pass
+
+    def restart_module(self, module: str) -> None:  # pragma: no cover - noop
+        pass
+
+    def save_state(
+        self, module: str, state: Dict[str, object]
+    ) -> None:  # pragma: no cover
+        pass
+
+    def restore_state(
+        self, module: str, state: Dict[str, object]
+    ) -> None:  # pragma: no cover
+        pass
+
+
+def test_manager_waits_for_resuscitator(tmp_path: Path) -> None:
+    lifecycle_bus.aioredis = None  # type: ignore[attr-defined]
+    lifecycle_bus.AIOKafkaProducer = None  # type: ignore[attr-defined]
+    lifecycle_bus.AIOKafkaConsumer = None  # type: ignore[attr-defined]
+    bus = DummyBus()
+    manager = DummyRecoveryManager(bus, tmp_path)
+
+    def confirm() -> None:
+        time.sleep(0.1)
+        lifecycle_bus.publish({"event": "agent_resuscitated", "agent": "beta"})
+
+    t = threading.Thread(target=confirm)
+    t.start()
+    manager.recover("beta", {})
+    t.join()
+
+    assert ("beta", "healthy") in bus.statuses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_dependency_installer.py"),
     str(ROOT / "tests" / "test_bootstrap.py"),
     str(ROOT / "tests" / "test_avatar_lipsync.py"),
+    str(ROOT / "tests" / "agents" / "nazarick" / "test_resuscitator_flow.py"),
     str(ROOT / "tests" / "test_boot_sequence.py"),
     str(ROOT / "tests" / "test_lip_sync.py"),
     str(ROOT / "tests" / "test_memory_search.py"),


### PR DESCRIPTION
## Summary
- add Nazarick resuscitator listening for `agent_down` events and issuing restart callbacks
- await resuscitator confirmation in recovery manager before marking module healthy
- cover restart and confirmation flow with integration tests

## Testing
- `pre-commit run --files agents/nazarick/resuscitator.py agents/razar/recovery_manager.py tests/agents/nazarick/test_resuscitator_flow.py tests/conftest.py` *(fails: Required test coverage of 80% not reached. Total coverage: 7.34%, failed tests/agents/razar/test_boot_sequence.py::test_boot_sequence_order_and_failure)*
- `pytest --no-cov tests/agents/nazarick/test_resuscitator_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68bdaff747a8832e934729d8f3d665b4