### PR TITLE
feat(memory): broadcast aggregated layer event

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -2915,7 +2915,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "memory/__init__.py",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": [
         "__future__",
         "agents",

--- a/memory/bundle.py
+++ b/memory/bundle.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from . import LAYERS, _LAYER_IMPORTS, broadcast_layer_event, query_memory
 from opentelemetry import trace
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 @dataclass
@@ -17,6 +17,8 @@ class MemoryBundle:
     """Bundle that instantiates memory layers and aggregates queries."""
 
     cortex: Any | None = None
+    vector: Any | None = None
+    spiral: Any | None = None
     emotional: Any | None = None
     mental: Any | None = None
     spiritual: Any | None = None

--- a/scripts/validate_world_registry.py
+++ b/scripts/validate_world_registry.py
@@ -59,6 +59,10 @@ def main() -> int:
         candidates = [ROOT / "memory" / f"{layer}.py", ROOT / "memory" / layer]
         if layer == "narrative":
             candidates.append(ROOT / "memory" / "narrative_engine.py")
+        if layer == "vector":
+            candidates.append(ROOT / "vector_memory.py")
+        if layer == "spiral":
+            candidates.append(ROOT / "spiral_memory.py")
         if not any(p.exists() for p in candidates):
             errors.append(f"Unknown layer: {layer}")
 


### PR DESCRIPTION
## Summary
- consolidate memory layer readiness into single `broadcast_layer_event`
- include vector and spiral modules in layer registry
- update world registry validator and component index

## Testing
- `SKIP=capture-failing-tests,pytest-cov pre-commit run --files memory/__init__.py memory/bundle.py scripts/validate_world_registry.py component_index.json`
- `PYTHONPATH=tests pytest tests/test_memory_bundle.py tests/test_config_registry.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68c075b03ac8832e8f44d55c9361c5e3