### PR TITLE
test: import PyAny for memory query

### DIFF
--- a/NEOABZU/memory/tests/query.rs
+++ b/NEOABZU/memory/tests/query.rs
@@ -1,6 +1,9 @@
 use neoabzu_memory::MemoryBundle;
-use pyo3::prelude::*;
-use pyo3::types::{PyAny, PyDict};
+use pyo3::{
+    prelude::*,
+    types::{PyAny, PyDict},
+    FromPyObject,
+};
 
 fn setup_stub_layers(py: Python<'_>) {
     let sys = py.import("sys").unwrap();


### PR DESCRIPTION
## Summary
- bring FromPyObject and PyAny into scope for memory query tests

## Testing
- `pre-commit run --files NEOABZU/memory/tests/query.rs` *(fails: Required test coverage of 80% not reached; tests/agents/razar/test_boot_sequence.py failed)*
- `pre-commit run verify-onboarding-refs`
- `cargo test -p neoabzu-memory --tests` *(fails: undefined references to Python symbols during linking)*

------
https://chatgpt.com/codex/tasks/task_e_68c5540fae58832e895ede8bdfb55996