### PR TITLE
feat: add chakra-tagged memory registry

### DIFF
--- a/memory/chakra_registry.py
+++ b/memory/chakra_registry.py
@@ -1,0 +1,81 @@
+"""Chakra-aware registry built on top of :mod:`vector_memory`.
+
+Each record is tagged with ``chakra``, ``timestamp`` and ``source`` metadata so
+agents can filter memories along energetic dimensions. Optionally integrates
+with :mod:`distributed_memory` for off-box persistence when a Redis url is
+provided.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import vector_memory
+except Exception:  # pragma: no cover - optional dependency
+    vector_memory = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from distributed_memory import DistributedMemory
+except Exception:  # pragma: no cover - optional dependency
+    DistributedMemory = None  # type: ignore[assignment]
+
+
+class ChakraRegistry:
+    """Persist and query chakra-tagged events."""
+
+    def __init__(
+        self,
+        *,
+        db_path: str | None = None,
+        redis_url: str | None = None,
+        redis_client: Any | None = None,
+    ) -> None:
+        if vector_memory is None:  # pragma: no cover - safeguard
+            raise RuntimeError("vector_memory module not available")
+        self._dist: Any | None = None
+        if redis_url or redis_client:
+            if DistributedMemory is None:  # pragma: no cover - safeguard
+                raise RuntimeError("distributed_memory module not available")
+            self._dist = DistributedMemory(
+                url=redis_url or "redis://localhost:6379/0", client=redis_client
+            )
+            vector_memory.configure(db_path=db_path, redis_client=self._dist.client)
+        else:
+            vector_memory.configure(db_path=db_path)
+
+    # ------------------------------------------------------------------
+    def record(self, chakra: str, text: str, source: str, **metadata: Any) -> None:
+        """Store ``text`` with chakra and source information."""
+
+        if vector_memory is None:  # pragma: no cover - safeguard
+            return
+        meta: Dict[str, Any] = {
+            "chakra": chakra,
+            "timestamp": datetime.utcnow().isoformat(),
+            "source": source,
+        }
+        meta.update(metadata)
+        vector_memory.add_vector(text, meta)
+
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        chakra: str,
+        query: str,
+        *,
+        k: int = 5,
+        filter: Optional[Dict[str, Any]] = None,
+        scoring: str = "hybrid",
+    ) -> List[Dict[str, Any]]:
+        """Search for events within a chakra matching ``query``."""
+
+        if vector_memory is None:  # pragma: no cover - safeguard
+            return []
+        meta_filter = dict(filter or {})
+        meta_filter["chakra"] = chakra
+        return vector_memory.search(query, filter=meta_filter, k=k, scoring=scoring)
+
+
+__all__ = ["ChakraRegistry"]

--- a/tests/memory/test_chakra_registry.py
+++ b/tests/memory/test_chakra_registry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from memory import chakra_registry as cr
+
+
+class DummyVM:
+    def __init__(self) -> None:
+        self.path: Path | None = None
+        self.data: list[dict[str, str]] = []
+
+    def configure(self, db_path: str | Path | None = None, **_: object) -> None:
+        if db_path is not None:
+            self.path = Path(db_path)
+            if self.path.exists():
+                self.data = json.loads(self.path.read_text())
+        elif self.path and self.path.exists():
+            self.data = json.loads(self.path.read_text())
+
+    def _save(self) -> None:
+        if self.path is not None:
+            self.path.write_text(json.dumps(self.data))
+
+    def add_vector(self, text: str, meta: dict[str, str]) -> None:
+        meta = dict(meta)
+        meta.setdefault("text", text)
+        self.data.append(meta)
+        self._save()
+
+    def search(
+        self,
+        query: str,
+        filter: dict[str, str] | None = None,
+        *,
+        k: int = 5,
+        scoring: str = "hybrid",
+    ) -> list[dict[str, str]]:
+        results: list[dict[str, str]] = []
+        for item in self.data:
+            if filter and any(item.get(k) != v for k, v in filter.items()):
+                continue
+            results.append(item)
+        return results[:k]
+
+
+def test_storage_retrieval_and_persistence(tmp_path, monkeypatch):
+    dummy = DummyVM()
+    monkeypatch.setattr(cr, "vector_memory", dummy)
+    db = tmp_path / "mem.json"
+
+    reg = cr.ChakraRegistry(db_path=db)
+    reg.record("heart", "compassion", "unit-test")
+    reg.record("root", "grounded", "unit-test")
+
+    hits = reg.search("heart", "compassion")
+    assert hits and hits[0]["chakra"] == "heart"
+    assert all(h["chakra"] == "heart" for h in hits)
+
+    reg2 = cr.ChakraRegistry(db_path=db)
+    hits2 = reg2.search("heart", "compassion")
+    assert hits2 and hits2[0]["source"] == "unit-test"


### PR DESCRIPTION
## Summary
- add `ChakraRegistry` to tag vector memory entries with chakra, timestamp, and source
- refactor experience replay and crown router to use chakra-aware registry
- add tests for registry storage and retrieval

## Testing
- `python -m pre_commit run --files agents/experience_replay.py crown_router.py tests/agents/nazarick/test_experience_replay.py memory/chakra_registry.py tests/memory/test_chakra_registry.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python - -c "/dev/null" tests/memory/test_chakra_registry.py tests/agents/nazarick/test_experience_replay.py` *(1 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc95f110832e86f1a27bb17fe248