### PR TITLE
Add boot sequence initialization

### DIFF
--- a/orchestration_master.py
+++ b/orchestration_master.py
@@ -8,6 +8,9 @@ from queue import Queue
 from typing import Any, Dict, List
 
 from memory import spiral_cortex
+from scripts import boot_sequence as _boot_sequence_module
+
+boot_sequence = _boot_sequence_module.boot_sequence
 
 
 AGENT_LOOKUP: Dict[str, str] = {

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts for maintenance and testing."""

--- a/scripts/boot_sequence.py
+++ b/scripts/boot_sequence.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "data"
+LOGS_DIR = ROOT / "logs"
+
+
+def boot_sequence() -> dict[str, str]:
+    """Initialize minimal services and required paths.
+
+    Ensures data and log directories exist before tests run.
+    Returns a mapping with the resolved paths so callers can
+    verify initialization if needed.
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    return {"data_dir": str(DATA_DIR), "logs_dir": str(LOGS_DIR)}


### PR DESCRIPTION
## Summary
- add `scripts.boot_sequence` to initialize data and log paths
- expose `boot_sequence` in `orchestration_master`

## Testing
- `pre-commit run --files orchestration_master.py scripts/__init__.py scripts/boot_sequence.py` *(fails: confirm-reading)*
- `pre-commit run verify-onboarding-refs`
- `pytest tests/integration` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68c5425fb820832e865fa755a889754b