### PR TITLE
test: use arrays for dashboard tests

### DIFF
--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -16,10 +16,12 @@ from streamlit.testing.v1.element_tree import UnknownElement
 def test_dashboard_app_renders_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
-        "timestamp": pd.Series(["2024-01-01T00:00:00"]),
-        "response_time": pd.Series([0.1]),
-        "coherence": pd.Series([0.9]),
-        "relevance": pd.Series([0.95]),
+        "timestamp": pd.Series(
+            np.array(["2024-01-01T00:00:00"], dtype="datetime64[ns]")
+        ),
+        "response_time": pd.Series(np.array([0.1])),
+        "coherence": pd.Series(np.array([0.9])),
+        "relevance": pd.Series(np.array([0.95])),
     }
 
     class DummyGO:
@@ -65,10 +67,15 @@ def test_dashboard_app_handles_no_metrics(monkeypatch):
 def test_dashboard_app_multiple_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
-        "timestamp": pd.Series(["2024-01-01T00:00:00", "2024-01-02T00:00:00"]),
-        "response_time": pd.Series([0.1, 0.2]),
-        "coherence": pd.Series([0.9, 0.85]),
-        "relevance": pd.Series([0.95, 0.9]),
+        "timestamp": pd.Series(
+            np.array(
+                ["2024-01-01T00:00:00", "2024-01-02T00:00:00"],
+                dtype="datetime64[ns]",
+            )
+        ),
+        "response_time": pd.Series(np.array([0.1, 0.2])),
+        "coherence": pd.Series(np.array([0.9, 0.85])),
+        "relevance": pd.Series(np.array([0.95, 0.9])),
     }
 
     class DummyGO:
@@ -164,10 +171,12 @@ def test_dashboard_app_prediction_none(monkeypatch):
 def test_dashboard_app_large_metrics(monkeypatch):
     fake_db = types.ModuleType("db_storage")
     fake_db.fetch_benchmarks = lambda: {
-        "timestamp": pd.Series([f"2024-01-{i:02d}T00:00:00" for i in range(1, 101)]),
-        "response_time": pd.Series([i * 0.1 for i in range(1, 101)]),
+        "timestamp": pd.Series(
+            np.array(pd.date_range("2024-01-01", periods=100, freq="D"))
+        ),
+        "response_time": pd.Series(np.array([i * 0.1 for i in range(1, 101)])),
         "coherence": pd.Series(np.full(100, 0.8)),
-        "relevance": pd.Series([0.85] * 100),
+        "relevance": pd.Series(np.array([0.85] * 100)),
     }
 
     class DummyGO:

--- a/tests/test_dashboard_qnl_mixer.py
+++ b/tests/test_dashboard_qnl_mixer.py
@@ -28,9 +28,11 @@ def test_qnl_mixer_processes_audio(monkeypatch):
     )
     fake_mix = types.SimpleNamespace(
         apply_audio_params=lambda data, sr, pitch, tempo, cutoff: data,
-        embedding_to_params=lambda emb: np.zeros(3),
+        embedding_to_params=lambda emb: np.array([0.0, 0.0, 0.0]),
     )
-    fake_qnl = types.SimpleNamespace(quantum_embed=lambda text: np.zeros(3))
+    fake_qnl = types.SimpleNamespace(
+        quantum_embed=lambda text: np.array([0.0, 0.0, 0.0])
+    )
 
     monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
     monkeypatch.setitem(sys.modules, "librosa.display", fake_librosa.display)


### PR DESCRIPTION
## Summary
- use NumPy arrays and pandas Series in dashboard tests
- ensure QNL mixer uses numeric arrays for embeddings

## Testing
- `SKIP=pytest-cov,capture-failing-tests pre-commit run --files tests/test_dashboard_app.py tests/test_dashboard_qnl_mixer.py`
- `pre-commit run verify-onboarding-refs`
- `pytest --no-cov tests/test_dashboard_app.py tests/test_dashboard_qnl_mixer.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5a446c9bc832e80f8c95419c66118