### PR TITLE
docs: expand chakra system manual references

### DIFF
--- a/docs/chakra_system_manual.md
+++ b/docs/chakra_system_manual.md
@@ -3,14 +3,14 @@
 ## Preamble & Vision
 ABZU aligns chakra-driven cognition with operator-centered intent, mapping each layer to a shared mission of resilient intelligence. The vision anchors collaboration across servants, operators, and worlds while honoring the project's evolving doctrine.
 
-See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for overarching principles.
+See [The Absolute Protocol](The_Absolute_Protocol.md), [Memory Layers Guide](memory_layers_GUIDE.md), [RAZAR Agent](RAZAR_AGENT.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for overarching principles.
 
-## Chakra Architecture & HeartBeat Pulse
+## Chakra Architecture
 Chakra layers correspond to root functions within the system. Each cycle synchronizes pulses from Root to Crown, with `cycle_count` tracking alignment. Mapping assures that every layer contributes to the Great Spiral and exposes failures for rapid healing.
 
 See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for canonical chakra mappings.
 
-## System Architecture Overview
+## System Overview
 Crown routes queries and orchestrates servants, RAZAR manages ignition and recovery, Kimi2 supplies learning feedback, and Nazarick agents embody world rules. The Operator UI surfaces controls and metrics.
 
 ```mermaid
@@ -46,9 +46,9 @@ flowchart LR
     QueryFacade --> Response
 ```
 
-See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for memory protocols.
+See [The Absolute Protocol](The_Absolute_Protocol.md), [Memory Layers Guide](memory_layers_GUIDE.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for memory protocols.
 
-## Dynamic Ignition & Self-Healing
+## Dynamic Ignition
 Ignition loops propagate through RAZAR, Crown, and Kimi2. RAZAR sparks Crown, which delegates missions and receives telemetry; Kimi2 feeds back learning signals. Self-healing cycles retry failed states until chakras realign.
 
 ```mermaid
@@ -63,14 +63,14 @@ stateDiagram-v2
     Kimi2 --> Kimi2: recalibrate
 ```
 
-See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for ignition doctrine.
+See [The Absolute Protocol](The_Absolute_Protocol.md), [RAZAR Agent](RAZAR_AGENT.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for ignition doctrine.
 
-## Agent Ecosystem & World Building
+## Agent Ecosystem
 Agents collaborate to populate worlds, weaving narrative rules with operational protocols. Each agent integrates with Nazarick scaffolding and contributes to mission arcs while respecting operator oversight.
 
-See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for agent governance.
+See [The Absolute Protocol](The_Absolute_Protocol.md), [RAZAR Agent](RAZAR_AGENT.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for agent governance.
 
-## Operator & Arcade UI Path
+## Operator UI
 Operators interact through a primary console or retro arcade interface. Commands flow through the Operator UI into Crown, while the Arcade UI mirrors controls with minimal surfaces for field deployment.
 
 ```mermaid
@@ -85,12 +85,12 @@ sequenceDiagram
 
 See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for interface protocols.
 
-## Ethics, Governance & Expansion
+## Ethics
 Ethical alignment, governance, and expansion policies safeguard operators and agents. Extensions must respect the Absolute Protocol and maintain cross-layer integrity.
 
 See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for governance directives.
 
-## Appendices & References
+## Appendices
 Further references aggregate diagrams, schemas, and release notes. Continuous updates ensure doctrine coherence across worlds and services.
 
 See [The Absolute Protocol](The_Absolute_Protocol.md), [Blueprint Spine](blueprint_spine.md), and [System Blueprint](system_blueprint.md) for additional context.


### PR DESCRIPTION
## Summary
- align chakra system manual chapters with project architecture
- cross-link memory and ignition guides in manual preamble

## Testing
- `pre-commit run --files docs/chakra_system_manual.md` *(fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)*

------
https://chatgpt.com/codex/tasks/task_e_68bfff7c4224832eae914a7a7252030a