### PR TITLE
test: verify heartbeat log and snapshot persistence

### DIFF
--- a/tests/monitoring/test_heartbeat_logger.py
+++ b/tests/monitoring/test_heartbeat_logger.py
@@ -3,41 +3,46 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from distributed_memory import CycleCounterStore
 from monitoring.heartbeat_logger import HeartbeatLogger
 from scripts.snapshot_state import create_snapshot, restore_snapshot
 
 
-def test_log_persistence(tmp_path: Path) -> None:
-    log_file = tmp_path / "heartbeat.log"
+def test_log_survival(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
     store = CycleCounterStore(path=tmp_path / "cycles.json")
-    logger = HeartbeatLogger(store=store, log_path=log_file)
+    logger = HeartbeatLogger(store=store)
     logger.log("root")
     # simulate restart
-    logger = HeartbeatLogger(store=store, log_path=log_file)
+    logger = HeartbeatLogger(store=store)
     logger.log("root")
-    lines = [json.loads(l) for l in log_file.read_text().splitlines()]
+    log_file = Path("logs/heartbeat.log")
+    lines = [json.loads(line) for line in log_file.read_text().splitlines()]
     assert [entry["cycle_id"] for entry in lines] == [1, 2]
 
 
-def test_snapshot_restore(tmp_path: Path) -> None:
-    registry = tmp_path / "agent_registry.json"
+def test_snapshot_restore(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    registry = Path("agents/nazarick/agent_registry.json")
+    registry.parent.mkdir(parents=True, exist_ok=True)
     registry.write_text(json.dumps({"agent": "test"}))
-    doctrine = tmp_path / "doctrine_index.md"
+    doctrine = Path("docs/doctrine_index.md")
+    doctrine.parent.mkdir(parents=True, exist_ok=True)
     doctrine.write_text("| File | Version |\n| --- | --- |\n| doc.md | 1.0 |\n")
-    snap_dir = tmp_path / "snaps"
     snap_path = create_snapshot(
-        snap_dir,
         registry_file=registry,
         doctrine_index=doctrine,
     )
+    assert snap_path.parent == Path("storage/snapshots")
     # mutate files to ensure restoration occurs
     registry.write_text("{}")
     restore_snapshot(
         snap_path,
         registry_file=registry,
-        doctrine_versions_file=tmp_path / "doctrine_versions.json",
+        doctrine_versions_file=Path("doctrine_versions.json"),
     )
     restored = json.loads(registry.read_text())
     assert restored == {"agent": "test"}
-    assert (tmp_path / "doctrine_versions.json").exists()
+    assert Path("doctrine_versions.json").exists()


### PR DESCRIPTION
## Summary
- add tests ensuring heartbeat logger appends to logs/heartbeat.log
- test snapshot creation and restore in storage/snapshots

## Testing
- `pre-commit run --files tests/monitoring/test_heartbeat_logger.py` *(fails: mypy errors across repository and pytest-cov missing coverage)*
- `pytest tests/monitoring/test_heartbeat_logger.py` *(fails: coverage <80%)*

------
https://chatgpt.com/codex/tasks/task_e_68be2bdf805c832ea3d447354e23ad8a