### PR TITLE
Add LWM frame rendering plug-ins

### DIFF
--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -106,6 +106,17 @@ optional lip‑sync audio. These assets are loaded by
 ``media.avatar.lwm_renderer`` before frames are generated. Omitting the mode or
 setting it to ``"2d"`` keeps the traditional flat rendering path.
 
+### Frame Rendering Plug-ins
+
+``core.video_engine`` exposes ``register_render_2d`` and ``register_render_3d``
+hooks so external modules can override the default frame builders. Plug‑ins
+provide callables with the same signature as the built‑in functions.
+
+The ``media.avatar.lwm_renderer`` module registers an LWM‑driven renderer using
+these hooks. Call ``configure_renderer()`` with mesh paths and optional
+lip‑sync audio to supply camera trajectories and audio data before starting the
+stream.
+
 ## Object-aware avatar selection
 
 The video engine can adapt the visible avatar based on the current visual

--- a/src/core/video_engine.py
+++ b/src/core/video_engine.py
@@ -231,8 +231,32 @@ def _default_render_3d_frame(
     return frame, idx
 
 
-render_2d_frame = _default_render_2d_frame
-render_3d_frame = _default_render_3d_frame
+# expose defaults for plug-ins
+default_render_2d_frame = _default_render_2d_frame
+default_render_3d_frame = _default_render_3d_frame
+
+render_2d_frame = default_render_2d_frame
+render_3d_frame = default_render_3d_frame
+
+
+def register_render_2d(
+    func: Callable[..., tuple[np.ndarray, int]]
+) -> Callable[..., tuple[np.ndarray, int]]:
+    """Register ``func`` as the active 2-D frame renderer."""
+
+    global render_2d_frame
+    render_2d_frame = func
+    return func
+
+
+def register_render_3d(
+    func: Callable[..., tuple[np.ndarray, int]]
+) -> Callable[..., tuple[np.ndarray, int]]:
+    """Register ``func`` as the active 3-D frame renderer."""
+
+    global render_3d_frame
+    render_3d_frame = func
+    return func
 
 
 def set_frame_renderers(
@@ -242,11 +266,10 @@ def set_frame_renderers(
 ) -> None:
     """Replace default frame rendering functions."""
 
-    global render_2d_frame, render_3d_frame
     if two_d is not None:
-        render_2d_frame = two_d
+        register_render_2d(two_d)
     if three_d is not None:
-        render_3d_frame = three_d
+        register_render_3d(three_d)
 
 
 def generate_avatar_stream(
@@ -362,5 +385,9 @@ __all__ = [
     "register_gesture_pipeline",
     "render_2d_frame",
     "render_3d_frame",
+    "register_render_2d",
+    "register_render_3d",
     "set_frame_renderers",
+    "default_render_2d_frame",
+    "default_render_3d_frame",
 ]


### PR DESCRIPTION
## Summary
- allow video engine to register 2‑D and 3‑D frame renderers
- implement `media.avatar.lwm_renderer` plug‑in for LWM scenes
- document avatar frame rendering plug‑in hooks

## Testing
- `pre-commit run --files docs/avatar_pipeline.md src/core/video_engine.py src/media/avatar/lwm_renderer.py docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents')*
- `pre-commit run --files src/media/avatar/lwm_renderer.py` *(fails: Missing Python packages: websockets)*
- `pytest -q -o addopts="" tests/test_emotion_loop.py::test_apply_expression_modifies_frame`

------
https://chatgpt.com/codex/tasks/task_e_68be19d259d4832eb5c66d380ecd4256