### PR TITLE
Augment servant prompts with memory context

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -49,7 +49,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 95e17141051be0be616df5b65f61f15859eee98f0a3b0f14283eff85ee89c008
+    sha256: 1097fc6dfcd0b32b03f8e42944baefb4e7e1e6b93329fc0f0317e46b9bb09d25
     summary:
       purpose: Project goals and scope.
       scope: Entire project.


### PR DESCRIPTION
## Summary
- allow crown_prompt_orchestrator to retrieve and append memory snippets when delegating to servants
- let operators toggle memory inclusion and expose `--no-memory` flag on CLI
- cover servant prompt augmentation, toggle behavior, and failure fallback with targeted tests

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files crown_prompt_orchestrator.py tests/crown/test_prompt_orchestrator.py onboarding_confirm.yml`
- `pytest tests/crown/test_prompt_orchestrator.py::test_servant_prompt_includes_memory tests/crown/test_prompt_orchestrator.py::test_servant_prompt_without_memory_when_disabled tests/crown/test_prompt_orchestrator.py::test_query_memory_failure_falls_back -q --no-cov --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c022a55ba0832e8ae6249427e75290