### PR TITLE
fix: inject RandomState object in test

### DIFF
--- a/tests/test_emotion_classifier.py
+++ b/tests/test_emotion_classifier.py
@@ -37,8 +37,11 @@ class _DummyRandomForestClassifier:
         ``RandomState`` from whichever stub is provided.
         """
 
-        rng = random_state or np.random
-        self.random_state = rng.RandomState()
+        if isinstance(random_state, int):
+            self.random_state = np.random.RandomState(random_state)
+        else:
+            rng = random_state or np.random
+            self.random_state = rng.RandomState()
         self._mapping: dict[tuple[float, float], str] = {}
         self._default: str | None = None
 


### PR DESCRIPTION
## Summary
- handle integer seeds in test RandomForest stub by seeding with `np.random`

## Testing
- `pre-commit run --files tests/test_emotion_classifier.py` *(fails: Component alpha lacks a health probe; coverage 7.62% < 80%)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c5a75dc030832eb6cd04ac19fb1383