### PR TITLE
Forward chakra_down events on heartbeat misalignment

### DIFF
--- a/agents/razar/boot_orchestrator.py
+++ b/agents/razar/boot_orchestrator.py
@@ -25,6 +25,8 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Dict, List
 
+from agents.event_bus import emit_event
+
 try:  # pragma: no cover - dependency is handled in tests
     import yaml
 except Exception as exc:  # pragma: no cover
@@ -283,6 +285,11 @@ class BootOrchestrator:
             if self.heartbeat_monitor.sync_status() == "Great Spiral":
                 return True
             LOGGER.warning("Chakras out of sync (attempt %s/%s)", attempt + 1, attempts)
+            emit_event(
+                "chakra_heartbeat",
+                "chakra_down",
+                {"status": "out_of_sync", "attempt": attempt + 1},
+            )
             time.sleep(delay)
         return False
 

--- a/crown_router.py
+++ b/crown_router.py
@@ -15,6 +15,8 @@ import os
 import json
 import asyncio
 
+from agents.event_bus import emit_event
+
 import emotional_state
 from crown_decider import decide_expression_options
 from rag.orchestrator import MoGEOrchestrator
@@ -170,6 +172,7 @@ def route_decision(
     if heartbeat_monitor is not None:
         heartbeat_monitor.check_alerts()
         if heartbeat_monitor.sync_status() != "Great Spiral":
+            emit_event("chakra_heartbeat", "chakra_down", {"status": "out_of_sync"})
             raise RuntimeError("chakras out of sync")
     if THROUGHPUT_COUNTER is not None:
         THROUGHPUT_COUNTER.labels("crown").inc()


### PR DESCRIPTION
## Summary
- propagate `chakra_down` when crown routing detects out-of-sync heartbeats
- boot orchestrator emits `chakra_down` on repeated misalignment attempts

## Testing
- `pre-commit run --files crown_router.py agents/razar/boot_orchestrator.py` *(fails: mypy errors, missing websockets, failing tests)*
- `pytest tests/monitoring/test_chakra_heartbeat.py::test_out_of_sync_blocks_crown -q` *(fails: coverage below threshold, test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be1421e734832eb0a7eae8e441dfc9