### PR TITLE
Add mission builder and persist wizard progress

### DIFF
--- a/docs/operator_onboarding.md
+++ b/docs/operator_onboarding.md
@@ -4,9 +4,9 @@ A guided walkthrough for composing and executing your first mission.
 
 ## Mission Builder
 
-1. Open `web_console/mission_builder/index.html` in a browser.
+1. Open `mission_builder/index.html` in a browser.
 2. Arrange blocks such as **Ignite**, **Query Memory**, and **Dispatch Agent** to describe your mission.
-3. Click **Save & Run** to store the mission under `missions/` and dispatch it through the task orchestrator.
+3. Click **Save & Run** to store the mission under `missions/` and dispatch it through `agents/task_orchestrator.py`.
 
 ```mermaid
 {{#include assets/mission_builder.mmd}}
@@ -17,8 +17,9 @@ The Mermaid source lives at [assets/mission_builder.mmd](assets/mission_builder.
 ## Game Dashboard Wizard
 
 Visiting `web_console/game_dashboard/` presents an onboarding wizard after setup.
-The wizard tracks progress in `localStorage` and guides you through mission creation
-and execution.
+The wizard detects missing configuration (like `avatar_config.toml` and required
+API tokens), stores progress in `localStorage`, and guides you through mission
+creation and execution.
 
 ```mermaid
 {{#include assets/mission_wizard.mmd}}

--- a/mission_builder/index.html
+++ b/mission_builder/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Mission Builder</title>
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <style>
+    html, body, #blocklyDiv { height: 100%; margin: 0; }
+    #controls { position: absolute; top: 10px; right: 10px; }
+  </style>
+</head>
+<body>
+  <div id="blocklyDiv"></div>
+  <div id="controls">
+    <button onclick="downloadMission()">Download Mission JSON</button>
+    <button onclick="saveMission()">Save &amp; Run</button>
+  </div>
+  <xml id="toolbox" style="display: none">
+    <block type="ignite"></block>
+    <block type="query_memory"></block>
+    <block type="dispatch_agent"></block>
+    <block type="mission_event"></block>
+  </xml>
+  <script src="mission_builder.js"></script>
+</body>
+</html>

--- a/mission_builder/mission_builder.js
+++ b/mission_builder/mission_builder.js
@@ -1,0 +1,125 @@
+/* global Blockly */
+
+const workspace = Blockly.inject('blocklyDiv', {
+  toolbox: document.getElementById('toolbox')
+});
+
+Blockly.defineBlocksWithJsonArray([
+  {
+    "type": "mission_event",
+    "message0": "event %1 capability %2",
+    "args0": [
+      { "type": "field_input", "name": "EVENT", "text": "event_type" },
+      { "type": "field_input", "name": "CAPABILITY", "text": "capability" }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 230,
+    "tooltip": "Emit an event with a capability",
+    "helpUrl": ""
+  }
+  ,
+  {
+    "type": "ignite",
+    "message0": "ignite target %1",
+    "args0": [
+      { "type": "field_input", "name": "TARGET", "text": "crown" }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 0,
+    "tooltip": "Ignite a target",
+    "helpUrl": ""
+  },
+  {
+    "type": "query_memory",
+    "message0": "query memory %1",
+    "args0": [
+      { "type": "field_input", "name": "QUERY", "text": "search" }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 120,
+    "tooltip": "Query stored memories",
+    "helpUrl": ""
+  },
+  {
+    "type": "dispatch_agent",
+    "message0": "dispatch agent %1 task %2",
+    "args0": [
+      { "type": "field_input", "name": "AGENT", "text": "agent" },
+      { "type": "field_input", "name": "TASK", "text": "task" }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 60,
+    "tooltip": "Dispatch an agent",
+    "helpUrl": ""
+  }
+]);
+
+function missionToJson() {
+  const mission = [];
+  const blocks = workspace.getTopBlocks(true);
+  for (const block of blocks) {
+    if (block.type === 'mission_event') {
+      mission.push({
+        event_type: block.getFieldValue('EVENT'),
+        payload: { capability: block.getFieldValue('CAPABILITY') }
+      });
+    } else if (block.type === 'ignite') {
+      mission.push({
+        event_type: 'ignite',
+        payload: {
+          capability: 'ignite',
+          target: block.getFieldValue('TARGET')
+        }
+      });
+    } else if (block.type === 'query_memory') {
+      mission.push({
+        event_type: 'query_memory',
+        payload: {
+          capability: 'query_memory',
+          query: block.getFieldValue('QUERY')
+        }
+      });
+    } else if (block.type === 'dispatch_agent') {
+      mission.push({
+        event_type: 'dispatch',
+        payload: {
+          capability: 'dispatch',
+          agent: block.getFieldValue('AGENT'),
+          task: block.getFieldValue('TASK')
+        }
+      });
+    }
+  }
+  return mission;
+}
+
+function downloadMission() {
+  const data = JSON.stringify(missionToJson(), null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'mission.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+async function saveMission() {
+  const name = prompt('Mission name');
+  if (!name) return;
+  const mission = missionToJson();
+  await fetch('/missions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, mission })
+  });
+}
+
+window.downloadMission = downloadMission;
+window.saveMission = saveMission;

--- a/web_console/game_dashboard/setupWizard.js
+++ b/web_console/game_dashboard/setupWizard.js
@@ -2,7 +2,13 @@ import React from 'https://esm.sh/react@18';
 import { BASE_URL } from '../main.js';
 
 export default function SetupWizard({ onComplete }) {
-  const [status, setStatus] = React.useState({ avatar: false, tokens: false });
+  const [status, setStatus] = React.useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('wizardStatus')) || { avatar: false, tokens: false };
+    } catch {
+      return { avatar: false, tokens: false };
+    }
+  });
   const [step, setStep] = React.useState(() => Number(localStorage.getItem('wizardStep') || 0));
 
   const steps = [
@@ -33,7 +39,9 @@ export default function SetupWizard({ onComplete }) {
     const tokens = await fetch(`${BASE_URL}/token-status`)
       .then((r) => r.ok)
       .catch(() => false);
-    setStatus({ avatar, tokens });
+    const nextStatus = { avatar, tokens };
+    setStatus(nextStatus);
+    localStorage.setItem('wizardStatus', JSON.stringify(nextStatus));
     if (avatar && tokens) {
       localStorage.setItem('setupWizardCompleted', 'true');
       onComplete();


### PR DESCRIPTION
## Summary
- add standalone `mission_builder/` with Blockly blocks that export missions through `agents/task_orchestrator`
- persist setup wizard config status in `localStorage` to flag gaps across sessions
- document new mission builder path and wizard behavior in operator onboarding guide

## Testing
- `pre-commit run --files web_console/game_dashboard/setupWizard.js mission_builder/index.html mission_builder/mission_builder.js docs/operator_onboarding.md docs/INDEX.md` *(failed: verify-chakra-monitoring, verify-self-healing)*
- `pytest tests/agents/nazarick/test_task_orchestrator.py` *(failed: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68be3146ad4c832ea3693c7d1716437d