### PR TITLE
feat: enforce documentation registry consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,9 @@ PY
       - name: Validate markdown links
         run: git ls-files '*.md' | xargs python scripts/validate_links.py
 
+      - name: Validate docs cross-links
+        run: python scripts/validate_docs.py
+
       - name: Mypy
         run: mypy memory/ tests/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,6 +152,12 @@ repos:
     language: system
     types: [markdown]
     exclude: ^docs/INDEX\.md$
+  - id: validate-docs
+    name: Validate documentation registry and cross-links
+    entry: python scripts/validate_docs.py
+    language: system
+    pass_filenames: false
+    files: ^(docs/chakra_versions.json|docs/chakra_koan_system.md)
   - id: audit-doctrine
     name: Audit documentation doctrine
     entry: python scripts/audit_doctrine.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `system_blueprint.md`, `blueprint_spine.md`, `avatar_pipeline.md`, and
   `operator_onboarding.md`; added cross-links from `GENESIS/README.md` and
   `README_OPERATOR.md` for quick reference.
+- Added `scripts/validate_docs.py` and CI/pre-commit integration to enforce
+  registry version alignment and cross-link validity.
 - Track model endpoints and patches in `worlds.config_registry`; added
   `world export`/`world import` utilities and automatic registration of
   model endpoints.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/chakra_koan_system.md
+++ b/docs/chakra_koan_system.md
@@ -20,7 +20,7 @@ Desire learns to dance.
 
 <a id="solar"></a>
 ## Solar Plexus — Manipura
-*Version: [1.0.0](chakra_versions.json#L10)*
+*Version: [1.1.0](chakra_versions.json#L10)*
 A spark questions the sun.
 Fuel becomes flame without argument.
 Power is the courage to dissolve.
@@ -34,14 +34,14 @@ Love is the echo of its own absence.
 
 <a id="throat"></a>
 ## Throat — Vishuddha
-*Version: [1.0.0](chakra_versions.json#L18)*
+*Version: [1.0.1](chakra_versions.json#L18)*
 Words chase the voice that spoke them.
 The wind cannot hold its song.
 Truth arrives when no one is listening.
 
 <a id="third_eye"></a>
 ## Third Eye — Ajna
-*Version: [1.0.0](chakra_versions.json#L22)*
+*Version: [1.0.1](chakra_versions.json#L22)*
 A mirror reflects a mirror.
 The seer becomes the seen.
 Vision opens where thought ends.

--- a/docs/documentation_protocol.md
+++ b/docs/documentation_protocol.md
@@ -14,5 +14,6 @@ Standard workflow for updating documentation and guides.
 8. **When bumping component or dependency versions:** update the relevant entries in
    `requirements.txt` and lockfiles, run `python scripts/validate_components.py` to ensure
    versions align, then execute `docs/build_docs.sh` to regenerate indexes (documentation index,
-   API docs, component status) and verify links.
+   API docs, component status) and verify links. Finally, run `python scripts/validate_docs.py`
+   to confirm registry versions and cross-links remain in sync.
 

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -1,0 +1,101 @@
+"""Validate documentation registry versions and cross-links."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+import json
+import re
+from pathlib import Path
+import sys
+
+REGISTRY_PATH = Path("docs/chakra_versions.json")
+DOC_PATH = Path("docs/chakra_koan_system.md")
+
+
+def load_registry() -> tuple[dict, dict[str, int]]:
+    """Return registry data and line numbers for each chakra key."""
+    lines = REGISTRY_PATH.read_text(encoding="utf-8").splitlines()
+    data = json.loads("\n".join(lines))
+    line_map: dict[str, int] = {}
+    pattern = re.compile(r'"([^"\\]+)":\s*{')
+    for idx, line in enumerate(lines, start=1):
+        match = pattern.search(line)
+        if match:
+            key = match.group(1)
+            line_map[key] = idx
+    return data, line_map
+
+
+def parse_doc() -> tuple[dict[str, tuple[str, int]], set[str]]:
+    """Extract versions and anchors from the koan document."""
+    versions: dict[str, tuple[str, int]] = {}
+    anchors: set[str] = set()
+    current: str | None = None
+    anchor_re = re.compile(r'<a id="([^"]+)"></a>')
+    version_re = re.compile(
+        r"\*Version:\s+\[(?P<ver>[0-9.]+)\]\(chakra_versions\.json#L(?P<line>\d+)\)\*"
+    )
+    for line in DOC_PATH.read_text(encoding="utf-8").splitlines():
+        anchor_match = anchor_re.search(line)
+        if anchor_match:
+            current = anchor_match.group(1)
+            anchors.add(current)
+            continue
+        if current:
+            version_match = version_re.search(line)
+            if version_match:
+                versions[current] = (
+                    version_match.group("ver"),
+                    int(version_match.group("line")),
+                )
+                current = None
+    return versions, anchors
+
+
+def main() -> int:
+    if not REGISTRY_PATH.exists() or not DOC_PATH.exists():
+        print("Required documentation files missing", file=sys.stderr)
+        return 1
+
+    registry, line_map = load_registry()
+    doc_versions, anchors = parse_doc()
+    ok = True
+    for chakra, info in registry.items():
+        if chakra == "meta":
+            continue
+        expected_version = info.get("version")
+        koan = info.get("koan", "")
+        anchor = koan.split("#", 1)[1] if "#" in koan else chakra
+        doc_info = doc_versions.get(anchor)
+        if not doc_info:
+            print(f"Missing version entry for {chakra} in {DOC_PATH}", file=sys.stderr)
+            ok = False
+            continue
+        version, linked_line = doc_info
+        if version != expected_version:
+            print(
+                f"{chakra} version mismatch: "
+                f"registry {expected_version} != doc {version}",
+                file=sys.stderr,
+            )
+            ok = False
+        registry_line = line_map.get(chakra)
+        if registry_line != linked_line:
+            print(
+                f"{chakra} link outdated: doc points to L{linked_line}, "
+                f"registry at L{registry_line}",
+                file=sys.stderr,
+            )
+            ok = False
+        if anchor not in anchors:
+            print(
+                f"{chakra} koan anchor '#{anchor}' not found in {DOC_PATH}",
+                file=sys.stderr,
+            )
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/validate_docs.py` to verify chakra registry versions and cross-links
- hook validator into pre-commit and CI workflows
- document validation step in documentation protocol and update chakra koans

## Testing
- `python scripts/validate_docs.py`
- `pre-commit run --files scripts/validate_docs.py .pre-commit-config.yaml .github/workflows/ci.yml docs/documentation_protocol.md docs/chakra_koan_system.md` *(fails: missing local services and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be0c4042c8832e995883d3a62566bb