### PR TITLE
feat: extend operator API with ignition and memory controls

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -6,7 +6,7 @@ Arcade-style web interface for issuing commands through the Operator API.
 - Start the Operator API and serve `web_operator/templates/arcade.html` with `arcade.css`.
 - A Sumerian greeting modal displays on load.
 - **Ignite** sends `/start_ignition`.
-- **Query Memory** posts to `/query` with a text payload.
+ - **Query Memory** posts to `/memory/query` with a text payload.
 - **Status** retrieves `/status` for component health summaries.
 - **Add Model** posts to `/operator/models` with a model name and builtin.
 - **Remove Model** deletes `/operator/models/{name}`.
@@ -16,6 +16,13 @@ Arcade-style web interface for issuing commands through the Operator API.
 - `OPERATOR_API_URL` – base URL of the Operator API (default `http://localhost:8000`).
 - `OPERATOR_TOKEN` – Bearer token for secured endpoints.
 - `CROWN_URL` – location of Crown/Kimi invoked by RAZAR.
+
+## API Contracts
+| Endpoint | Method | Request | Response |
+|----------|--------|---------|----------|
+| `/start_ignition` | POST | `-` | `{ "status": "started" }` |
+| `/memory/query` | POST | `{ "query": "<text>" }` | `{ "results": {...} }` |
+| `/handover` | POST | `{ "component": "<name>", "error": "<msg>" }` *(optional)* | `{ "handover": true }` |
 
 ## Integration Flow
 ```mermaid
@@ -52,6 +59,7 @@ flowchart TD
 ## Version History
 | Version | Date       | Notes                              |
 |---------|------------|------------------------------------|
+| 0.5.0   | 2025-11-09 | Document `/start_ignition`, `/memory/query`, and `/handover` API contracts |
 | 0.4.0   | 2025-11-08 | Add model, remove model, and ethics update controls |
 | 0.3.0   | 2025-11-07 | Document runtime model management  |
 | 0.2.0   | 2025-11-06 | Added query endpoint and greeting  |

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -49,7 +49,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 1097fc6dfcd0b32b03f8e42944baefb4e7e1e6b93329fc0f0317e46b9bb09d25
+    sha256: 8d40c6c58155bbdd26ada7565e1a6b5ea322ef5386128265dd57ba4d0ccf4fd4
     summary:
       purpose: Project goals and scope.
       scope: Entire project.
@@ -198,12 +198,15 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: ea9f08b052f39410c287b1574207f93efc3a506889e707ba2c9a71c632b29147
+    sha256: f9a5d859d28053530a8b810cab10d8a32099fd3b7405e80a41a1d7b60ae3c0d7
     summary:
       purpose: Core contribution rules.
       scope: All contributors.
-      key_rules: Declare __version__ synced with component_index.json, include change justification, verify key-document summaries, apply the core PR checklist, maintain coverage thresholds, and forbid placeholder markers.
-      insight: Use the PR checklist to synchronize versions, connectors, and document summaries while keeping coverage high and removing placeholders before commit.
+      key_rules: Declare __version__ synced with component_index.json, include change
+        justification, verify key-document summaries, apply the core PR checklist,
+        maintain coverage thresholds, and forbid placeholder markers.
+      insight: Use the PR checklist to synchronize versions, connectors, and document
+        summaries while keeping coverage high and removing placeholders before commit.
   docs/dependency_registry.md:
     sha256: e5c7b4b2f8e2d9daf82d8dc9320245a5612e1fbdc230209a22eb0a397ed0f47a
     summary:
@@ -256,16 +259,19 @@ documents:
   agents/nazarick/nazarick_core_architecture.md:
     sha256: d30ed1392ff91d4269e644da871f2ed5bb565e5d202a8abf683e10c80845f516
     summary:
-      purpose: Design real-time observability framework and channel hierarchy for Spiral OS.
+      purpose: Design real-time observability framework and channel hierarchy for
+        Spiral OS.
       scope: Nazarick monitoring architecture and operator interface.
-      key_rules: Stream agent events with narrative tags and archive critical logs immutably.
+      key_rules: Stream agent events with narrative tags and archive critical logs
+        immutably.
       insight: Operator commands supersede all agent actions.
   agents/nazarick/nazarick_memory_blueprint.md:
     sha256: 45bbde8a01a6531d169f537380e47c54b07a8a97641b611a4d833b1631f5f621
     summary:
       purpose: Blueprint for human-like agent personality, memory, planning, and expression.
       scope: Nazarick agent traits, memory stores, and communication protocols.
-      key_rules: Store memories in vectors, summarize long interactions, and coordinate via defined APIs.
+      key_rules: Store memories in vectors, summarize long interactions, and coordinate
+        via defined APIs.
       insight: Personality fragments from vectors adapt agents to current state.
   docs/nazarick_agents.md:
     sha256: 9cfdb5732c777137ca29fe3796729c7a2fd3af751dddf6dca9faedd435c0321f
@@ -286,7 +292,8 @@ documents:
   docs/assets/narrative_engine_flow.mmd:
     sha256: 9b418b5de9a790064dca91375f560d6378c8d111a0c563deafb637a8e65284d9
     summary:
-      purpose: Mermaid flow diagram of event→Mistral→multi-track outputs→memory/operator.
+      purpose: "Mermaid flow diagram of event\u2192Mistral\u2192multi-track outputs\u2192\
+        memory/operator."
       scope: Nazarick narrative system pipeline.
       key_rules: Visual reference for narrative engine routing.
       insight: Consult to understand event propagation to memory and operator.
@@ -312,5 +319,5 @@ documents:
       key_rules: Run to verify dependencies before committing.
       insight: Run before committing to catch missing dependencies.
 checklist:
-  - "Narrative document entries verified"
-  - "Reviewed core memory docs and protocol before implementing optional fallbacks"
+- Narrative document entries verified
+- Reviewed core memory docs and protocol before implementing optional fallbacks

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -15,9 +15,34 @@ import MissionMap from './mission_map.js';
 
 function GameDashboard() {
   const buttons = [
-    { id: 'ignite', label: 'Ignite', action: () => fetch(`${BASE_URL}/ignite`, { method: 'POST' }) },
-    { id: 'memory', label: 'Memory Query', action: () => fetch(`${BASE_URL}/memory/query`, { method: 'POST' }) },
-    { id: 'handover', label: 'Handover', action: () => fetch(`${BASE_URL}/handover`, { method: 'POST' }) }
+    {
+      id: 'ignite',
+      label: 'Ignite',
+      action: () =>
+        fetch(`${BASE_URL}/start_ignition`, { method: 'POST' })
+          .then((r) => r.json())
+          .then((d) => console.log(d)),
+    },
+    {
+      id: 'memory',
+      label: 'Memory Query',
+      action: () =>
+        fetch(`${BASE_URL}/memory/query`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: 'demo' }),
+        })
+          .then((r) => r.json())
+          .then((d) => console.log(d)),
+    },
+    {
+      id: 'handover',
+      label: 'Handover',
+      action: () =>
+        fetch(`${BASE_URL}/handover`, { method: 'POST' })
+          .then((r) => r.json())
+          .then((d) => console.log(d)),
+    },
   ];
   const [wizardDone, setWizardDone] = React.useState(() => localStorage.getItem('setupWizardCompleted') === 'true');
   const [missionDone, setMissionDone] = React.useState(() => localStorage.getItem('missionWizardCompleted') === 'true');

--- a/web_console/main.js
+++ b/web_console/main.js
@@ -545,14 +545,34 @@ function initArcade() {
     const removeModel = document.getElementById('remove-model-btn');
     const updateEthics = document.getElementById('update-ethics-btn');
     const actionResult = document.getElementById('action-result');
-    ignite.addEventListener('click', () => {
-        fetch(`${BASE_URL}/ignite`, { method: 'POST' });
+    ignite.addEventListener('click', async () => {
+        try {
+            const resp = await fetch(`${BASE_URL}/start_ignition`, { method: 'POST' });
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Ignition error: ' + err;
+        }
     });
-    memory.addEventListener('click', () => {
-        fetch(`${BASE_URL}/memory/scan`, { method: 'POST' });
+    memory.addEventListener('click', async () => {
+        const prompt = document.getElementById('memory-query').value;
+        try {
+            const resp = await fetch(`${BASE_URL}/memory/query`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ query: prompt })
+            });
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Memory query error: ' + err;
+        }
     });
-    handover.addEventListener('click', () => {
-        fetch(`${BASE_URL}/handover`, { method: 'POST' });
+    handover.addEventListener('click', async () => {
+        try {
+            const resp = await fetch(`${BASE_URL}/handover`, { method: 'POST' });
+            actionResult.textContent = await resp.text();
+        } catch (err) {
+            actionResult.textContent = 'Handover error: ' + err;
+        }
     });
     addModel.addEventListener('click', async () => {
         const name = document.getElementById('add-model-name').value;

--- a/web_operator/templates/arcade.html
+++ b/web_operator/templates/arcade.html
@@ -31,7 +31,7 @@
     }
     document.getElementById('ignite').onclick = () => streamText('/start_ignition', {method:'POST'});
     document.getElementById('query').onclick = async () => {
-      const resp = await fetch('/query', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({query:'demo'})});
+      const resp = await fetch('/memory/query', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({query:'demo'})});
       const data = await resp.json();
       document.getElementById('log').textContent = JSON.stringify(data, null, 2);
     };


### PR DESCRIPTION
## Summary
- add `/start_ignition`, `/memory/query`, and `/handover` endpoints to `operator_api`
- wire console scripts to call new endpoints with live feedback
- document operator console API contracts

## Testing
- `pre-commit run --files operator_api.py web_console/main.js web_console/game_dashboard/dashboard.js web_operator/templates/arcade.html docs/operator_console.md tests/test_operator_api.py onboarding_confirm.yml` *(fails: tests require unavailable components and monitoring scripts)*
- `python scripts/validate_docs.py`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c053e05564832ebf44b6b4f5253b40