### PR TITLE
Add heartbeat logger and state snapshot utilities

### DIFF
--- a/distributed_memory.py
+++ b/distributed_memory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import json
 from pathlib import Path
@@ -99,6 +99,20 @@ class CycleCounterStore:
             self.client.set(self.key, json.dumps(counts))
         else:
             self.path.write_text(json.dumps(counts), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    def increment(self, chakra: str) -> int:
+        """Increment and persist the cycle count for ``chakra``.
+
+        Returns the updated cycle identifier, allowing callers to track
+        monotonically increasing heartbeat cycles across restarts.
+        """
+
+        counts = self.load()
+        new_val = counts.get(chakra, 0) + 1
+        counts[chakra] = new_val
+        self.save(counts)
+        return new_val
 
 
 __all__ = ["DistributedMemory", "CycleCounterStore"]

--- a/monitoring/heartbeat_logger.py
+++ b/monitoring/heartbeat_logger.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from distributed_memory import CycleCounterStore
+from agents.event_bus import subscribe
+from citadel.event_producer import Event
+
+__all__ = ["HeartbeatLogger"]
+
+
+class HeartbeatLogger:
+    """Append chakra heartbeat cycles to a persistent log.
+
+    Each received ``heartbeat`` event increments a per-chakra cycle counter
+    stored via :class:`CycleCounterStore`. The updated cycle identifier and
+    timestamp are written to ``logs/heartbeat.log`` in JSON lines format.
+    """
+
+    def __init__(
+        self,
+        store: CycleCounterStore | None = None,
+        *,
+        log_path: str | Path = "logs/heartbeat.log",
+    ) -> None:
+        self.store = store or CycleCounterStore(path="chakra_cycles.json")
+        self.log_path = Path(log_path)
+
+    async def listen(self) -> None:
+        """Subscribe to global heartbeat events and record them."""
+
+        async def handler(event: Event) -> None:
+            if event.event_type != "heartbeat":
+                return
+            chakra = event.payload.get("chakra")
+            if chakra:
+                self.log(str(chakra))
+
+        await subscribe(handler)
+
+    def log(self, chakra: str, *, timestamp: float | None = None) -> int:
+        """Record a cycle for ``chakra`` and return its identifier."""
+
+        cycle_id = self.store.increment(chakra)
+        entry = {
+            "chakra": chakra,
+            "cycle_id": cycle_id,
+            "timestamp": timestamp or time.time(),
+        }
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry))
+            fh.write("\n")
+        return cycle_id

