### PR TITLE
Isolate NEOABZU tooling with dedicated CI

### DIFF
--- a/.github/workflows/neoabzu.yml
+++ b/.github/workflows/neoabzu.yml
@@ -1,0 +1,41 @@
+# CI pipeline dedicated to the NEOABZU workspace
+name: NEOABZU CI
+
+on:
+  push:
+    paths:
+      - 'NEOABZU/**'
+      - '.github/workflows/neoabzu.yml'
+  pull_request:
+    paths:
+      - 'NEOABZU/**'
+      - '.github/workflows/neoabzu.yml'
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run NEOABZU tests
+        run: cargo test --manifest-path NEOABZU/Cargo.toml
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install helpers
+        run: |
+          cd NEOABZU
+          pip install -e .
+      - name: Run Python tests
+        run: |
+          cd NEOABZU
+          pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Isolated NEOABZU tooling with a dedicated `pyproject.toml` and CI workflow, keeping ABZU tests unaffected.
 - Documented PyO3 and gRPC interface contracts in `NEOABZU/Reignition.md` and
   introduced a CI job that builds Rust crates and runs Python integration tests.
 - Initialized NEOABZU Rust workspace with core lambda-calculus interpreter and Python bindings.

--- a/NEOABZU/Reignition.md
+++ b/NEOABZU/Reignition.md
@@ -7,6 +7,7 @@ NEOABZU ignites a fresh substrate for ABZU components.
 - Prototype computation through a minimal lambda-calculus interpreter with Python bindings.
 - Maintain alignment with the architectural vision outlined in [docs/ABZU_blueprint.md](../docs/ABZU_blueprint.md) and
   the operational practices described in [docs/system_blueprint.md](../docs/system_blueprint.md).
+- Provide Python helper scaffolding via `pyproject.toml` and isolate testing through a dedicated CI workflow.
 
 This document tracks early milestones as we grow the workspace into a fully fledged system.
 

--- a/NEOABZU/pyproject.toml
+++ b/NEOABZU/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "neoabzu"
+version = "0.1.0"
+description = "Python helpers for the NEOABZU Rust workspace"
+requires-python = ">=3.10"
+authors = [{name = "NEOABZU Team"}]
+dependencies = []


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for NEOABZU Python helpers
- document mission and CI separation in `NEOABZU/Reignition.md`
- create `neoabzu.yml` workflow to run NEOABZU tests only

## Testing
- `pre-commit run --files .github/workflows/neoabzu.yml NEOABZU/pyproject.toml`
- `python scripts/verify_docs_up_to_date.py`
- `cargo test --manifest-path NEOABZU/Cargo.toml`
- `pytest -p no:cov --override-ini="addopts="`

------
https://chatgpt.com/codex/tasks/task_e_68c1ac8a1f94832ea38c63aedfa252e7