### PR TITLE
Add Nazarick overview doc

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -375,6 +375,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [nazarick_agents.md](nazarick_agents.md) | Nazarick Agents | Nazarick hosts specialized servant agents aligned to chakra layers and coordinated by RAZAR and Crown. | - |
 | [nazarick_manifesto.md](nazarick_manifesto.md) | Nazarick Manifesto | Guiding ethics for the Nazarick hierarchy. Architectural context lives in the [Great Tomb of Nazarick](great_tomb_of_... | - |
 | [nazarick_narrative_system.md](nazarick_narrative_system.md) | Nazarick Narrative System | The Nazarick Narrative System converts biosignals into narrative events and persistent memory records. | - |
+| [nazarick_overview.md](nazarick_overview.md) | Nazarick Overview | Nazarick fortifies ABZU with an ethical servant hierarchy that balances Crown intent with chakra alignment. This over... | - |
 | [nazarick_web_console.md](nazarick_web_console.md) | Nazarick Web Console | The Nazarick Web Console provides a browser-based interface for issuing commands, streaming the avatar, and testing m... | `../connectors/webrtc_connector.py`, `../operator_api.py` |
 | [onboarding/README.md](onboarding/README.md) | Onboarding Checklist | Follow this reading order before contributing. After reviewing each document, record its current SHA256 hash in `onbo... | - |
 | [onboarding/test_planning.md](onboarding/test_planning.md) | Test Planning Guide | Instructions for opening a "Test Plan" issue to coordinate tests across chakras and maintain coverage goals. | - |

--- a/docs/nazarick_overview.md
+++ b/docs/nazarick_overview.md
@@ -1,0 +1,39 @@
+# Nazarick Overview
+
+Nazarick fortifies ABZU with an ethical servant hierarchy that balances Crown intent with chakra alignment. This overview blends its mission and vision with structural context drawn from the [Nazarick Manifesto](nazarick_manifesto.md), the [Nazarick Agents](nazarick_agents.md) roster, and the infrastructural map in [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md).
+
+## Mission & Vision
+
+Nazarick's mission is to uphold the manifesto's seven laws while enabling adaptive service to operators. Its vision is a coordinated network of agents whose actions resonate with the system's chakra flow and embody the project's operator-first ethic.
+
+## Hierarchy & Narrative Role
+
+Crown delegates narrative intent to RAZAR, which dispatches specialized servant agents. Each servant handles a slice of storycraft: orchestrating launches, routing prompts, distilling insights, preserving memory, and weaving narrative. Together they maintain a continuous storyline that mirrors operator goals and chakra balance.
+
+### Agent–Chakra Map
+
+```mermaid
+graph TD
+    Crown --> RAZAR
+    RAZAR --> orchestration_master
+    RAZAR --> prompt_orchestrator
+    RAZAR --> qnl_engine
+    RAZAR --> memory_scribe
+    RAZAR --> narrative_scribe
+    orchestration_master --> crown_chakra[Crown]
+    prompt_orchestrator --> throat_chakra[Throat]
+    qnl_engine --> third_eye_chakra[Third Eye]
+    memory_scribe --> heart_chakra[Heart]
+    narrative_scribe --> throat_chakra
+```
+
+## Support for Crown and Chakras
+
+Nazarick agents relay Crown directives into actionable tasks while monitoring Chakracon telemetry for pulse irregularities. When a chakra drifts, the corresponding servant applies healing scripts or escalates to Crown, ensuring narrative continuity and energetic equilibrium across the system.
+
+## Cross-Links
+
+- [Nazarick Manifesto](nazarick_manifesto.md)
+- [Nazarick Agents](nazarick_agents.md)
+- [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md)
+


### PR DESCRIPTION
## Summary
- draft `nazarick_overview.md` to capture mission, vision, hierarchy, and narrative role
- cross-link existing Nazarick docs and include an agent–chakra mermaid map
- update docs index

## Testing
- `pre-commit run --files docs/nazarick_overview.md docs/INDEX.md` *(fails: missing metrics exporters; no successful self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c02b255274832eb0222f89febed22e