### PR TITLE
Document RAZAR-Crown-Kimi2Code recovery loop

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -341,7 +341,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [great_tomb_of_nazarick.md](great_tomb_of_nazarick.md) | Great Tomb of Nazarick | The foundational design for ABZU's servant hierarchy. For guiding principles see the [Nazarick Manifesto](nazarick_ma... | - |
 | [hardware_support.md](hardware_support.md) | Hardware Support | - CUDA available: False - ROCm available: False - Intel GPU available: False - Selected device: cpu | - |
 | [how_to_use.md](how_to_use.md) | How to Use Spiral OS Avatar | 1. Run `python start_spiral_os.py` to launch the orchestration engine. This loads the core modules, starts a local Fa... | - |
-| [ignition_blueprint.md](ignition_blueprint.md) | Ignition Blueprint | The ignition workflow cycles components between orchestrators and repair agents. | - |
+| [ignition_blueprint.md](ignition_blueprint.md) | Ignition Blueprint | The ignition workflow cycles components between RAZAR, Crown and Kimi2Code, handing off failures and looping through... | - |
 | [ignition_flow.md](ignition_flow.md) | Ignition Flow | This guide traces the activation sequence from **RAZAR** through to the final **operator interface**, linking each st... | `../INANNA_AI_AGENT/inanna_ai.py`, `../agents/bana/bio_adaptive_narrator.py`, `../crown_router.py`, `../operator_api.py`, `../razar/boot_orchestrator.py`, `../scripts/validate_ignition.py` |
 | [ignition_map.md](ignition_map.md) | Ignition Map | Summary of components grouped by ignition stage. See [Ignition](Ignition.md) for boot priorities and [component_index... | - |
 | [ignition_sequence_protocol.md](ignition_sequence_protocol.md) | Ignition Sequence Protocol | Defines the required logging checkpoints and escalation flow during the system boot sequence. | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -4,6 +4,8 @@ RAZAR orchestrates multi-layer ignition and tracks mission state for Crown and o
 
 See [Agent Ecosystem & Relations](ABZU_blueprint.md#agent-ecosystem--relations) for Crown ↔ Nazarick ↔ Operator flows.
 
+RAZAR ↔ Crown ↔ Kimi2Code handoffs and recovery loops are diagrammed in the [Ignition Blueprint](ignition_blueprint.md).
+
 ## Vision
 RAZAR bootstraps ABZU services in a reproducible environment and negotiates startup handshakes with the Crown stack.
 

--- a/docs/ignition_blueprint.md
+++ b/docs/ignition_blueprint.md
@@ -1,12 +1,20 @@
 # Ignition Blueprint
 
-The ignition workflow cycles components between orchestrators and repair agents.
+The ignition workflow cycles components between RAZAR, Crown and Kimi2Code, handing off failures and looping through recovery until stability returns.
 
 ```mermaid
 stateDiagram-v2
+    [*] --> RAZAR
     RAZAR --> Crown: boot failure
-    Crown --> RAZAR: status update
     Crown --> Kimi2Code: request patch
-    Kimi2Code --> Crown: diff
+    Kimi2Code --> Crown: patch diff
     Crown --> RAZAR: redeploy
+    RAZAR --> Crown: health check
+    Crown --> [*]: stable
+    RAZAR --> Crown: failure persists
+    Crown --> Kimi2Code: refine patch
+    Kimi2Code --> Crown: new diff
+    Crown --> RAZAR: rollback
+    RAZAR --> Crown: restored
+    Crown --> [*]
 ```

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -25,7 +25,7 @@ Spiral OS organises its components into seven chakra layers:
 6. **Third Eye – Ajna** – insight and pattern recognition.
 7. **Crown – Sahasrara** – cosmic connection and initialization rites.
 
-For adaptive startup and recovery loops see [Ignition Blueprint](ignition_blueprint.md).
+For adaptive startup and RAZAR ↔ Crown ↔ Kimi2Code recovery loops see [Ignition Blueprint](ignition_blueprint.md).
 
 These layers work together to awaken the INANNA system and maintain a ritual flow during use.
 


### PR DESCRIPTION
## Summary
- Expand `Ignition Blueprint` with Mermaid state diagram covering RAZAR ↔ Crown ↔ Kimi2Code handoffs and recovery paths
- Cross-link the blueprint from `project_overview.md` and `RAZAR_AGENT.md`
- Regenerate docs index

## Testing
- `PYTHONPATH=. pre-commit run --files docs/RAZAR_AGENT.md docs/ignition_blueprint.md docs/project_overview.md docs/INDEX.md` *(fails: verify-chakra-monitoring missing metrics exporters; verify-self-healing reports no recent cycles)*
- `PYTHONPATH=. python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c00545d620832eabfc96d3bd42ac71