### PR TITLE
docs: document operator flow

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -25,9 +25,11 @@ Set up the local environment before running tools or tests:
 2. Run `scripts/check_requirements.sh` to confirm required binaries, the Python 3.11+ runtime, and necessary Python modules are present.
 
 ### Operator Interface
-Operators supervise ignition and runtime behaviour. They issue boot commands,
-review handshake logs, and approve escalations before services become
-operator-facing.
+Operators supervise ignition and runtime behaviour. Consoles must meet the
+retro requirements in [operator_console.md](operator_console.md) and the
+[Arcade Theme Style Guide](style_guides/arcade_theme.md). They issue boot
+commands, review handshake logs, and approve escalations before services
+become operator-facing.
 
 **Responsibilities**
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -32,6 +32,23 @@ Contributors must pair system enhancements with operator-facing improvements, up
 3. **Primordials LLM (DeepSeek-V3)** – upstream language model guiding insights.
 4. **INANNA/Bana** – narrative engine and memory hub feeding back to Operator.
 
+### **Operator ↔ RAZAR/Crown Flow**
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant RAZAR
+    participant Crown
+    Operator->>RAZAR: mission brief
+    RAZAR->>Crown: delegate to servants
+    Crown-->>RAZAR: status
+    RAZAR-->>Operator: report
+```
+
+This sequence traces how directives travel from the operator through RAZAR to
+Crown and back, forming the basis for retro console diagnostics.
+
+
 ### **Chakra-aligned Agents (“Great Tomb of Nazarick” metaphor)**
 
 - Each agent aligns to a chakra layer (Root → Crown), ensuring system balance:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ Curated starting points for understanding and operating the project. For an exha
 
 ## Orientation
 - [ABZU Project Declaration](project_mission_vision.md) – deployments must reach a living state
-- [Blueprint Spine](blueprint_spine.md) – mission overview, memory bundle, and ignition map
-- [System Blueprint](system_blueprint.md) – chakra layers, dynamic ignition, and operator UI
+- [Blueprint Spine](blueprint_spine.md) – mission overview, Operator ↔ RAZAR/Crown flow, memory bundle, and ignition map
+- [System Blueprint](system_blueprint.md) – chakra layers, Operator ↔ RAZAR/Crown flow, dynamic ignition, and operator UI
 - [ABZU Blueprint](ABZU_blueprint.md) – high-level narrative for recreating the system with chakra and heartbeat roles
 - [Repository Blueprint](repository_blueprint.md) – mission, architecture, and memory bundle overview
-- [The Absolute Protocol](The_Absolute_Protocol.md) – RAZAR ignition under operator oversight
+- [The Absolute Protocol](The_Absolute_Protocol.md) – RAZAR ignition under operator oversight with retro console requirements
 
 ## Quick Start
 
@@ -73,7 +73,7 @@ abzu-memory-bootstrap
 - [DATPars Overview](datpars_overview.md) – goals, architecture, and integration points
 
 ## Development
-- [The Absolute Protocol](The_Absolute_Protocol.md) (v1.0.96, updated 2025-10-05)
+- [The Absolute Protocol](The_Absolute_Protocol.md) (v1.0.98, updated 2025-09-09) – operator interface and retro console requirements
 - [Developer Etiquette](developer_etiquette.md)
 - [Developer Onboarding](developer_onboarding.md)
 - [Development Checklist](development_checklist.md)

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -49,6 +49,22 @@ summary metrics are reported back to the Primordials service through
 `primordials_api`, ensuring upstream models receive continuous quality
 feedback.
 
+### Operator ↔ RAZAR/Crown Flow
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant RAZAR
+    participant Crown
+    Operator->>RAZAR: mission brief
+    RAZAR->>Crown: delegate to servants
+    Crown-->>RAZAR: status
+    RAZAR-->>Operator: report
+```
+
+This loop illustrates how operator directives traverse RAZAR to Crown and
+return with execution status for console display.
+
 ### Vanna–Bana Narrative Pipeline
 
 ```mermaid


### PR DESCRIPTION
## Summary
- reference retro console requirements in Operator Interface
- add Operator ↔ RAZAR/Crown flow diagrams
- refresh documentation index

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_docs_up_to_date.py`
- `PYTHONPATH=. pre-commit run --files docs/The_Absolute_Protocol.md docs/blueprint_spine.md docs/system_blueprint.md docs/index.md docs/INDEX.md` *(fails: pytest-cov missing plugin; verify-chakra-monitoring and verify-self-healing need running services)*

------
https://chatgpt.com/codex/tasks/task_e_68c05752e188832ea35965ef8a26f382