### PR TITLE
docs: add unified memory bundle chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP gateway exposes context registration and model invocation via MCP; added `config/mcp.toml` and `docs/mcp_overview.md`.
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.
+- Unified Memory Bundle chapter clarifies `layer_init` and `query_memory` flow in `docs/ABZU_blueprint.md`.
 - `docs/operator_onboarding.md` documents mission workflows with Mermaid diagrams and cross-links in `system_blueprint.md`.
 - `datpars` placeholder package with stub interfaces and `docs/datpars_overview.md`.
 - Documented Chakra Heartbeat Alignment for Nazarick agents with Mermaid mapping; cross-linked `chakra_metrics.md` and `ignition_blueprint.md`.

--- a/docs/ABZU_blueprint.md
+++ b/docs/ABZU_blueprint.md
@@ -1,7 +1,7 @@
 # ABZU Blueprint
 
 **Version:** v0.1.0
-**Last updated:** 2025-10-05
+**Last updated:** 2025-10-09
 
 ## Mission & Vision
 ABZU ignites inner narratives before external action, weaving memory bundles, dynamic ignition, and operator guidance into a living system that "knows itself" before engaging others [project_mission_vision.md](project_mission_vision.md).
@@ -31,24 +31,6 @@ See [Seeding Crown Memory](project_overview.md#seeding-crown-memory)
 for scan paths and the vector-store flow.
 
 ## Macro Architecture
-
-### Memory Bundle
-Unified memory layers exchange initialization signals through an event bus, allowing operators to query a consolidated memory spine [memory_layers_GUIDE.md](memory_layers_GUIDE.md).
-```mermaid
-flowchart TD
-    Operator -->|query| MemoryBundle
-    MemoryBundle --> Cortex
-    MemoryBundle --> Emotional
-    MemoryBundle --> Mental
-    MemoryBundle --> Spiritual
-    MemoryBundle --> Narrative
-    Cortex --> MemoryBundle
-    Emotional --> MemoryBundle
-    Mental --> MemoryBundle
-    Spiritual --> MemoryBundle
-    Narrative --> MemoryBundle
-    MemoryBundle -->|aggregated result| Operator
-```
 
 ### RAZAR Ignition
 RAZAR orchestrates multi-layer boot sequences, prepares environments, launches components, and records mission outcomes for operator oversight [RAZAR_AGENT.md](RAZAR_AGENT.md).
@@ -95,6 +77,15 @@ sequenceDiagram
     ReplicaWorld-->>BANA: telemetry
 ```
 
+## Unified Memory Bundle
+ABZU groups its Cortex, Emotional, Mental, Spiritual, and Narrative layers into a single bundle. `broadcast_layer_event("layer_init")` announces readiness across the stack, and `query_memory` fans out requests across all layers to return a unified answer. For deeper design notes, see the [Memory Layers Guide](memory_layers_GUIDE.md) and the [System Blueprint](system_blueprint.md#memory-bundle).
+
+```mermaid
+{{#include figures/memory_bundle.mmd}}
+```
+
+The Mermaid source lives at [figures/memory_bundle.mmd](figures/memory_bundle.mmd).
+
 ## Chakra Architecture & HeartBeat Pulse
 The chakra cycle engine synchronizes core modules with a unified pulse so agents can monitor and heal their aligned layers. The diagram maps primary modules to chakras and the returning heartbeat that keeps them in lockstep.
 
@@ -121,3 +112,5 @@ sequenceDiagram
 - Agent roster and roles: [agents/nazarick/nazarick_core_architecture.md](../agents/nazarick/nazarick_core_architecture.md)
 - World services scaffold: [worlds/services.py](../worlds/services.py)
 - Additional guidance: [RAZAR_AGENT.md](RAZAR_AGENT.md), [memory_layers_GUIDE.md](memory_layers_GUIDE.md), [project_mission_vision.md](project_mission_vision.md)
+
+Backlinks: [System Blueprint](system_blueprint.md) | [The Absolute Protocol](The_Absolute_Protocol.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -201,7 +200,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
 | [ABZU_DEPLOYMENT.md](ABZU_DEPLOYMENT.md) | ABZU Deployment | This guide outlines the environment preparation, boot order, and rollback steps for deploying ABZU. | - |
 | [ABZU_SUBSYSTEM_OVERVIEW.md](ABZU_SUBSYSTEM_OVERVIEW.md) | ABZU Subsystem Overview | The diagram below outlines how the primary subsystems collaborate within ABZU. | - |
-| [ABZU_blueprint.md](ABZU_blueprint.md) | ABZU Blueprint | **Version:** v0.1.0 **Last updated:** 2025-10-05 | `../INANNA_AI/corpus_memory.py`, `../agents/event_bus.py`, `../crown_router.py`, `../memory/bundle.py`, `../razar/boot_orchestrator.py`, `../scripts/bootstrap_memory.py`, `../video_stream.py`, `../worlds/services.py` |
+| [ABZU_blueprint.md](ABZU_blueprint.md) | ABZU Blueprint | **Version:** v0.1.0 **Last updated:** 2025-10-09 | `../INANNA_AI/corpus_memory.py`, `../agents/event_bus.py`, `../crown_router.py`, `../memory/bundle.py`, `../razar/boot_orchestrator.py`, `../scripts/bootstrap_memory.py`, `../video_stream.py`, `../worlds/services.py` |
 | [ABZU_project_declaration.md](ABZU_project_declaration.md) | ABZU_project_declaration.md | - | - |
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Layer | Albedo is a personality layer that shapes responses through a four-phase alchemical cycle. | - |
 | [Albedo_GUIDE.md](Albedo_GUIDE.md) | Albedo Guide | - | - |


### PR DESCRIPTION
## Summary
- document unified memory bundle with `layer_init` and `query_memory`
- embed memory bundle diagram and cross-link to memory layers guide
- reference System Blueprint and The Absolute Protocol for doctrinal navigation

## Testing
- `pre-commit run --files docs/ABZU_blueprint.md docs/INDEX.md CHANGELOG.md` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; no successful self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c084203d48832e839f894c2f5395ab