### PR TITLE
test: use typed arrays in dashboard tests

### DIFF
--- a/docs/testing/failure_inventory.md
+++ b/docs/testing/failure_inventory.md
@@ -168,3 +168,6 @@ Failures from `pytest` runs are appended via [`scripts/capture_failing_tests.py`
 - 2025-09-13: ERROR tests/test_transformers_generate.py - ValueError: cv2.__spec__ is None
 - 2025-09-13: ERROR tests/test_voice_cloner_cli.py
 - 2025-09-13: ERROR tests/web_console/test_conversation_timeline.py - RuntimeError: Form data requires "python-multipart" to be installed.
+
+- 2025-09-13: ERROR tests/crown/server/test_openwebui_bridge.py - RuntimeError: GLM health check failed: 503 Server Error: Service Unavailable for url: https://glm.example.com/glm41v_9b/health
+- 2025-09-13: ERROR tests/crown/server/test_server.py - ValueError: Duplicated timeseries in CollectorRegistry: {'http_request_duration_seconds_bucket', 'http_request_duration_seconds_count', 'http_request_duration_seconds_sum', 'http_request_duration_seconds', 'http_request_duration_seconds_created'}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -17,8 +17,8 @@ def test_dashboard_app_renders_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
         "timestamp": pd.Series(["2024-01-01T00:00:00"]),
-        "response_time": np.array([0.1]),
-        "coherence": np.array([0.9]),
+        "response_time": pd.Series([0.1]),
+        "coherence": pd.Series([0.9]),
         "relevance": pd.Series([0.95]),
     }
 
@@ -66,8 +66,8 @@ def test_dashboard_app_multiple_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
         "timestamp": pd.Series(["2024-01-01T00:00:00", "2024-01-02T00:00:00"]),
-        "response_time": np.array([0.1, 0.2]),
-        "coherence": np.array([0.9, 0.85]),
+        "response_time": pd.Series([0.1, 0.2]),
+        "coherence": pd.Series([0.9, 0.85]),
         "relevance": pd.Series([0.95, 0.9]),
     }
 
@@ -165,8 +165,8 @@ def test_dashboard_app_large_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
         "timestamp": pd.Series([f"2024-01-{i:02d}T00:00:00" for i in range(1, 101)]),
-        "response_time": np.array([i * 0.1 for i in range(1, 101)]),
-        "coherence": np.full(100, 0.8),
+        "response_time": pd.Series([i * 0.1 for i in range(1, 101)]),
+        "coherence": pd.Series(np.full(100, 0.8)),
         "relevance": pd.Series([0.85] * 100),
     }
 

--- a/tests/test_dashboard_qnl_mixer.py
+++ b/tests/test_dashboard_qnl_mixer.py
@@ -28,7 +28,7 @@ def test_qnl_mixer_processes_audio(monkeypatch):
     )
     fake_mix = types.SimpleNamespace(
         apply_audio_params=lambda data, sr, pitch, tempo, cutoff: data,
-        embedding_to_params=lambda emb: (0, 0, 0),
+        embedding_to_params=lambda emb: np.zeros(3),
     )
     fake_qnl = types.SimpleNamespace(quantum_embed=lambda text: np.zeros(3))
 
@@ -40,7 +40,7 @@ def test_qnl_mixer_processes_audio(monkeypatch):
 
     at = AppTest.from_file(_app_path())
     at.run()
-    at.file_uploader[0].upload(b"00", "test.wav")
+    at.file_uploader[0].upload(np.zeros(4, dtype=np.int16).tobytes(), "test.wav")
     at.text_input[0].set_value("qnl")
     at.run(timeout=10)
 


### PR DESCRIPTION
## Summary
- ensure dashboard tests use pandas Series for benchmark metrics
- provide numpy arrays for quantum mixer embedding and uploads

## Testing
- `pre-commit run --files tests/test_dashboard_app.py tests/test_dashboard_qnl_mixer.py` *(fails: Required test coverage of 80% not reached. Total coverage: 7.62%)*
- `pre-commit run verify-onboarding-refs`
- `pytest --no-cov tests/test_dashboard_app.py tests/test_dashboard_qnl_mixer.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5713be9b8832ea8359f176a862f01