### PR TITLE
Gate pyo3 extension modules behind feature flag

### DIFF
--- a/NEOABZU/memory/Cargo.toml
+++ b/NEOABZU/memory/Cargo.toml
@@ -9,14 +9,15 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.21", default-features = false, features = ["macros"] }
 once_cell = "1.19"
 tracing = { version = "0.1", optional = true }
 opentelemetry = { version = "0.21", optional = true }
 tracing-opentelemetry = { version = "0.23", optional = true }
 
 [features]
-default = []
+default = ["pyo3/auto-initialize"]
+python-extension = ["pyo3/extension-module"]
 tracing = ["dep:tracing"]
 opentelemetry = ["tracing", "dep:opentelemetry", "dep:tracing-opentelemetry"]
 

--- a/NEOABZU/memory/README.md
+++ b/NEOABZU/memory/README.md
@@ -1,0 +1,14 @@
+# neoabzu-memory
+
+Neo-ABZU memory primitives.
+
+## Usage
+
+- **Run tests** with default features (links against `libpython` and enables `pyo3/auto-initialize`):
+  ```bash
+  cargo test
+  ```
+- **Build the Python extension module** by disabling default features and enabling `python-extension`:
+  ```bash
+  cargo build --release --no-default-features --features python-extension
+  ```

--- a/NEOABZU/rag/Cargo.toml
+++ b/NEOABZU/rag/Cargo.toml
@@ -10,13 +10,14 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 neoabzu-memory = { path = "../memory" }
-pyo3 = { version = "0.21", features = ["extension-module", "auto-initialize"] }
+pyo3 = { version = "0.21", default-features = false, features = ["macros"] }
 tracing = { version = "0.1", optional = true }
 opentelemetry = { version = "0.21", optional = true }
 tracing-opentelemetry = { version = "0.23", optional = true }
 
 [features]
-default = []
+default = ["pyo3/auto-initialize"]
+python-extension = ["pyo3/extension-module", "neoabzu-memory/python-extension"]
 tracing = ["dep:tracing", "neoabzu-memory/tracing"]
 opentelemetry = [
     "tracing",

--- a/NEOABZU/rag/README.md
+++ b/NEOABZU/rag/README.md
@@ -1,0 +1,14 @@
+# neoabzu-rag
+
+Retrieval-augmented generation components for Neo-ABZU.
+
+## Usage
+
+- **Run tests** with default features (links against `libpython` and enables `pyo3/auto-initialize`):
+  ```bash
+  cargo test
+  ```
+- **Build the Python extension module** by disabling default features and enabling `python-extension`:
+  ```bash
+  cargo build --release --no-default-features --features python-extension
+  ```

--- a/NEOABZU/vector/Cargo.toml
+++ b/NEOABZU/vector/Cargo.toml
@@ -9,12 +9,13 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.21", default-features = false, features = ["macros"] }
 tracing = { version = "0.1", optional = true }
 opentelemetry = { version = "0.21", optional = true }
 tracing-opentelemetry = { version = "0.23", optional = true }
 
 [features]
-default = []
+default = ["pyo3/auto-initialize"]
+python-extension = ["pyo3/extension-module"]
 tracing = ["dep:tracing"]
 opentelemetry = ["tracing", "dep:opentelemetry", "dep:tracing-opentelemetry"]

--- a/NEOABZU/vector/README.md
+++ b/NEOABZU/vector/README.md
@@ -1,0 +1,14 @@
+# neoabzu-vector
+
+Rust vector operations for Neo-ABZU.
+
+## Usage
+
+- **Run tests** with the default feature set (links against `libpython` and enables `pyo3/auto-initialize`):
+  ```bash
+  cargo test
+  ```
+- **Build the Python extension module** by disabling default features and enabling `python-extension`:
+  ```bash
+  cargo build --release --no-default-features --features python-extension
+  ```


### PR DESCRIPTION
## Summary
- gate pyo3 `extension-module` behind `python-extension` feature in vector, memory, and rag crates
- enable `pyo3/auto-initialize` by default for test builds
- document how to run tests versus build the Python extensions

## Testing
- `cargo test -p neoabzu-vector --manifest-path NEOABZU/Cargo.toml`
- `cargo test -p neoabzu-memory --manifest-path NEOABZU/Cargo.toml` *(fails: assertion failed: failed.is_empty)*
- `cargo test -p neoabzu-rag --manifest-path NEOABZU/Cargo.toml`
- `pre-commit run --files NEOABZU/vector/Cargo.toml NEOABZU/vector/README.md NEOABZU/memory/Cargo.toml NEOABZU/memory/README.md NEOABZU/rag/Cargo.toml NEOABZU/rag/README.md` *(fails: Capture failing tests, coverage <80%)*
- `pre-commit run verify-onboarding-refs`

------
https://chatgpt.com/codex/tasks/task_e_68c59e0be550832eaf9f8b8a2f6a3757