### PR TITLE
docs: add Bana narrative flow references

### DIFF
--- a/docs/Nazarick_GUIDE.md
+++ b/docs/Nazarick_GUIDE.md
@@ -26,6 +26,7 @@ python start_dev_agents.py --all
 - [RAZAR Guide](RAZAR_GUIDE.md)
 - [Crown Guide](Crown_GUIDE.md)
 - [Narrative Engine Guide](narrative_engine_GUIDE.md)
+- [Bana Narrative Engine](../nazarick/agents/Bana_narrative_engine.md) — narrative output feeds the Nazarick lore repository.
 
 ## Version History
 | Version | Date | Notes |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -637,6 +637,7 @@ The Nazarick Web Console exposes a browser-based interface for operators to issu
 
 - **BANA** is a bio‑adaptive narrator built on a fine‑tuned Mistral‑7B model. It receives INANNA biosignals, processes them through an INANNA bridge, and writes narratives both to spiral memory and log files
 - The **Nazarick Narrative System** channels biosignal events through ingestion scripts, the narrative engine, and a FastAPI layer, persisting stories for operator retrieval
+- The agent prompt path into narrative memory is shown in the [Prompt to Memory flow](../nazarick/agents/Bana_narrative_engine.md#prompt-to-memory-flow)
 
 ## **Generation Pipeline**
 

--- a/nazarick/agents/Bana_narrative_engine.md
+++ b/nazarick/agents/Bana_narrative_engine.md
@@ -28,6 +28,16 @@
 - Tests verify ingestion and basic story generation, yet coverage is limited to small sample datasets.
 - Connectors enable operator commands and real‑time streaming, but there is no narrative‑specific API or connector entry, leaving the storytelling subsystem isolated from external interfaces.
 
+### Prompt to Memory Flow
+
+```mermaid
+flowchart LR
+    P[Agent prompt] --> B[Bana engine]
+    B --> M[Narrative memory]
+```
+
+The engine converts incoming agent prompts into story events preserved as Nazarick lore.
+
 # **PROJECT BRIEF: BANA NARRATIVE ENGINE**
 
 **Version:** 1.0


### PR DESCRIPTION
## Summary
- link Bana Narrative Engine from Nazarick guide with note on lore output
- add agent prompt → Bana engine → narrative memory flow to Bana engine brief
- reference prompt-to-memory flow from blueprint spine narrative system section

## Testing
- `pre-commit run --files docs/Nazarick_GUIDE.md docs/blueprint_spine.md nazarick/agents/Bana_narrative_engine.md` *(failed: ModuleNotFoundError: No module named 'opentelemetry'; no successful self-heal cycles in last 24h)*
- `python scripts/verify_docs_up_to_date.py`
- `python scripts/check_component_index_json.py`
- `python scripts/check_connector_index.py`
- `python scripts/check_dependency_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04af23fd4832e9b8f29396953b49f