### PR TITLE
chore: clarify python-multipart dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -70,4 +70,4 @@ vanna==0.7.9
     # optional: NLQ queries
 
 python-multipart>=0.0.5
-    # required for FastAPI multipart form data parsing
+    # required for FastAPI multipart form data parsing (fixes file upload runtime error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,4 @@ vanna==0.7.9
     # optional: NLQ queries
 
 python-multipart>=0.0.5
-    # required for FastAPI multipart form data parsing
+    # required for FastAPI multipart form data parsing (fixes file upload runtime error)


### PR DESCRIPTION
## Summary
- clarify comment describing python-multipart requirement for FastAPI uploads

## Testing
- `SKIP=capture-failing-tests,pytest-cov,verify-docs-up-to-date pre-commit run --files requirements.txt dev-requirements.txt`
- `pre-commit run verify-onboarding-refs`
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pytest tests/test_operator_api.py tests/crown/server/test_server.py`
- `pytest tests/crown/server/test_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed18ef8c832e8439f2478e861034