### PR TITLE
feat(nazarick): expose capabilities and triggers

### DIFF
--- a/agents/nazarick/agent_registry.json
+++ b/agents/nazarick/agent_registry.json
@@ -44,5 +44,17 @@
       "code_path": "memory_scribe.py",
       "triggers": ["persist"]
     }
+  ],
+  "capabilities": [
+    "orchestration",
+    "prompt_routing",
+    "qnl_processing",
+    "memory_persistence"
+  ],
+  "triggers": [
+    "launch",
+    "prompt",
+    "insight",
+    "persist"
   ]
 }

--- a/tests/agents/nazarick/test_agent_directory.py
+++ b/tests/agents/nazarick/test_agent_directory.py
@@ -13,3 +13,16 @@ def test_lookup_by_capability():
     agents = directory.get_by_capability("prompt_routing")
     ids = [a["id"] for a in agents]
     assert ids == ["prompt_orchestrator"]
+
+
+def test_lookup_by_trigger():
+    directory = AgentDirectory.from_file(REGISTRY_FILE)
+    agents = directory.get_by_trigger("prompt")
+    ids = [a["id"] for a in agents]
+    assert ids == ["prompt_orchestrator"]
+
+
+def test_registry_metadata_exposed():
+    directory = AgentDirectory.from_file(REGISTRY_FILE)
+    assert "prompt_routing" in directory.capabilities
+    assert "prompt" in directory.triggers


### PR DESCRIPTION
## Summary
- include global `capabilities` and `triggers` in the Nazarick agent registry
- index agents by capability and trigger in `AgentDirectory`
- document new metadata and trigger lookups in tests

## Testing
- `pre-commit run --files agents/nazarick/agent_registry.json agents/nazarick/service_launcher.py tests/agents/nazarick/test_agent_directory.py` *(fails: mypy, capture-failing-tests, pytest-cov)*
- `pytest tests/agents/nazarick/test_agent_directory.py` *(fails: Required test coverage of 80% not reached. Total coverage: 4.38%)*

------
https://chatgpt.com/codex/tasks/task_e_68be223ebf7c832ebc9e5fa398e8f5e9