### PR TITLE
docs: document Vanna–Bana narrative pipeline

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -368,7 +368,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [music_avatar_architecture.md](music_avatar_architecture.md) | Music Avatar Architecture | The Crown agent can reflect on musical input by combining feature extraction with language model reasoning.  The `mus... | - |
 | [music_generation_usage.md](music_generation_usage.md) | Music Generation Usage | Generate audio from text prompts or ritual invocations. | - |
 | [narrative_engine_GUIDE.md](narrative_engine_GUIDE.md) | Narrative Engine Guide | - | - |
-| [narrative_system.md](narrative_system.md) | Narrative System | The narrative system transforms physiological CSV data into cohesive multitrack stories through event composition. | - |
+| [narrative_system.md](narrative_system.md) | Narrative System | The narrative system transforms physiological CSV data into cohesive multitrack stories through event composition. Th... | - |
 | [nazarick/README.md](nazarick/README.md) | Nazarick | Nazarick houses chakra-aligned servant agents. The triadic flow between Crown, Nazarick, and the operator is outlined... | - |
 | [nazarick_agent_profiles.md](nazarick_agent_profiles.md) | Nazarick Agent Profiles | Each servant agent blends a narrative persona with distinct vocal and visual traits. | - |
 | [nazarick_agents.md](nazarick_agents.md) | Nazarick Agents | Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown. | - |
@@ -442,6 +442,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ui_service.md](ui_service.md) | UI Service | - | - |
 | [updates/2025-08.md](updates/2025-08.md) | August 2025 Roadmap | - | - |
 | [use_cases/ritual_demo.md](use_cases/ritual_demo.md) | Ritual Demo | This walkthrough demonstrates the small ritual sample included with the repository. The `examples/ritual_demo.py` scr... | - |
+| [vanna_bana_pipeline.md](vanna_bana_pipeline.md) | Vanna–Bana Pipeline | Vanna Data queries feed narrative generation by passing SQL results to the Bana engine, a fine-tuned Mistral 7B model... | - |
 | [vanna_usage.md](vanna_usage.md) | Vanna Data Agent Usage | The `vanna_data` agent translates natural language prompts into SQL queries using the [Vanna](https://github.com/vann... | - |
 | [vector_memory.md](vector_memory.md) | Vector Memory | Source: [`../vector_memory.py`](../vector_memory.py) Related Guides: [`rag_pipeline.md`](rag_pipeline.md), [`rag_musi... | `../vector_memory.py` |
 | [video_generation.md](video_generation.md) | Video Generation Pipeline | This document outlines the simplified video generation pipeline and how styles are configured. | - |

--- a/docs/bana_engine.md
+++ b/docs/bana_engine.md
@@ -2,6 +2,8 @@
 
 This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sources, event processing, and where generated stories are saved.
 
+For how Bana consumes results from the Vanna data agent, see [Vanna–Bana Pipeline](vanna_bana_pipeline.md).
+
 See the corresponding entries in [component_index.json](../component_index.json) for metadata on the engine and its datasets.
 
 ## Architecture

--- a/docs/narrative_system.md
+++ b/docs/narrative_system.md
@@ -1,6 +1,6 @@
 # Narrative System
 
-The narrative system transforms physiological CSV data into cohesive multitrack stories through event composition.
+The narrative system transforms physiological CSV data into cohesive multitrack stories through event composition. The upstream query flow is described in [Vanna–Bana Pipeline](vanna_bana_pipeline.md).
 
 ## Flow
 

--- a/docs/vanna_bana_pipeline.md
+++ b/docs/vanna_bana_pipeline.md
@@ -1,0 +1,23 @@
+# Vanna–Bana Pipeline
+
+Vanna Data queries feed narrative generation by passing SQL results to the Bana engine, a fine-tuned Mistral 7B model. The engine creates multitrack stories—prose, audio cues, visual directives, and USD actions—which are persisted in memory for later retrieval.
+
+```mermaid
+flowchart LR
+    OP[Operator] --> V[Vanna]
+    V --> B[Bana (Mistral 7B)]
+    B --> MT[Multitrack]
+    MT --> P[Prose Track]
+    MT --> A[Audio Track]
+    MT --> VI[Visual Track]
+    MT --> U[USD Track]
+    MT --> M[Memory]
+```
+
+1. **Operator** issues a natural language query.
+2. **Vanna** converts the query to SQL, executes it, and returns rows.
+3. **Bana** interprets the rows with a Mistral 7B model, composing narrative events.
+4. **Multitrack** output includes prose, audio cues, visual directives, and USD actions.
+5. **Memory** stores the tracks and corresponding event logs.
+
+See [Vanna Data Agent Usage](vanna_usage.md) for configuration details and [Bana Engine](bana_engine.md) for model architecture. The broader narrative flow is outlined in [Narrative System](narrative_system.md).

--- a/docs/vanna_usage.md
+++ b/docs/vanna_usage.md
@@ -2,6 +2,8 @@
 
 The `vanna_data` agent translates natural language prompts into SQL queries using the [Vanna](https://github.com/vanna-ai/vanna) library. Query results are stored in mental memory while narrative summaries are appended to `data/narrative.log`.
 
+For the end-to-end storytelling flow, see [Vanna–Bana Pipeline](vanna_bana_pipeline.md).
+
 ## Setup
 
 1. `pip install vanna`


### PR DESCRIPTION
## Summary
- add `vanna_bana_pipeline.md` outlining how Vanna Data queries feed Bana narrative generation
- link pipeline guide from Vanna usage, Bana engine, and narrative system docs

## Testing
- `pre-commit run --files docs/vanna_bana_pipeline.md docs/vanna_usage.md docs/bana_engine.md docs/narrative_system.md docs/INDEX.md` *(fails: Verify chakra monitoring; Verify self healing)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c018960914832ebb15bbabffa854fb