### PR TITLE
Add self-healing ledger with persistent heartbeat state

### DIFF
--- a/monitoring/self_healing_ledger.py
+++ b/monitoring/self_healing_ledger.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Log self-healing events and persist heartbeat state."""
+
+__version__ = "0.1.0"
+
+import json
+import time
+from pathlib import Path
+from typing import Dict
+
+from distributed_memory import HeartbeatTimestampStore
+
+__all__ = ["SelfHealingLedger"]
+
+
+class SelfHealingLedger:
+    """Record component recovery steps and heartbeat timestamps."""
+
+    def __init__(
+        self,
+        store: HeartbeatTimestampStore | None = None,
+        *,
+        log_path: str | Path = "logs/self_healing.json",
+    ) -> None:
+        self.store = store or HeartbeatTimestampStore(path="heartbeat_state.json")
+        self.log_path = Path(log_path)
+        self._beats: Dict[str, float] = {}
+
+    def recover_state(self) -> Dict[str, float]:
+        """Load persisted heartbeat timestamps and return them."""
+
+        self._beats = self.store.load()
+        return dict(self._beats)
+
+    # ------------------------------------------------------------------
+    def _write(self, entry: Dict[str, object]) -> None:
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry))
+            fh.write("\n")
+
+    # ------------------------------------------------------------------
+    def component_down(self, component: str, *, timestamp: float | None = None) -> None:
+        entry = {
+            "event": "component_down",
+            "component": component,
+            "timestamp": timestamp or time.time(),
+        }
+        self._write(entry)
+
+    # ------------------------------------------------------------------
+    def repair_attempt(self, component: str, *, timestamp: float | None = None) -> None:
+        entry = {
+            "event": "repair_attempt",
+            "component": component,
+            "timestamp": timestamp or time.time(),
+        }
+        self._write(entry)
+
+    # ------------------------------------------------------------------
+    def final_status(
+        self, component: str, status: str, *, timestamp: float | None = None
+    ) -> None:
+        ts = timestamp or time.time()
+        entry = {
+            "event": "final_status",
+            "component": component,
+            "status": status,
+            "timestamp": ts,
+        }
+        self._write(entry)
+        self._beats[component] = ts
+        self.store.update(component, ts)

--- a/tests/monitoring/test_self_healing_ledger.py
+++ b/tests/monitoring/test_self_healing_ledger.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from distributed_memory import HeartbeatTimestampStore
+from monitoring.self_healing_ledger import SelfHealingLedger
+
+
+def test_log_continuity_and_state_recovery(tmp_path: Path) -> None:
+    log_file = tmp_path / "self_healing.json"
+    store = HeartbeatTimestampStore(path=tmp_path / "beats.json")
+
+    ledger = SelfHealingLedger(store=store, log_path=log_file)
+    ledger.component_down("root", timestamp=1)
+    ledger.repair_attempt("root", timestamp=2)
+    ledger.final_status("root", "recovered", timestamp=3)
+
+    # simulate restart
+    ledger = SelfHealingLedger(store=store, log_path=log_file)
+    state = ledger.recover_state()
+    assert state == {"root": 3}
+
+    ledger.component_down("root", timestamp=4)
+    ledger.final_status("root", "recovered", timestamp=5)
+
+    lines = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert len(lines) == 5
+    assert lines[0]["event"] == "component_down"
+    assert lines[3]["event"] == "component_down"
+
+    state = ledger.recover_state()
+    assert state == {"root": 5}


### PR DESCRIPTION
## Summary
- extend distributed memory with HeartbeatTimestampStore and bump version
- log component outages and recovery steps via new SelfHealingLedger
- test ledger log continuity and state recovery across restarts

## Testing
- `pytest --no-cov tests/monitoring/test_self_healing_ledger.py` *(skipped: requires unavailable resource)*
- `pre-commit run --files distributed_memory.py monitoring/self_healing_ledger.py tests/monitoring/test_self_healing_ledger.py` *(failed: verify-versions mismatch, missing websockets)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd98a10b8832eb1292772adc7f834