### PR TITLE
refactor: ensure PyO3 test import includes FromPyObject

### DIFF
--- a/NEOABZU/memory/tests/query.rs
+++ b/NEOABZU/memory/tests/query.rs
@@ -1,9 +1,6 @@
 use neoabzu_memory::MemoryBundle;
-use pyo3::{
-    prelude::*,
-    types::{PyAny, PyDict},
-    FromPyObject,
-};
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict};
 
 fn setup_stub_layers(py: Python<'_>) {
     let sys = py.import("sys").unwrap();


### PR DESCRIPTION
## Summary
- rely on `pyo3::prelude` and `pyo3::types` to bring `FromPyObject` into scope in `query` test

## Testing
- `pre-commit run --files NEOABZU/memory/tests/query.rs` *(fails: rust-fmt-clippy, check-env missing websockets, pytest-cov args)*
- `pre-commit run verify-onboarding-refs`
- `cargo test -p neoabzu-memory --tests` *(fails: linking with `cc`)*

------
https://chatgpt.com/codex/tasks/task_e_68c56e59a3e0832e89dac748e83acf64