### PR TITLE
feat: add sacred memory fallback

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -351,7 +350,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.4 **Last updated:** 2025-09-07 | `../scripts/bootstrap_memory.py` |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.5 **Last updated:** 2025-09-08 | `../scripts/bootstrap_memory.py` |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,7 +1,7 @@
 # Memory Layers Guide
 
-**Version:** v1.0.4
-**Last updated:** 2025-09-07
+**Version:** v1.0.5
+**Last updated:** 2025-09-08
 
 This guide describes the event bus protocol and query flow connecting the
 Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
@@ -138,7 +138,7 @@ results = aggregate_search("omen", source_weights={"spiritual": 2.0})
 Some memory layers rely on external services and may be absent. Each has a
 no-op fallback in `memory/optional/`—including `cortex`, `emotional`, `mental`,
 `spiritual`, `narrative_engine`, `vector_memory`, `spiral_memory`, `search`,
-`search_api`, and `music_memory`. When a layer import raises
+`search_api`, `music_memory`, and `sacred`. When a layer import raises
 `ModuleNotFoundError`, initialization automatically loads the matching
 fallback, which exposes the same public API but returns empty data structures.
 Fallback layers are reported as `defaulted`, and calls such as

--- a/memory/optional/__init__.py
+++ b/memory/optional/__init__.py
@@ -11,4 +11,5 @@ __all__ = [
     "search",
     "search_api",
     "music_memory",
+    "sacred",
 ]

--- a/memory/optional/sacred.py
+++ b/memory/optional/sacred.py
@@ -1,0 +1,26 @@
+"""No-op sacred glyph generator when torch or Pillow are unavailable."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+SACRED_DIR = Path("data/sacred")
+
+
+class SacredVAE:  # pragma: no cover - placeholder stub
+    """Placeholder VAE returning empty artifacts."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        pass
+
+
+def generate_sacred_glyph(inputs: Dict[str, Iterable[float]]) -> Tuple[Path, str]:
+    """Return an empty path and phrase when sacred dependencies are missing."""
+
+    return Path(), ""
+
+
+__all__ = ["generate_sacred_glyph", "SacredVAE", "SACRED_DIR"]


### PR DESCRIPTION
## Summary
- add `sacred` placeholder module that yields empty results
- expose optional `sacred` layer in fallback package
- document optional layer behavior including new `sacred` fallback

## Testing
- `PYTHONPATH=$PWD pre-commit run --files memory/optional/sacred.py memory/optional/__init__.py docs/memory_layers_GUIDE.md` *(fails: missing metrics exporters and self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68beea2e3374832e9669a1230d2bc967