### PR TITLE
feat: add signal bus with kafka backend

### DIFF
--- a/communication/telegram_bot.py
+++ b/communication/telegram_bot.py
@@ -14,7 +14,7 @@ import logging
 from telegram import Update
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
-from connectors.signal_bus import publish, subscribe
+import connectors.signal_bus as signal_bus
 from connectors.message_formatter import format_message
 from .gateway import Gateway, authentication
 
@@ -47,7 +47,7 @@ class TelegramBot:
 
             self._application.create_task(_send())
 
-        subscribe("telegram:out", _outbound)
+        signal_bus.subscribe("telegram:out", _outbound)
 
     async def _handle_message(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -57,7 +57,7 @@ class TelegramBot:
         authentication.verify_token("telegram", self._token)
         user_id = str(update.effective_user.id)
         content = update.message.text or ""
-        publish("telegram:in", {"user": user_id, "content": content})
+        signal_bus.publish("telegram:in", {"user": user_id, "content": content})
         await self._gateway.handle_incoming("telegram", user_id, content)
 
     def run(self) -> None:

--- a/tools/bot_discord.py
+++ b/tools/bot_discord.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import requests
 
-from connectors.signal_bus import publish, subscribe
+import connectors.signal_bus as signal_bus
 from connectors.base import ConnectorHeartbeat
 from connectors.message_formatter import format_message
 
@@ -57,7 +57,7 @@ def create_client() -> Any:
     async def on_message(message: discord.Message) -> None:  # pragma: no cover
         if message.author.bot:
             return
-        publish(
+        signal_bus.publish(
             "discord:in",
             {
                 "channel": message.channel.id,
@@ -82,7 +82,7 @@ def create_client() -> Any:
         if channel:
             loop.create_task(channel.send(format_message("discord", text)))
 
-    subscribe("discord:out", _outbound)
+    signal_bus.subscribe("discord:out", _outbound)
 
     return client
 

--- a/tools/bot_telegram.py
+++ b/tools/bot_telegram.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import requests
 
-from connectors.signal_bus import publish, subscribe
+import connectors.signal_bus as signal_bus
 from connectors.base import ConnectorHeartbeat
 from connectors.message_formatter import format_message
 
@@ -60,7 +60,7 @@ def send_voice(chat_id: int, path: Path) -> None:
 
 def handle_message(chat_id: int, text: str) -> None:
     """Forward ``text`` to the GLM and return the reply."""
-    publish("telegram:in", {"chat_id": chat_id, "content": text})
+    signal_bus.publish("telegram:in", {"chat_id": chat_id, "content": text})
     reply = send_glm_command(text)
     send_message(chat_id, reply)
     try:
@@ -74,7 +74,7 @@ def handle_message(chat_id: int, text: str) -> None:
 
 
 if _API:
-    subscribe(
+    signal_bus.subscribe(
         "telegram:out",
         lambda payload: send_message(
             int(payload.get("chat_id", 0)), payload.get("content", "")


### PR DESCRIPTION
## Summary
- extend signal bus with optional Kafka backend and update backend selection
- route Discord and Telegram connectors through signal bus module
- cover signal bus selection and fan-out in tests

## Testing
- `pre-commit run --files communication/telegram_bot.py connectors/signal_bus.py tests/connectors/test_signal_bus.py tools/bot_discord.py tools/bot_telegram.py` *(mypy, pytest-cov skipped)*
- `pytest --no-cov tests/connectors/test_signal_bus.py` *(all tests skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68beae900ee8832e8a34cb7b3c87db9d