### PR TITLE
docs: add blueprint manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented Chakra Heartbeat Alignment for Nazarick agents with Mermaid mapping; cross-linked `chakra_metrics.md` and `ignition_blueprint.md`.
 - Wrapped `agents.event_bus.emit_event` and memory layer queries with OpenTelemetry spans.
 - Structured manual detailing chakra architecture, system components, memory bundle, and operator paths with Mermaid diagrams and doctrine cross-links.
+- Blueprint manual capturing vision, chakra architecture, operator console routes, memory bundle initialization, and dynamic ignition.
 - Added Nazarick stewardship section and integration diagrams linking Crown and RAZAR in core blueprints.
 - Exposed `/healthz` and `/metrics` on the sidekick helper service.
 - Documented Prometheus/Grafana dashboard setup in `docs/operations.md`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -272,6 +272,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [avatar_pipeline.md](avatar_pipeline.md) | Avatar Pipeline | The avatar pipeline synchronises generated speech with visual animation. It reads configuration from `guides/avatar_c... | - |
 | [avatar_setup.md](avatar_setup.md) | Avatar Setup | Configure the avatar pipeline by defining environment variables and adjusting textures. | - |
 | [bana_engine.md](bana_engine.md) | Bana Engine | This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sourc... | - |
+| [blueprint_manual.md](blueprint_manual.md) | Blueprint Manual | - | - |
 | [blueprint_spine.md](blueprint_spine.md) | **ABZU Project: Deep-Dive Overview** | See the [Doctrine Index](doctrine_index.md) for canonical paths with checksums, versions, and last update history. Fo... | `../connectors/signal_bus.py` |
 | [chakra_architecture.md](chakra_architecture.md) | Chakra Architecture | This document summarizes the major modules aligned with each chakra layer, their operational state, current quality l... | - |
 | [chakra_healing.md](chakra_healing.md) | Chakra Healing | The chakra healing suite provides recovery scripts invoked by resource guardians when Chakracon metrics exceed safe t... | - |

--- a/docs/blueprint_manual.md
+++ b/docs/blueprint_manual.md
@@ -1,0 +1,36 @@
+# Blueprint Manual
+
+## Preamble & Vision
+ABZU's blueprint manual articulates the project's guiding intent and sets a unified direction for chakra-aligned development. It frames the operator-first ethos and describes how each subsystem contributes to a resilient, evolving intelligence.
+
+## Chakra Architecture
+The chakra architecture synchronizes services from Root to Crown. Each layer transmits signals upward while providing stability and feedback to lower layers, forming a recursive loop of intent, action, and reflection.
+
+## System Overview
+Crown orchestrates servant agents while RAZAR handles recovery and ignition logic. The operator guides flows that traverse the console and API before reaching the appropriate service.
+
+```mermaid
+flowchart LR
+    Operator --> Console --> API
+    API --> RAZAR
+    API --> Crown
+```
+
+## Operator Console
+The console bridges human intent with ABZU's inner systems. Operators can review telemetry, issue commands, and observe responses via a unified interface. See the [Nazarick Web Console](nazarick_web_console.md) and the [Operator Interface Guide](operator_interface_GUIDE.md) for detailed usage patterns.
+
+## Memory Bundle
+Memories initialize in layered bundles that merge vector embeddings with narrative summaries. Each layer stores context and exposes hooks for rapid recall. Consult the [Memory Layers Guide](memory_layers_GUIDE.md) for canonical schemas.
+
+```mermaid
+flowchart TD
+    Boot --> LoadBundle[Load Memory Bundle]
+    LoadBundle --> InitLayers[Initialize Layers]
+    InitLayers --> Ready[Bundle Active]
+```
+
+## Dynamic Ignition
+Dynamic ignition sequences coordinate model loading, memory alignment, and operator handoff. RAZAR triggers ignition while Crown validates readiness before routing tasks.
+
+## Appendices
+Additional specifications, component registries, and operational checklists live throughout the documentation set. Cross-reference this manual with the [System Blueprint](system_blueprint.md) and related guides for deeper context.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -5,8 +5,9 @@
 The system blueprint maps ABZU’s chakra layers, core services, and agents. It
 acts as a starting compass for new contributors—consult the
 [ABZU Blueprint](ABZU_blueprint.md) for the high-level narrative to recreate the
-system, including chakra and heartbeat roles, and the [Blueprint Spine](blueprint_spine.md) for mission context. For
-curated entry points see the [Documentation Index](index.md) and the
+system, including chakra and heartbeat roles, and the [Blueprint Spine](blueprint_spine.md) for mission context. The chaptered
+[Blueprint Manual](blueprint_manual.md) offers operator-focused guidance across
+console, memory, and ignition flows. For curated entry points see the [Documentation Index](index.md) and the
 [auto-generated index](INDEX.md) for a complete catalog, including the
 [Blueprint Export](BLUEPRINT_EXPORT.md) and [Onboarding Guide](onboarding_guide.md).
 Read the [Project Overview](project_overview.md) to understand goals, review the


### PR DESCRIPTION
## Summary
- add blueprint manual covering vision, chakra architecture, system overview, operator console, memory bundle, dynamic ignition, and appendices with Mermaid diagrams
- reference new manual from system blueprint
- record addition in changelog

## Testing
- `PYTHONPATH=. pre-commit run --files docs/blueprint_manual.md docs/system_blueprint.md CHANGELOG.md docs/INDEX.md` *(fails: missing metrics exporters and no self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04def47d4832ea263586fb7cbfe71