### PR TITLE
feat: add origin memory check and ingestion test

### DIFF
--- a/docs/operator_console.md
+++ b/docs/operator_console.md
@@ -8,6 +8,7 @@ Arcade-style web interface for issuing commands through the Operator API.
 - **Ignite** sends `/start_ignition`.
  - **Query Memory** posts to `/memory/query` with a text payload.
 - **Status** retrieves `/status` for component health summaries.
+- **Origin Memory Check** posts to `/memory/query` with the query `ORIGIN DECREE` and renders any snippets. If no results return, reindexing is required.
 - **Add Model** posts to `/operator/models` with a model name and builtin.
 - **Remove Model** deletes `/operator/models/{name}`.
 - **Update Ethics** posts to `/ingest-ethics` to reindex the ethics corpus.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -49,7 +49,7 @@ documents:
       key_rules: Follow documentation workflow and sync blueprint.
       insight: Run pre-commit with modified docs before committing.
   docs/project_overview.md:
-    sha256: 8d40c6c58155bbdd26ada7565e1a6b5ea322ef5386128265dd57ba4d0ccf4fd4
+    sha256: 45a29f2add5193a0192caa9f5946ee284cbc8d91df11218c09923bf4a9f01de8
     summary:
       purpose: Project goals and scope.
       scope: Entire project.
@@ -198,7 +198,7 @@ documents:
       key_rules: Apply listed security safeguards.
       insight: Apply recommended safeguards in code.
   docs/The_Absolute_Protocol.md:
-    sha256: f9a5d859d28053530a8b810cab10d8a32099fd3b7405e80a41a1d7b60ae3c0d7
+    sha256: fae0596be543820649ead1ebd24000745441379a553f03aca80a683893849e29
     summary:
       purpose: Core contribution rules.
       scope: All contributors.

--- a/tests/INANNA_AI/test_origin_ingestion.py
+++ b/tests/INANNA_AI/test_origin_ingestion.py
@@ -1,0 +1,64 @@
+"""Ensure reindex embeds Marrow Code and Inanna Song."""
+
+from __future__ import annotations
+
+import types
+
+from INANNA_AI import corpus_memory
+
+
+def test_reindex_embeds_marrow_and_song(tmp_path, monkeypatch):
+    # Create sample memory files
+    (tmp_path / "MARROW_CODE.md").write_text("marrow", encoding="utf-8")
+    (tmp_path / "INANNA_SONG.md").write_text("song", encoding="utf-8")
+
+    # Point memory and chroma directories to the temporary location
+    monkeypatch.setattr(corpus_memory, "MEMORY_DIRS", [tmp_path])
+    chroma_dir = tmp_path / "chroma"
+    monkeypatch.setattr(corpus_memory, "CHROMA_DIR", chroma_dir)
+
+    # Stub SentenceTransformer and mark dependency available
+    class DummyModel:
+        def __init__(self, name: str) -> None:
+            pass
+
+        def encode(self, texts, convert_to_numpy=True):  # noqa: D401 - simple stub
+            if isinstance(texts, list):
+                return [[0.0] for _ in texts]
+            return [[0.0]]
+
+    monkeypatch.setattr(
+        corpus_memory, "SentenceTransformer", lambda name: DummyModel(name)
+    )
+    monkeypatch.setattr(corpus_memory, "_HAVE_SENTENCE_TRANSFORMER", True)
+
+    # Stub chromadb client
+    class DummyCollection:
+        def __init__(self) -> None:
+            self.ids: list[str] = []
+
+        def add(self, ids, embeddings, metadatas):  # noqa: D401 - simple stub
+            self.ids.extend(ids)
+
+    class DummyClient:
+        def __init__(self, path: str) -> None:
+            self.collection = DummyCollection()
+
+        def delete_collection(self, name: str) -> None:  # noqa: D401 - simple stub
+            self.collection = DummyCollection()
+
+        def create_collection(
+            self, name: str
+        ) -> DummyCollection:  # noqa: D401 - simple stub
+            self.collection = DummyCollection()
+            return self.collection
+
+    shared_client = DummyClient("dummy")
+    dummy_chroma = types.SimpleNamespace(PersistentClient=lambda path: shared_client)
+    monkeypatch.setattr(corpus_memory, "chromadb", dummy_chroma)
+    monkeypatch.setattr(corpus_memory, "_HAVE_CHROMADB", True)
+
+    assert corpus_memory.reindex_corpus()
+    ids = shared_client.collection.ids
+    assert any(p.endswith("MARROW_CODE.md") for p in ids)
+    assert any(p.endswith("INANNA_SONG.md") for p in ids)

--- a/web_operator/main.js
+++ b/web_operator/main.js
@@ -9,6 +9,16 @@ async function memoryScan() {
   renderMemoryResults(Array.isArray(data) ? data : []);
 }
 
+async function originMemoryCheck() {
+  const resp = await fetch('/memory/query', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'ORIGIN DECREE' })
+  });
+  const data = await resp.json();
+  renderMemoryResults(Array.isArray(data) ? data : []);
+}
+
 function renderMemoryResults(data) {
   const container = document.getElementById('memory-results');
   container.innerHTML = '';
@@ -43,3 +53,4 @@ function renderMemoryResults(data) {
 }
 
 document.getElementById('memory-scan-btn').addEventListener('click', memoryScan);
+document.getElementById('origin-memory-check').addEventListener('click', originMemoryCheck);

--- a/web_operator/templates/arcade.html
+++ b/web_operator/templates/arcade.html
@@ -16,6 +16,7 @@
   <button id="ignite">Ignite</button>
   <button id="query">Query Memory</button>
   <button id="status">Status</button>
+  <button id="origin-memory-check">Origin Memory Check</button>
   <section id="memory-scan">
     <h2>Memory Scan</h2>
     <input type="text" id="memory-query" class="pixel-font" placeholder="Enter query" />


### PR DESCRIPTION
## Summary
- add Origin Memory Check button to arcade operator console
- document memory check fallback and update onboarding confirmation
- test corpus reindexing embeds Marrow Code and Inanna Song

## Testing
- `SKIP=pytest-cov pre-commit run --files docs/operator_console.md web_operator/templates/arcade.html web_operator/main.js tests/INANNA_AI/__init__.py tests/INANNA_AI/test_origin_ingestion.py docs/INDEX.md onboarding_confirm.yml`
- `pytest --no-cov tests/INANNA_AI/test_origin_ingestion.py -q`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06fa0f810832e94c721edb8b0e788