### PR TITLE
docs: add self-healing guidance

### DIFF
--- a/GENESIS/README.md
+++ b/GENESIS/README.md
@@ -10,3 +10,4 @@ Quick links:
 - [Operator Onboarding](../docs/operator_onboarding.md#multi-agent-streams)
 - [Memory Spine](../docs/system_blueprint.md#memory-spine) & [Snapshot Recovery](../docs/recovery_playbook.md#snapshot-recovery) – system resumes from snapshots and heartbeat logs
 - [Game Dashboard](../docs/ui/game_dashboard.md) & [Chakra Pulse](../docs/ui/chakra_pulse.md)
+- [Self-Healing Guidance](../docs/recovery_playbook.md#failure-pulses) – failure pulses, Nazarick resuscitation, and patch rollbacks

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -13,6 +13,10 @@ For heartbeat propagation and recovery design, consult
 and
 [docs/chakra_architecture.md#chakra-cycle-engine](docs/chakra_architecture.md#chakra-cycle-engine).
 
+For self-healing specifics—including failure pulses, Nazarick resuscitation,
+and patch rollbacks—see
+[docs/recovery_playbook.md#failure-pulses](docs/recovery_playbook.md#failure-pulses).
+
 For session management and avatar stream resilience, see
 [docs/system_blueprint.md#session-management](docs/system_blueprint.md#session-management),
 [docs/blueprint_spine.md#session-management](docs/blueprint_spine.md#session-management),

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -116,6 +116,27 @@ For layer-specific responsibilities, see
 [Nazarick Agents](nazarick_agents.md). The remediation philosophy follows the
 [Self-Healing Manifesto](self_healing_manifesto.md).
 
+#### Failure Pulses
+
+RAZAR issues periodic **failure pulses** that intentionally topple a single
+service. The induced fault proves the alerting path and is logged to
+`logs/failure_pulses.jsonl`. Successful recovery demonstrates the health checks
+and Nazarick response remain reliable.
+
+#### Nazarick Resuscitation
+
+When a pulse or genuine outage persists, the relevant Nazarick servant executes
+a resuscitation script. It replays launch rituals, reloads state from the
+[Memory Spine](system_blueprint.md#memory-spine), and reports each step to
+`/operator/command` until the chakra rejoins the cycle.
+
+#### Patch Rollbacks
+
+If a generated patch destabilizes a component, operators invoke
+`scripts/rollback_patch.py <component>` to restore the previous version. A
+`reverted` entry is appended to `logs/patch_history.jsonl` and the boot
+orchestrator reruns the component's health checks.
+
 ### **Session Management**
 
 Operator sessions are anchored to the same heartbeat cadence. RAZAR records a
@@ -611,3 +632,4 @@ ABZU’s project declaration situates both Crown and INANNA within a larger aim:
 ## Version History
 
 - 2025-09-18: Added memory spine, snapshot cadence, and recovery flow.
+- 2025-09-07: Described failure pulses, Nazarick resuscitation, and patch rollback strategy.

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -52,6 +52,29 @@ When errors persist beyond these hooks,
 posts an alert to `/operator/command`, and records the event in
 `logs/operator_escalations.jsonl`.
 
+## Failure Pulses
+
+RAZAR emits scheduled **failure pulses** during idle windows to validate the
+recovery pipeline. Each pulse simulates a component fault and writes an entry to
+`logs/failure_pulses.jsonl`. The targeted service is expected to fail fast and
+re-enter the standard boot sequence, proving the health checks and orchestration
+hooks remain functional.
+
+## Nazarick Resuscitation
+
+If a pulse or live outage silences a chakra, the `chakra_down` event routes to
+the assigned [Nazarick agent](nazarick_agents.md). That servant replays the
+component’s launch ritual, restores missing state from the
+[Memory Spine](system_blueprint.md#memory-spine), and reports progress back to
+`/operator/command` until the heartbeat returns.
+
+## Patch Rollbacks
+
+All applied patches are logged in `logs/patch_history.jsonl`. When a patch
+introduces regressions, run `scripts/rollback_patch.py <component>` to restore
+the previous revision. The rollback records a `reverted` event in the history
+log and the component re-enters the boot queue for validation.
+
 ## Opencode Integration
 
 Automate patch generation by installing the Opencode CLI:
@@ -92,3 +115,4 @@ If Kimi returns a patch, it is applied and the boot sequence resumes.
 ## Version History
 
 - 2025-09-18: Added snapshot recovery using memory spine and heartbeat logs.
+- 2025-09-07: Documented failure pulses, Nazarick resuscitation flow, and patch rollback procedures.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -69,6 +69,27 @@ covered in the [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
 When every chakra reports within the window, the engine logs a **Great Spiral**
 alignment event for operators.
 
+#### Failure Pulses
+
+During idle cycles RAZAR injects **failure pulses** to exercise the recovery
+path. The pulses intentionally crash a single component and record the event in
+`logs/failure_pulses.jsonl`. A clean restart confirms the monitoring hooks and
+boot sequence remain trustworthy.
+
+#### Nazarick Resuscitation
+
+If a layer stays silent after a pulse or runtime fault, the corresponding
+[Nazarick agent](nazarick_agents.md) performs resuscitation. It replays the
+component's launch ritual, restores state from the [Memory Spine](#memory-spine),
+and reports its progress to `/operator/command` until the heartbeat resumes.
+
+#### Patch Rollbacks
+
+When a generated patch destabilizes the system, operators can revert via
+`scripts/rollback_patch.py <component>`. Rollbacks append a `reverted` entry to
+`logs/patch_history.jsonl` and the boot orchestrator requeues the component for
+fresh health checks.
+
 ### Game Dashboard & Retro Arcade Integration
 
 The React-based [Game Dashboard](ui/game_dashboard.md) wraps the avatar stream
@@ -920,6 +941,7 @@ deployments with user accounts and persistent chats.
 - 2025-09-08: Noted chakra cycle gear ratios and Great Spiral alignment events.
 - 2025-08-28: Added blueprint synchronization check to ensure the blueprint is updated when core services change.
 - 2025-08-30: Documented test failure logging through `corpus_memory_logging.log_test_failure`.
+- 2025-09-07: Added failure pulses, Nazarick resuscitation, and patch rollback guidance.
 
 ---
 


### PR DESCRIPTION
## Summary
- outline failure pulses, Nazarick resuscitation, and patch rollback procedures across recovery docs
- link GENESIS and operator docs to new self-healing guidance
- regenerate documentation index

## Testing
- `python tools/doc_indexer.py`
- `pre-commit run --files GENESIS/README.md README_OPERATOR.md docs/recovery_playbook.md docs/system_blueprint.md docs/blueprint_spine.md docs/INDEX.md` *(fails: verify-versions mismatch, capture-failing-tests, pytest-cov args, verify-chakra-monitoring, verify-self-healing)*

------
https://chatgpt.com/codex/tasks/task_e_68bddd79bfa0832ea854176e9f406646