### PR TITLE
docs: add MCP migration guidance

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -293,6 +292,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [connector_health_protocol.md](connector_health_protocol.md) | Connector Health Protocol | Ensures registered connectors are reachable before merging. | - |
 | [connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) | Connector Index | Canonical registry of ABZU's connectors. Each entry lists the purpose, version, primary service endpoints, linked age... | `../../communication/telegram_bot.py`, `../../connectors/primordials_api.py`, `../../connectors/webrtc_connector.py`, `../../narrative_api.py`, `../../operator_api.py`, `../../razar/crown_handshake.py`, `../../razar/crown_link.py`, `../../server.py` |
 | [connectors/README.md](connectors/README.md) | Connector Overview | Guidelines for modules that bridge Spiral OS to external services. The live registry of available connectors lives in... | - |
+| [connectors/mcp_migration.md](connectors/mcp_migration.md) | MCP Migration Guide | This guide explains how to convert existing API connectors to the **Model Context Protocol (MCP)**. | - |
 | [contribution_guide.md](contribution_guide.md) | Contribution Guide | Thank you for considering a contribution! | - |
 | [contributor_checklist.md](contributor_checklist.md) | Contributor Checklist | This checklist distills mandatory practices for ABZU contributors. | - |
 | [crown_manifest.md](crown_manifest.md) | CROWN Manifest | The **CROWN** agent runs the GLM-4.1V-9B model and acts as the root layer of Spiral OS. It holds the highest permissi... | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -555,6 +555,24 @@ All endpoints must publish machine-validated schemas:
 - CI executes `scripts/component_inventory.py` to fail builds when connector versions mismatch the registry or required entries are missing.
 - Run `python scripts/health_check_connectors.py` before merging to confirm connectors respond.
 
+#### Model Context Protocol Migration
+
+ABZU is adopting the **Model Context Protocol (MCP)** to standardize authentication,
+capability negotiation, and logging for internal service connectors. MCP reduces
+ad‑hoc HTTP clients and gives operators a consistent way to trace calls across the
+stack.
+
+- **MCP connectors** – `operator_api`, `operator_upload`, and `crown_handshake`
+  already speak MCP. `primordials_api` and `narrative_api` are queued for
+  conversion.
+- **External APIs** – `telegram_bot`, `open_web_ui`, and the browser-facing
+  `webrtc` connector rely on standard HTTP endpoints and will remain outside the
+  MCP surface.
+
+Track migration status in the
+[Connector Index](connectors/CONNECTOR_INDEX.md) and mark entries as `mcp` when
+the port completes.
+
 ### Dependency Index Protocol
 
 - Maintain [dependency_index.md](dependency_index.md) enumerating third-party libraries and internal packages.

--- a/docs/absolute_protocol_checklist.md
+++ b/docs/absolute_protocol_checklist.md
@@ -5,4 +5,5 @@ Complete this checklist before tagging a release. Mark each item with `[x]` once
 - [ ] `docs/INDEX.md` regenerated and committed
 - [ ] All tests pass (`pytest`)
 - [ ] Code coverage meets project threshold
