### PR TITLE
Route memory queries through Crown bundle

### DIFF
--- a/NEOABZU/crown/src/lib.rs
+++ b/NEOABZU/crown/src/lib.rs
@@ -120,10 +120,19 @@ fn route_inevitability(py: Python<'_>, expr: &str) -> PyResult<Py<PyDict>> {
     Ok(result.into_py(py))
 }
 
+#[pyfunction]
+fn query_memory(py: Python<'_>, text: &str) -> PyResult<Py<PyDict>> {
+    let memory = PyModule::import(py, "neoabzu_memory")?;
+    let func = memory.getattr("query_memory")?;
+    func.call1((text,))?.extract()
+}
+
 #[pymodule]
-fn neoabzu_crown(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn neoabzu_crown(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(route_query, m)?)?;
     m.add_function(wrap_pyfunction!(route_decision, m)?)?;
     m.add_function(wrap_pyfunction!(route_inevitability, m)?)?;
+    m.add_function(wrap_pyfunction!(query_memory, m)?)?;
+    PyModule::import(py, "neoabzu_memory")?;
     Ok(())
 }

--- a/NEOABZU/crown/tests/memory_query.rs
+++ b/NEOABZU/crown/tests/memory_query.rs
@@ -1,0 +1,120 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+fn setup_stub_layers(py: Python<'_>) {
+    let sys = py.import("sys").unwrap();
+    let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
+
+    macro_rules! stub {
+        ($name:expr, $code:expr) => {
+            let module = PyModule::from_code(py, $code, "", $name).unwrap();
+            modules.set_item($name, module).unwrap();
+        };
+    }
+
+    let agents = PyModule::new(py, "agents").unwrap();
+    modules.set_item("agents", agents).unwrap();
+    stub!(
+        "agents.event_bus",
+        "events = []\n\ndef emit_event(actor, action, metadata):\n    events.append((actor, action, metadata))\n"
+    );
+
+    stub!(
+        "memory.cortex",
+        "def query_spirals(**kw):\n    return ['c']\n"
+    );
+    stub!(
+        "vector_memory",
+        "def query_vectors(*a, **k):\n    return ['v']\n"
+    );
+    stub!(
+        "spiral_memory",
+        "def spiral_recall(q):\n    return 's'\n"
+    );
+    stub!(
+        "memory.emotional",
+        "def fetch_emotion_history(limit):\n    return ['e']\n"
+    );
+    stub!(
+        "memory.mental",
+        "def query_related_tasks(q):\n    return ['m']\n"
+    );
+    stub!(
+        "memory.spiritual",
+        "def lookup_symbol_history(q):\n    return ['p']\n"
+    );
+    stub!(
+        "memory.narrative_engine",
+        "def stream_stories():\n    return ['n']\n"
+    );
+    stub!(
+        "neoabzu_core",
+        "def evaluate(expr):\n    return 'core'\n"
+    );
+}
+
+#[test]
+fn crown_exposes_memory_query() {
+    Python::with_gil(|py| {
+        setup_stub_layers(py);
+        let crown = PyModule::import(py, "neoabzu_crown").unwrap();
+        let func = crown.getattr("query_memory").unwrap();
+        let res: Py<PyDict> = func.call1(("demo",)).unwrap().extract().unwrap();
+        let d = res.as_ref(py);
+        let cortex: Vec<String> = d.get_item("cortex").unwrap().extract().unwrap();
+        let vector: Vec<String> = d.get_item("vector").unwrap().extract().unwrap();
+        let spiral: String = d.get_item("spiral").unwrap().extract().unwrap();
+        let emotional: Vec<String> = d.get_item("emotional").unwrap().extract().unwrap();
+        let mental: Vec<String> = d.get_item("mental").unwrap().extract().unwrap();
+        let spiritual: Vec<String> = d.get_item("spiritual").unwrap().extract().unwrap();
+        let narrative: Vec<String> = d.get_item("narrative").unwrap().extract().unwrap();
+        let core: String = d.get_item("core").unwrap().extract().unwrap();
+        let failed: Vec<String> = d.get_item("failed_layers").unwrap().extract().unwrap();
+        assert_eq!(cortex, vec!["c"]);
+        assert_eq!(vector, vec!["v"]);
+        assert_eq!(spiral, "s");
+        assert_eq!(emotional, vec!["e"]);
+        assert_eq!(mental, vec!["m"]);
+        assert_eq!(spiritual, vec!["p"]);
+        assert_eq!(narrative, vec!["n"]);
+        assert_eq!(core, "core");
+        assert!(failed.is_empty());
+    });
+}
+
+#[test]
+fn crown_import_triggers_layer_init() {
+    Python::with_gil(|py| {
+        setup_stub_layers(py);
+        PyModule::import(py, "neoabzu_crown").unwrap();
+        let actor: String = py
+            .eval("agents.event_bus.events[0][0]", None, None)
+            .unwrap()
+            .extract()
+            .unwrap();
+        let action: String = py
+            .eval("agents.event_bus.events[0][1]", None, None)
+            .unwrap()
+            .extract()
+            .unwrap();
+        assert_eq!(actor, "memory");
+        assert_eq!(action, "layer_init");
+        for layer in [
+            "cortex",
+            "vector",
+            "spiral",
+            "emotional",
+            "mental",
+            "spiritual",
+            "narrative",
+            "core",
+        ] {
+            let check: bool = py
+                .eval(&format!("'{layer}' in agents.event_bus.events[0][2]['layers']"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert!(check);
+        }
+    });
+}

--- a/NEOABZU/memory/src/lib.rs
+++ b/NEOABZU/memory/src/lib.rs
@@ -363,6 +363,8 @@ fn neoabzu_memory(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(broadcast_layer_event, m)?)?;
     m.add_function(wrap_pyfunction!(eval_core, m)?)?;
     m.add_function(wrap_pyfunction!(reduce_inevitable_core, m)?)?;
+    let mut bundle = MemoryBundle::new();
+    bundle.initialize(py)?;
     Ok(())
 }
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -385,6 +385,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
 | [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | - |
+| [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | This crosswalk outlines how memory layers connect to Crown during startup. | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -1,0 +1,9 @@
+# Migration Crosswalk
+
+This crosswalk outlines how memory layers connect to Crown during startup.
+
+- The `neoabzu_memory` bundle initializes emotional, mental, spiritual, and narrative layers and
+  broadcasts a `layer_init` event over the bus.
+- `neoabzu_crown` imports this bundle at module load and exposes `query_memory`,
+  routing memory queries through Crown while preserving layer aggregation.
+- Integration tests validate the broadcast and the query path.


### PR DESCRIPTION
## Summary
- broadcast `layer_init` when `neoabzu_memory` loads to register emotional, mental, spiritual, and narrative layers
- expose `query_memory` via Crown and import the memory bundle on module init
- test Crown routing of memory queries and document migration crosswalk

## Testing
- `python -m pre_commit run --files NEOABZU/memory/src/lib.rs NEOABZU/crown/src/lib.rs NEOABZU/crown/tests/memory_query.rs docs/migration_crosswalk.md docs/INDEX.md` *(failed: Verify chakra monitoring, Verify self healing)*
- `python -m pre_commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`
- `cd NEOABZU/memory && cargo test` *(failed: linking with `cc` failed: exit status: 1)*
- `cd NEOABZU/crown && cargo test` *(failed: linking with `cc` failed: exit status: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f42b85e0832ea98982bf22ef7d27