### PR TITLE
Fix PyO3 extraction in memory query tests

### DIFF
--- a/NEOABZU/memory/tests/query.rs
+++ b/NEOABZU/memory/tests/query.rs
@@ -1,6 +1,6 @@
 use neoabzu_memory::MemoryBundle;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyAny, PyDict};
 
 fn setup_stub_layers(py: Python<'_>) {
     let sys = py.import("sys").unwrap();
@@ -29,10 +29,7 @@ fn setup_stub_layers(py: Python<'_>) {
         "vector_memory",
         "def query_vectors(*a, **k):\n    return ['v']\n"
     );
-    stub!(
-        "spiral_memory",
-        "def spiral_recall(q):\n    return 's'\n"
-    );
+    stub!("spiral_memory", "def spiral_recall(q):\n    return 's'\n");
     stub!(
         "memory.emotional",
         "def fetch_emotion_history(limit):\n    return ['e']\n"
@@ -58,15 +55,43 @@ fn query_returns_all_layers() {
         let mut bundle = MemoryBundle::new();
         bundle.initialize(py).unwrap();
         let res = bundle.query(py, "demo").unwrap();
-        let d = res.as_ref(py);
-        let cortex: Vec<String> = d.get_item("cortex").unwrap().extract().unwrap();
-        let vector: Vec<String> = d.get_item("vector").unwrap().extract().unwrap();
-        let spiral: String = d.get_item("spiral").unwrap().extract().unwrap();
-        let emotional: Vec<String> = d.get_item("emotional").unwrap().extract().unwrap();
-        let mental: Vec<String> = d.get_item("mental").unwrap().extract().unwrap();
-        let spiritual: Vec<String> = d.get_item("spiritual").unwrap().extract().unwrap();
-        let narrative: Vec<String> = d.get_item("narrative").unwrap().extract().unwrap();
-        let failed: Vec<String> = d.get_item("failed_layers").unwrap().extract().unwrap();
+        let d: &PyAny = res.as_ref(py);
+        let cortex = d
+            .get_item("cortex")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let vector = d
+            .get_item("vector")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let spiral = d.get_item("spiral").unwrap().extract::<String>().unwrap();
+        let emotional = d
+            .get_item("emotional")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let mental = d
+            .get_item("mental")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let spiritual = d
+            .get_item("spiritual")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let narrative = d
+            .get_item("narrative")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
+        let failed = d
+            .get_item("failed_layers")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap();
         assert_eq!(cortex, vec!["c"]);
         assert_eq!(vector, vec!["v"]);
         assert_eq!(spiral, "s");
@@ -94,16 +119,37 @@ fn query_handles_failed_layers() {
         for (module_name, func_name, layer) in cases {
             setup_stub_layers(py);
             let sys = py.import("sys").unwrap();
-            let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
-            let module: &PyModule = modules.get_item(module_name).unwrap().downcast().unwrap();
-            let boom = PyModule::from_code(py, "def f(*a, **k):\n    raise Exception('boom')\n", "", "boom").unwrap();
-            module.setattr(func_name, boom.getattr("f").unwrap()).unwrap();
+            let modules: &PyDict = sys
+                .getattr("modules")
+                .unwrap()
+                .downcast::<PyDict>()
+                .unwrap();
+            let module: &PyModule = modules
+                .get_item(module_name)
+                .unwrap()
+                .unwrap()
+                .downcast::<PyModule>()
+                .unwrap();
+            let boom = PyModule::from_code(
+                py,
+                "def f(*a, **k):\n    raise Exception('boom')\n",
+                "",
+                "boom",
+            )
+            .unwrap();
+            module
+                .setattr(func_name, boom.getattr("f").unwrap())
+                .unwrap();
 
             let mut bundle = MemoryBundle::new();
             bundle.initialize(py).unwrap();
             let res = bundle.query(py, "demo").unwrap();
-            let d = res.as_ref(py);
-            let failed: Vec<String> = d.get_item("failed_layers").unwrap().extract().unwrap();
+            let d: &PyAny = res.as_ref(py);
+            let failed = d
+                .get_item("failed_layers")
+                .unwrap()
+                .extract::<Vec<String>>()
+                .unwrap();
             assert!(failed.contains(&layer.to_string()));
         }
     });


### PR DESCRIPTION
## Summary
- import `PyAny` so `FromPyObject` is in scope
- use explicit `extract::<T>()` on test lookups and adjust downcasts for `PyDict::get_item`

## Testing
- `pre-commit run --files NEOABZU/memory/tests/query.rs` *(fails: Missing Python packages: websockets; pytest-cov error)*
- `pre-commit run verify-onboarding-refs`
- `cargo test -p neoabzu-memory --tests` *(fails: missing Python lib symbols during linking)*

------
https://chatgpt.com/codex/tasks/task_e_68c53d510e2c832ea558ce9599133694