### PR TITLE
feat: add telemetry spans and service metrics

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -179,6 +179,11 @@ curl http://localhost:8000/healthz
 curl http://localhost:8000/metrics | head
 ```
 
+To explore dashboards:
+
+1. Start a Prometheus server scraping each service's `/metrics` endpoint.
+2. Launch Grafana and import `monitoring/grafana-dashboard.json` for default panels.
+
 Agent interactions emit OpenTelemetry spans. With the collector running and
 `OTEL_EXPORTER_OTLP_ENDPOINT` set, spans appear in the collector's UI for
 correlation with metrics. Memory queries emit spans for each layer, enabling


### PR DESCRIPTION
## Summary
- trace event publication and consumption in `agents.event_bus`
- add span instrumentation for memory queries
- document `/metrics` and `/healthz` usage with Prometheus/Grafana

## Testing
- `pre-commit run --files agents/event_bus.py memory_store.py memory/narrative_engine.py docs/operations.md`
- `python scripts/verify_docs_up_to_date.py`
- `pytest tests/test_metrics_endpoints.py tests/narrative_engine/test_ingest_persist_retrieve.py` *(fails: ModuleNotFoundError: No module named 'data.biosignals')*

------
https://chatgpt.com/codex/tasks/task_e_68beefc4206c832e90ed3937f86db09d