### PR TITLE
docs: document rStar escalation flow

### DIFF
--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -97,6 +97,19 @@ ai_invoker.handover("crown_router", "Health check failed", use_opencode=True)
 
 If Kimi supplies a patch, it is applied and the component relaunches.
 
+### rStar Escalation
+RAZAR tracks consecutive repair attempts for each component. After nine
+unsuccessful tries it escalates the failure context to the `rStar` patch
+service for external triage.
+
+Configuration knobs:
+
+- `RAZAR_RSTAR_THRESHOLD` – attempts before escalation (default `9`)
+- `RSTAR_ENDPOINT` – URL for the `rStar` patch API
+- `RSTAR_TOKEN` – access token for the API
+
+Set `RAZAR_RSTAR_THRESHOLD=0` to disable escalation entirely.
+
 ### Recovery Flow
 ```mermaid
 flowchart TD

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,7 @@ abzu-memory-bootstrap
 - [Example Feature](features/example_feature.md)
 - [RAZAR Agent](RAZAR_AGENT.md)
 - [RAZAR Self-Healing Overview](RAZAR_AGENT.md#self-healing-overview)
+- [RAZAR rStar Escalation](RAZAR_AGENT.md#rstar-escalation)
 - [Persona API Guide](persona_api_guide.md) – utilities for managing persona interactions
 
 ## Indices

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -211,6 +211,14 @@ When a generated patch destabilizes the system, operators can revert via
 `logs/patch_history.jsonl` and the boot orchestrator requeues the component for
 fresh health checks.
 
+#### rStar Escalation
+
+Repeated failures trigger an escalation path. After nine unsuccessful repair
+attempts RAZAR forwards the fault context to the external `rStar` patch
+service. Operators can tune escalation with `RAZAR_RSTAR_THRESHOLD` and set the
+service parameters via `RSTAR_ENDPOINT` and `RSTAR_TOKEN`. See
+[RAZAR rStar Escalation](RAZAR_AGENT.md#rstar-escalation) for details.
+
 ### Game Dashboard & Retro Arcade Integration
 
 The React-based [Game Dashboard](ui/game_dashboard.md) wraps the avatar stream


### PR DESCRIPTION
## Summary
- document rStar escalation threshold and knobs in RAZAR agent guide
- surface escalation path in system blueprint and docs index

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_docs_up_to_date.py`
- `pre-commit run --files docs/RAZAR_AGENT.md docs/index.md docs/system_blueprint.md docs/INDEX.md` *(fails: verify-versions mismatch, missing websockets, pytest-cov arg error, link validation, verify-chakra-monitoring, verify-self-healing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b1ea71fc832eadf0afd167478da1