### PR TITLE
feat: add connector heartbeat panel and arcade widget

### DIFF
--- a/tests/web_console/test_connector_panel.py
+++ b/tests/web_console/test_connector_panel.py
@@ -1,0 +1,63 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GD_DIR = ROOT / "web_console" / "game_dashboard"
+
+
+def test_dashboard_imports_connectors_panel() -> None:
+    js = (GD_DIR / "dashboard.js").read_text(encoding="utf-8")
+    assert "connectors_panel/connectors_panel.js" in js
+    assert "ConnectorsPanel" in js
+
+
+def test_connectors_panel_has_id() -> None:
+    comp = (GD_DIR / "connectors_panel" / "connectors_panel.js").read_text(
+        encoding="utf-8"
+    )
+    assert "connectors-panel" in comp
+
+
+def test_connector_panel_updates_on_events() -> None:
+    js_path = GD_DIR / "connectors_panel" / "connectors_panel.js"
+    script = f"""
+const fs = require('fs');
+let code = fs.readFileSync('{js_path.as_posix()}', 'utf8');
+code = code.replace(/import[^\n]+\n/g, '');
+code = code.replace('export default function ConnectorsPanel', 'function ConnectorsPanel');
+code += '\nreturn ConnectorsPanel;';
+let state = [];
+let idx = 0;
+const React = {{
+  createElement: (t,p,...c) => ({{ t, p: p || {{}}, c }}),
+  useState: (init) => {{
+    const i = idx;
+    state[i] = state[i] !== undefined ? state[i] : init;
+    function setState(v) {{ state[i] = typeof v === 'function' ? v(state[i]) : v; }}
+    idx++;
+    return [state[i], setState];
+  }},
+  useEffect: (fn) => fn()
+}};
+let handlers = {{}};
+const bus = {{
+  subscribe: (ch, cb) => {{ (handlers[ch] = handlers[ch] || []).push(cb); return () => {{}}; }},
+  publish: (ch, payload) => {{ (handlers[ch] || []).forEach(cb => cb(payload)); }}
+}};
+function render(n) {{
+  if (typeof n === 'string') return n;
+  return `<${{n.t}}>${{(n.c||[]).map(render).join('')}}</${{n.t}}>`;
+}}
+const Comp = new Function('React', code)(React);
+let view = Comp({{ bus }});
+bus.publish('connectors', {{ name: 'alpha', status: 'down' }});
+idx = 0;
+view = Comp({{ bus }});
+console.log(render(view));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, check=True
+    )
+    output = result.stdout.strip()
+    assert "alpha" in output
+    assert "down" in output

--- a/web_console/arcade.css
+++ b/web_console/arcade.css
@@ -57,6 +57,16 @@ body {
     font-size: 0.75rem;
 }
 
+#connector-widget {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+}
+
+.connector-alert {
+    color: #f00;
+    animation: flash 1s steps(2, start) infinite;
+}
+
 body::before {
     content: '';
     position: absolute;

--- a/web_console/arcade.html
+++ b/web_console/arcade.html
@@ -11,6 +11,7 @@
         <div id="backend-status"></div>
         <div id="chakra-bar"></div>
         <div id="last-alignment">Last alignment: --</div>
+        <div id="connector-widget"></div>
         <div class="controls">
             <button id="ignite-btn">Ignite</button>
             <button id="memory-btn">Memory Query</button>

--- a/web_console/game_dashboard/connectors_panel/connectors_panel.js
+++ b/web_console/game_dashboard/connectors_panel/connectors_panel.js
@@ -1,0 +1,67 @@
+import React from 'https://esm.sh/react@18';
+
+function ensureBus() {
+  const g = globalThis;
+  if (!g.signalBus) {
+    g.signalBus = {
+      _subs: {},
+      publish(ch, payload) {
+        (this._subs[ch] || []).forEach((cb) => cb(payload));
+      },
+      subscribe(ch, cb) {
+        (this._subs[ch] = this._subs[ch] || []).push(cb);
+        return () => {
+          this._subs[ch] = (this._subs[ch] || []).filter((f) => f !== cb);
+        };
+      }
+    };
+  }
+  return g.signalBus;
+}
+
+export default function ConnectorsPanel({ bus } = {}) {
+  const signalBus = bus || ensureBus();
+  const [status, setStatus] = React.useState({});
+
+  React.useEffect(() => {
+    const unsub = signalBus.subscribe('connectors', (evt) => {
+      setStatus((s) => ({ ...s, [evt.name]: evt.status }));
+    });
+    return () => unsub();
+  }, [signalBus]);
+
+  function restart(name) {
+    signalBus.publish('connectors:restart', { name });
+  }
+  function mute(name) {
+    signalBus.publish('connectors:mute', { name });
+  }
+
+  return React.createElement(
+    'div',
+    { id: 'connectors-panel' },
+    React.createElement('h3', null, 'Connectors'),
+    React.createElement(
+      'div',
+      { className: 'connector-rows' },
+      Object.entries(status).map(([name, s]) =>
+        React.createElement(
+          'div',
+          { key: name, className: 'connector-row' },
+          React.createElement('span', { className: 'connector-name' }, name),
+          React.createElement('span', { className: 'connector-status' }, s),
+          React.createElement(
+            'button',
+            { onClick: () => restart(name) },
+            'Restart'
+          ),
+          React.createElement(
+            'button',
+            { onClick: () => mute(name) },
+            'Mute'
+          )
+        )
+      )
+    )
+  );
+}

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -10,6 +10,7 @@ import AgentStatusPanel from './agent_status_panel.js';
 import MemoryPanel from './memory_panel/memory_panel.js';
 import ChakraStatusPanel from './chakra_status_panel/chakra_status_panel.js';
 import SelfHealingPanel from './self_healing_panel/self_healing_panel.js';
+import ConnectorsPanel from './connectors_panel/connectors_panel.js';
 
 function GameDashboard() {
   const buttons = [
@@ -85,6 +86,7 @@ function GameDashboard() {
       React.createElement(ChakraStatusBoard),
       React.createElement(ChakraStatusPanel),
       React.createElement(AgentStatusPanel),
+      React.createElement(ConnectorsPanel),
       React.createElement(MemoryPanel),
       React.createElement(SelfHealingPanel)
     )


### PR DESCRIPTION
## Summary
- show live connector heartbeats with restart/mute controls in game dashboard
- surface connector-down indicator in arcade console
- test connector panel reacts to signal bus events

## Testing
- `pre-commit run --files web_console/arcade.css web_console/arcade.html web_console/arcade.js web_console/game_dashboard/dashboard.js web_console/game_dashboard/connectors_panel/connectors_panel.js tests/web_console/test_connector_panel.py` *(fails: verify-versions: component index mismatch, pytest-cov coverage 7%)*
- `pytest tests/web_console/test_connector_panel.py -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeefcdb70832ea8ea62cfd14f2bd4