### PR TITLE
docs: add 3D avatar api reference

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -266,6 +266,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [assets/razar_flow.mmd](assets/razar_flow.mmd) | razar_flow.mmd | - | - |
 | [assets/remote_assistance_sequence.mmd](assets/remote_assistance_sequence.mmd) | remote_assistance_sequence.mmd | - | - |
 | [audio_ingestion.md](audio_ingestion.md) | Audio Ingestion | This guide outlines how Spiral OS loads audio files and enriches them with optional features such as tempo and key de... | - |
+| [avatar_3d_api.md](avatar_3d_api.md) | 3D Avatar API | The 3D Avatar API streams animated meshes to viewers and exposes configuration hooks for the avatar pipeline. Crown r... | - |
 | [avatar_animation.md](avatar_animation.md) | Avatar Animation Modules | This document describes the lightweight avatar animation helpers found in `ai_core.avatar`. | - |
 | [avatar_ethics.md](avatar_ethics.md) | Avatar Ethics | The avatar and call features rely on audiovisual data that may reveal personal information. Operators must handle rec... | - |
 | [avatar_pipeline.md](avatar_pipeline.md) | Avatar Pipeline | The avatar pipeline synchronises generated speech with visual animation. It reads configuration from `guides/avatar_c... | - |

--- a/docs/avatar_3d_api.md
+++ b/docs/avatar_3d_api.md
@@ -1,0 +1,39 @@
+# 3D Avatar API
+
+The 3D Avatar API streams animated meshes to viewers and exposes
+configuration hooks for the avatar pipeline. Crown routes operator
+commands to the service which renders frames and synchronises audio.
+
+## Streaming Flow
+
+```mermaid
+flowchart LR
+    Operator --> Crown --> "3D Avatar Service" --> Viewer
+```
+
+## Configuration
+
+The service reads mesh paths, camera paths, and optional lip‑sync audio
+from `avatar_config.toml`. Set `mode = "3d"` under `[avatars]` to enable
+three‑dimensional rendering. Crown forwards the configuration on
+startup and when operators adjust avatar options.
+
+## Dependencies
+
+The API activates additional packages when present:
+
+| Package      | Purpose |
+|--------------|---------|
+| `aiortc`     | Provides WebRTC transport for real‑time streaming |
+| `ffmpeg`     | Encodes and muxes avatar video output |
+| `SadTalker`  | Drives facial animation directly from speech samples |
+| `Wav2Lip`    | Supplies high‑quality lip‑sync fallback |
+| `ControlNet` | Enables gesture modulation via diffusion guides |
+| `AnimateDiff`| Generates motion sequences for gestures |
+
+Missing packages simply disable their corresponding features while the
+service continues with basic rendering.
+
+## Version History
+
+- 2025-10-24: Initial draft.

--- a/docs/avatar_pipeline.md
+++ b/docs/avatar_pipeline.md
@@ -106,6 +106,8 @@ optional lip‑sync audio. These assets are loaded by
 ``media.avatar.lwm_renderer`` before frames are generated. Omitting the mode or
 setting it to ``"2d"`` keeps the traditional flat rendering path.
 
+For streaming and configuration details see the [3D Avatar API](avatar_3d_api.md).
+
 ### Frame Rendering Plug-ins
 
 ``core.video_engine`` exposes ``register_render_2d`` and ``register_render_3d``

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ abzu-memory-bootstrap
 - [UI Service](ui_service.md) – lightweight FastAPI interface for memory queries
 - [Operator Console](operator_console.md) – Arcade UI for Operator API commands
 - [Arcade UI](arcade_ui.md) – features, env vars, quickstart, and memory scan sequence
+- [3D Avatar API](avatar_3d_api.md) – streaming configuration and dependencies
 - [Operator Interface Guide](operator_interface_GUIDE.md) – REST endpoints for Crown and RAZAR control
 - [Bootstrap World Script](../scripts/bootstrap_world.py) – initialize mandatory layers and report status
 


### PR DESCRIPTION
## Summary
- document 3D avatar streaming, config, and dependencies
- link avatar pipeline and docs index to 3D Avatar API

## Testing
- `python scripts/verify_docs_up_to_date.py`
- `pre-commit run --files docs/avatar_3d_api.md docs/avatar_pipeline.md docs/index.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68c011cfd26c832ebafc059864247fe9