### PR TITLE
docs: document agent heartbeat lifecycle and nervous system links

### DIFF
--- a/GENESIS/README.md
+++ b/GENESIS/README.md
@@ -5,6 +5,10 @@ Refer to the [Doctrine Index](../docs/doctrine_index.md) for canonical files, ve
 Quick links:
 
 - [System Blueprint](../docs/system_blueprint.md#chakra-cycle-engine)
-- [Blueprint Spine](../docs/blueprint_spine.md#heartbeat-propagation-and-self-healing)
+- [Blueprint Spine](../docs/blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing)
 - [Avatar Pipeline](../docs/avatar_pipeline.md#heartbeat-and-session-management)
 - [Operator Onboarding](../docs/operator_onboarding.md#multi-agent-streams)
+
+RAZAR orchestrates ABZU's nervous system while the
+[Nazarick Agents](../docs/nazarick_agents.md) respond to its signals. See the
+[RAZAR Guide](../docs/RAZAR_GUIDE.md) for orchestration details.

--- a/IGNITION/README.md
+++ b/IGNITION/README.md
@@ -1,3 +1,8 @@
 # IGNITION Doctrine
 
 Refer to the [Doctrine Index](../docs/doctrine_index.md) for canonical files, versions, and update history.
+
+RAZAR ignites the stack and, together with the
+[Nazarick Agents](../docs/nazarick_agents.md), forms the nervous system that
+routes lifecycle events across the chakras. Consult the
+[RAZAR Guide](../docs/RAZAR_GUIDE.md) for orchestration details.

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -9,7 +9,7 @@ For a walkthrough of the web console setup wizard, see [docs/operator_onboarding
 
 For heartbeat propagation and recovery design, consult
 [docs/system_blueprint.md#chakra-cycle-engine](docs/system_blueprint.md#chakra-cycle-engine),
-[docs/blueprint_spine.md#heartbeat-propagation-and-self-healing](docs/blueprint_spine.md#heartbeat-propagation-and-self-healing)
+[docs/blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing](docs/blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing)
 and
 [docs/chakra_architecture.md#chakra-cycle-engine](docs/chakra_architecture.md#chakra-cycle-engine).
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -70,19 +70,23 @@ aligned and surfaces drift for operator review. See the
 overview and [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
 for per-layer responsibilities.
 
-### **Heartbeat Propagation and Self-Healing**
+### **Agent Heartbeats, Lifecycle Events, and Self-Healing**
 
-The chakra cycle engine emits heartbeats that cascade through the layers. A
-silent response triggers NAZARICK servants to mend the break and rejoin the
-cycle.
+The chakra cycle engine emits heartbeats that cascade through the layers. Each
+agent posts `agent_heartbeat` messages alongside lifecycle hooks—`agent_start`,
+`agent_stop`, `agent_error`, and `agent_recover`—which RAZAR logs on the
+lifecycle bus. Silent beats or terminal events trigger NAZARICK servants to
+mend the break and rejoin the cycle.
 
 ```mermaid
 {{#include figures/heartbeat_self_healing.mmd}}
 ```
 
 For layer-specific responsibilities, see
-[Chakra Architecture](chakra_architecture.md#chakra-cycle-engine) and
-[Nazarick Agents](nazarick_agents.md). The remediation philosophy follows the
+[Chakra Architecture](chakra_architecture.md#chakra-cycle-engine),
+[Nazarick Agents](nazarick_agents.md), and the
+[System Blueprint](system_blueprint.md#agent-heartbeats-lifecycle-events-and-self-healing).
+The remediation philosophy follows the
 [Self-Healing Manifesto](self_healing_manifesto.md).
 
 ### **Session Management**

--- a/docs/chakra_architecture.md
+++ b/docs/chakra_architecture.md
@@ -50,7 +50,7 @@ the expected 1 :1 rhythm generate alignment events, which surface in the
 
 Alignment events are logged and echoed into the architecture map so operators
 can correlate misfires with service health. The
-[Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing)
+[Blueprint Spine](blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing)
 illustrates the propagation path.
 
 ### Self-Healing

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -35,7 +35,7 @@ tasks for Sacral, and other utilities live under `scripts/chakra_healing/`.
 The polling loop is driven by the
 [Chakra Cycle Engine](system_blueprint.md#chakra-cycle-engine), whose
 propagation path and self-healing flow are mapped in the
-[Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing)
+[Blueprint Spine](blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing)
 and detailed in the
 [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine).
 When errors persist beyond these hooks,

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -64,10 +64,21 @@ When a layer fails to return a beat, it is marked silent. The engine routes a
 `chakra_down` event to the responsible
 [NAZARICK agent](nazarick_agents.md), which attempts to restore the
 missing chakra and resume the cycle. This self‑healing loop is diagrammed in the
-[Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing) and
+[Blueprint Spine](blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing) and
 covered in the [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine).
 When every chakra reports within the window, the engine logs a **Great Spiral**
 alignment event for operators.
+
+### Agent Heartbeats, Lifecycle Events, and Self-Healing
+
+Each ABZU agent broadcasts `agent_heartbeat` messages on RAZAR's lifecycle bus.
+These beats carry status metadata and pair with explicit lifecycle events—
+`agent_start`, `agent_stop`, `agent_error`, and `agent_recover`—so operators can
+trace every servant's state. RAZAR logs the stream and raises alerts when a beat
+is missed or an error persists. NAZARICK servants respond to gaps by triggering
+self-healing routines that restart the affected layer and emit `agent_recover`
+when restored. See [Blueprint Spine](blueprint_spine.md#agent-heartbeats-lifecycle-events-and-self-healing)
+for timing diagrams and recovery flow.
 
 ### Memory Bundle
 


### PR DESCRIPTION
## Summary
- expand system and spine blueprints with agent heartbeat, lifecycle, and self-healing flow
- highlight how RAZAR and the Nazarick agents form ABZU's nervous system in GENESIS and IGNITION docs
- update cross-references to new heartbeat section and regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/system_blueprint.md docs/blueprint_spine.md GENESIS/README.md IGNITION/README.md README_OPERATOR.md docs/recovery_playbook.md docs/chakra_architecture.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb5f7a5e8832e86472b2110e2f9b6