### PR TITLE
feat: add boot sequence launcher

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -211,11 +211,16 @@ startup sequence remains auditable.
 
 ### Boot Orchestrator and Prioritized Tests
 
-Run the lightweight boot orchestrator to execute the ignition sequence:
+Run the lightweight boot orchestrator to execute the ignition sequence using the
+bundled minimal configuration:
 
 ```bash
-python -m agents.razar.boot_orchestrator
+python -m razar.boot_orchestrator --config razar/boot_config.json
 ```
+
+The `scripts/boot_sequence.py` helper mirrors this command for tests by
+initializing required directories and launching the components defined in the
+configuration.
 
 After services start, execute the tiered test suites:
 

--- a/scripts/boot_sequence.py
+++ b/scripts/boot_sequence.py
@@ -2,18 +2,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from razar import boot_orchestrator
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = ROOT / "data"
 LOGS_DIR = ROOT / "logs"
 
 
-def boot_sequence() -> dict[str, str]:
-    """Initialize minimal services and required paths.
+def boot_sequence(config_path: Path | None = None) -> dict[str, str]:
+    """Run the minimal boot sequence using :mod:`razar.boot_orchestrator`.
 
-    Ensures data and log directories exist before tests run.
-    Returns a mapping with the resolved paths so callers can
-    verify initialization if needed.
+    The helper ensures the data and log directories exist, loads the
+    component configuration, and launches each component. It waits for all
+    processes to exit before returning a mapping with the resolved paths so
+    callers can verify initialization if needed.
     """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
+    cfg = config_path or ROOT / "razar" / "boot_config.json"
+    components = boot_orchestrator.load_config(cfg)
+    procs = [boot_orchestrator.launch_component(c) for c in components]
+    for proc in procs:
+        proc.wait()
+
     return {"data_dir": str(DATA_DIR), "logs_dir": str(LOGS_DIR)}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    boot_sequence()


### PR DESCRIPTION
## Summary
- enable boot sequence script to run razar.boot_orchestrator with bundled config
- document how to invoke minimal boot orchestrator configuration

## Testing
- `pre-commit run --files scripts/boot_sequence.py docs/developer_onboarding.md docs/INDEX.md`
- `pre-commit run verify-onboarding-refs`
- `pytest --no-cov tests/test_boot_sequence.py`


------
https://chatgpt.com/codex/tasks/task_e_68c54bc05e84832ebbdf0bb7670df0ca