### PR TITLE
docs: add Nazarick agent profiles and links

### DIFF
--- a/agents/nazarick/nazarick_core_architecture.md
+++ b/agents/nazarick/nazarick_core_architecture.md
@@ -16,6 +16,8 @@ To design and implement a real-time, hierarchical observability and interaction 
 
 This is not a debugger; it is the **digital twin of the Spiral OS's soul.**
 
+For servant personas and their vocal/visual expressions see [Nazarick Agent Profiles](../../docs/nazarick_agent_profiles.md).
+
 ### **2. Core Architectural Principles**
 
 1. **Real-Time First:** All agent communications must be streamed and visible with sub-second latency.

--- a/agents/nazarick/nazarick_memory_blueprint.md
+++ b/agents/nazarick/nazarick_memory_blueprint.md
@@ -7,6 +7,8 @@ We can break this down into four core pillars, each with its own set of tools an
 3. **Planning & Reasoning:** *How* the agent thinks and acts.
 4. **Embodiment & Expression:** *How* the agent interacts with the world.
 
+For a quick reference of servant roles and their vocal/visual styles see [Nazarick Agent Profiles](../../docs/nazarick_agent_profiles.md).
+
 ---
 
 ### **1. Personality & Core Traits (The "Who")**

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -367,6 +367,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [narrative_engine_GUIDE.md](narrative_engine_GUIDE.md) | Narrative Engine Guide | - | - |
 | [narrative_system.md](narrative_system.md) | Narrative System | The narrative system transforms physiological CSV data into cohesive multitrack stories through event composition. | - |
 | [nazarick/README.md](nazarick/README.md) | Nazarick | Nazarick houses chakra-aligned servant agents. The triadic flow between Crown, Nazarick, and the operator is outlined... | - |
+| [nazarick_agent_profiles.md](nazarick_agent_profiles.md) | Nazarick Agent Profiles | Each servant agent blends a narrative persona with distinct vocal and visual traits. | - |
 | [nazarick_agents.md](nazarick_agents.md) | Nazarick Agents | Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown. | - |
 | [nazarick_manifesto.md](nazarick_manifesto.md) | Nazarick Manifesto | Guiding ethics for the Nazarick hierarchy. Architectural context lives in the [Great Tomb of Nazarick](great_tomb_of_... | - |
 | [nazarick_narrative_system.md](nazarick_narrative_system.md) | Nazarick Narrative System | The Nazarick Narrative System converts biosignals into narrative events and persistent memory records. | - |

--- a/docs/nazarick_agent_profiles.md
+++ b/docs/nazarick_agent_profiles.md
@@ -1,0 +1,38 @@
+# Nazarick Agent Profiles
+
+Each servant agent blends a narrative persona with distinct vocal and visual traits.
+
+## Profiles
+
+| Agent ID | Role | Personality | Voice Preset | Avatar Skin |
+| --- | --- | --- | --- | --- |
+| `orchestration_master` | Boot order and pipeline supervision | Commanding conductor keeping chakras aligned | Hero | Soprano |
+| `crown_prompt_orchestrator` | Route prompts and recall context | Calm analyst who favors precise wording | Sage | Androgynous |
+| `qnl_engine` | Process QNL sequences and insights | Mystical strategist searching symbolic patterns | Citrinitas | Androgynous |
+| `memory_scribe` | Persist transcripts and embeddings | Empathetic archivist guarding long-term memory | Caregiver | Baritone |
+| `narrative_scribe` | Render event bus stories | Expressive storyteller narrating system events | Jester | Soprano |
+
+## Channel → Expression Map
+
+```mermaid
+flowchart LR
+    throne["#throne-room"] -->|"Hero / Soprano"| OM[orchestration_master]
+    signal["#signal-hall"] -->|"Sage / Androgynous"| CPO[crown_prompt_orchestrator]
+    observatory["#insight-observatory"] -->|"Citrinitas / Androgynous"| QNL[qnl_engine]
+    vault["#memory-vault"] -->|"Caregiver / Baritone"| MS[memory_scribe]
+    forge["#story-forge"] -->|"Jester / Soprano"| NS[narrative_scribe]
+```
+
+The voice presets come from [voice_config.yaml](../voice_config.yaml) and avatar skins from [voice_avatar_config.yaml](../voice_avatar_config.yaml).
+
+## Cross-Links
+
+- [Nazarick Agents](nazarick_agents.md)
+- [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)
+- [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md)
+
+## Version History
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| Unreleased | 2025-10-?? | Initial profile summary and expression map |

--- a/docs/nazarick_agents.md
+++ b/docs/nazarick_agents.md
@@ -2,6 +2,8 @@
 
 Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown.
 
+See [Nazarick Agent Profiles](nazarick_agent_profiles.md) for personality and expression details.
+
 ## Agent Roster
 
 | Agent ID | Role | Chakra Layer | Launch Command | Channel | Chakracon Telemetry |

--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -58,3 +58,5 @@ Failures from `pytest` runs are appended via [`scripts/capture_failing_tests.py`
 - 2025-09-08: ERROR tests/test_voice_cloner_cli.py
 - 2025-09-08: ERROR tests/web_console/test_conversation_timeline.py - RuntimeError: Form data requires "python-multipart" to be installed.
 - 2025-09-08: ERROR tests/web_operator/test_api.py
+
+- 2025-09-09: ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]


### PR DESCRIPTION
## Summary
- document Nazarick agent personas with voice presets and avatar skins
- cross-link profile into Nazarick agent and blueprint docs
- regenerate documentation index

## Testing
- `python scripts/verify_docs_up_to_date.py`
- `PYTHONPATH=. pre-commit run --files docs/nazarick_agent_profiles.md docs/nazarick_agents.md agents/nazarick/nazarick_core_architecture.md agents/nazarick/nazarick_memory_blueprint.md docs/INDEX.md docs/testing/failure_inventory.md` *(fails: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68bff707fdb4832e9a103830ab9121aa