### PR TITLE
chore: enforce MCP usage in connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,9 @@ PY
       - name: Verify component maturity
         run: python scripts/verify_component_maturity.py
 
+      - name: Check MCP connectors
+        run: python scripts/check_mcp_connectors.py
+
       - name: Profiling
         run: python -m cProfile -m task_profiling
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,11 @@ repos:
     entry: python scripts/verify_ip_tags.py
     language: system
     pass_filenames: false
+  - id: check-mcp-connectors
+    name: Ensure MCP connectors avoid raw HTTP
+    entry: python scripts/check_mcp_connectors.py
+    language: system
+    pass_filenames: false
   - id: check-connector-index
     name: Check connector index entries
     entry: python scripts/check_connector_index.py

--- a/docs/contributor_checklist.md
+++ b/docs/contributor_checklist.md
@@ -18,6 +18,7 @@ This checklist distills mandatory practices for ABZU contributors.
 
 ## Test Requirements
 - Run `pre-commit run --files <changed files>` on every commit.
+- Run `python scripts/check_mcp_connectors.py` and fix any flagged API connectors.
 - Execute relevant tests with `pytest`. Document failing tests in [testing/failure_inventory.md](testing/failure_inventory.md) before merging.
 
 ## Version History

--- a/scripts/check_mcp_connectors.py
+++ b/scripts/check_mcp_connectors.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Verify connectors use MCP instead of raw HTTP endpoints."""
+from __future__ import annotations
+
+import pathlib
+import re
+
+# Files allowed to use raw HTTP despite MCP mandate
+ALLOWED = {
+    "connectors/primordials_api.py",
+    "connectors/message_formatter.py",
+}
+
+# regex patterns for HTTP usage and MCP references
+HTTP_PATTERN = re.compile(r"http[s]?://|requests\\.|urllib\\.|httpx\\.")
+MCP_PATTERN = re.compile(r"\bMCP\b", re.IGNORECASE)
+
+
+def scan_file(path: pathlib.Path) -> bool:
+    """Return True if file uses HTTP without MCP mention."""
+    text = path.read_text(encoding="utf-8")
+    if HTTP_PATTERN.search(text) and not MCP_PATTERN.search(text):
+        return True
+    return False
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    connector_dir = repo_root / "connectors"
+
+    offenders: list[str] = []
+    for py_file in connector_dir.rglob("*.py"):
+        rel = py_file.relative_to(repo_root).as_posix()
+        if rel in ALLOWED:
+            continue
+        if scan_file(py_file):
+            offenders.append(rel)
+
+    if offenders:
+        for rel in offenders:
+            print(f"MCP missing for connector: {rel}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `check_mcp_connectors.py` to flag connectors using raw HTTP without MCP
- wire MCP check into pre-commit and CI workflow
- remind contributors to run the MCP connector check

## Testing
- `PYTHONPATH=. pre-commit run --files scripts/check_mcp_connectors.py .pre-commit-config.yaml .github/workflows/ci.yml docs/contributor_checklist.md` *(fails: missing metrics endpoints; no self-heal cycles)*


------
https://chatgpt.com/codex/tasks/task_e_68bdff4ed794832eb897c56f6e03bf02