### PR TITLE
chore: note file-upload dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -70,4 +70,4 @@ vanna==0.7.9
     # optional: NLQ queries
 
 python-multipart>=0.0.5
-    # required for FastAPI multipart form data parsing (fixes file upload runtime error)
+    # required for FastAPI file uploads

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,4 @@ vanna==0.7.9
     # optional: NLQ queries
 
 python-multipart>=0.0.5
-    # required for FastAPI multipart form data parsing (fixes file upload runtime error)
+    # required for FastAPI file uploads


### PR DESCRIPTION
## Summary
- clarify purpose of python-multipart dependency for FastAPI uploads

## Testing
- `pre-commit run --files requirements.txt dev-requirements.txt` *(fails: Run tests with coverage (unrecognized arguments))*
- `pre-commit run verify-onboarding-refs`
- `pytest tests/test_operator_api.py tests/crown/server` *(fails: 5 failed)*
- `pytest tests/test_auto_retrain.py` *(fails: KeyboardInterrupt during heavy import)*
- `pytest tests/test_boot_sequence.py` *(fails: coverage below threshold)*
- `cargo build -p neoabzu-vector --features tracing`
- `cargo build -p neoabzu-core --features tracing`
- `cargo build -p neoabzu-fusion --features tracing`
- `cargo build -p neoabzu-rag --features tracing`


------
https://chatgpt.com/codex/tasks/task_e_68c5f965c158832ea9cd777660b1c4fe