### PR TITLE
Add DATPars placeholder package and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.
 - `docs/operator_onboarding.md` documents mission workflows with Mermaid diagrams and cross-links in `system_blueprint.md`.
+- `datpars` placeholder package with stub interfaces and `docs/datpars_overview.md`.
 - Wrapped `agents.event_bus.emit_event` and memory layer queries with OpenTelemetry spans.
 - Structured manual detailing chakra architecture, system components, memory bundle, and operator paths with Mermaid diagrams and doctrine cross-links.
 - Exposed `/healthz` and `/metrics` on the sidekick helper service.

--- a/datpars/__init__.py
+++ b/datpars/__init__.py
@@ -1,0 +1,9 @@
+"""Placeholder package for DATPars utilities."""
+
+from __future__ import annotations
+
+from .interfaces import DataParser, ParserFactory
+
+__all__ = ["__version__", "DataParser", "ParserFactory"]
+
+__version__ = "0.0.0"

--- a/datpars/interfaces.py
+++ b/datpars/interfaces.py
@@ -1,0 +1,19 @@
+"""Stub interfaces for DATPars parsers."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class DataParser(Protocol):
+    """Parse raw sources into structured records."""
+
+    def parse(self, source: str) -> dict[str, Any]:
+        """Parse ``source`` and return a structured representation."""
+
+
+class ParserFactory(Protocol):
+    """Create parser instances for specific formats."""
+
+    def create(self, name: str) -> DataParser:
+        """Return a parser for the given format ``name``."""

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -303,6 +303,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [data_flow.md](data_flow.md) | Request to Memory Data Flow | ```mermaid graph LR A[Client Request] --> B[Root Chakra] B --> C[Sacral] C --> D[Solar Plexus] D --> E[Heart] E --> F... | `../crown_prompt_orchestrator.py`, `../emotional_state.py`, `../insight_compiler.py`, `../learning_mutator.py`, `../memory_store.py`, `../server.py`, `../start_spiral_os.py`, `../vector_memory.py` |
 | [data_manifest.md](data_manifest.md) | Data Manifest | This document enumerates datasets and external resources used by the project. | `../aspect_processor.py`, `../memory/sacred.py`, `../src/core/memory_physical.py` |
 | [data_security.md](data_security.md) | Data Security and Compliance | This document outlines how training data should be handled with respect to GDPR and HIPAA regulations. | - |
+| [datpars_overview.md](datpars_overview.md) | DATPars Overview | - | `../datpars/interfaces.py` |
 | [dependencies.md](dependencies.md) | Dependency Tree | Generated via `pipdeptree`. | - |
 | [dependency-graph.md](dependency-graph.md) | Dependency Graph | Generated with `pipdeptree --packages spiral-os`. | - |
 | [dependency_index.md](dependency_index.md) | Dependency Index | Generated automatically. Tracks external and internal dependencies across the project. | - |

--- a/docs/datpars_overview.md
+++ b/docs/datpars_overview.md
@@ -1,0 +1,26 @@
+# DATPars Overview
+
+## Goals
+
+DATPars standardizes data parsing across Spiral OS. It aims to convert
+raw inputs from external sources into structured events that the system can
+route through memory and orchestration layers.
+
+## Architecture
+
+The module exposes lightweight interfaces for implementing format‑specific
+parsers. Each parser adheres to a minimal contract defined in
+[`datpars.interfaces`](../datpars/interfaces.py). Implementations can be
+registered with a factory to keep ingestion pluggable.
+
+## Integration Points
+
+DATPars sits near the edge of the ingestion pipeline. Connectors and
+operators hand raw payloads to a parser instance before handing the
+resulting records to memory or RAZAR workflows. The placeholder package
+currently defines only the core interfaces while concrete parsers live in
+future extensions.
+
+## Version History
+
+- 0.0.0 – Initial placeholder with stub interfaces.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ abzu-memory-bootstrap
 
 ## Data
 - [Data Manifest](data_manifest.md)
+- [DATPars Overview](datpars_overview.md) – goals, architecture, and integration points
 
 ## Development
 - [The Absolute Protocol](The_Absolute_Protocol.md) (v1.0.96, updated 2025-10-05)

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -46,6 +46,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md).
 * **Nazarick Web Console** – developer dashboard bridging Crown and Nazarick interfaces. See [Crown vs. Nazarick Modes](nazarick_web_console.md#crown-vs-nazarick-modes).
 * **Arcade UI** – features, quickstart, and memory scan sequence. See [arcade_ui.md](arcade_ui.md).
+* **DATPars** – unified parsing interfaces for ingesting external data. See [datpars_overview.md](datpars_overview.md).
 
 When a command arrives, the orchestrator consults the current emotional state and vector memory to select a model. If hex data or ritual text is present, it hands the payload to the QNL engine which returns symbolic notes. The Sonic Core turns those notes into audio and animates the avatar while new vectors are logged for future reference. This flow allows the layers to reinforce one another so the system speaks and remembers with continuity.
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -925,6 +925,10 @@ RAZAR tracks modules flagged as experimental in
 These components are not required for baseline operation and may change
 rapidly. During boot RAZAR:
 
+The new `datpars` module defines common interfaces for upcoming ingestion
+workflows. See [datpars_overview.md](datpars_overview.md) for goals and
+architecture.
+
 - Marks in‑development components with a warning and delays their startup
   until explicitly enabled.
 - Falls back to mock implementations if dependencies are missing.


### PR DESCRIPTION
## Summary
- add `datpars` placeholder package with stub parsing interfaces
- document DATPars goals, architecture, and integration points
- link DATPars overview from main index, project overview, and system blueprint

## Testing
- `PYTHONPATH=. pre-commit run --files datpars/__init__.py datpars/interfaces.py docs/datpars_overview.md docs/index.md docs/project_overview.md docs/system_blueprint.md CHANGELOG.md docs/INDEX.md` *(failed: missing metrics exporters and no self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`

------
https://chatgpt.com/codex/tasks/task_e_68c00f9becac832e8856ddd7ba9436b1