### PR TITLE
Add MCP gateway with context and model endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Documented chakra-tagged signals, heartbeat propagation, and recovery flows
   across connector and operator guides; added tests for connector links.
+- MCP gateway exposes context registration and model invocation via MCP; added `config/mcp.toml` and `docs/mcp_overview.md`.
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.
 - `docs/operator_onboarding.md` documents mission workflows with Mermaid diagrams and cross-links in `system_blueprint.md`.

--- a/config/mcp.toml
+++ b/config/mcp.toml
@@ -1,0 +1,9 @@
+[models]
+crown = "models/crown.gguf"
+deepseek = "models/deepseek.gguf"
+
+[rate_limits]
+requests_per_minute = 60
+
+[auth]
+key = "change-me"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -344,6 +344,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ip_registry.md](ip_registry.md) | IP Registry | The following modules are tagged with `@ip-sensitive` and require tracking in this registry. | - |
 | [learning_pipeline.md](learning_pipeline.md) | Learning Pipeline | The learning pipeline pairs two utilities: | - |
 | [logging_guidelines.md](logging_guidelines.md) | RAZAR Logging Guidelines | The mission logger records component activity in `logs/razar.log` using one JSON object per line. Each entry contains: | - |
+| [mcp_overview.md](mcp_overview.md) | MCP Gateway Overview | The MCP gateway bridges existing FastAPI services with the Model Context Protocol. It exposes context registration an... | - |
 | [memory_architecture.md](memory_architecture.md) | Memory Architecture | The system layers multiple specialised stores, each recording a different facet of experience. Every layer supports t... | `../memory/cortex.py`, `../memory/emotional.py`, `../memory/mental.py`, `../memory/narrative_engine.py`, `../memory/spiritual.py`, `../scripts/init_memory_layers.py` |
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -510,6 +510,7 @@ After “awakening,” the Crown LLM continuously manages prompt routing, model 
 - **`avatar_expression_engine`** renders the 3‑D persona and streams frames while playing audio, using SadTalker/Wav2Lip when available or falling back to a simple mouth overlay.
 - **`expressive_output`** coordinates speech synthesis, music, and video streaming so external GUIs can register callbacks for live animation.
 - A WebRTC gateway exposes the stream to browsers and bridges Discord and Telegram chats through connectors documented in [Communication Interfaces](communication_interfaces.md).
+- The MCP gateway registers context and invokes internal models via the Model Context Protocol; see [MCP Gateway Overview](mcp_overview.md).
 - See the [Avatar Pipeline](avatar_pipeline.md) for configuration, including texture selection via `guides/avatar_config.toml` and optional 3‑D scene support.
 
 ---

--- a/docs/mcp_overview.md
+++ b/docs/mcp_overview.md
@@ -1,0 +1,17 @@
+# MCP Gateway Overview
+
+The MCP gateway bridges existing FastAPI services with the Model Context Protocol.
+It exposes context registration and model invocation over MCP while continuing to
+serve the legacy HTTP routes.
+
+## Configuration
+- `config/mcp.toml` defines model paths, rate limits, and API keys.
+
+## Endpoints
+- **`/context/register`** – register conversation context.
+- **`/model/invoke`** – invoke a configured model.
+
+## Version History
+- 2025-10-??: Initial version.
+
+Backlinks: [Blueprint Spine](blueprint_spine.md)

--- a/mcp/gateway.py
+++ b/mcp/gateway.py
@@ -1,0 +1,81 @@
+"""Model Context Protocol gateway.
+
+This server bridges existing FastAPI routes with the Model Context Protocol
+(MCP). It loads internal models from configuration and exposes handlers for
+context registration and model invocation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import tomllib
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from invocation_engine import invoke
+
+__version__ = "0.1.0"
+
+server = FastMCP("abzu-mcp")
+contexts: Dict[str, Dict[str, Any]] = {}
+models: Dict[str, str] = {}
+rate_limit: int = 0
+auth_key: str | None = None
+
+
+@server.tool()
+async def register_context(
+    id: str, data: Dict[str, Any] | None = None
+) -> Dict[str, str]:
+    """Register ``data`` for ``id`` and return confirmation."""
+    contexts[id] = data or {}
+    return {"status": "registered"}
+
+
+@server.custom_route("/context/register", methods=["POST"])
+async def register_context_route(request: Request) -> JSONResponse:
+    payload = await request.json()
+    result = await register_context(payload.get("id", ""), payload.get("data"))
+    return JSONResponse(result)
+
+
+@server.tool()
+async def invoke_model(model: str, text: str) -> Dict[str, Any]:
+    """Invoke ``model`` with ``text`` via the existing invocation engine."""
+    if model not in models:
+        raise ValueError("unknown model")
+    result = invoke(text)
+    return {"model": model, "result": result}
+
+
+@server.custom_route("/model/invoke", methods=["POST"])
+async def invoke_model_route(request: Request) -> JSONResponse:
+    if auth_key and request.headers.get("x-api-key") != auth_key:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    payload = await request.json()
+    result = await invoke_model(payload.get("model", ""), payload.get("text", ""))
+    return JSONResponse(result)
+
+
+def _load_config() -> None:
+    """Populate models, rate limits, and auth key from ``config/mcp.toml``."""
+    global rate_limit, auth_key
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "mcp.toml"
+    with cfg_path.open("rb") as fh:
+        cfg = tomllib.load(fh)
+    models.update(cfg.get("models", {}))
+    rate_limit = int(cfg.get("rate_limits", {}).get("requests_per_minute", 0))
+    auth_key = cfg.get("auth", {}).get("key")
+
+
+def main() -> None:
+    """Start the MCP server after loading configuration."""
+    _load_config()
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    main()


### PR DESCRIPTION
## Summary
- add MCP gateway bridging FastAPI routes with MCP tools for context registration and model invocation
- configure model paths, rate limits, and API key in `config/mcp.toml`
- document gateway usage and link from blueprint spine

## Testing
- `pre-commit run --files mcp/gateway.py config/mcp.toml docs/mcp_overview.md docs/blueprint_spine.md CHANGELOG.md docs/INDEX.md` *(fails: missing metrics exporters and no recent self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf540b6f8832e8338c7979850fcce