### PR TITLE
test: replace placeholder metrics with arrays

### DIFF
--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -7,20 +7,20 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 from streamlit.testing.v1 import AppTest
 from streamlit.testing.v1.element_tree import UnknownElement
 
 
 def test_dashboard_app_renders_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
-    fake_db.fetch_benchmarks = lambda: [
-        {
-            "timestamp": "2024-01-01T00:00:00",
-            "response_time": 0.1,
-            "coherence": 0.9,
-            "relevance": 0.95,
-        }
-    ]
+    fake_db.fetch_benchmarks = lambda: {
+        "timestamp": pd.Series(["2024-01-01T00:00:00"]),
+        "response_time": np.array([0.1]),
+        "coherence": np.array([0.9]),
+        "relevance": pd.Series([0.95]),
+    }
 
     class DummyGO:
         def predict_best_llm(self):
@@ -64,20 +64,12 @@ def test_dashboard_app_handles_no_metrics(monkeypatch):
 
 def test_dashboard_app_multiple_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
-    fake_db.fetch_benchmarks = lambda: [
-        {
-            "timestamp": "2024-01-01T00:00:00",
-            "response_time": 0.1,
-            "coherence": 0.9,
-            "relevance": 0.95,
-        },
-        {
-            "timestamp": "2024-01-02T00:00:00",
-            "response_time": 0.2,
-            "coherence": 0.85,
-            "relevance": 0.9,
-        },
-    ]
+    fake_db.fetch_benchmarks = lambda: {
+        "timestamp": pd.Series(["2024-01-01T00:00:00", "2024-01-02T00:00:00"]),
+        "response_time": np.array([0.1, 0.2]),
+        "coherence": np.array([0.9, 0.85]),
+        "relevance": pd.Series([0.95, 0.9]),
+    }
 
     class DummyGO:
         def predict_best_llm(self):
@@ -171,15 +163,12 @@ def test_dashboard_app_prediction_none(monkeypatch):
 
 def test_dashboard_app_large_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
-    fake_db.fetch_benchmarks = lambda: [
-        {
-            "timestamp": f"2024-01-{i:02d}T00:00:00",
-            "response_time": i * 0.1,
-            "coherence": 0.8,
-            "relevance": 0.85,
-        }
-        for i in range(1, 101)
-    ]
+    fake_db.fetch_benchmarks = lambda: {
+        "timestamp": pd.Series([f"2024-01-{i:02d}T00:00:00" for i in range(1, 101)]),
+        "response_time": np.array([i * 0.1 for i in range(1, 101)]),
+        "coherence": np.full(100, 0.8),
+        "relevance": pd.Series([0.85] * 100),
+    }
 
     class DummyGO:
         def predict_best_llm(self):

--- a/tests/test_dashboard_qnl_mixer.py
+++ b/tests/test_dashboard_qnl_mixer.py
@@ -22,7 +22,9 @@ def test_qnl_mixer_processes_audio(monkeypatch):
         display=types.SimpleNamespace(specshow=lambda *a, **k: None),
     )
     fake_sf = types.SimpleNamespace(
-        write=lambda buf, data, sr, format="WAV": buf.write(b"data")
+        write=lambda buf, data, sr, format="WAV": buf.write(
+            np.zeros(1, dtype=np.int16).tobytes()
+        )
     )
     fake_mix = types.SimpleNamespace(
         apply_audio_params=lambda data, sr, pitch, tempo, cutoff: data,


### PR DESCRIPTION
## Summary
- use numpy arrays and pandas Series in dashboard tests instead of placeholder scalars
- write audio bytes from a numpy array in qnl mixer test

## Testing
- `pytest --no-cov tests/test_dashboard_app.py tests/test_dashboard_qnl_mixer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c558c482f0832e9e7bb5a27bae2786