### PR TITLE
docs: reference unified memory bundle

### DIFF
--- a/docs/ABZU_SUBSYSTEM_OVERVIEW.md
+++ b/docs/ABZU_SUBSYSTEM_OVERVIEW.md
@@ -61,6 +61,8 @@ graph TD
 - **Query traversal** – `MemoryBundle.query()` fans requests across every layer and aggregates the responses before returning to the RAG Orchestrator.
 - See [Memory Layers Guide](memory_layers_GUIDE.md) for implementation specifics.
 
+Additional context is provided in [ABZU Blueprint – Unified Memory Bundle](ABZU_blueprint.md#unified-memory-bundle), [System Blueprint – Unified Memory Bundle](system_blueprint.md#memory-bundle), and [The Absolute Protocol – Unified Memory Bundle](The_Absolute_Protocol.md#unified-memory-bundle).
+
 ## Memory Bundle Layers
 
 ```mermaid

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ abzu-memory-bootstrap
 ```
 
 ## Memory Bundle
+- [ABZU Blueprint – Unified Memory Bundle](ABZU_blueprint.md#unified-memory-bundle) – single bundle gating initialization and unified query
+- [System Blueprint – Unified Memory Bundle](system_blueprint.md#memory-bundle) – cross-layer memory flow and spine integration
 - [The Absolute Protocol – Unified Memory Bundle](The_Absolute_Protocol.md#unified-memory-bundle) – `layer_init` broadcast and `query_memory` façade
 - [Subsystem Overview](ABZU_SUBSYSTEM_OVERVIEW.md#memory-bundle-layers) – full five-layer bundle diagram and roles
 - [Memory Layers Guide](memory_layers_GUIDE.md) – bus protocol with diagrams: [Memory Bundle](figures/memory_bundle.mmd), [Layer Initialization Broadcast](figures/layer_init_broadcast.mmd), [Query Memory Aggregation](figures/query_memory_aggregation.mmd)

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -64,6 +64,8 @@ The Crown can delegate requests to auxiliary servant models when specialized beh
 
 `MemoryBundle` unifies the Cortex, Emotional, Mental, Spiritual and Narrative layers. `bundle.initialize()` emits a single `layer_init` event on the `memory` bus so every layer reports readiness together. Subsequent `query_memory` calls fan out requests across the layers and merge their results into one payload. See [Memory Layers Guide](memory_layers_GUIDE.md) for implementation details and the unified diagram below.
 
+For architectural context, consult [ABZU Blueprint – Unified Memory Bundle](ABZU_blueprint.md#unified-memory-bundle), [System Blueprint – Unified Memory Bundle](system_blueprint.md#memory-bundle), and [The Absolute Protocol – Unified Memory Bundle](The_Absolute_Protocol.md#unified-memory-bundle).
+
 ```mermaid
 {{#include figures/memory_bundle.mmd}}
 ```


### PR DESCRIPTION
## Summary
- index unified memory bundle chapters in blueprint, system blueprint, and Absolute Protocol
- reference unified memory bundle chapters from project and subsystem overviews

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_docs_up_to_date.py`
- `pre-commit run --files docs/index.md docs/INDEX.md docs/project_overview.md docs/ABZU_SUBSYSTEM_OVERVIEW.md` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; no successful self-heal cycles in last 24h)*

------
https://chatgpt.com/codex/tasks/task_e_68c0888598f4832ebcaf2bb467915287