### PR TITLE
docs: link Memory Bundle in architecture index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ abzu-memory-bootstrap
 - [RAZAR Guide](RAZAR_GUIDE.md) – boot orchestration and startup handshakes
 - [Crown Guide](Crown_GUIDE.md) – routes operator commands to servant models
 - [INANNA Guide](INANNA_GUIDE.md) – core GLM interface and memory access
+- [Memory Bundle](memory_layers_GUIDE.md) – bus protocol connecting memory layers
 ## Nazarick
 - [Avatar & Voice Stack](blueprint_spine.md#avatar--voice-stack) – servant templates and UI pipeline
 - [Nazarick UI Pipeline](system_blueprint.md#avatar--voice-stack) – avatar and voice flow overview


### PR DESCRIPTION
## Summary
- link Memory Bundle guide from Architecture section
- rebuild documentation index

## Testing
- `python scripts/build_docs_index.py` *(fails: No such file or directory)*
- `python tools/doc_indexer.py`
- `pre-commit run --files docs/index.md docs/INDEX.md` *(fails: missing deps and verify-chakra-monitoring)*

------
https://chatgpt.com/codex/tasks/task_e_68c003f245d8832e87020df76a2abde9