### PR TITLE
docs: clarify world bootstrap workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `world export`/`world import` utilities and automatic registration of
   model endpoints.
 - Expanded `bootstrap_world.py` to initialize memory layers, start Crown, and load agent profiles; exposed as `abzu-bootstrap-world`.
+- `bootstrap_world.py` now logs completion after mandatory layers and agent profiles initialize.
 - Enforced explicit health probes for RAZAR boot components and added boot
   sequence tests.
 - Memory introspection API with query, purge, and snapshot endpoints plus web console memory panel.

--- a/component_index.json
+++ b/component_index.json
@@ -834,7 +834,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/bootstrap_world.py",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": [
         "__future__",
         "agents",
@@ -3813,7 +3813,7 @@
       "chakra": "unknown",
       "type": "connector",
       "path": "connectors/mcp_gateway_example.py",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": [
         "__future__",
         "httpx",

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,14 +44,14 @@ abzu-memory-bootstrap
 ## Setup
 - [Setup Guide](setup.md)
 - [Environment Setup](environment_setup.md)
-- [Quickstart Setup](setup_quickstart.md) – minimal world configuration
+- [Quickstart Setup](setup_quickstart.md) – minimal installation and world creation
 ## Usage
 - [How to Use](how_to_use.md)
 - [UI Service](ui_service.md) – lightweight FastAPI interface for memory queries
 - [Operator Console](operator_console.md) – Arcade UI for Operator API commands
 - [Arcade UI](arcade_ui.md) – features, env vars, quickstart, and memory scan sequence
 - [Operator Interface Guide](operator_interface_GUIDE.md) – REST endpoints for Crown and RAZAR control
-- [Bootstrap World Script](../scripts/bootstrap_world.py) – populate mandatory layers with defaults
+- [Bootstrap World Script](../scripts/bootstrap_world.py) – initialize mandatory layers and report status
 
 ## Data
 - [Data Manifest](data_manifest.md)

--- a/docs/setup_quickstart.md
+++ b/docs/setup_quickstart.md
@@ -14,10 +14,12 @@
 
 ## World Creation
 
-After installation, create and initialize a world with:
+After installation, bootstrap the default world:
 
 ```bash
 abzu-bootstrap-world
 ```
 
-The command prepares local file-backed memory stores under `data/`, starts Crown services, and launches required agent profiles. Set `WORLD_NAME` to select a specific world manifest; otherwise, the default manifest is used.
+The command wraps `scripts/bootstrap_world.py`, which prepares file-backed memory stores under `data/`, initializes mandatory layers, and prints the status for each. Set `WORLD_NAME` to select a specific manifest; otherwise, the default manifest is used.
+
+Run `abzu-bootstrap-world -h` for optional arguments and flags.

--- a/scripts/bootstrap_world.py
+++ b/scripts/bootstrap_world.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Initialize memory layers, start Crown, and load agent profiles."""
+"""Initialize mandatory layers, start Crown, and report readiness."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from init_crown_agent import initialize_crown
 from memory.bundle import MemoryBundle
 from worlds.services import load_manifest, warn_missing_services
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 def _prepare_file_backed_storage(root: Path) -> None:
@@ -58,6 +58,8 @@ def main() -> None:
     events = launch_required_agents()
     for event in events:
         logging.info("agent %s: %s", event.get("agent"), event.get("status"))
+
+    logging.info("World bootstrap complete")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document minimal installation and world creation steps
- note world bootstrap script status reporting
- link quickstart guide and script from docs index

## Testing
- `pre-commit run --files docs/setup_quickstart.md` *(fails: Component alpha lacks a health probe; coverage 7.27% < 80%)*
- `python scripts/verify_docs_up_to_date.py`

------
https://chatgpt.com/codex/tasks/task_e_68bee2e70fa0832ebd05b46c67d5590b