--- a/scripts/snapshot_state.py
+++ b/scripts/snapshot_state.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+__all__ = ["create_snapshot", "restore_snapshot"]
+
+
+def _load_agent_registry(path: Path) -> Dict[str, Any]:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def _load_doctrine_versions(path: Path) -> Dict[str, str]:
+    versions: Dict[str, str] = {}
+    if not path.exists():
+        return versions
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("|") or "---" in line:
+            continue
+        parts = [p.strip() for p in line.strip("|").split("|")]
+        if len(parts) >= 2:
+            file_name, version = parts[0], parts[1]
+            versions[file_name] = version
+    return versions
+
+
+def _load_vector_snapshot() -> Dict[str, Any]:
+    try:
+        from vector_memory import persist_snapshot  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return {}
+    try:
+        path = persist_snapshot()
+    except Exception:  # pragma: no cover - snapshot best effort
+        return {}
+    return {"snapshot": str(path)}
+
+
+def create_snapshot(
+    out_dir: str | Path = "storage/snapshots",
+    *,
+    registry_file: str | Path = "agents/nazarick/agent_registry.json",
+    doctrine_index: str | Path = "docs/doctrine_index.md",
+) -> Path:
+    """Serialize key state into ``out_dir`` and return the snapshot path."""
+
+    data = {
+        "agent_registry": _load_agent_registry(Path(registry_file)),
+        "doctrine_versions": _load_doctrine_versions(Path(doctrine_index)),
+        "vector_embeddings": _load_vector_snapshot(),
+    }
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    snap_path = out / f"snapshot_{int(time.time())}.json"
+    snap_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    return snap_path
+
+
+def restore_snapshot(
+    snapshot_file: str | Path,
+    *,
+    registry_file: str | Path = "agents/nazarick/agent_registry.json",
+    doctrine_versions_file: str | Path | None = None,
+    vector_embeddings_file: str | Path | None = None,
+) -> Dict[str, Any]:
+    """Restore state from ``snapshot_file`` and return the data."""
+
+    data: Dict[str, Any] = json.loads(Path(snapshot_file).read_text(encoding="utf-8"))
+    Path(registry_file).parent.mkdir(parents=True, exist_ok=True)
+    Path(registry_file).write_text(
+        json.dumps(data.get("agent_registry", {}), ensure_ascii=False),
+        encoding="utf-8",
+    )
+    if doctrine_versions_file is not None:
+        Path(doctrine_versions_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(doctrine_versions_file).write_text(
+            json.dumps(data.get("doctrine_versions", {}), ensure_ascii=False),
+            encoding="utf-8",
+        )
+    if vector_embeddings_file is not None:
+        Path(vector_embeddings_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(vector_embeddings_file).write_text(
+            json.dumps(data.get("vector_embeddings", {}), ensure_ascii=False),
+            encoding="utf-8",
+        )
+    return data
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    path = create_snapshot()
+    print(f"snapshot written to {path}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "test_config_registry.py"),
     str(ROOT / "tests" / "tools" / "test_opencode_client.py"),
     str(ROOT / "tests" / "razar" / "test_remote_repair.py"),
+    str(ROOT / "tests" / "monitoring" / "test_heartbeat_logger.py"),
 }
 
 

--- a/tests/monitoring/test_heartbeat_logger.py
+++ b/tests/monitoring/test_heartbeat_logger.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from distributed_memory import CycleCounterStore
+from monitoring.heartbeat_logger import HeartbeatLogger
+from scripts.snapshot_state import create_snapshot, restore_snapshot
+
+
+def test_log_persistence(tmp_path: Path) -> None:
+    log_file = tmp_path / "heartbeat.log"
+    store = CycleCounterStore(path=tmp_path / "cycles.json")
+    logger = HeartbeatLogger(store=store, log_path=log_file)
+    logger.log("root")
+    # simulate restart
+    logger = HeartbeatLogger(store=store, log_path=log_file)
+    logger.log("root")
+    lines = [json.loads(l) for l in log_file.read_text().splitlines()]
+    assert [entry["cycle_id"] for entry in lines] == [1, 2]
+
+
+def test_snapshot_restore(tmp_path: Path) -> None:
+    registry = tmp_path / "agent_registry.json"
+    registry.write_text(json.dumps({"agent": "test"}))
+    doctrine = tmp_path / "doctrine_index.md"
+    doctrine.write_text("| File | Version |\n| --- | --- |\n| doc.md | 1.0 |\n")
+    snap_dir = tmp_path / "snaps"
+    snap_path = create_snapshot(
+        snap_dir,
+        registry_file=registry,
+        doctrine_index=doctrine,
+    )
+    # mutate files to ensure restoration occurs
+    registry.write_text("{}")
+    restore_snapshot(
+        snap_path,
+        registry_file=registry,
+        doctrine_versions_file=tmp_path / "doctrine_versions.json",
+    )
+    restored = json.loads(registry.read_text())
+    assert restored == {"agent": "test"}
+    assert (tmp_path / "doctrine_versions.json").exists()


### PR DESCRIPTION
## Summary
- extend distributed memory with cycle counters and logging
- introduce heartbeat logger to persist chakra pulse cycles
- add snapshot_state script and tests for logging persistence and restoration

## Testing
- `pytest --no-cov tests/monitoring/test_heartbeat_logger.py`
- `pre-commit run --files distributed_memory.py monitoring/heartbeat_logger.py scripts/snapshot_state.py tests/monitoring/test_heartbeat_logger.py tests/conftest.py` *(fails: required test coverage not reached; verify-chakra-monitoring missing metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbfc8b7e8832e972d1ef3463c7e0e