### PR TITLE
Escalate to rstar after repeated ai_invoker failures

### DIFF
--- a/config/razar_ai_agents.json
+++ b/config/razar_ai_agents.json
@@ -1,4 +1,5 @@
 {
+  "active": "demo_agent",
   "agents": [
     {
       "name": "demo_agent",


### PR DESCRIPTION
## Summary
- track consecutive ai_invoker failures and escalate to `rstar` after ten attempts
- persist active agent override to `config/razar_ai_agents.json`
- annotate invocation log entries with event metadata for audit

## Testing
- `pre-commit run --files razar/boot_orchestrator.py config/razar_ai_agents.json` *(fails: Required test coverage of 80% not reached; Component alpha lacks a health probe)*
- `pytest tests/agents/razar/test_boot_sequence.py::test_boot_sequence_order_and_failure -q` *(fails: Component alpha lacks a health probe)*

------
https://chatgpt.com/codex/tasks/task_e_68c0abbe5a8c832e85ddea3c4ac03bd1