### PR TITLE
docs: add failure recovery overview

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -61,6 +61,23 @@ graph LR
     C --> E[aggregated response]
 ```
 
+## Failure Modes & Recovery
+
+Spiral OS shields operators from component faults through layered defenses.
+Defensive querying returns partial results when a memory layer is missing, and
+each module automatically falls back to an optional stub instead of raising an
+error. RAZAR watches heartbeat telemetry and, upon detection of a silent
+component, invokes repair loops that patch or restart the failing service.
+
+```mermaid
+graph LR
+    Detect[Detection] --> Fallback
+    Fallback --> Recover[Recovery]
+```
+
+See the [Memory Layers Guide](memory_layers_GUIDE.md) for fallback mechanics
+and the [Recovery Playbook](recovery_playbook.md) for detailed repair flows.
+
 ## Ethics Corpus Update Flow
 
 ```mermaid


### PR DESCRIPTION
## Summary
- document defensive querying, layer fallbacks, and RAZAR repair loops
- link to memory layer and recovery guides

## Testing
- `PYTHONPATH=. pre-commit run --files docs/project_overview.md` *(fails: missing metrics exporters and self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bef3c09fec832e9f58a557c51e4109