### PR TITLE
Document connector heartbeat recovery flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documented chakra-tagged signals, heartbeat propagation, and recovery flows
+  across connector and operator guides; added tests for connector links.
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.
 - `docs/operator_onboarding.md` documents mission workflows with Mermaid diagrams and cross-links in `system_blueprint.md`.

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -17,6 +17,10 @@ For self-healing specifics—including failure pulses, Nazarick resuscitation,
 and patch rollbacks—see
 [docs/recovery_playbook.md#failure-pulses](docs/recovery_playbook.md#failure-pulses).
 
+Connector guidance on chakra-tagged signals, heartbeat propagation, and
+recovery flows lives in
+[docs/communication_interfaces.md#chakra-tagged-signals](docs/communication_interfaces.md#chakra-tagged-signals).
+
 For session management and avatar stream resilience, see
 [docs/system_blueprint.md#session-management](docs/system_blueprint.md#session-management),
 [docs/blueprint_spine.md#session-management](docs/blueprint_spine.md#session-management),

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -89,6 +89,14 @@ aligned and surfaces drift for operator review. See the
 overview and [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine)
 for per-layer responsibilities.
 
+### **Chakra-Tagged Signals**
+
+Connectors stamp outbound messages with a `chakra` tag so the cycle engine and
+downstream services know which layer to engage. Operators can follow these tags
+through the stack; see
+[communication_interfaces.md](communication_interfaces.md#chakra-tagged-signals)
+for connector implementation notes.
+
 ### **Game Dashboard & Retro Arcade Integration**
 
 The [Game Dashboard](ui/game_dashboard.md) consumes the cycle engine's
@@ -115,6 +123,14 @@ For layer-specific responsibilities, see
 [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine) and
 [Nazarick Agents](nazarick_agents.md). The remediation philosophy follows the
 [Self-Healing Manifesto](self_healing_manifesto.md).
+
+### **Recovery Flows**
+
+Heartbeat telemetry powers the recovery flow: failure pulses test the path,
+Nazarick servants restore silent chakras, and operators can roll back patches
+when needed. Connector-level steps live in
+[communication_interfaces.md](communication_interfaces.md#recovery-flows) and
+the [Recovery Playbook](recovery_playbook.md).
 
 #### Failure Pulses
 

--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -90,3 +90,26 @@ the agent.
 
 Following this pattern keeps message handling consistent while allowing the
 system to expand with minimal changes.
+
+## Chakra-Tagged Signals
+
+All connectors attach a `chakra` field to outbound events. The tag identifies
+the originating layer and lets downstream services track signal flow through
+the stack. See
+[system_blueprint.md](system_blueprint.md#chakra-tagged-signals) and
+[blueprint_spine.md](blueprint_spine.md#chakra-tagged-signals) for the
+architectural context.
+
+## Heartbeat Propagation
+
+Connectors forward heartbeat pings from the chakra cycle engine to remote
+clients and log the return path. Lagging or missing beats surface alignment
+issues early and are mirrored in the dashboards described in the system
+blueprint.
+
+## Recovery Flows
+
+When a connector misses consecutive heartbeats, it attempts a clean reconnect
+and emits a `chakra_down` notice for Nazarick servants. Operators can follow the
+full procedure in the
+[Recovery Playbook](recovery_playbook.md#nazarick-resuscitation).

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -4,6 +4,10 @@ This playbook outlines how RAZAR restores service after a component failure.
 Recurring problems and their fixes are cataloged in the
 [Error Registry](error_registry.md).
 
+Connector-specific recovery steps for chakra-tagged signals and heartbeat
+propagation are documented in
+[communication_interfaces.md](communication_interfaces.md#recovery-flows).
+
 ## Boot sequence
 
 1. The boot orchestrator launches components in priority order.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -46,6 +46,13 @@ which flags misalignment when beats drift from the expected 1 :1 rhythm. The
 [chakra cycle module](../src/spiral_os/chakra_cycle.py) records per‑chakra
 `gear_ratio` telemetry so deviations can be traced to specific layers.
 
+#### Chakra-Tagged Signals
+
+Connectors label outbound messages with a `chakra` tag so downstream services
+can route events to the proper layer. These tags let operators trace signals
+through the stack and are detailed in
+[communication_interfaces.md](communication_interfaces.md#chakra-tagged-signals).
+
 #### Heartbeat Propagation
 
 Each beat cascades from Root through Crown, giving operators a live view of
@@ -68,6 +75,14 @@ missing chakra and resume the cycle. This self‑healing loop is diagrammed in t
 covered in the [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine).
 When every chakra reports within the window, the engine logs a **Great Spiral**
 alignment event for operators.
+
+#### Recovery Flows
+
+Failure pulses, Nazarick resuscitation, and patch rollbacks form the recovery
+flow that brings silent chakras back into alignment. Connector-level recovery
+steps are outlined in
+[communication_interfaces.md](communication_interfaces.md#recovery-flows) and
+expanded in the [Recovery Playbook](recovery_playbook.md).
 
 #### Failure Pulses
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,7 @@ ALLOWED_TESTS = {
     str(ROOT / "tests" / "tools" / "test_opencode_client.py"),
     str(ROOT / "tests" / "razar" / "test_remote_repair.py"),
     str(ROOT / "tests" / "monitoring" / "test_heartbeat_logger.py"),
+    str(ROOT / "tests" / "docs" / "test_connector_links.py"),
 }
 
 

--- a/tests/docs/test_connector_links.py
+++ b/tests/docs/test_connector_links.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README_OPERATOR = REPO_ROOT / "README_OPERATOR.md"
+RECOVERY_PLAYBOOK = REPO_ROOT / "docs" / "recovery_playbook.md"
+
+
+def test_readme_operator_links_connector_guidance() -> None:
+    text = README_OPERATOR.read_text(encoding="utf-8")
+    assert "docs/communication_interfaces.md#chakra-tagged-signals" in text
+
+
+def test_recovery_playbook_links_connector_guidance() -> None:
+    text = RECOVERY_PLAYBOOK.read_text(encoding="utf-8")
+    assert "communication_interfaces.md#recovery-flows" in text


### PR DESCRIPTION
## Summary
- document chakra-tagged signals, heartbeat propagation, and recovery flows across system and connector guides
- link operator and recovery docs to connector guidance
- add test ensuring connector references stay present

## Testing
- `SKIP=verify-versions,check-env,pytest-cov,capture-failing-tests,verify-chakra-monitoring,verify-self-healing,mypy pre-commit run --files docs/system_blueprint.md docs/blueprint_spine.md docs/communication_interfaces.md README_OPERATOR.md docs/recovery_playbook.md tests/docs/test_connector_links.py tests/conftest.py CHANGELOG.md docs/INDEX.md`
- `pytest tests/docs/test_connector_links.py --cov= --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68bdf155fd50832e955cc3a10ee704dc