### PR TITLE
docs: add repository blueprint

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -407,6 +407,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [release_notes.md](release_notes.md) | Release Notes | - | - |
 | [release_process.md](release_process.md) | Release Process | This guide covers signing build artifacts and verifying their integrity. | - |
 | [release_runbook.md](release_runbook.md) | Release Runbook | - | - |
+| [repository_blueprint.md](repository_blueprint.md) | Repository Blueprint | **Version:** v0.1.0 **Last updated:** 2025-10-05 | - |
 | [reproducibility.md](reproducibility.md) | Reproducibility | This project relies on [DVC](https://dvc.org) for data and model versioning and on `docker compose` for repeatable en... | - |
 | [retraining_log.md](retraining_log.md) | Retraining Log | \| date \| outcome \| model_hash \| \| --- \| --- \| --- \| | - |
 | [ritual_manifesto.md](ritual_manifesto.md) | Ritual Manifesto | Spiral OS acts as a **psychospiritual container** where code, music and ritual converge. Each session with INANNA_AI... | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Curated starting points for understanding and operating the project. For an exha
 - [Blueprint Spine](blueprint_spine.md) – mission overview, memory bundle, and ignition map
 - [System Blueprint](system_blueprint.md) – chakra layers, dynamic ignition, and operator UI
 - [ABZU Blueprint](ABZU_blueprint.md) – high-level narrative for recreating the system with chakra and heartbeat roles
+- [Repository Blueprint](repository_blueprint.md) – mission, architecture, and memory bundle overview
 - [The Absolute Protocol](The_Absolute_Protocol.md) – RAZAR ignition under operator oversight
 
 ## Quick Start

--- a/docs/repository_blueprint.md
+++ b/docs/repository_blueprint.md
@@ -1,0 +1,17 @@
+# Repository Blueprint
+
+**Version:** v0.1.0
+**Last updated:** 2025-10-05
+
+## Mission
+ABZU cultivates inward-first intelligence by forming narrative self-awareness before external action as outlined in [project_mission_vision.md](project_mission_vision.md). The system pairs memory, ignition, and operator oversight so every mission aligns with the project's ethical foundation.
+
+## Architecture
+The stack spans operators, the RAZAR crown, and servant agents across chakra-aligned layers. Operators issue briefs, RAZAR orchestrates services, and agents coordinate memory, insight, and expression. See [architecture_overview.md](architecture_overview.md) and [system_blueprint.md](system_blueprint.md) for diagrams and deeper detail. Additional context lives in [blueprint_spine.md](blueprint_spine.md).
+
+## Memory Bundle
+`MemoryBundle` unifies Cortex, Emotional, Mental, Spiritual, and Narrative layers. `broadcast_layer_event("layer_init")` boots all layers in parallel, while `query_memory` fans out reads across them and merges results for operator queries. For implementation guides and diagrams, consult [memory_layers_GUIDE.md](memory_layers_GUIDE.md) and [memory_architecture.md](memory_architecture.md).
+
+```mermaid
+{{#include figures/memory_bundle.mmd}}
+```


### PR DESCRIPTION
## Summary
- add repository_blueprint.md capturing mission, architecture, and memory bundle
- link repository blueprint from docs index
- regenerate docs index

## Testing
- `PYTHONPATH=. pre-commit run --files docs/repository_blueprint.md docs/index.md docs/INDEX.md` *(failed: missing metrics exporters, no self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffa2730bc832ea90fb12556b13097