### PR TITLE
Add boot sequence config and tests

### DIFF
--- a/scripts/boot_config.json
+++ b/scripts/boot_config.json
@@ -1,0 +1,14 @@
+{
+  "components": [
+    {
+      "name": "basic_service",
+      "command": ["python", "-c", "print('basic service running')"],
+      "health_check": ["python", "-c", "import sys; sys.exit(0)"]
+    },
+    {
+      "name": "complex_service",
+      "command": ["python", "-c", "print('complex service running')"],
+      "health_check": ["python", "-c", "import sys; sys.exit(0)"]
+    }
+  ]
+}

--- a/scripts/boot_sequence.py
+++ b/scripts/boot_sequence.py
@@ -20,7 +20,7 @@ def boot_sequence(config_path: Path | None = None) -> dict[str, str]:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
-    cfg = config_path or ROOT / "razar" / "boot_config.json"
+    cfg = config_path or Path(__file__).with_name("boot_config.json")
     components = boot_orchestrator.load_config(cfg)
     procs = [boot_orchestrator.launch_component(c) for c in components]
     for proc in procs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,18 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
+
+
+@pytest.fixture(scope="session")
+def boot_config_path() -> Path:
+    """Location of the minimal boot configuration."""
+    return ROOT / "scripts" / "boot_config.json"
+
 
 # Skip tests that rely on unavailable heavy resources unless explicitly allowed
 ALLOWED_TESTS: set[str] = {

--- a/tests/test_boot_sequence.py
+++ b/tests/test_boot_sequence.py
@@ -1,8 +1,8 @@
 import json
-from pathlib import Path
 
 import pytest
 
+from scripts.boot_sequence import boot_sequence
 from razar import boot_orchestrator
 from razar.bootstrap_utils import STATE_FILE
 
@@ -13,12 +13,9 @@ def _clear_state():
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 
-def test_boot_sequence_success():
+def test_boot_sequence_success(boot_config_path):
     _clear_state()
-    components = boot_orchestrator.load_config(Path("razar/boot_config.json"))
-    procs = [boot_orchestrator.launch_component(c) for c in components]
-    for proc in procs:
-        proc.wait()
+    boot_sequence(boot_config_path)
     data = json.loads(STATE_FILE.read_text())
     assert data["probes"]["basic_service"]["status"] == "ok"
     assert data["probes"]["complex_service"]["status"] == "ok"


### PR DESCRIPTION
## Summary
- add minimal boot_config.json and adjust boot launcher to use it
- provide pytest fixture exposing boot config path
- update boot sequence tests to exercise new config

## Testing
- `pytest tests/test_boot_sequence.py -q --no-cov`
- `pre-commit run --files scripts/boot_sequence.py tests/conftest.py tests/test_boot_sequence.py scripts/boot_config.json` *(fails: Required test coverage of 80% not reached; tests/agents/razar/test_boot_sequence.py::test_boot_sequence_order_and_failure fails)*
- `pre-commit run verify-onboarding-refs`

------
https://chatgpt.com/codex/tasks/task_e_68c566a180f8832eaf0c1f735250b7be