### PR TITLE
Add optional memory fallbacks

### DIFF
--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -135,10 +135,13 @@ results = aggregate_search("omen", source_weights={"spiritual": 2.0})
 
 ## Optional Layers
 
-Some memory layers rely on external services and may be absent. The package
-automatically substitutes the corresponding module from `memory/optional/`
-whenever an import fails, exposing the same public API but returning empty
-results. Fallback layers are reported as `defaulted`, and calls such as
+Some memory layers rely on external services and may be absent. Each has a
+no-op fallback in `memory/optional/`—including `cortex`, `emotional`, `mental`,
+`spiritual`, `narrative_engine`, `vector_memory`, `spiral_memory`, `search`,
+`search_api`, and `music_memory`. When a layer import raises
+`ModuleNotFoundError`, initialization automatically loads the matching
+fallback, which exposes the same public API but returns empty data structures.
+Fallback layers are reported as `defaulted`, and calls such as
 `aggregate_search` simply yield empty results for them while logging any
 underlying errors. Queries still return data from the remaining active layers.
 

--- a/memory/optional/__init__.py
+++ b/memory/optional/__init__.py
@@ -9,4 +9,6 @@ __all__ = [
     "vector_memory",
     "spiral_memory",
     "search",
+    "search_api",
+    "music_memory",
 ]

--- a/memory/optional/music_memory.py
+++ b/memory/optional/music_memory.py
@@ -1,0 +1,35 @@
+"""No-op music memory layer used when the real implementation is unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, Dict, List, Sequence
+
+Vector = Sequence[float]
+
+
+def add_track(
+    embedding: Vector,
+    metadata: Dict[str, Any],
+    emotion: str,
+    *,
+    track_id: str | None = None,
+    db_path: Any | None = None,
+) -> str:
+    """Discard music tracks and return an empty identifier."""
+    return track_id or ""
+
+
+def query_tracks(
+    embedding: Vector,
+    *,
+    k: int = 5,
+    emotion: str | None = None,
+    db_path: Any | None = None,
+) -> List[Dict[str, Any]]:
+    """Return an empty list as no tracks are stored."""
+    return []
+
+
+__all__ = ["add_track", "query_tracks", "Vector"]

--- a/memory/optional/search_api.py
+++ b/memory/optional/search_api.py
@@ -1,0 +1,15 @@
+"""Fallback search API returning no results."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Any, Dict, List
+
+
+def aggregate_search(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+    """Return an empty list when search dependencies are unavailable."""
+    return []
+
+
+__all__ = ["aggregate_search"]


### PR DESCRIPTION
## Summary
- add no-op fallback modules for search and music memory layers
- load fallback modules when imports fail due to missing dependencies
- document optional layer behavior and defaulted status in memory layers guide

## Testing
- `pre-commit run --files docs/memory_layers_GUIDE.md memory/__init__.py memory/bundle.py memory/optional/__init__.py memory/optional/music_memory.py memory/optional/search_api.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; no successful self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed839b87c832ea1068f9eaeabe417