### PR TITLE
Add backup and rollback for opencode patches

### DIFF
--- a/tests/razar/test_ai_invoker.py
+++ b/tests/razar/test_ai_invoker.py
@@ -34,6 +34,7 @@ def test_handover_uses_opencode_and_applies_patch(monkeypatch, tmp_path: Path) -
 
     monkeypatch.setattr(ai_invoker.subprocess, "run", fake_run)
     monkeypatch.setattr(code_repair_module, "repair_module", fake_repair)
+    monkeypatch.setattr(ai_invoker.health_checks, "run", lambda name: True)
     monkeypatch.setattr(ai_invoker, "PATCH_LOG_PATH", tmp_path / "patch.json")
 
     result = ai_invoker.handover("comp", "boom", use_opencode=True)
@@ -41,3 +42,65 @@ def test_handover_uses_opencode_and_applies_patch(monkeypatch, tmp_path: Path) -
     assert called["module"] == tmp_path / "mod.py"
     assert called["tests"] == [tmp_path / "test_mod.py"]
     assert called["error"] == "boom"
+
+
+def test_handover_snapshots_target_before_patch(monkeypatch, tmp_path: Path) -> None:
+    module_path = tmp_path / "mod.py"
+    module_path.write_text("original", encoding="utf-8")
+
+    diff = f"+++ b/{module_path}\n"
+
+    monkeypatch.setattr(
+        ai_invoker.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(ai_invoker.opencode_client, "complete", lambda ctx: diff)
+
+    backups = tmp_path / "backups"
+    monkeypatch.setattr(ai_invoker, "PATCH_BACKUP_DIR", backups)
+    monkeypatch.setattr(ai_invoker, "PATCH_LOG_PATH", tmp_path / "patch.json")
+
+    monkeypatch.setattr(
+        code_repair_module,
+        "repair_module",
+        lambda module, tests, err: True,
+    )
+    monkeypatch.setattr(ai_invoker.health_checks, "run", lambda name: True)
+
+    result = ai_invoker.handover("comp", "boom", use_opencode=True)
+    assert result is True
+    snaps = list(backups.iterdir())
+    assert len(snaps) == 1
+    assert snaps[0].read_text(encoding="utf-8") == "original"
+
+
+def test_handover_rolls_back_on_failed_check(monkeypatch, tmp_path: Path) -> None:
+    module_path = tmp_path / "mod.py"
+    module_path.write_text("original", encoding="utf-8")
+
+    diff = f"+++ b/{module_path}\n"
+
+    monkeypatch.setattr(
+        ai_invoker.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(ai_invoker.opencode_client, "complete", lambda ctx: diff)
+
+    backups = tmp_path / "backups"
+    monkeypatch.setattr(ai_invoker, "PATCH_BACKUP_DIR", backups)
+    monkeypatch.setattr(ai_invoker, "PATCH_LOG_PATH", tmp_path / "patch.json")
+
+    def fake_repair(module, tests, err):
+        module.write_text("patched", encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(code_repair_module, "repair_module", fake_repair)
+    monkeypatch.setattr(ai_invoker.health_checks, "run", lambda name: False)
+
+    result = ai_invoker.handover("comp", "boom", use_opencode=True)
+    assert result is False
+    assert module_path.read_text(encoding="utf-8") == "original"
+    snaps = list(backups.iterdir())
+    assert len(snaps) == 1


### PR DESCRIPTION
## Summary
- snapshot target files before applying opencode diffs
- restore backups when post-restart checks fail
- test snapshot creation and rollback failure scenarios

## Testing
- `pre-commit run --files razar/ai_invoker.py tests/razar/test_ai_invoker.py` *(fails: mypy missing stubs; verify-versions mismatches; capture-failing-tests interrupted)*
- `pytest tests/razar/test_ai_invoker.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd770fff4832e903897d35c7bd881