### PR TITLE
Chore: enforce shared-file ABZU tests in CI

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,9 @@
+# Repository settings managed via configuration-as-code
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - ABZU CI
+          - NEOABZU CI

--- a/.github/workflows/abzu.yml
+++ b/.github/workflows/abzu.yml
@@ -1,0 +1,29 @@
+name: ABZU CI
+
+on:
+  push:
+    paths-ignore:
+      - 'NEOABZU/**'
+      - '.github/workflows/neoabzu.yml'
+  pull_request:
+    paths-ignore:
+      - 'NEOABZU/**'
+      - '.github/workflows/neoabzu.yml'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,9 @@ coverage run -m pytest
 coverage report
 ```
 
+ABZU CI runs the test suite whenever shared files change. A pull request can
+only merge once both **ABZU CI** and **NEOABZU CI** report success.
+
 ## Component Version Mandate
 
 Every source module must define a `__version__` attribute. Bump this value for
@@ -150,6 +153,7 @@ Before submitting a pull request, confirm:
 - Prefix pull request titles with a category such as `Feature:`, `Fix:`, or `Chore:` (e.g., `Feature: Voice Cloning V2`).
 - Keep changes focused; submit separate PRs for unrelated fixes.
 - Ensure documentation is updated and tests pass.
+- Merging requires green status from both `ABZU CI` and `NEOABZU CI` workflows.
 - Pull requests that fail `pre-commit run --all-files` will not be merged.
 - Register new modules in [docs/component_priorities.yaml](docs/component_priorities.yaml) with a priority (P1–P5), criticality tag, and issue categories so RAZAR can orchestrate startup.
 - Record project-wide documentation or architectural changes in


### PR DESCRIPTION
## Summary
- add ABZU CI workflow to run tests when non-NEOABZU files change
- require ABZU CI and NEOABZU CI as protected checks
- document CI requirements in contributing guide

## Testing
- `pre-commit run --files .github/workflows/abzu.yml .github/settings.yml CONTRIBUTING.md` *(fails: test coverage below threshold and a test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c63601ec832ea7283118b9da9f9c