### PR TITLE
Add NoOpTracer fallback when OpenTelemetry is missing

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -365,7 +366,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.8 **Last updated:** 2025-09-09 | `../scripts/bootstrap_memory.py` |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | `../scripts/bootstrap_memory.py` |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |

--- a/docs/memory_layers_GUIDE.md
+++ b/docs/memory_layers_GUIDE.md
@@ -1,7 +1,7 @@
 # Memory Layers Guide
 
-**Version:** v1.0.8
-**Last updated:** 2025-09-09
+**Version:** v1.0.9
+**Last updated:** 2025-09-30
 
 This guide describes the event bus protocol and query flow connecting the
 Cortex, Emotional, Mental, Spiritual, and Narrative memory layers.
@@ -158,8 +158,9 @@ underlying errors. Queries still return data from the remaining active layers.
 ## Tracing
 
 `MemoryBundle` emits OpenTelemetry spans when the `opentelemetry` package is
-installed. If the module is absent, it falls back to a no-op tracer so
-initialization and queries proceed without tracing.
+installed. If the module is absent, it falls back to an internal
+`NoOpTracer` that provides the minimal tracing interface so initialization and
+queries proceed without instrumentation.
 
 ## Installation Options
 

--- a/memory/bundle.py
+++ b/memory/bundle.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from importlib import import_module
-from contextlib import nullcontext
 from typing import Any, Dict
 
 from . import LAYERS, _LAYER_IMPORTS, broadcast_layer_event, query_memory
@@ -15,11 +14,21 @@ try:  # pragma: no cover - optional dependency
     _TRACER = trace.get_tracer(__name__)
 except ImportError:  # pragma: no cover - dependency missing
 
-    class _NoOpTracer:
-        def start_as_current_span(self, *args: Any, **kwargs: Any):  # noqa: ANN001
-            return nullcontext()
+    class NoOpSpan:
+        def __enter__(self) -> "NoOpSpan":
+            return self
 
-    _TRACER = _NoOpTracer()
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            return False
+
+        def set_attribute(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class NoOpTracer:
+        def start_as_current_span(self, *_: Any, **__: Any) -> NoOpSpan:
+            return NoOpSpan()
+
+    _TRACER = NoOpTracer()
 
 __version__ = "0.1.4"
 

--- a/tests/test_memory_bundle.py
+++ b/tests/test_memory_bundle.py
@@ -12,7 +12,7 @@ from memory.bundle import MemoryBundle
 
 qm = importlib.import_module("memory.query_memory")
 import pytest
-import conftest as conftest_module
+from tests import conftest as conftest_module
 from pathlib import Path
 
 conftest_module.ALLOWED_TESTS.update(
@@ -76,6 +76,8 @@ def test_initialize_marks_skipped_layer(monkeypatch):
 
     def fake_import(name: str):
         if name == "memory.mental":
+            raise ModuleNotFoundError(name)
+        if name == "memory.optional.mental":
             return OptionalModule()
         return real_import(name)
 

--- a/tests/test_memory_bundle_tracing.py
+++ b/tests/test_memory_bundle_tracing.py
@@ -3,7 +3,7 @@ import importlib
 import sys
 from pathlib import Path
 
-import conftest as conftest_module
+from tests import conftest as conftest_module
 
 conftest_module.ALLOWED_TESTS.update(
     {str(Path(__file__).resolve()), str(Path(__file__))}
@@ -29,4 +29,5 @@ def test_memory_bundle_without_opentelemetry(monkeypatch):
     bundle = module.MemoryBundle()
 
     with bundle._tracer.start_as_current_span("test") as span:
-        assert span is None
+        assert hasattr(span, "set_attribute")
+        span.set_attribute("foo", "bar")


### PR DESCRIPTION
## Summary
- handle missing OpenTelemetry by adding internal NoOpTracer and using it as default tracer
- document NoOpTracer fallback in memory layers guide
- adjust tests for new tracer behavior

## Testing
- `pre-commit run --files memory/bundle.py docs/memory_layers_GUIDE.md tests/test_memory_bundle.py tests/test_memory_bundle_tracing.py` (failed: ModuleNotFoundError: No module named 'agents'; no successful self-heal cycles)
- `python scripts/verify_docs_up_to_date.py`
- `pytest --no-cov tests/test_memory_bundle.py tests/test_memory_bundle_tracing.py`


------
https://chatgpt.com/codex/tasks/task_e_68c09589e280832e8e233ceebd70e68f