### PR TITLE
Handle missing OpenTelemetry in memory bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mission brief and operator chat examples with connector checklist cross-links in Crown and operator docs.
 - Removed unused `boot_sequence` placeholder from `orchestration_master.py`.
 - Hardened Crown prompt orchestrator to target known exceptions and surface unexpected failures.
+- Wrapped OpenTelemetry import in `memory.bundle` and defaulted to a no-op tracer when the package is absent.
 - Boot orchestrator reruns health checks after AI-generated patches and stops
   after the configurable `--remote-attempts` limit, logging each handover.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -365,7 +365,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.7 **Last updated:** 2025-09-09 | `../scripts/bootstrap_memory.py` |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.8 **Last updated:** 2025-09-09 | `../scripts/bootstrap_memory.py` |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,6 +1,6 @@
 # Memory Layers Guide
 
-**Version:** v1.0.7
+**Version:** v1.0.8
 **Last updated:** 2025-09-09
 
 This guide describes the event bus protocol and query flow connecting the
@@ -154,6 +154,12 @@ fallback, which exposes the same public API but returns empty data structures.
 Fallback layers are reported as `skipped`, and calls such as
 `aggregate_search` simply yield empty results for them while logging any
 underlying errors. Queries still return data from the remaining active layers.
+
+## Tracing
+
+`MemoryBundle` emits OpenTelemetry spans when the `opentelemetry` package is
+installed. If the module is absent, it falls back to a no-op tracer so
+initialization and queries proceed without tracing.
 
 ## Installation Options
 

--- a/tests/test_memory_bundle_tracing.py
+++ b/tests/test_memory_bundle_tracing.py
@@ -1,0 +1,32 @@
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+import conftest as conftest_module
+
+conftest_module.ALLOWED_TESTS.update(
+    {str(Path(__file__).resolve()), str(Path(__file__))}
+)
+
+
+def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.startswith("opentelemetry"):
+        raise ImportError(name)
+    return _real_import(name, globals, locals, fromlist, level)
+
+
+_real_import = builtins.__import__
+
+
+def test_memory_bundle_without_opentelemetry(monkeypatch):
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    monkeypatch.delitem(sys.modules, "opentelemetry", raising=False)
+    monkeypatch.delitem(sys.modules, "opentelemetry.trace", raising=False)
+    monkeypatch.delitem(sys.modules, "memory.bundle", raising=False)
+
+    module = importlib.import_module("memory.bundle")
+    bundle = module.MemoryBundle()
+
+    with bundle._tracer.start_as_current_span("test") as span:
+        assert span is None


### PR DESCRIPTION
## Summary
- guard MemoryBundle tracing import and default to no-op tracer when OpenTelemetry is absent
- document optional tracing dependency in memory layers guide
- add regression test for missing OpenTelemetry

## Testing
- `pre-commit run --files memory/bundle.py docs/memory_layers_GUIDE.md docs/INDEX.md tests/test_memory_bundle_tracing.py CHANGELOG.md` (fails: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles in last 24h)
- `PYTHONPATH=tests pytest tests/test_memory_bundle_tracing.py -q --no-cov` (skipped: requires unavailable resources)


------
https://chatgpt.com/codex/tasks/task_e_68c0928da13c832e9614c7e71ef75bf7