### PR TITLE
Document game dashboard and retro arcade links

### DIFF
--- a/GENESIS/README.md
+++ b/GENESIS/README.md
@@ -9,3 +9,4 @@ Quick links:
 - [Avatar Pipeline](../docs/avatar_pipeline.md#heartbeat-and-session-management)
 - [Operator Onboarding](../docs/operator_onboarding.md#multi-agent-streams)
 - [Memory Spine](../docs/system_blueprint.md#memory-spine) & [Snapshot Recovery](../docs/recovery_playbook.md#snapshot-recovery) – system resumes from snapshots and heartbeat logs
+- [Game Dashboard](../docs/ui/game_dashboard.md) & [Chakra Pulse](../docs/ui/chakra_pulse.md)

--- a/IGNITION/README.md
+++ b/IGNITION/README.md
@@ -5,3 +5,4 @@ Refer to the [Doctrine Index](../docs/doctrine_index.md) for canonical files, ve
 Startup routines can reload from memory spine snapshots and heartbeat logs
 ([System Blueprint](../docs/system_blueprint.md#memory-spine),
 [Recovery Playbook](../docs/recovery_playbook.md#snapshot-recovery)).
+Review the [Game Dashboard](../docs/ui/game_dashboard.md) and [Chakra Pulse](../docs/ui/chakra_pulse.md) guides for operator telemetry and retro arcade widgets.

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -89,6 +89,18 @@ aligned and surfaces drift for operator review. See the
 overview and [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
 for per-layer responsibilities.
 
+### **Game Dashboard & Retro Arcade Integration**
+
+The [Game Dashboard](ui/game_dashboard.md) consumes the cycle engine's
+`/chakra/status` feed. Its [Chakra Pulse](ui/chakra_pulse.md) panel animates
+per-layer beat frequencies and highlights `great_spiral` alignment events for
+operators. A companion Agent Status board lists recent actions and heartbeat
+timestamps.
+
+Minimal deployments can enable [Arcade Mode](ui/arcade_mode.md), which mirrors
+the chakra pulse flow with sprite-style widgets and an alignment timestamp. The
+retro console provides diagnostics when the full dashboard is unavailable.
+
 ### **Heartbeat Propagation and Self-Healing**
 
 The chakra cycle engine emits heartbeats that cascade through the layers. A

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -67,17 +67,19 @@ how quickly each layer confirms its heartbeat:
 - `chakra_cycles_total` – total completed heartbeat-confirmation cycles per chakra
 - `chakra_cycle_duration_seconds` – seconds between a heartbeat and its confirmation
 
-The game dashboard renders these metrics in the **Chakra Pulse** panel. Colored
-orbs pulse at the reported frequencies, an "aligned" glow marks synchronized
-chakras, and the panel lists the timestamps of recent `great_spiral` events for
-historical context.
+The [Game Dashboard](ui/game_dashboard.md) renders these metrics in the
+[Chakra Pulse](ui/chakra_pulse.md) panel. Colored orbs pulse at the reported
+frequencies, an "aligned" glow marks synchronized chakras, and the panel lists
+the timestamps of recent `great_spiral` events for historical context.
 
 ## Agent status panel
 
 `monitoring/agent_status_endpoint.py` summarizes heartbeat timestamps and
-related state for each agent. The **Agent Status** panel in the game dashboard
-polls `/agents/status` and lists every agent with its last heartbeat, most
-recent action, and chakra alignment marker:
+related state for each agent. The **Agent Status** panel in the
+[Game Dashboard](ui/game_dashboard.md) polls `/agents/status` and lists every
+agent with its last heartbeat, most recent action, and chakra alignment marker.
+Arcade deployments can use [Arcade Mode](ui/arcade_mode.md) for a retro
+presentation of the same telemetry:
 
 ```bash
 curl http://localhost:8000/agents/status

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -69,6 +69,19 @@ covered in the [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
 When every chakra reports within the window, the engine logs a **Great Spiral**
 alignment event for operators.
 
+### Game Dashboard & Retro Arcade Integration
+
+The React-based [Game Dashboard](ui/game_dashboard.md) wraps the avatar stream
+with mission maps and operator telemetry. Its [Chakra Pulse](ui/chakra_pulse.md)
+panel animates heartbeat metrics from `monitoring/chakra_heartbeat.py`,
+highlighting `great_spiral` alignments and layer drift in real time.
+
+For minimal deployments, [Arcade Mode](ui/arcade_mode.md) mirrors the same
+chakra pulse flow using sprite-style widgets. The retro console polls
+`/chakra/status` and flashes a pulse bar plus last alignment timestamp, giving
+operators a lightweight diagnostic surface when the full dashboard is
+unavailable.
+
 ### Memory Bundle
 
 ABZU groups its Cortex, Emotional, Mental, Spiritual, and Narrative layers into a unified memory bundle that Crown and subsidiary services consult for state exchange and recall. `broadcast_layer_event("layer_init")` signals readiness across the bundle, while `query_memory` fans out incoming requests and aggregates a single response. For deeper detail, see [Blueprint Spine](blueprint_spine.md) and the [Memory Layers Guide](memory_layers_GUIDE.md).

--- a/tests/docs/test_ui_links.py
+++ b/tests/docs/test_ui_links.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS = REPO_ROOT / "docs"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _assert_links(text: str) -> None:
+    assert "ui/game_dashboard.md" in text
+    assert "ui/chakra_pulse.md" in text
+
+
+def test_ui_docs_present() -> None:
+    assert (DOCS / "ui" / "game_dashboard.md").exists()
+    assert (DOCS / "ui" / "chakra_pulse.md").exists()
+
+
+def test_genesis_links() -> None:
+    _assert_links(_read(REPO_ROOT / "GENESIS" / "README.md"))
+
+
+def test_ignition_links() -> None:
+    _assert_links(_read(REPO_ROOT / "IGNITION" / "README.md"))
+
+
+def test_monitoring_links() -> None:
+    _assert_links(_read(DOCS / "monitoring.md"))


### PR DESCRIPTION
## Summary
- Add Game Dashboard and Retro Arcade sections to system and blueprint docs
- Cross-link GENESIS, IGNITION, and monitoring guides to Chakra Pulse UI docs
- Test UI doc references via `tests/docs/test_ui_links.py`

## Testing
- `PYTHONPATH=. pre-commit run --files GENESIS/README.md IGNITION/README.md docs/system_blueprint.md docs/blueprint_spine.md docs/monitoring.md tests/docs/test_ui_links.py docs/INDEX.md` *(fails: missing metrics exporters and self-heal cycles)*
- `pytest tests/docs/test_ui_links.py --cov=docs --cov-fail-under=0` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2e70448832e8b694f6db8757c83