### PR TITLE
docs: describe avatar streaming

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -17,9 +17,11 @@ For self-healing specifics—including failure pulses, Nazarick resuscitation,
 and patch rollbacks—see
 [docs/recovery_playbook.md#failure-pulses](docs/recovery_playbook.md#failure-pulses).
 
-Connector guidance on chakra-tagged signals, heartbeat propagation, and
-recovery flows lives in
-[docs/communication_interfaces.md#chakra-tagged-signals](docs/communication_interfaces.md#chakra-tagged-signals).
+Connector guidance on chakra-tagged signals, heartbeat propagation, recovery
+flows, and Discord/Telegram avatar streaming lives in
+[docs/communication_interfaces.md#chakra-tagged-signals](docs/communication_interfaces.md#chakra-tagged-signals)
+and
+[docs/communication_interfaces.md#discord-telegram-avatar-streaming](docs/communication_interfaces.md#discord-telegram-avatar-streaming).
 
 For session management and avatar stream resilience, see
 [docs/system_blueprint.md#session-management](docs/system_blueprint.md#session-management),

--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -76,6 +76,19 @@ Both connectors expect the tokens to be defined in the environment (or
 relay responses back to their respective channels, enabling remote control of
 the agent.
 
+## Discord/Telegram Avatar Streaming
+
+The ``connectors/avatar_broadcast.py`` helper forwards rendered avatar frames
+to social platforms. It retrieves the active video track for an agent and sends
+each frame plus optional heartbeat metadata to:
+
+- ``tools.bot_discord`` for delivery into a Discord channel
+- ``tools.bot_telegram`` for delivery into a Telegram chat
+
+Provide the channel or chat identifiers alongside the agent name when invoking
+``broadcast``. The function runs asynchronously and mirrors heartbeats so
+remote viewers can monitor stream health.
+
 ## Adding New Channels
 
 1. Implement an adapter that receives messages from the external service.

--- a/guides/avatar_config.toml
+++ b/guides/avatar_config.toml
@@ -8,6 +8,10 @@ albedo_layer = "skins/alpha/albedo.png"
 rubedo_layer = "skins/alpha/rubedo.png"
 citrinitas_layer = "skins/alpha/citrinitas.png"
 
+[agents.alpha.broadcast]
+discord_channel = 1234567890
+telegram_chat = 111222333
+
 [agents.beta]
 eye_color = [255, 64, 64]
 sigil = "cube"
@@ -17,3 +21,7 @@ nigredo_layer = "skins/beta/nigredo.png"
 albedo_layer = "skins/beta/albedo.png"
 rubedo_layer = "skins/beta/rubedo.png"
 citrinitas_layer = "skins/beta/citrinitas.png"
+
+[agents.beta.broadcast]
+discord_channel = 987654321
+telegram_chat = 444555666


### PR DESCRIPTION
## Summary
- document Discord and Telegram avatar streaming
- show per-agent broadcast example in avatar_config
- reference streaming docs from operator README

## Testing
- `pre-commit run --files docs/communication_interfaces.md guides/avatar_config.toml README_OPERATOR.md docs/INDEX.md` *(fails: missing metrics exporter and self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68be2094a9fc832e85255a847d9ed1e4