### PR TITLE
Add agent-aware WebRTC endpoints and multi-avatar tests

### DIFF
--- a/src/cli/console_interface.py
+++ b/src/cli/console_interface.py
@@ -40,9 +40,10 @@ def _send_audio_path(path: Path) -> None:
     """Notify the video stream service of new audio."""
 
     url = os.getenv("VIDEO_STREAM_URL", "http://localhost:8000")
+    agent = os.getenv("VIDEO_STREAM_AGENT", "agent")
     try:
         requests.post(
-            f"{url.rstrip('/')}/avatar-audio",
+            f"{url.rstrip('/')}/{agent}/avatar-audio",
             json={"path": str(path)},
             timeout=5,
         )

--- a/tests/test_vast_check.py
+++ b/tests/test_vast_check.py
@@ -107,9 +107,9 @@ def test_vast_check_success(monkeypatch, capsys):
     async def ready() -> dict[str, str]:
         return {"status": "ready"}
 
-    @app.post("/offer")
-    async def offer(data: dict) -> dict[str, str]:
-        return {"sdp": "ans", "type": "answer"}
+    @app.post("/{agent}/offer")
+    async def offer(agent: str, data: dict) -> dict[str, str]:
+        return {"sdp": f"ans-{agent}", "type": "answer"}
 
     mod = importlib.import_module("scripts.vast_check")
 

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -5,7 +5,11 @@ const API_URL =
     (typeof window !== 'undefined' && window.WEB_CONSOLE_API_URL) ||
     'http://localhost:8000/glm-command';
 const BASE_URL = API_URL.replace(/\/[a-zA-Z_-]+$/, '');
-const OFFER_URL = `${BASE_URL}/offer`;
+const AGENT =
+    (typeof process !== 'undefined' && process.env && process.env.WEB_CONSOLE_AGENT) ||
+    (typeof window !== 'undefined' && window.WEB_CONSOLE_AGENT) ||
+    'agent';
+const OFFER_URL = `${BASE_URL}/${AGENT}/offer`;
 const STARTUP_LOG_URL = 'logs/nazarick_startup.json';
 const REGISTRY_URL = 'agents/nazarick/agent_registry.json';
 const EVENTS_URL = `${BASE_URL.replace(/^http/, 'ws')}/operator/events`;

--- a/web_console/operator.js
+++ b/web_console/operator.js
@@ -3,7 +3,10 @@ const API_URL =
     (typeof window !== 'undefined' && window.WEB_CONSOLE_API_URL) ||
     'http://localhost:8000/glm-command';
 const BASE_URL = API_URL.replace(/\/[a-zA-Z_-]+$/, '');
-const OFFER_URL = `${BASE_URL}/offer`;
+const AGENT =
+    (typeof window !== 'undefined' && window.WEB_CONSOLE_AGENT) ||
+    'agent';
+const OFFER_URL = `${BASE_URL}/${AGENT}/offer`;
 const UPLOAD_URL = `${BASE_URL}/operator/upload`;
 
 function sendCommand(cmd) {


### PR DESCRIPTION
## Summary
- Map avatar sessions by agent with heartbeat support
- Pass agent identifiers to WebRTC offer and avatar-audio routes
- Cover multi-agent streaming and heartbeat with tests

## Testing
- `pre-commit run --files src/cli/console_interface.py scripts/vast_check.py tests/test_vast_check.py web_console/main.js web_console/operator.js tests/web_console/test_multi_avatar_stream.py` *(fails: Required test coverage of 80% not reached)*
- `pytest tests/web_console/test_multi_avatar_stream.py tests/web_console/test_webrtc_gateway.py tests/test_vast_check.py --cov-fail-under=0 -q` *(3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be16303aac832e9a92a36aabb9d296