### PR TITLE
Expose additional NEOABZU PyO3 modules with Python wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``version``, and ``recovery_url`` metadata and now checks ``RECOVERY_URL`` at
   call time.
 - MCP gateway exposes context registration and model invocation via MCP; added `config/mcp.toml` and `docs/mcp_overview.md`.
+- Maturin targets and Python wrappers for `fusion`, `persona`, `crown`, and `rag` crates with usage shown in `docs/core_usage.md`.
 - Mission builder with Ignite, Query Memory, and Dispatch Agent blocks plus server-side Save & Run routing through `agents/task_orchestrator`.
 - Game dashboard onboarding wizard guides operators through creating and running their first mission with progress stored in `localStorage`.
 - Unified Memory Bundle chapter clarifies `layer_init` and `query_memory` flow in `docs/ABZU_blueprint.md`.

--- a/NEOABZU/neoabzu/__init__.py
+++ b/NEOABZU/neoabzu/__init__.py
@@ -1,3 +1,21 @@
-from . import core, memory, vector, numeric
+from . import (
+    core,
+    memory,
+    vector,
+    numeric,
+    fusion,
+    persona,
+    crown,
+    rag,
+)
 
-__all__ = ["core", "memory", "vector", "numeric"]
+__all__ = [
+    "core",
+    "memory",
+    "vector",
+    "numeric",
+    "fusion",
+    "persona",
+    "crown",
+    "rag",
+]

--- a/NEOABZU/neoabzu/crown.py
+++ b/NEOABZU/neoabzu/crown.py
@@ -1,0 +1,15 @@
+"""Thin wrapper around the Rust-based crown router."""
+
+from neoabzu_crown import (
+    route_query,
+    route_decision,
+    route_inevitability,
+    query_memory,
+)
+
+__all__ = [
+    "route_query",
+    "route_decision",
+    "route_inevitability",
+    "query_memory",
+]

--- a/NEOABZU/neoabzu/fusion.py
+++ b/NEOABZU/neoabzu/fusion.py
@@ -1,0 +1,5 @@
+"""Thin wrapper around the Rust-based fusion module."""
+
+from neoabzu_fusion import Invariant, fuse
+
+__all__ = ["Invariant", "fuse"]

--- a/NEOABZU/neoabzu/persona.py
+++ b/NEOABZU/neoabzu/persona.py
@@ -1,0 +1,17 @@
+"""Thin wrapper around the Rust-based persona state manager."""
+
+from neoabzu_persona import (
+    get_current_layer,
+    set_current_layer,
+    get_last_emotion,
+    set_last_emotion,
+    load_persona_profiles,
+)
+
+__all__ = [
+    "get_current_layer",
+    "set_current_layer",
+    "get_last_emotion",
+    "set_last_emotion",
+    "load_persona_profiles",
+]

--- a/NEOABZU/neoabzu/rag.py
+++ b/NEOABZU/neoabzu/rag.py
@@ -1,0 +1,5 @@
+"""Thin wrapper around the Rust-based retrieval engine."""
+
+from neoabzu_rag import retrieve_top
+
+__all__ = ["retrieve_top"]

--- a/NEOABZU/pyproject.toml
+++ b/NEOABZU/pyproject.toml
@@ -33,5 +33,21 @@ path = "vector"
 name = "neoabzu_numeric"
 path = "numeric"
 
+[[tool.maturin.targets]]
+name = "neoabzu_fusion"
+path = "fusion"
+
+[[tool.maturin.targets]]
+name = "neoabzu_persona"
+path = "persona"
+
+[[tool.maturin.targets]]
+name = "neoabzu_crown"
+path = "crown"
+
+[[tool.maturin.targets]]
+name = "neoabzu_rag"
+path = "rag"
+
 [tool.neoabzu.workspace]
-members = ["core", "memory", "vector", "persona", "crown", "rag", "numeric"]
+members = ["core", "memory", "vector", "fusion", "persona", "crown", "rag", "numeric"]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -321,6 +321,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [connectors/mcp_migration.md](connectors/mcp_migration.md) | MCP Migration Guide | This guide explains how to convert existing API connectors to the **Model Context Protocol (MCP)**. | - |
 | [contribution_guide.md](contribution_guide.md) | Contribution Guide | Thank you for considering a contribution! | - |
 | [contributor_checklist.md](contributor_checklist.md) | Contributor Checklist | This checklist distills mandatory practices for ABZU contributors. | - |
+| [core_usage.md](core_usage.md) | Core Usage | Install the compiled wheels: | - |
 | [crown_manifest.md](crown_manifest.md) | CROWN Manifest | The **CROWN** agent runs the GLM-4.1V-9B model and acts as the root layer of Spiral OS. It holds the highest permissi... | - |
 | [crown_servant_models.md](crown_servant_models.md) | Crown Servant Models | Guidance for deploying auxiliary servant models used by Crown. | `../memory/query_memory.py` |
 | [data_flow.md](data_flow.md) | Request to Memory Data Flow | ```mermaid graph LR A[Client Request] --> B[Root Chakra] B --> C[Sacral] C --> D[Solar Plexus] D --> E[Heart] E --> F... | `../crown_prompt_orchestrator.py`, `../emotional_state.py`, `../insight_compiler.py`, `../learning_mutator.py`, `../memory_store.py`, `../server.py`, `../start_spiral_os.py`, `../vector_memory.py` |

--- a/docs/core_usage.md
+++ b/docs/core_usage.md
@@ -1,0 +1,20 @@
+# Core Usage
+
+Install the compiled wheels:
+
+```bash
+pip install neoabzu
+```
+
+Import modules that mirror the original APSU APIs:
+
+```python
+from neoabzu import core, memory, fusion, persona, crown, rag, vector, numeric
+```
+
+Each submodule exposes the Rust-accelerated functions directly, e.g.:
+
+```python
+result = core.evaluate("(λx.x)(42)")
+items = rag.retrieve_top("meaning", 3)
+```


### PR DESCRIPTION
## Summary
- build NEOABZU fusion, persona, crown, and rag crates as PyO3 modules
- expose new crates via thin Python wrappers and update package exports
- document installation and import usage

## Testing
- `cargo build --manifest-path NEOABZU/Cargo.toml --quiet` *(failed: linking with `cc` failed: exit status: 1)*
- `pre-commit run --files NEOABZU/pyproject.toml NEOABZU/neoabzu/fusion.py NEOABZU/neoabzu/persona.py NEOABZU/neoabzu/crown.py NEOABZU/neoabzu/rag.py NEOABZU/neoabzu/__init__.py docs/core_usage.md CHANGELOG.md docs/INDEX.md` *(failed: verify-chakra-monitoring; verify-self-healing)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c538147984832eae72a88b8b39bf75