### PR TITLE
docs: document mission brief handover flow

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -361,6 +361,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
 | [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.6 **Last updated:** 2025-09-09 | `../scripts/bootstrap_memory.py` |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
+| [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |
 | [module_execution_flow.md](module_execution_flow.md) | Module Execution Flow | Overview of key modules with their inputs, core processing, outputs, and error handling. Flowcharts summarize the exe... | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -6,6 +6,8 @@ See [Agent Ecosystem & Relations](ABZU_blueprint.md#agent-ecosystem--relations) 
 
 RAZAR ↔ Crown ↔ Kimi2Code handoffs and recovery loops are diagrammed in the [Ignition Blueprint](ignition_blueprint.md).
 
+Mission brief exchange and servant routing are summarized in [Mission Brief Exchange & Servant Routing](mission_brief_exchange.md).
+
 ## Vision
 RAZAR bootstraps ABZU services in a reproducible environment and negotiates startup handshakes with the Crown stack.
 
@@ -263,6 +265,7 @@ logs/mission_briefs/
 ## Version History
 | Version | Date | Notes |
 |---------|------|-------|
+| 0.2.4 | 2025-10-09 | Linked mission brief exchange and servant routing guide. |
 | 0.2.3 | 2025-09-21 | Added remote assistance section with flow diagram plus schema diagrams and ignition example. |
 | 0.2.2 | 2025-09-21 | Expanded remote assistance workflow and patch logging. |
 | 0.1.0 | 2025-08-30 | Initial release of RAZAR runtime orchestrator. |

--- a/docs/crown_manifest.md
+++ b/docs/crown_manifest.md
@@ -6,6 +6,8 @@ The **CROWN** agent runs the GLM-4.1V-9B model and acts as the root layer of Spi
 
 The archetypal layers described in [spiritual_architecture.md](spiritual_architecture.md) present personas such as Nigredo and Albedo. The CROWN coordinates these layers, dispatching prompts to each personality and receiving their responses. By updating the vector memory store the CROWN influences how future interactions surface across the layers.
 
+For the mission brief exchange and servant routing sequence see [Mission Brief Exchange & Servant Routing](mission_brief_exchange.md).
+
 ## Console connection
 
 Commands typed into the Crown Console reach the agent through `crown_prompt_orchestrator.py`. The CROWN interprets these requests, sends them to GLM-4.1V-9B and triggers ritual logic in `state_transition_engine.py` when specific phrases appear.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ abzu-memory-bootstrap
 - [Crown Agent Overview](CROWN_OVERVIEW.md)
 - [RAZAR Guide](RAZAR_GUIDE.md) – boot orchestration and startup handshakes
 - [Crown Guide](Crown_GUIDE.md) – routes operator commands to servant models
+- [Mission Brief Exchange & Servant Routing](mission_brief_exchange.md) – RAZAR handoff, failure escalation, and servant responses
 - [INANNA Guide](INANNA_GUIDE.md) – core GLM interface and memory access
 - [Memory Bundle](memory_layers_GUIDE.md) – bus protocol connecting memory layers
 ## Nazarick

--- a/docs/mission_brief_exchange.md
+++ b/docs/mission_brief_exchange.md
@@ -1,0 +1,22 @@
+# Mission Brief Exchange & Servant Routing
+
+This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and how Crown dispatches work to servant models.
+
+## Mission Brief Exchange
+- RAZAR parses mission briefs and forwards them to Crown during startup.
+- Crown records the brief and acknowledges readiness for operator review.
+
+## Failure Escalation via `ai_invoker.handover`
+When a component fails, RAZAR calls `ai_invoker.handover` to delegate recovery to a remote agent. Suggested patches are applied before services resume.
+
+## Servant Model Routing
+Crown routes operator requests or delegated tasks to registered servant models, returning their responses to the operator.
+
+```mermaid
+flowchart LR
+    A[RAZAR] --> B[Crown]
+    B --> C[Servant Models]
+    C --> D[Responses]
+```
+
+See also the [RAZAR Agent](RAZAR_AGENT.md) and the [CROWN Manifest](crown_manifest.md) for implementation details.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -240,14 +240,14 @@ documents:
       key_rules: Review before altering system protection code.
       insight: Review before modifying system protection code.
   docs/INDEX.md:
-    sha256: 085dba828951b4b0d687fbec3f3709d3f2d1d612d025d3aaf6425349ee3cad2e
+    sha256: cd2b46a27f8c995d42ac40da806075fd9bdbeac926ccf8befaa41778840413ff
     summary:
       purpose: Generated documentation index.
       scope: Repository documentation.
       key_rules: Regenerate index after documentation updates.
       insight: Regenerate with tools/doc_indexer.py after updating docs.
   docs/index.md:
-    sha256: 2bebadb178d21dad74f8805be1721fd3c01883fd4c69d656a53aa5503e362ad7
+    sha256: 0d2f495589fa5ed997dea3e713da028476b77ce84445fdc275b3ea31b7a195ef
     summary:
       purpose: Curated documentation entry points.
       scope: Top-level docs index.
@@ -291,7 +291,7 @@ documents:
       key_rules: Visual reference for narrative engine routing.
       insight: Consult to understand event propagation to memory and operator.
   docs/RAZAR_AGENT.md:
-    sha256: 880bc26efd9eccc0c1886b529727a8acf25cc06776058acd035726f99655c030
+    sha256: bb9b8ae172a9bc370dddb2f5a3e2e9f37cc3f03f349f59e1452371dd0d5fb557
     summary:
       purpose: Comprehensive RAZAR agent guide.
       scope: RAZAR agent workflows and deployment.


### PR DESCRIPTION
## Summary
- add mission brief exchange and servant routing guide with diagram
- link Crown and RAZAR docs and index to mission brief exchange guide
- refresh onboarding confirmation hashes for updated docs

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/crown_manifest.md docs/index.md docs/mission_brief_exchange.md docs/INDEX.md onboarding_confirm.yml` *(fails: Missing Python packages: websockets; ModuleNotFoundError: No module named 'opentelemetry'; verify_chakra_monitoring failed)*
- `python scripts/verify_doc_hashes.py`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01f7de774832e83174ef3d822df13