### PR TITLE
Add OpenCV spec check and pin headless build

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,7 +27,7 @@ beautifulsoup4
 pyyaml
 pydub
 sounddevice
-opencv-python
+opencv-python-headless==4.12.0.88
 av
 tokenizers
 langchain

--- a/tests/test_transformers_generate.py
+++ b/tests/test_transformers_generate.py
@@ -17,6 +17,12 @@ importlib.import_module("huggingface_hub")
 from transformers import AutoTokenizer, GPT2LMHeadModel
 
 
+def test_cv2_has_spec():
+    import cv2
+
+    assert cv2.__spec__ is not None
+
+
 @pytest.mark.parametrize("model_name", ["distilgpt2"])
 def test_generate_returns_text(model_name):
     device = "cuda" if torch.cuda.is_available() else "cpu"


### PR DESCRIPTION
## Summary
- ensure OpenCV exposes a module spec during import
- pin tests to a headless OpenCV build so imports succeed in CI

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files tests/test_transformers_generate.py tests/requirements.txt`
- `pre-commit run verify-onboarding-refs`
- `pytest --no-cov tests/test_opencv_import.py tests/test_transformers_generate.py::test_cv2_has_spec tests/test_transformers_generate.py::test_generate_returns_text -q`

------
https://chatgpt.com/codex/tasks/task_e_68c574e72010832eb7c3808cccea7bab