### PR TITLE
docs: clarify servant memory context

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -300,7 +300,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [contribution_guide.md](contribution_guide.md) | Contribution Guide | Thank you for considering a contribution! | - |
 | [contributor_checklist.md](contributor_checklist.md) | Contributor Checklist | This checklist distills mandatory practices for ABZU contributors. | - |
 | [crown_manifest.md](crown_manifest.md) | CROWN Manifest | The **CROWN** agent runs the GLM-4.1V-9B model and acts as the root layer of Spiral OS. It holds the highest permissi... | - |
-| [crown_servant_models.md](crown_servant_models.md) | Crown Servant Models | Guidance for deploying auxiliary servant models used by Crown. | - |
+| [crown_servant_models.md](crown_servant_models.md) | Crown Servant Models | Guidance for deploying auxiliary servant models used by Crown. | `../memory/query_memory.py` |
 | [data_flow.md](data_flow.md) | Request to Memory Data Flow | ```mermaid graph LR A[Client Request] --> B[Root Chakra] B --> C[Sacral] C --> D[Solar Plexus] D --> E[Heart] E --> F... | `../crown_prompt_orchestrator.py`, `../emotional_state.py`, `../insight_compiler.py`, `../learning_mutator.py`, `../memory_store.py`, `../server.py`, `../start_spiral_os.py`, `../vector_memory.py` |
 | [data_manifest.md](data_manifest.md) | Data Manifest | This document enumerates datasets and external resources used by the project. | `../aspect_processor.py`, `../memory/sacred.py`, `../src/core/memory_physical.py` |
 | [data_security.md](data_security.md) | Data Security and Compliance | This document outlines how training data should be handled with respect to GDPR and HIPAA regulations. | - |

--- a/docs/crown_servant_models.md
+++ b/docs/crown_servant_models.md
@@ -21,6 +21,21 @@ servants:
     health_url: "http://localhost:8001/health"
 ```
 
+## Memory and Prompt Context
+Servant models operate solely on the prompt text they receive. They do not
+share Crown's vector or spiral memory layers. If additional context is needed,
+call `query_memory` and prepend the returned data to the servant prompt before
+dispatching the request.
+
+```python
+from memory.query_memory import query_memory
+
+results = query_memory("latest project status")
+prompt = f"{results['spiral']}\n\n{user_prompt}"
+```
+
+See [memory/query_memory.py](../memory/query_memory.py) for retrieval examples.
+
 ## Deployment Steps
 1. **Download weights**
    ```bash


### PR DESCRIPTION
## Summary
- note servant models only receive prompt text and lack access to Crown's vector or spiral memory
- show how to inject `query_memory` results into servant prompts with example
- reference memory retrieval implementation

## Testing
- `pre-commit run --files docs/crown_servant_models.md` *(fails: pytest-cov argument error; verify-chakra-monitoring missing agents; verify-self-healing no cycles)*
- `python scripts/verify_docs_up_to_date.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0213816bc832ea497438cb8aa4ae3