### PR TITLE
feat: expose recovery metadata in message formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Memory introspection API and dashboard panel for querying and purging chakra memories.
 - Documented chakra-tagged signals, heartbeat propagation, and recovery flows
   across connector and operator guides; added tests for connector links.
+- ``connectors.message_formatter`` wraps outbound messages with ``chakra``,
+  ``version``, and ``recovery_url`` metadata and now checks ``RECOVERY_URL`` at
+  call time.
 - MCP gateway exposes context registration and model invocation via MCP; added `config/mcp.toml` and `docs/mcp_overview.md`.
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -116,7 +116,10 @@ architectural context.
 ## Heartbeat Propagation
 
 Connectors forward heartbeat pings from the chakra cycle engine to remote
-clients and log the return path. Lagging or missing beats surface alignment
+clients and log the return path. Each ping is wrapped by
+``connectors.message_formatter.format_message``, which injects the `chakra`,
+`version`, and `recovery_url` fields so operators can trace problems and
+surface recovery instructions. Lagging or missing beats surface alignment
 issues early and are mirrored in the dashboards described in the system
 blueprint.
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -71,8 +71,10 @@ current status of each connector.
 #### Heartbeat Propagation
 
 Each beat cascades from Root through Crown, giving operators a live view of
-layer responsiveness. Lag or silence on any hop is logged for follow‑up and
-feeds recovery routines in other guides.
+layer responsiveness. Connectors emit these pings via
+``connectors.message_formatter.format_message`` so every hop carries the
+``chakra``, ``version``, and ``recovery_url`` fields. Lag or silence on any hop
+is logged for follow‑up and feeds recovery routines in other guides.
 
 #### Heartbeat Ratios
 

--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -1,0 +1,60 @@
+# Failure Inventory
+
+Failures from `pytest` runs are appended via [`scripts/capture_failing_tests.py`](../../scripts/capture_failing_tests.py).
+
+## Failures
+
+- 2025-09-08: ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
+
+- 2025-09-08: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/channel_schema.sql
+- 2025-09-08: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/agent_interactions.sql
+- 2025-09-08: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/timescaledb_agent_events.sql
+- 2025-09-08: ERROR    nlq_api:nlq_api.py:35 failed to train Vanna on schemas/log_schema.sql
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR    fastapi:utils.py:114 Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/agents/test_bana.py
+- 2025-09-08: ERROR tests/agents/test_bana_narrator.py
+- 2025-09-08: ERROR tests/connectors/test_avatar_broadcast.py
+- 2025-09-08: ERROR tests/connectors/test_connector_heartbeat.py
+- 2025-09-08: ERROR tests/crown/server/test_openwebui_bridge.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/crown/server/test_server.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/crown/test_orchestrator_music.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/integration/test_core_regressions.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/monitoring/test_escalation_notifier.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/narrative_engine/test_biosignal_transformation.py
+- 2025-09-08: ERROR tests/narrative_engine/test_dataset_hashes.py
+- 2025-09-08: ERROR tests/narrative_engine/test_event_storage.py
+- 2025-09-08: ERROR tests/narrative_engine/test_ingest_persist_retrieve.py
+- 2025-09-08: ERROR tests/narrative_engine/test_ingestion_to_mistral_output.py
+- 2025-09-08: ERROR tests/narrative_engine/test_jsonl_ingest_persist_retrieve.py
+- 2025-09-08: ERROR tests/razar/test_ai_invoker.py
+- 2025-09-08: ERROR tests/root/test_metrics_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_auto_retrain.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_autoretrain_full.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_avatar_state_logging.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_boot_sequence.py
+- 2025-09-08: ERROR tests/test_bots.py
+- 2025-09-08: ERROR tests/test_dashboard_app.py - AttributeError: 'str' object has no attribute 'dtype'
+- 2025-09-08: ERROR tests/test_dashboard_qnl_mixer.py - AttributeError: 'str' object has no attribute 'dtype'
+- 2025-09-08: ERROR tests/test_emotion_classifier.py - AttributeError: 'types.SimpleNamespace' object has no attribute 'RandomState'
+- 2025-09-08: ERROR tests/test_initial_listen.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_interconnectivity.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_memory_bundle.py - AttributeError: module 'conftest' has no attribute 'ALLOWED_TESTS'
+- 2025-09-08: ERROR tests/test_memory_bus.py - AttributeError: module 'conftest' has no attribute 'ALLOWED_TESTS'
+- 2025-09-08: ERROR tests/test_mix_tracks.py
+- 2025-09-08: ERROR tests/test_operator_api.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/test_operator_audit.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/test_operator_command_route.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/test_quarantine_manager.py
+- 2025-09-08: ERROR tests/test_retrain_model.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_spiral_cortex_memory.py - AttributeError: module 'feedback_logging' has no attribute 'NOVELTY_THRESHOLD'
+- 2025-09-08: ERROR tests/test_transformers_generate.py - ValueError: cv2.__spec__ is None
+- 2025-09-08: ERROR tests/test_vector_memory.py
+- 2025-09-08: ERROR tests/test_voice_cloner_cli.py
+- 2025-09-08: ERROR tests/web_console/test_conversation_timeline.py - RuntimeError: Form data requires "python-multipart" to be installed.
+- 2025-09-08: ERROR tests/web_operator/test_api.py

--- a/tests/connectors/test_message_formatter.py
+++ b/tests/connectors/test_message_formatter.py
@@ -32,3 +32,10 @@ def test_format_message_defaults_present() -> None:
     assert data["chakra"] == "root"
     assert data["version"]
     assert data["recovery_url"]
+
+
+def test_format_message_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("RECOVERY_URL", "env-url")
+    msg = format_message("root", "hi")
+    data = json.loads(msg)
+    assert data["recovery_url"] == "env-url"


### PR DESCRIPTION
## Summary
- surface chakra, version, and recovery URL metadata in connector messages
- document heartbeat propagation through connectors and blueprint
- verify recovery URL overrides via new tests

## Testing
- `pre-commit run --files connectors/message_formatter.py tests/connectors/test_message_formatter.py docs/communication_interfaces.md docs/system_blueprint.md CHANGELOG.md docs/testing/failure_inventory.md` *(fails: mypy errors, doc-indexer modified files, pytest-cov coverage check, missing agents modules)*
- `pytest tests/connectors/test_message_formatter.py --no-cov` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68beb466b100832eb88997060dd9aab5