### PR TITLE
docs: add crown memory seeding

### DIFF
--- a/docs/ABZU_blueprint.md
+++ b/docs/ABZU_blueprint.md
@@ -27,6 +27,8 @@ python -m INANNA_AI.corpus_memory --reindex
 ```
 
 Running this command reindexes [corpus_memory.py](../INANNA_AI/corpus_memory.py) so the Crown internalizes these origins.
+See [Seeding Crown Memory](project_overview.md#seeding-crown-memory)
+for scan paths and the vector-store flow.
 
 ## Macro Architecture
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Curated starting points for understanding and operating the project. For an exha
 - [ABZU Blueprint](ABZU_blueprint.md) – high-level narrative for recreating the system with chakra and heartbeat roles
 - [Repository Blueprint](repository_blueprint.md) – mission, architecture, and memory bundle overview
 - [The Absolute Protocol](The_Absolute_Protocol.md) – RAZAR ignition under operator oversight with retro console requirements
+- [Seeding Crown Memory](project_overview.md#seeding-crown-memory) – corpus scan paths and reindex command
 
 ## Quick Start
 

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -85,6 +85,30 @@ graph LR
 See the [Memory Layers Guide](memory_layers_GUIDE.md) for fallback mechanics
 and the [Recovery Playbook](recovery_playbook.md) for detailed repair flows.
 
+## Seeding Crown Memory
+
+`corpus_memory` scans foundational documents from key directories:
+
+- `INANNA_AI`
+- `GENESIS`
+- `IGNITION`
+- `QNL_LANGUAGE`
+- the GitHub mirror configured by `crown_config.GITHUB_DIR`
+
+After editing files in these paths, rebuild the vector store so the Crown
+references the latest doctrine:
+
+```bash
+python -m INANNA_AI.corpus_memory --reindex
+```
+
+```mermaid
+graph LR
+    Operator --> Reindex[corpus_memory.reindex_corpus]
+    Reindex --> VectorStore
+    VectorStore --> Crown
+```
+
 ## Ethics Corpus Update Flow
 
 ```mermaid


### PR DESCRIPTION
## Summary
- document corpus_memory scan paths and reindex command
- cross-link crown memory seeding from ABZU blueprint and docs index

## Testing
- `pre-commit run --files docs/project_overview.md docs/ABZU_blueprint.md docs/index.md docs/INDEX.md` *(failed: ModuleNotFoundError: No module named 'agents')*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06c307fd8832eaa0d24b0ce473426