### PR TITLE
feat: add message formatter with metadata

### DIFF
--- a/communication/telegram_bot.py
+++ b/communication/telegram_bot.py
@@ -15,6 +15,7 @@ from telegram import Update
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
 from connectors.signal_bus import publish, subscribe
+from connectors.message_formatter import format_message
 from .gateway import Gateway, authentication
 
 logger = logging.getLogger(__name__)
@@ -39,8 +40,9 @@ class TelegramBot:
                 return
 
             async def _send() -> None:
+                payload_text = format_message("telegram", text)
                 await self._application.bot.send_message(
-                    chat_id=int(chat_id), text=text
+                    chat_id=int(chat_id), text=payload_text
                 )
 
             self._application.create_task(_send())

--- a/connectors/message_formatter.py
+++ b/connectors/message_formatter.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utilities for formatting outbound connector messages.
+
+Each formatted message is serialized as JSON and includes three metadata
+fields in addition to the original ``content``:
+
+``chakra``
+    The chakra tag identifying the message origin.
+``version``
+    Version string for the formatter. Can be overridden when calling
+    :func:`format_message`.
+``recovery_url``
+    URL pointing to recovery instructions. Defaults to the value of the
+    ``RECOVERY_URL`` environment variable or a placeholder.
+"""
+
+import json
+import os
+from typing import Any, Dict
+
+__all__ = ["format_message"]
+
+__version__ = "0.1.0"
+
+_DEFAULT_RECOVERY_URL = os.getenv("RECOVERY_URL", "https://status.abzu.ai/recover")
+
+
+def format_message(
+    chakra: str,
+    content: str,
+    *,
+    version: str | None = None,
+    recovery_url: str | None = None,
+) -> str:
+    """Return ``content`` JSON-encoded with metadata fields.
+
+    Parameters
+    ----------
+    chakra:
+        Chakra tag identifying the message origin.
+    content:
+        Text content of the message.
+    version:
+        Optional version string. Defaults to ``__version__``.
+    recovery_url:
+        Optional recovery URL. Defaults to ``RECOVERY_URL`` environment
+        variable or a placeholder value.
+    """
+
+    data: Dict[str, Any] = {
+        "chakra": chakra,
+        "content": content,
+        "version": version or __version__,
+        "recovery_url": recovery_url or _DEFAULT_RECOVERY_URL,
+    }
+    return json.dumps(data)

--- a/tests/connectors/test_message_formatter.py
+++ b/tests/connectors/test_message_formatter.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "message_formatter",
+    Path(__file__).resolve().parents[2] / "connectors" / "message_formatter.py",
+)
+message_formatter = importlib.util.module_from_spec(spec)
+assert spec.loader is not None  # for type checkers
+spec.loader.exec_module(message_formatter)
+format_message = message_formatter.format_message
+
+
+def test_format_message_includes_metadata() -> None:
+    msg = format_message("crown", "hello", version="1.2", recovery_url="url")
+    data = json.loads(msg)
+    assert data["content"] == "hello"
+    assert data["chakra"] == "crown"
+    assert data["version"] == "1.2"
+    assert data["recovery_url"] == "url"
+
+
+def test_format_message_defaults_present() -> None:
+    msg = format_message("root", "hi")
+    data = json.loads(msg)
+    assert data["content"] == "hi"
+    assert data["chakra"] == "root"
+    assert data["version"]
+    assert data["recovery_url"]

--- a/tools/bot_discord.py
+++ b/tools/bot_discord.py
@@ -13,6 +13,7 @@ import requests
 
 from connectors.signal_bus import publish, subscribe
 from connectors.base import ConnectorHeartbeat
+from connectors.message_formatter import format_message
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ def create_client() -> Any:
             },
         )
         reply = send_glm_command(message.content)
-        await message.channel.send(reply)
+        await message.channel.send(format_message("discord", reply))
         try:
             from core import expressive_output
 
@@ -70,7 +71,7 @@ def create_client() -> Any:
         text = payload.get("content", "")
         channel = client.get_channel(int(channel_id)) if channel_id else None
         if channel:
-            loop.create_task(channel.send(text))
+            loop.create_task(channel.send(format_message("discord", text)))
 
     subscribe("discord:out", _outbound)
 

--- a/tools/bot_telegram.py
+++ b/tools/bot_telegram.py
@@ -13,6 +13,7 @@ import requests
 
 from connectors.signal_bus import publish, subscribe
 from connectors.base import ConnectorHeartbeat
+from connectors.message_formatter import format_message
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,8 @@ def send_message(chat_id: int, text: str) -> None:
     """Send ``text`` to ``chat_id`` via Telegram."""
     if not _API:
         raise RuntimeError("TELEGRAM_BOT_TOKEN not configured")
-    requests.post(f"{_API}/sendMessage", json={"chat_id": chat_id, "text": text})
+    payload = format_message("telegram", text)
+    requests.post(f"{_API}/sendMessage", json={"chat_id": chat_id, "text": payload})
 
 
 def send_voice(chat_id: int, path: Path) -> None:


### PR DESCRIPTION
## Summary
- format connector messages with chakra, version, and recovery URL metadata
- route Discord and Telegram outputs through the formatter
- test message formatter metadata defaults and overrides

## Testing
- `pre-commit run --files connectors/message_formatter.py tools/bot_discord.py tools/bot_telegram.py communication/telegram_bot.py tests/connectors/test_message_formatter.py` *(fails: Library stubs not installed for "yaml" and more)*
- `pytest tests/connectors/test_message_formatter.py`

------
https://chatgpt.com/codex/tasks/task_e_68bded2de8ac832eaddf225cc03b3d5f