### PR TITLE
Add feature parity matrix for NEOABZU

### DIFF
--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -1,0 +1,13 @@
+# Feature Parity Matrix
+
+Track NEOABZU progress toward ABZU functionality. Update this table as milestones complete to keep contributors aligned.
+
+| ABZU Module | Status | NEOABZU Plan |
+| --- | --- | --- |
+| User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
+| Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | rewrite in Rust |
+| Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | rewrite in Rust |
+| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | rewrite in Rust |
+| Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | rewrite in Rust |
+| Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |
+


### PR DESCRIPTION
## Summary
- add feature parity matrix outlining ABZU subsystems and NEOABZU reuse/rewrite/drop plans

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files NEOABZU/docs/feature_parity.md`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3164d1c832e96a7affae3030c49