### PR TITLE
Document Nazarick avatar & voice stack with UI pipeline diagram

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -334,6 +334,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [figures/layer_init_query_flow.mmd](figures/layer_init_query_flow.mmd) | layer_init_query_flow.mmd | - | - |
 | [figures/memory_bundle.mmd](figures/memory_bundle.mmd) | Memory bundle initialization and query aggregation diagram | Version: v1.1.0 Last updated: 2025-09-07 | - |
 | [figures/memory_layer_flow.mmd](figures/memory_layer_flow.mmd) | Memory layer flow diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/nazarick_ui_pipeline.mmd](figures/nazarick_ui_pipeline.mmd) | nazarick_ui_pipeline.mmd | - | - |
 | [figures/operator_query_sequence.mmd](figures/operator_query_sequence.mmd) | Operator query sequence diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
 | [figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd) | Query memory aggregation diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
 | [frontend_dependencies.md](frontend_dependencies.md) | Frontend Dependencies | This page outlines the core libraries used by the `floor_client` interface. Refer to each project's documentation for... | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -44,6 +44,16 @@ Contributors must pair system enhancements with operator-facing improvements, up
     - **Crown**: High-level orchestration (RAZAR).
 - Agents like **Prompt Orchestrator**, **QNL Engine**, **Memory Scribe**, and **Nazarick Servants** manage specialized roles in this hierarchy.
 
+### Avatar & Voice Stack
+
+Nazarick's servant interface streams coordinated visuals and audio through a unified avatar and voice stack. Personality templates shape each servant's style and tone: [Albedo](../agents/nazarick/albedo_agent_template.md), [Cocytus](../agents/nazarick/cocytus_agent_template.md), [Demurge](../agents/nazarick/demurge_agent_template.md), [Gargantua](../agents/nazarick/gargantua_agent_template.md), [Pandora](../agents/nazarick/pandora_agent_template.md), [Pleiades](../agents/nazarick/pleiades_agent_template.md), [Sebastiara](../agents/nazarick/sebastiara_agent_template.md), and [Shalltear](../agents/nazarick/shalltear_agent_template.md).
+
+```mermaid
+{{#include figures/nazarick_ui_pipeline.mmd}}
+```
+
+The Mermaid source lives at [figures/nazarick_ui_pipeline.mmd](figures/nazarick_ui_pipeline.mmd).
+
 ### **Memory Bundle**
 
 ABZU synchronizes its Cortex, Emotional, Mental, Spiritual, and Narrative stores through a unified memory bundle. `broadcast_layer_event("layer_init")` boots all layers in parallel, and `query_memory` fans out reads across them before combining results into a single response that an Operator Agent can relay to consoles.

--- a/docs/figures/nazarick_ui_pipeline.mmd
+++ b/docs/figures/nazarick_ui_pipeline.mmd
@@ -1,0 +1,7 @@
+graph LR
+    Operator[Operator] -->|commands| UI[Nazarick UI]
+    UI -->|selects| Templates[Nazarick Personality Templates]
+    Templates --> Avatar[Avatar Renderer]
+    Templates --> Voice[Voice Synthesizer]
+    Avatar -->|frames| Display[Operator Display]
+    Voice -->|audio| Speakers[Operator Speakers]

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ abzu-memory-bootstrap
 - [Crown Guide](Crown_GUIDE.md) – routes operator commands to servant models
 - [INANNA Guide](INANNA_GUIDE.md) – core GLM interface and memory access
 ## Nazarick
+- [Avatar & Voice Stack](blueprint_spine.md#avatar--voice-stack) – servant templates and UI pipeline
+- [Nazarick UI Pipeline](system_blueprint.md#avatar--voice-stack) – avatar and voice flow overview
 - [Great Tomb of Nazarick](great_tomb_of_nazarick.md)
 - [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)
 - [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -46,6 +46,17 @@ summary metrics are reported back to the Primordials service through
 `primordials_api`, ensuring upstream models receive continuous quality
 feedback.
 
+### Avatar & Voice Stack
+
+The Nazarick UI pipeline links personality templates to real‑time avatar and
+voice rendering. Templates such as [Albedo](../agents/nazarick/albedo_agent_template.md), [Cocytus](../agents/nazarick/cocytus_agent_template.md), [Demurge](../agents/nazarick/demurge_agent_template.md), [Gargantua](../agents/nazarick/gargantua_agent_template.md), [Pandora](../agents/nazarick/pandora_agent_template.md), [Pleiades](../agents/nazarick/pleiades_agent_template.md), [Sebastiara](../agents/nazarick/sebastiara_agent_template.md), and [Shalltear](../agents/nazarick/shalltear_agent_template.md) define the look and tone for each servant.
+
+```mermaid
+{{#include figures/nazarick_ui_pipeline.mmd}}
+```
+
+See [figures/nazarick_ui_pipeline.mmd](figures/nazarick_ui_pipeline.mmd) for the Mermaid source.
+
 ### Chakra Cycle Engine
 
 The chakra cycle engine distributes a steady heartbeat across every layer and


### PR DESCRIPTION
## Summary
- Expand blueprint and system blueprints with an **Avatar & Voice Stack** section linking Nazarick personality templates.
- Add a Nazarick UI pipeline Mermaid diagram to both sections and include figure source.
- Update Nazarick index entries to surface the new subsections and regenerate the documentation index.

## Testing
- `pre-commit run --files docs/blueprint_spine.md docs/system_blueprint.md docs/index.md docs/figures/nazarick_ui_pipeline.mmd docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3f2ba398832ea8a87711091abc29