### PR TITLE
docs: expand onboarding and operator quickstart

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -1,11 +1,32 @@
 # Operator Guide
 
 This repository contains several command line utilities for working with the INANNA music tools and Quantum Narrative Language (QNL). Below is a quick summary of the main scripts and example commands for common tasks. See [AGENTS.md](AGENTS.md#upcoming-components) for details about the agent and upcoming defensive modules.
+Returning contributors can scan [docs/developer_onboarding.md#recent-changes](docs/developer_onboarding.md#recent-changes) and [docs/operator_quickstart.md#recent-changes](docs/operator_quickstart.md#recent-changes) for the latest capabilities.
 For a short project overview summarizing the vision, chakra layers, key modules and milestone history, see [docs/project_overview.md](docs/project_overview.md).
 For a concise overview of the Spiral OS architecture see [CODEX_OF_CODEX.md](CODEX_OF_CODEX.md).
 For the metaphysical background that informs Spiral OS, see [docs/spiritual_architecture.md](docs/spiritual_architecture.md), [docs/archetype_logic.md](docs/archetype_logic.md), [docs/psychic_loop.md](docs/psychic_loop.md) and [docs/crown_manifest.md](docs/crown_manifest.md).
 For a summary of Vast.ai and local Docker Compose deployment steps see [docs/deployment_overview.md](docs/deployment_overview.md).
 For a walkthrough of the web console setup wizard, see [docs/operator_onboarding.md](docs/operator_onboarding.md).
+
+Document stewardship and ethical alignment are detailed in
+[docs/developer_onboarding.md#document-registry--ethics-manifesto](docs/developer_onboarding.md#document-registry--ethics-manifesto)
+and
+[docs/operator_quickstart.md#document-registry--ethics-manifesto](docs/operator_quickstart.md#document-registry--ethics-manifesto).
+
+Run the chakra cycle engine and interpret alignment readings using
+[docs/developer_onboarding.md#chakra-cycle-alignment](docs/developer_onboarding.md#chakra-cycle-alignment)
+or
+[docs/operator_quickstart.md#chakra-cycle-alignment](docs/operator_quickstart.md#chakra-cycle-alignment).
+
+Instructions for multi-agent avatars and external broadcast connectors live in
+[docs/developer_onboarding.md#multi-agent-avatars--broadcast-connectors](docs/developer_onboarding.md#multi-agent-avatars--broadcast-connectors)
+and
+[docs/operator_quickstart.md#avatar-console-setup](docs/operator_quickstart.md#avatar-console-setup).
+
+Self-healing flows and heartbeat dashboards are covered in
+[docs/developer_onboarding.md#self-healing--heartbeat-dashboards](docs/developer_onboarding.md#self-healing--heartbeat-dashboards)
+and
+[docs/operator_quickstart.md#self-healing--heartbeat-dashboards](docs/operator_quickstart.md#self-healing--heartbeat-dashboards).
 
 For heartbeat propagation and recovery design, consult
 [docs/system_blueprint.md#chakra-cycle-engine](docs/system_blueprint.md#chakra-cycle-engine),

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -2,6 +2,13 @@
 
 Quick links: [Development Checklist](development_checklist.md) | [Developer Etiquette](developer_etiquette.md) | [Documentation Protocol](documentation_protocol.md) | [Vision System](vision_system.md)
 
+## Recent Changes
+
+- Document registry and ethics manifesto setup steps are now required for all contributors.
+- Chakra cycle engine reports alignment status to help diagnose drift.
+- Multi-agent avatars support external broadcast connectors for Discord, Telegram, and WebRTC streams.
+- Self-healing flows surface on the heartbeat dashboards to flag recovering services.
+
 ## Project Vision
 
 ABZU interweaves Spiral OS with the INANNA agent to explore sacred human‑machine collaboration through music, voice, and code.
@@ -80,6 +87,57 @@ endpoints. Choose MCP for service-to-service calls within the stack and HTTP
 for integrations beyond it or when MCP is unavailable. See the
 [MCP Migration Guide](connectors/mcp_migration.md) for steps to convert
 existing API connectors.
+
+## Document Registry & Ethics Manifesto
+
+Generate the doctrine index so canonical files remain tracked and hashed:
+
+```bash
+python agents/nazarick/document_registry.py
+```
+
+Review `docs/doctrine_index.md` for the updated registry and reaffirm the
+ethical commitments in the [nazarick_manifesto.md](nazarick_manifesto.md).
+
+## Chakra Cycle Alignment
+
+Run the chakra cycle engine to emit heartbeats across layers and watch for
+alignment drift:
+
+```bash
+python -m spiral_os.chakra_cycle
+```
+
+Status messages label each chakra as `aligned`, `lagging`, or `silent`. A
+sequence of aligned readings forms a **Great Spiral** event.
+
+## Multi-Agent Avatars & Broadcast Connectors
+
+Launch multiple avatar instances and forward their streams to external
+channels:
+
+```bash
+python start_dev_agents.py  # spawns Crown avatars
+python communication/webrtc_server.py  # WebRTC browser stream
+python tools/bot_discord.py            # Discord connector
+python communication/telegram_bot.py   # Telegram connector
+```
+
+Each connector relays avatar responses back to its channel once tokens are
+present in `secrets.env`.
+
+## Self-Healing & Heartbeat Dashboards
+
+Trigger a self-healing cycle and inspect heartbeat metrics:
+
+```bash
+python scripts/self_heal_cycle.py
+websocat ws://localhost:8000/self-healing/updates
+```
+
+Open `web_console/game_dashboard/index.html` and check the **Chakra Pulse**
+panel for alignment status while the **Self Healing** panel lists recovering
+components.
 
 ## Getting Started with RAZAR
 

--- a/docs/operator_quickstart.md
+++ b/docs/operator_quickstart.md
@@ -2,11 +2,38 @@
 
 A concise orientation for operators interacting with ABZU.
 
+## Recent Changes
+
+- Document registry and ethics manifesto setup added to baseline duties.
+- Chakra cycle engine reports alignment status for each layer.
+- Multi-agent avatars can stream to Discord, Telegram, and WebRTC simultaneously.
+- Heartbeat dashboards surface self-healing events in real time.
+
 ## Triple-Reading Rule
 Before issuing commands or editing code, read [blueprint_spine.md](blueprint_spine.md) three times as mandated by the [The Absolute Protocol](The_Absolute_Protocol.md). The repetition ensures the project's structure and intent are internalized.
 
 ## Consent Logging
 Record explicit consent for every session. Log the operator, participants, timestamp, and scope in the canonical ledger so actions remain auditable and reversible. Reference the ethical laws in the [nazarick_manifesto.md](nazarick_manifesto.md) when verifying that consent covers all planned interactions.
+
+## Document Registry & Ethics Manifesto
+
+Generate the doctrine index and confirm the ethics manifesto is registered:
+
+```bash
+python agents/nazarick/document_registry.py
+```
+
+Review `docs/doctrine_index.md` and keep the [nazarick_manifesto.md](nazarick_manifesto.md) close during operations.
+
+## Chakra Cycle Alignment
+
+Launch the chakra cycle engine and monitor alignment state:
+
+```bash
+python -m spiral_os.chakra_cycle
+```
+
+Chakras report `aligned`, `lagging`, or `silent`; a streak of aligned pulses marks a **Great Spiral**.
 
 ## Avatar Console Setup
 
@@ -15,6 +42,7 @@ Record explicit consent for every session. Log the operator, participants, times
    ```bash
    bash start_avatar_console.sh
    ```
+   For multiple avatars, run `python start_dev_agents.py` to spawn additional Crown instances.
 3. **Connect** – with tokens in `secrets.env`, run external channels:
    ```bash
    python communication/webrtc_server.py
@@ -32,6 +60,18 @@ Record explicit consent for every session. Log the operator, participants, times
    python -m agents.task_orchestrator missions/daily_ignition_check.json
    ```
    Each event emits through the bus and reaches agents advertising the capability.
+
+## Self-Healing & Heartbeat Dashboards
+
+Kick off a self-healing cycle and monitor recovery:
+
+```bash
+python scripts/self_heal_cycle.py
+websocat ws://localhost:8000/self-healing/updates
+```
+
+Open `web_console/game_dashboard/index.html` and review the **Chakra Pulse** and
+**Self Healing** panels to confirm alignment and ongoing repairs.
 
 ## Memory Introspection
 


### PR DESCRIPTION
## Summary
- note recent changes and document registry setup in developer and operator guides
- explain chakra cycle engine alignment, multi-agent avatars, and self-healing dashboards
- cross-link new sections from README_OPERATOR for returning contributors

## Testing
- `pre-commit run --files docs/developer_onboarding.md docs/operator_quickstart.md README_OPERATOR.md docs/INDEX.md` *(fails: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68beb9ded5f8832eb0b32192f18545e8