### PR TITLE
docs: clarify memory bundle flows

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -131,6 +131,16 @@ The Mermaid source lives at [figures/memory_bundle.mmd](figures/memory_bundle.mm
 
 `MemoryBundle.initialize()` emits a single `broadcast_layer_event("layer_init")` so all five layers report readiness in parallel. Services wait on this broadcast before issuing `query_memory` requests, guaranteeing that startup completes before any memory queries occur.
 
+#### Initialization and Query Aggregation
+
+`broadcast_layer_event("layer_init")` primes every layer before the `query_memory` façade fans out reads and merges the replies into a unified recall.
+
+```mermaid
+{{#include figures/layer_init_query_flow.mmd}}
+```
+
+The Mermaid source lives at [figures/layer_init_query_flow.mmd](figures/layer_init_query_flow.mmd) and is shared across the repository to keep bundle diagrams aligned.
+
 ### Dynamic Ignition
 
 RAZAR evaluates ignition plans at runtime so services launch only when the operator authorizes them, keeping startup lightweight and responsive.

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -371,9 +371,15 @@ Modules are organized by chakra (Root through Crown), with additional Nazarick a
 
 ## **4. Memory Bundle**
 
-ABZU layers five memory stores—Cortex, Emotional, Mental, Spiritual, and Narrative—each switchable between file-based JSON/SQLite and vector-DB back ends via environment variables. See [Memory Layers Guide](memory_layers_GUIDE.md) and diagrams like [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd) and [Memory Layer Flow](figures/memory_layer_flow.mmd) for event sequencing and query aggregation.
+The Cortex, Emotional, Mental, Spiritual, and Narrative stores converge in a unified bundle. `broadcast_layer_event("layer_init")` starts all layers in parallel, and the `query_memory` façade gathers their replies into a single recall stream for operator agents.
 
-Once these stores ignite, RAZAR activates the Bana engine to narrate state transitions across layers.
+```mermaid
+{{#include figures/layer_init_query_flow.mmd}}
+```
+
+The Mermaid source lives at [figures/layer_init_query_flow.mmd](figures/layer_init_query_flow.mmd).
+
+Once the bundle reports readiness, RAZAR activates the Bana engine to narrate transitions across layers.
 
 ## **5. BANA Narrative Engine and INANNA Bridge**
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -328,6 +328,10 @@ graph TD
     RAZAR --> Console
 ```
 
+### Memory Bundle Architecture
+
+`MemoryBundle` links the Cortex, Emotional, Mental, Spiritual, and Narrative layers behind a common bus. `broadcast_layer_event("layer_init")` announces readiness, while the `query_memory` façade fans out recalls and returns a merged view for Crown and operator agents.
+
 ### Document Map
 
 - **High‑level docs**


### PR DESCRIPTION
## Summary
- detail layer initialization and query aggregation in The Absolute Protocol with shared mermaid diagram
- narrate unified memory bundle in Blueprint Spine and embed the same diagram
- note Memory Bundle Architecture in System Blueprint referencing query façade

## Testing
- `PYTHONPATH=. pre-commit run --files docs/The_Absolute_Protocol.md docs/blueprint_spine.md docs/system_blueprint.md docs/INDEX.md` *(fails: missing metrics exporters; no self-heal cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68c0869a7b2c832ea5032b2127009d45