### PR TITLE
feat(razar): retry handover with health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mission brief and operator chat examples with connector checklist cross-links in Crown and operator docs.
 - Removed unused `boot_sequence` placeholder from `orchestration_master.py`.
 - Hardened Crown prompt orchestrator to target known exceptions and surface unexpected failures.
+- Boot orchestrator reruns health checks after AI-generated patches and stops
+  after the configurable `--remote-attempts` limit, logging each handover.
 
 ### Chakra Versions
 

--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Bumped `crown_handshake` to 0.2.4 and recorded version in connector registry.
 - Boot orchestrator retries failed components with `ai_invoker.handover` and
   logs each attempt in `logs/razar_ai_invocations.json`.
+- AI handover retry loop reruns health checks after each patch and aborts after
+  a configurable attempt limit.
 
 ## [0.1.0] - 2025-08-30
 

--- a/docs/recovery_playbook.md
+++ b/docs/recovery_playbook.md
@@ -13,9 +13,9 @@ propagation are documented in
 1. The boot orchestrator launches components in priority order.
 2. Each launch runs a service-specific probe from `agents.razar.health_checks`.
 3. On failure the orchestrator retries the component locally a limited number of times.
-4. If local retries fail, `ai_invoker.handover(component, error, use_opencode=True)` requests an automated patch. Each attempt is logged to `logs/razar_ai_invocations.json`.
-5. When run with `--long-task`, the orchestrator keeps invoking the handover until the component passes its health check or the operator aborts with `Ctrl+C`. Each attempt and resulting patch is appended to `logs/razar_long_task.json`.
-6. Without `--long-task`, returned patches are applied and the health check reruns until it succeeds or the remote attempt limit is reached.
+4. If local retries fail, `ai_invoker.handover(component, error, use_opencode=True)` requests an automated patch and then reruns the component's health check.
+5. The orchestrator repeats this handover/health‑check loop until the component recovers or the configured `--remote-attempts` limit is hit. Each attempt is logged to `logs/razar_ai_invocations.json`.
+6. When run with `--long-task`, the orchestrator keeps invoking the handover indefinitely until the component passes its health check or the operator aborts with `Ctrl+C`. Each attempt and resulting patch is appended to `logs/razar_long_task.json`.
 7. After exhausting remote attempts or an operator abort, the component's metadata is quarantined under `quarantine/` and an entry is appended to `docs/quarantine_log.md`.
 8. The last successful component is recorded in `logs/razar_state.json` so subsequent runs resume from that point.
 


### PR DESCRIPTION
## Summary
- re-run component health checks after each AI-generated patch
- document handover retry loop and update changelogs

## Testing
- `python scripts/verify_docs_up_to_date.py`
- `PYTHONPATH=. pre-commit run --files razar/boot_orchestrator.py docs/recovery_playbook.md CHANGELOG.md CHANGELOG_razar.md` *(fails: connection refused querying metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68beed4da520832ebde405fef24f2a06