### PR TITLE
docs: document datpars interface

### DIFF
--- a/NEOABZU/docs/index.md
+++ b/NEOABZU/docs/index.md
@@ -24,6 +24,9 @@ Pre-commit enforces that `onboarding_confirm.yml` references `docs/blueprint_spi
 
 Enable the `tracing` and `opentelemetry` features on these crates to emit spans for diagnostics during development.
 
+## Interfaces
+- [datpars](../../docs/datpars_overview.md) – ingestion interface definitions
+
 ## Guides
 - [OROBOROS Engine](OROBOROS_Engine.md)
 - [OROBOROS Lexicon](OROBOROS_Lexicon.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -1018,15 +1018,18 @@ RAZAR tracks modules flagged as experimental in
 These components are not required for baseline operation and may change
 rapidly. During boot RAZAR:
 
-The new `datpars` module defines common interfaces for upcoming ingestion
-workflows. See [datpars_overview.md](datpars_overview.md) for goals and
-architecture.
+Emerging modules include:
 
-Neo‑ABZU extends this surface with `narrative` and `numeric` crates. The
-`narrative` crate captures reduction steps and Sumerian phoneme embeddings,
-while `numeric` exposes PCA utilities through PyO3 bindings. Both crates offer
-optional `tracing` and `opentelemetry` features that emit spans for diagnostics
-when enabled.
+- `datpars` – shared ingestion interfaces for upcoming workflows. See
+  [datpars_overview.md](datpars_overview.md) for goals and architecture.
+- `narrative` – captures reduction steps and Sumerian phoneme embeddings.
+  Narrative guides:
+  [Bana Engine](bana_engine.md) and
+  [Scribe Narrative Engine](../NEOABZU/docs/Scribe_narrative_engine.md).
+- `numeric` – exposes PCA utilities through PyO3 bindings.
+
+`narrative` and `numeric` offer optional `tracing` and `opentelemetry`
+features that emit spans for diagnostics when enabled.
 
 - Marks in‑development components with a warning and delays their startup
   until explicitly enabled.


### PR DESCRIPTION
## Summary
- describe datpars, narrative, and numeric modules in system blueprint
- link Bana and Scribe narrative guides from the blueprint
- list datpars interface in the Neo-ABZU index

## Testing
- `pre-commit run --files docs/system_blueprint.md NEOABZU/docs/index.md docs/INDEX.md` *(fails: capture-failing-tests, pytest coverage below threshold)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py` *(fails: doctrine index timestamps out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e9c22dd4832e99e523a4ba352002