### PR TITLE
Add rStar patch service integration

### DIFF
--- a/config/razar_ai_agents.json
+++ b/config/razar_ai_agents.json
@@ -15,6 +15,14 @@
         "type": "api_key",
         "key": "BACKUP_KEY"
       }
+    },
+    {
+      "name": "rstar",
+      "endpoint": "${RSTAR_ENDPOINT}",
+      "auth": {
+        "type": "bearer",
+        "token": "${RSTAR_TOKEN}"
+      }
     }
   ]
 }

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -81,3 +81,12 @@ docker build -f docker/Dockerfile.gpu -t abzu-gpu .
 - **GPU environment:** NVIDIA GPU with compute capability ≥7.0, CUDA 12.1‑compatible drivers, and 12 GB+ VRAM.
 
 Run `scripts/check_requirements.sh` after installation to verify the setup.
+
+## rStar service
+
+Expose the `rStar` patch API by setting its endpoint and access token:
+
+```bash
+export RSTAR_ENDPOINT=http://localhost:8000/patch
+export RSTAR_TOKEN=your_token
+```

--- a/rstar_service/Dockerfile
+++ b/rstar_service/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/microsoft/rStar.git && pip install ./rStar
+RUN pip install fastapi uvicorn
+COPY app.py /app/app.py
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/rstar_service/app.py
+++ b/rstar_service/app.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import rstar
+
+app = FastAPI()
+
+
+class PatchRequest(BaseModel):
+    data: str
+
+
+@app.post("/patch")
+def patch(req: PatchRequest):
+    if not hasattr(rstar, "patch"):
+        raise HTTPException(status_code=501, detail="rstar.patch not implemented")
+    result = rstar.patch(req.data)
+    return {"result": result}


### PR DESCRIPTION
## Summary
- containerize microsoft/rStar with a minimal REST patch endpoint
- register rStar agent with endpoint and token configuration
- document RSTAR_ENDPOINT and RSTAR_TOKEN setup

## Testing
- `PYTHONPATH=. pre-commit run --files rstar_service/app.py rstar_service/Dockerfile config/razar_ai_agents.json docs/environment_setup.md docs/INDEX.md` *(fails: missing metrics exporters, no self-heal cycles)*
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9980b5c832ea5d3466f4d10ad39