### PR TITLE
Clarify connector protocols and heartbeat flow

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -109,20 +109,20 @@ implementation notes.
 ### **Connector Matrix**
 
 ABZU exposes multiple connectors, each tagged with a `chakra` and a
-`cycle_count` heartbeat. This matrix summarises their interface style. Detailed
-setup steps live in the
-[communication_interfaces](communication_interfaces.md#connector-matrix) guide,
-while architectural placement appears in the
+`cycle_count` heartbeat. This matrix summarises each connector's purpose,
+protocol choice, heartbeat behaviour, and version. Detailed setup steps live in
+the [communication_interfaces](communication_interfaces.md#connector-matrix)
+guide, while architectural placement appears in the
 [System Blueprint](system_blueprint.md#connector-matrix).
 
-| Connector | Interface | Heartbeat (`chakra`, `cycle_count`) | Version |
-|-----------|-----------|-------------------------------------|---------|
-| WebRTC | API | Forwards beats with both fields over the data channel. | 0.3.3 |
-| Discord Bot | API + MCP | Emits `discord` beats and mirrors cycle counts to channels. | 0.3.0 |
-| Telegram Bot | API + MCP | Emits `telegram` beats with cycle counts. | 0.1.0 |
-| Avatar Broadcast | API | Relays heartbeat events to social streams. | 0.1.0 |
-| Primordials API | API | Posts metrics tagged with both fields. | 0.1.1 |
-| MCP Gateway Example | MCP | Uses MCP handshake with heartbeat metadata. | 0.1.0 |
+| Connector | Purpose | Protocol | Heartbeat (`chakra`, `cycle_count`) | Version |
+|-----------|---------|----------|-------------------------------------|---------|
+| WebRTC | Real-time browser media stream | API – browsers rely on WebRTC/HTTP | Forwards beats with both fields over the data channel. | 0.3.3 |
+| Discord Bot | Community chat bridge | API + MCP – Discord API externally, MCP internally for logging | Emits `discord` beats and mirrors cycle counts to channels. | 0.3.0 |
+| Telegram Bot | Remote chat control | API + MCP – Telegram API externally, MCP internally to unify command dispatch | Emits `telegram` beats with cycle counts. | 0.1.0 |
+| Avatar Broadcast | Stream avatar frames to social platforms | API – social platforms expose HTTP endpoints only | Relays heartbeat events to social streams. | 0.1.0 |
+| Primordials API | Metric bridge to upstream Primordials service | API – external service lacks MCP | Posts metrics tagged with both fields. | 0.1.1 |
+| MCP Gateway Bridge | Demonstrates pure MCP requests for internal models | MCP – showcases full MCP handshake | Uses MCP handshake with heartbeat metadata. | 0.1.0 |
 
 ### **Model Context Protocol Migration**
 
@@ -164,9 +164,9 @@ servants to mend the break and rejoin the cycle.
 For layer-specific responsibilities, see
 [Chakra Architecture](chakra_architecture.md#chakra-cycle-engine) and
 [Nazarick Agents](nazarick_agents.md). Connector heartbeat formats are detailed
-in [communication_interfaces.md](communication_interfaces.md#connector-matrix)
-and [system_blueprint.md](system_blueprint.md#connector-matrix). The remediation
-philosophy follows the
+in [communication_interfaces.md](communication_interfaces.md#heartbeat-propagation)
+and [system_blueprint.md](system_blueprint.md#heartbeat-propagation). The
+remediation philosophy follows the
 [Self-Healing Manifesto](self_healing_manifesto.md).
 
 ### **Recovery Flows**

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -80,19 +80,21 @@ current status of each connector.
 #### Connector Matrix
 
 ABZU bridges external and internal services through a mix of API and MCP
-connectors. The table summarises their interface type and heartbeat behaviour.
-See [communication_interfaces.md](communication_interfaces.md#connector-matrix)
-for setup steps and versions, and
-[blueprint_spine.md](blueprint_spine.md#connector-matrix) for narrative context.
+connectors. The table summarises each connector's purpose, protocol choice,
+heartbeat behaviour, and version. See
+[communication_interfaces.md](communication_interfaces.md#connector-matrix) for
+setup steps and
+[blueprint_spine.md](blueprint_spine.md#connector-matrix) for narrative
+context.
 
-| Connector | Interface | Heartbeat (`chakra`, `cycle_count`) |
-|-----------|-----------|-------------------------------------|
-| WebRTC | API | Data channel pings include both fields. |
-| Discord Bot | API + MCP | Publishes `discord` beats and relays cycle counts to channels. |
-| Telegram Bot | API + MCP | Emits `telegram` beats with cycle counts. |
-| Avatar Broadcast | API | Relays heartbeat events with both fields to social streams. |
-| Primordials API | API | Posts metrics tagged with `chakra` and `cycle_count`. |
-| MCP Gateway Example | MCP | Uses MCP handshake with heartbeat metadata. |
+| Connector | Purpose | Protocol | Heartbeat (`chakra`, `cycle_count`) | Version |
+|-----------|---------|----------|-------------------------------------|---------|
+| WebRTC | Real-time browser media stream | API – browsers rely on WebRTC/HTTP | Data channel pings include both fields. | 0.3.3 |
+| Discord Bot | Community chat bridge | API + MCP – Discord API externally, MCP internally for logging | Publishes `discord` beats and relays cycle counts to channels. | 0.3.0 |
+| Telegram Bot | Remote chat control | API + MCP – Telegram API externally, MCP internally to unify command dispatch | Emits `telegram` beats with cycle counts. | 0.1.0 |
+| Avatar Broadcast | Stream avatar frames to social platforms | API – social platforms expose HTTP endpoints only | Relays heartbeat events with both fields to social streams. | 0.1.0 |
+| Primordials API | Metric bridge to upstream Primordials service | API – external service lacks MCP | Posts metrics tagged with `chakra` and `cycle_count`. | 0.1.1 |
+| MCP Gateway Bridge | Demonstrates pure MCP requests for internal models | MCP – showcases full MCP handshake | Uses MCP handshake with heartbeat metadata. | 0.1.0 |
 
 #### Heartbeat Propagation
 
@@ -101,7 +103,10 @@ layer responsiveness. Connectors emit these pings via
 ``connectors.message_formatter.format_message`` so every hop carries the
 ``chakra``, ``cycle_count``, ``version``, and ``recovery_url`` fields. Lag or
 silence on any hop is logged for follow‑up and feeds recovery routines in other
-guides.
+guides. Connector-level behaviour is described in
+[communication_interfaces.md](communication_interfaces.md#heartbeat-propagation)
+and the self-healing flow appears in
+[blueprint_spine.md](blueprint_spine.md#heartbeat-propagation-and-self-healing).
 
 #### Heartbeat Ratios
 


### PR DESCRIPTION
## Summary
- detail connector purpose, protocol rationale, and heartbeat propagation across docs
- add setup guidance for Primordials API and MCP gateway bridge
- cross-link heartbeat propagation sections for easier navigation

## Testing
- `python scripts/check_connectors.py`
- `python scripts/verify_docs_up_to_date.py`
- `pre-commit run --files docs/communication_interfaces.md docs/system_blueprint.md docs/blueprint_spine.md docs/INDEX.md` *(fails: connection refused for verify-chakra-monitoring metrics exporters)*

------
https://chatgpt.com/codex/tasks/task_e_68becfbeedac832eb42e2d719290b4a4