### PR TITLE
feat(crown): add inevitability route

### DIFF
--- a/NEOABZU/crown/src/lib.rs
+++ b/NEOABZU/crown/src/lib.rs
@@ -101,9 +101,29 @@ fn route_decision(
     Ok(decision.into_py(py))
 }
 
+#[pyfunction]
+fn route_inevitability(py: Python<'_>, expr: &str) -> PyResult<Py<PyDict>> {
+    let core = PyModule::import(py, "neoabzu_core")?;
+    let reduce = core.getattr("reduce_inevitable")?;
+    let (inevitability, journey): (f32, Vec<String>) = reduce.call1((expr,))?.extract()?;
+
+    let narrative = format!("{inevitability}:{journey:?}");
+    let statuses = PyDict::new(py);
+    statuses.set_item("narrative", narrative)?;
+    let memory = PyModule::import(py, "neoabzu_memory")?;
+    let broadcast = memory.getattr("broadcast_layer_event")?;
+    broadcast.call1((statuses,))?;
+
+    let result = PyDict::new(py);
+    result.set_item("inevitability", inevitability)?;
+    result.set_item("journey", journey)?;
+    Ok(result.into_py(py))
+}
+
 #[pymodule]
 fn neoabzu_crown(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(route_query, m)?)?;
     m.add_function(wrap_pyfunction!(route_decision, m)?)?;
+    m.add_function(wrap_pyfunction!(route_inevitability, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `route_inevitability` to invoke `core::reduce_inevitable` via PyO3
- broadcast narrative output to memory layer using `broadcast_layer_event`
- expose new route from `neoabzu_crown`

## Testing
- `pre-commit run --files crown/src/lib.rs` *(failed: missing dependencies; rust-fmt-clippy, verify-versions, check-env, pytest-cov skipped)*
- `pre-commit run verify-onboarding-refs`
- `SKIP=rust-fmt-clippy,verify-versions,check-env,pytest-cov pre-commit run --files crown/src/lib.rs`
- `cargo build -p neoabzu-core --lib`
- `cargo build -p neoabzu-memory --lib`
- `cargo build -p neoabzu-crown --lib`
- `PYTHONPATH=/workspace/ABZU/NEOABZU/target/debug python - <<'PY'
import sys, types
_events = []

def emit_event(actor, action, metadata):
    _events.append((actor, action, metadata))

bus = types.SimpleNamespace(emit_event=emit_event)
agents_mod = types.SimpleNamespace(event_bus=bus)
sys.modules['agents'] = agents_mod
sys.modules['agents.event_bus'] = bus

import neoabzu_crown
result = neoabzu_crown.route_inevitability("(♀ :: ∞) :: ∅")
print(result)
print(_events)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c4b6b009a8832e97fc446068f98ec8