### PR TITLE
Add pluggable distributed memory backends with replication

### DIFF
--- a/config/memory_backends.toml
+++ b/config/memory_backends.toml
@@ -1,0 +1,8 @@
+[primary]
+type = "redis"
+url = "redis://localhost:6379/0"
+key = "vector_memory"
+
+[fallback]
+type = "json"
+path = "vector_memory_backup.json"

--- a/distributed_memory.py
+++ b/distributed_memory.py
@@ -1,21 +1,47 @@
-"""Redis-backed helper for off-box vector memory backups."""
-
 from __future__ import annotations
 
-__version__ = "0.1.2"
+"""Pluggable distributed memory with write-through replication."""
+
+__version__ = "0.2.0"
 
 import json
 from pathlib import Path
 from typing import Any, Dict, Sequence, Tuple
+
+import tomllib
 
 try:  # pragma: no cover - optional dependency
     import redis
 except Exception:  # pragma: no cover - optional dependency
     redis = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    import boto3
+except Exception:  # pragma: no cover - optional dependency
+    boto3 = None  # type: ignore
 
-class DistributedMemory:
-    """Store vector entries in Redis for distributed persistence."""
+
+# ---------------------------------------------------------------------------
+class MemoryBackend:
+    """Interface for persistence backends."""
+
+    def backup(
+        self, id_: str, vector: Sequence[float], metadata: Dict[str, Any]
+    ) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def restore(
+        self,
+    ) -> Dict[str, Tuple[list[float], Dict[str, Any]]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def clear(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+class RedisBackend(MemoryBackend):
+    """Store vectors in a Redis hash."""
 
     def __init__(
         self,
@@ -25,7 +51,7 @@ class DistributedMemory:
         client: Any | None = None,
     ) -> None:
         if redis is None:  # pragma: no cover - dependency check
-            raise RuntimeError("redis package required for DistributedMemory")
+            raise RuntimeError("redis package required for RedisBackend")
         self.client = client or redis.Redis.from_url(url)
         self.key = key
 
@@ -45,15 +71,189 @@ class DistributedMemory:
         return out
 
     # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.client.delete(self.key)
+
+
+# ---------------------------------------------------------------------------
+class JSONBackend(MemoryBackend):
+    """Persist vectors to a local JSON file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    # ------------------------------------------------------------------
+    def _load(self) -> Dict[str, Any]:
+        if self.path.exists():
+            try:
+                return json.loads(self.path.read_text(encoding="utf-8"))
+            except Exception:
+                return {}
+        return {}
+
+    # ------------------------------------------------------------------
+    def backup(
+        self, id_: str, vector: Sequence[float], metadata: Dict[str, Any]
+    ) -> None:
+        data = self._load()
+        data[id_] = {"vector": list(vector), "metadata": metadata}
+        self.path.write_text(json.dumps(data), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    def restore(self) -> Dict[str, Tuple[list[float], Dict[str, Any]]]:
+        raw = self._load()
+        return {k: (v["vector"], v["metadata"]) for k, v in raw.items()}
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        if self.path.exists():
+            self.path.unlink()
+
+
+# ---------------------------------------------------------------------------
+class S3Backend(MemoryBackend):
+    """Persist vectors to S3 or MinIO."""
+
+    def __init__(
+        self,
+        bucket: str,
+        key: str,
+        *,
+        endpoint: str | None = None,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        client: Any | None = None,
+    ) -> None:
+        if boto3 is None:  # pragma: no cover - dependency check
+            raise RuntimeError("boto3 package required for S3Backend")
+        if client is None:
+            client = boto3.client(
+                "s3",
+                endpoint_url=endpoint,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        self.client = client
+        self.bucket = bucket
+        self.key = key
+
+    # ------------------------------------------------------------------
+    def _load(self) -> Dict[str, Any]:
+        try:
+            obj = self.client.get_object(Bucket=self.bucket, Key=self.key)
+        except Exception:
+            return {}
+        body = obj["Body"].read()
+        try:
+            return json.loads(body)
+        except Exception:
+            return {}
+
+    # ------------------------------------------------------------------
+    def backup(
+        self, id_: str, vector: Sequence[float], metadata: Dict[str, Any]
+    ) -> None:
+        data = self._load()
+        data[id_] = {"vector": list(vector), "metadata": metadata}
+        body = json.dumps(data).encode("utf-8")
+        self.client.put_object(Bucket=self.bucket, Key=self.key, Body=body)
+
+    # ------------------------------------------------------------------
+    def restore(self) -> Dict[str, Tuple[list[float], Dict[str, Any]]]:
+        raw = self._load()
+        return {k: (v["vector"], v["metadata"]) for k, v in raw.items()}
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        try:
+            self.client.delete_object(Bucket=self.bucket, Key=self.key)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+def _backend_from_config(cfg: Dict[str, Any]) -> MemoryBackend:
+    backend_type = cfg.get("type", "redis").lower()
+    if backend_type == "redis":
+        return RedisBackend(
+            url=cfg.get("url", "redis://localhost:6379/0"),
+            key=cfg.get("key", "vector_memory"),
+        )
+    if backend_type in {"json", "file"}:
+        return JSONBackend(path=cfg["path"])
+    if backend_type in {"s3", "minio"}:
+        return S3Backend(
+            bucket=cfg["bucket"],
+            key=cfg.get("key", "vector_memory.json"),
+            endpoint=cfg.get("endpoint"),
+            access_key=cfg.get("access_key"),
+            secret_key=cfg.get("secret_key"),
+        )
+    raise ValueError(f"Unknown backend type: {backend_type}")
+
+
+# ---------------------------------------------------------------------------
+class DistributedMemory:
+    """Replicate writes to a primary backend with optional fallback."""
+
+    def __init__(
+        self, primary: MemoryBackend, fallback: MemoryBackend | None = None
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(
+        cls, path: str | Path = Path("config/memory_backends.toml")
+    ) -> "DistributedMemory":
+        cfg = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+        primary = _backend_from_config(cfg["primary"])
+        fallback = _backend_from_config(cfg["fallback"]) if "fallback" in cfg else None
+        return cls(primary, fallback)
+
+    # ------------------------------------------------------------------
+    def backup(
+        self, id_: str, vector: Sequence[float], metadata: Dict[str, Any]
+    ) -> None:
+        self.primary.backup(id_, vector, metadata)
+        if self.fallback is not None:
+            try:  # pragma: no cover - best effort replication
+                self.fallback.backup(id_, vector, metadata)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    def restore(self) -> Dict[str, Tuple[list[float], Dict[str, Any]]]:
+        try:
+            data = self.primary.restore()
+        except Exception:
+            data = {}
+        if data:
+            return data
+        if self.fallback is not None:
+            return self.fallback.restore()
+        return data
+
+    # ------------------------------------------------------------------
     def restore_to(self, store: Any) -> None:
         for id_, (vec, meta) in self.restore().items():
             store.add(id_, vec, meta)
 
     # ------------------------------------------------------------------
     def clear(self) -> None:
-        self.client.delete(self.key)
+        try:
+            self.primary.clear()
+        except Exception:
+            pass
+        if self.fallback is not None:
+            try:
+                self.fallback.clear()
+            except Exception:
+                pass
 
 
+# ---------------------------------------------------------------------------
 class CycleCounterStore:
     """Persist chakra cycle counts in Redis or a JSON file."""
 
@@ -115,4 +315,11 @@ class CycleCounterStore:
         return new_val
 
 
-__all__ = ["DistributedMemory", "CycleCounterStore"]
+__all__ = [
+    "MemoryBackend",
+    "RedisBackend",
+    "JSONBackend",
+    "S3Backend",
+    "DistributedMemory",
+    "CycleCounterStore",
+]

--- a/tests/memory/test_replication.py
+++ b/tests/memory/test_replication.py
@@ -1,0 +1,56 @@
+"""Tests for distributed memory replication."""
+
+import json
+from distributed_memory import DistributedMemory
+
+
+def _make_config(tmp_path):
+    cfg = tmp_path / "memory_backends.toml"
+    cfg.write_text(
+        f"""
+[primary]
+type = "json"
+path = "{tmp_path / 'primary.json'}"
+
+[fallback]
+type = "json"
+path = "{tmp_path / 'fallback.json'}"
+"""
+    )
+    return cfg
+
+
+def test_primary_outage_uses_fallback(tmp_path, monkeypatch):
+    cfg = _make_config(tmp_path)
+    dm = DistributedMemory.from_config(cfg)
+    dm.backup("a", [1.0, 2.0], {"n": "a"})
+
+    # Ensure replication wrote to both files
+    p_data = json.loads((tmp_path / "primary.json").read_text())
+    f_data = json.loads((tmp_path / "fallback.json").read_text())
+    assert p_data == f_data
+
+    # Simulate primary outage
+    def boom():
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(dm.primary, "restore", boom)
+
+    restored = dm.restore()
+    assert "a" in restored
+    assert restored["a"][0] == [1.0, 2.0]
+
+
+def test_fallback_outage_ignored(tmp_path, monkeypatch):
+    cfg = _make_config(tmp_path)
+    dm = DistributedMemory.from_config(cfg)
+    dm.backup("a", [1.0, 2.0], {"n": "a"})
+
+    def boom():
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(dm.fallback, "restore", boom)
+
+    restored = dm.restore()
+    assert "a" in restored
+    assert restored["a"][0] == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- implement pluggable memory backend interface supporting Redis, JSON, and S3, with write-through replication
- declare primary and fallback stores via new `config/memory_backends.toml`
- test replication fallback when primary or secondary backend is unavailable

## Testing
- `pre-commit run --files distributed_memory.py config/memory_backends.toml tests/memory/test_replication.py` (skipped pytest hooks)
- `pytest -o addopts="" -rs tests/memory/test_replication.py` *(tests skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc30120bc832e947e6a91bb881116