+- [ ] Verify MCP compliance for all internal connectors
 - [ ] `environment.yml` and `environment.gpu.yml` unchanged

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -97,6 +97,21 @@ through the stack; see
 [communication_interfaces.md](communication_interfaces.md#chakra-tagged-signals)
 for connector implementation notes.
 
+### **Model Context Protocol Migration**
+
+Internal service connectors are moving to the **Model Context Protocol (MCP)** so
+they share a common handshake and logging surface. MCP covers calls within the
+stack and replaces bespoke HTTP clients with a unified gateway.
+
+- **MCP connectors** – `operator_api`, `operator_upload`, and `crown_handshake`
+  already speak MCP. `primordials_api` and `narrative_api` are next in line.
+- **External APIs** – Connectors that reach outside the stack, such as
+  `telegram_bot`, `open_web_ui`, and the browser-facing `webrtc` bridge, remain
+  HTTP-only.
+
+Migration status for each connector is tracked in the
+[Connector Index](connectors/CONNECTOR_INDEX.md).
+
 ### **Game Dashboard & Retro Arcade Integration**
 
 The [Game Dashboard](ui/game_dashboard.md) consumes the cycle engine's

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -2,6 +2,9 @@
 
 Canonical registry of ABZU's connectors. Each entry lists the purpose, version, primary service endpoints, linked agents, authentication method, status, and links to source code, documentation, and a JSON or YAML schema describing the interface. Operator interface entries detail the supported chat, file, image, audio, and video flows. Update this index whenever a connector's interface changes. For shared patterns across connectors see the [Connector Overview](README.md). This index is cross‑referenced from [Key Documents](../KEY_DOCUMENTS.md) and [The Absolute Protocol](../The_Absolute_Protocol.md); see the [Connector Registry Protocol](../The_Absolute_Protocol.md#connector-registry-protocol) for the checklist.
 
+For instructions on converting legacy API connectors to the Model Context Protocol,
+refer to the [MCP Migration Guide](mcp_migration.md).
+
 | id | purpose | version | auth | endpoints | linked agents | status | code | docs | schema |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `operator_api` | operator chat command dispatch | 0.3.3 | Bearer | `POST /operator/command` | Orchestration Master | experimental | [operator_api.py](../../operator_api.py) | [operator_protocol.md](../operator_protocol.md) | N/A |

--- a/docs/connectors/mcp_migration.md
+++ b/docs/connectors/mcp_migration.md
@@ -1,0 +1,44 @@
+# MCP Migration Guide
+
+This guide explains how to convert existing API connectors to the **Model Context Protocol (MCP)**.
+
+## Rationale
+
+MCP supplies a shared handshake, authentication, and logging layer for internal
+services. Migrating connectors reduces bespoke HTTP clients and makes call
+traces easier for operators to follow.
+
+## Conversion Steps
+
+1. **Wrap the connector with an MCP server.** Expose actions as MCP commands and
+   list available capabilities.
+2. **Implement a client shim.** Replace direct HTTP requests with an
+   `mcp.Client` that negotiates versions and sends structured payloads.
+3. **Update the registry.** Mark the entry in
+   [CONNECTOR_INDEX.md](CONNECTOR_INDEX.md) with `status: migrating` or `mcp`
+   once complete.
+4. **Revise schemas and tests.** Provide a JSON or YAML schema for the MCP
+   surface and expand unit tests to cover the handshake and error paths.
+
+### Example: Converting `operator_api`
+
+```python
+# before: direct HTTP call
+resp = requests.post("/operator/command", json=payload)
+
+# after: MCP client
+from mcp import Client
+
+with Client("operator_api") as client:
+    resp = client.start_call("command", payload)
+```
+
+### Common Pitfalls
+
+- Missing capability declarations cause runtime negotiation failures.
+- Old HTTP endpoints left in the code path produce duplicate requests.
+- Connector index entries not updated to `mcp` status.
+- Schemas omitted or out of sync with implemented commands.
+
+Following these steps keeps connectors consistent and discoverable as MCP
+replaces ad‑hoc HTTP implementations across the stack.

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -77,7 +77,9 @@ Enable the Model Context Protocol during development by setting
 `ABZU_USE_MCP=1`. Internal services will route requests through the MCP gateway
 while external connectors and third-party APIs continue using standard HTTP
 endpoints. Choose MCP for service-to-service calls within the stack and HTTP
-for integrations beyond it or when MCP is unavailable.
+for integrations beyond it or when MCP is unavailable. See the
+[MCP Migration Guide](connectors/mcp_migration.md) for steps to convert
+existing API connectors.
 
 ## Getting Started with RAZAR
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -53,6 +53,21 @@ can route events to the proper layer. These tags let operators trace signals
 through the stack and are detailed in
 [communication_interfaces.md](communication_interfaces.md#chakra-tagged-signals).
 
+#### Model Context Protocol Migration
+
+Internal service connectors are being refactored to use the **Model Context
+Protocol (MCP)**. MCP provides a shared handshake, authentication, and logging
+layer so operators can audit service-to-service calls.
+
+- **MCP connectors** – `operator_api`, `operator_upload`, and `crown_handshake`
+  already support MCP. `primordials_api` and `narrative_api` are queued for
+  migration.
+- **External APIs** – `telegram_bot`, `open_web_ui`, and the browser-oriented
+  `webrtc` bridge depend on standard HTTP and will remain outside MCP.
+
+See [connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) for the
+current status of each connector.
+
 #### Heartbeat Propagation
 
 Each beat cascades from Root through Crown, giving operators a live view of


### PR DESCRIPTION
## Summary
- document rationale and status for Model Context Protocol connectors
- add MCP migration guide and cross-links
- expand absolute protocol checklist with MCP compliance check

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/blueprint_spine.md docs/system_blueprint.md docs/connectors/mcp_migration.md docs/absolute_protocol_checklist.md docs/developer_onboarding.md docs/connectors/CONNECTOR_INDEX.md docs/INDEX.md` *(fails: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfdf7f648832e935dfed9626abe53