### PR TITLE
feat: add connector heartbeats

### DIFF
--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -8,6 +8,7 @@ from .webrtc_connector import close_peers as webrtc_close_peers
 from .webrtc_connector import router as webrtc_router
 from .webrtc_connector import start_call as webrtc_start_call
 from .primordials_api import send_metrics as primordials_send_metrics
+from .base import ConnectorHeartbeat
 from narrative_api import router as narrative_router
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "webrtc_close_peers",
     "primordials_send_metrics",
     "narrative_router",
+    "ConnectorHeartbeat",
 ]

--- a/connectors/base.py
+++ b/connectors/base.py
@@ -1,0 +1,79 @@
+"""Connector mixins and base classes."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import threading
+import time
+from typing import Any, Dict
+
+from .signal_bus import publish, subscribe
+
+
+class ConnectorHeartbeat:
+    """Mixin emitting heartbeats and alerting on missed pulses.
+
+    Parameters
+    ----------
+    channel:
+        Base chakra name for the connector.
+    interval:
+        Seconds between heartbeats.
+    miss_threshold:
+        Number of missed heartbeats before publishing an alert.
+    """
+
+    def __init__(
+        self, channel: str, *, interval: float = 30.0, miss_threshold: int = 3
+    ) -> None:
+        self._channel = channel
+        self._interval = interval
+        self._miss_threshold = miss_threshold
+        self._stop = threading.Event()
+        self._send_enabled = True
+        self._last_seen = time.monotonic()
+        self._lock = threading.Lock()
+        self._unsubscribe = subscribe(f"{self._channel}:heartbeat", self._on_heartbeat)
+        self._sender = threading.Thread(target=self._send_loop, daemon=True)
+        self._monitor = threading.Thread(target=self._monitor_loop, daemon=True)
+
+    # public API -----------------------------------------------------------
+    def start(self) -> None:
+        """Start heartbeat emission and monitoring."""
+        self._sender.start()
+        self._monitor.start()
+
+    def stop(self) -> None:
+        """Stop heartbeat threads and unsubscribe."""
+        self._stop.set()
+        self._sender.join()
+        self._monitor.join()
+        self._unsubscribe()
+
+    def pause(self) -> None:
+        """Pause heartbeat emissions."""
+        self._send_enabled = False
+
+    def resume(self) -> None:
+        """Resume heartbeat emissions."""
+        self._send_enabled = True
+
+    # internal helpers -----------------------------------------------------
+    def _on_heartbeat(self, _payload: Dict[str, Any]) -> None:
+        with self._lock:
+            self._last_seen = time.monotonic()
+
+    def _send_loop(self) -> None:
+        while not self._stop.wait(self._interval):
+            if self._send_enabled:
+                publish(f"{self._channel}:heartbeat", {"channel": self._channel})
+
+    def _monitor_loop(self) -> None:
+        while not self._stop.wait(self._interval):
+            with self._lock:
+                elapsed = time.monotonic() - self._last_seen
+            if elapsed > self._interval * self._miss_threshold:
+                publish(f"{self._channel}:alert", {"channel": self._channel})
+                with self._lock:
+                    self._last_seen = time.monotonic()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,7 @@ def pytest_sessionstart(session):  # pragma: no cover - timing varies
 
 # Skip tests that rely on unavailable heavy resources unless explicitly allowed
 ALLOWED_TESTS = {
+    str(ROOT / "tests" / "connectors" / "test_connector_heartbeat.py"),
     str(ROOT / "tests" / "test_adaptive_learning_stub.py"),
     str(ROOT / "tests" / "test_env_validation.py"),
     str(ROOT / "tests" / "crown" / "test_config.py"),

--- a/tests/connectors/test_connector_heartbeat.py
+++ b/tests/connectors/test_connector_heartbeat.py
@@ -1,0 +1,46 @@
+import importlib
+import pathlib
+import sys
+import time
+from types import ModuleType
+from typing import Any, Callable, Dict
+
+pkg = ModuleType("connectors")
+pkg.__path__ = [str(pathlib.Path("connectors").resolve())]
+sys.modules.setdefault("connectors", pkg)
+
+connector_base = importlib.import_module("connectors.base")
+ConnectorHeartbeat = connector_base.ConnectorHeartbeat
+
+
+def test_alert_emitted_on_missed_heartbeats(monkeypatch: Any) -> None:
+    """Heartbeat alerts are published after consecutive misses."""
+    events: list[tuple[str, Dict[str, Any]]] = []
+    subs: Dict[str, list[Callable[[Dict[str, Any]], None]]] = {}
+
+    def fake_publish(chakra: str, payload: Dict[str, Any]) -> None:
+        for cb in subs.get(chakra, []):
+            cb(payload)
+        events.append((chakra, payload))
+
+    def fake_subscribe(
+        chakra: str, callback: Callable[[Dict[str, Any]], None]
+    ) -> Callable[[], None]:
+        subs.setdefault(chakra, []).append(callback)
+
+        def _unsub() -> None:
+            subs[chakra].remove(callback)
+
+        return _unsub
+
+    monkeypatch.setattr(connector_base, "publish", fake_publish)
+    monkeypatch.setattr(connector_base, "subscribe", fake_subscribe)
+
+    hb = ConnectorHeartbeat("test", interval=0.01, miss_threshold=2)
+    hb.start()
+    time.sleep(0.03)
+    hb.pause()  # stop sending heartbeats
+    time.sleep(0.05)
+    hb.stop()
+
+    assert any(ch == "test:alert" for ch, _ in events)

--- a/tools/bot_discord.py
+++ b/tools/bot_discord.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import asyncio
 import logging
@@ -12,6 +12,7 @@ from typing import Any
 import requests
 
 from connectors.signal_bus import publish, subscribe
+from connectors.base import ConnectorHeartbeat
 
 logger = logging.getLogger(__name__)
 
@@ -76,12 +77,26 @@ def create_client() -> Any:
     return client
 
 
+class DiscordConnector(ConnectorHeartbeat):
+    """Discord connector emitting heartbeats."""
+
+    def __init__(
+        self, token: str, *, interval: float = 30.0, miss_threshold: int = 3
+    ) -> None:
+        super().__init__("discord", interval=interval, miss_threshold=miss_threshold)
+        self._token = token
+        self._client = create_client()
+
+    def run(self) -> None:
+        self.start()
+        self._client.run(self._token)
+
+
 def main() -> None:
     """Run the Discord bot."""
     if _TOKEN is None:
         raise RuntimeError("DISCORD_BOT_TOKEN not configured")
-    client = create_client()
-    client.run(_TOKEN)
+    DiscordConnector(_TOKEN).run()
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/tools/bot_telegram.py
+++ b/tools/bot_telegram.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import logging
 import os
@@ -12,6 +12,7 @@ from pathlib import Path
 import requests
 
 from connectors.signal_bus import publish, subscribe
+from connectors.base import ConnectorHeartbeat
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,17 @@ if _API:
     )
 
 
+class TelegramConnector(ConnectorHeartbeat):
+    """Telegram connector emitting heartbeats."""
+
+    def __init__(self, *, interval: float = 30.0, miss_threshold: int = 3) -> None:
+        super().__init__("telegram", interval=interval, miss_threshold=miss_threshold)
+
+    def run(self) -> None:
+        self.start()
+        poll()
+
+
 def poll() -> None:
     """Continuously poll Telegram for updates."""
     if not _API:
@@ -97,7 +109,7 @@ def poll() -> None:
 
 def main() -> None:
     """Entry point for the Telegram bot."""
-    poll()
+    TelegramConnector().run()
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry


### PR DESCRIPTION
## Summary
- add ConnectorHeartbeat mixin for periodic pulse emissions and alerting
- integrate heartbeat mixin into Discord and Telegram connectors
- test missed heartbeats and alerting logic

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/connectors/test_connector_heartbeat.py -q -c /dev/null`
- `pre-commit run --files connectors/base.py connectors/__init__.py tools/bot_discord.py tools/bot_telegram.py tests/connectors/test_connector_heartbeat.py tests/conftest.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*


------
https://chatgpt.com/codex/tasks/task_e_68bdea5088c0832eb8fd571b506c7470