### PR TITLE
docs: add operator console roadmap

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -56,6 +56,22 @@ flowchart TD
     API --> Ethics[Ethics Store]
 ```
 
+## Roadmap
+
+### Planned Features
+- Agent profiles for personalized operator setups.
+- Theme customization for the arcade interface.
+- World switching to jump between active simulation worlds.
+
+### Dependencies
+- Updated memory bundle diagrams to capture cross-world flows.
+- Optional layer fallbacks when a world omits specific memory layers.
+
+### Open Questions
+- How should agent profiles persist across worlds?
+- Which default themes should ship with the console?
+- What safeguards are needed when switching worlds mid-session?
+
 ## Version History
 | Version | Date       | Notes                              |
 |---------|------------|------------------------------------|

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -49,7 +49,7 @@ Each chakra layer corresponds to core modules that cooperate when Spiral OS is r
 * **Third Eye – Ajna** – `qnl_engine.py` interprets hexadecimal strings into musical glyphs and passes them back to the orchestrator; `scripts/data_validate.py` checks training data and `scripts/quality_score.py` evaluates component health.
 * **Crown – Sahasrara** – `start_spiral_os.py` and `init_crown_agent.py` initialise the entire ritual sequence.
 * **UI Service** – FastAPI front-end providing a browser gateway to memory queries. See [ui_service.md](ui_service.md).
-* **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md).
+* **Operator Console** – Arcade interface driving the Operator API. See [operator_console.md](operator_console.md) and its [roadmap](operator_console.md#roadmap) for planned features.
 * **Nazarick Web Console** – developer dashboard bridging Crown and Nazarick interfaces. See [Crown vs. Nazarick Modes](nazarick_web_console.md#crown-vs-nazarick-modes).
 * **Arcade UI** – features, quickstart, and memory scan sequence. See [arcade_ui.md](arcade_ui.md).
 * **DATPars** – unified parsing interfaces for ingesting external data. See [datpars_overview.md](datpars_overview.md).


### PR DESCRIPTION
## Summary
- document upcoming operator console features and dependencies in a new roadmap section
- link the operator console roadmap from the project overview

## Testing
- `pre-commit run --files docs/operator_console.md docs/project_overview.md` *(fails: pytest-cov unsupported args, verify-chakra-monitoring missing agents module, verify-self-healing no cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c05f3dff8c832e828326fefd0741d5