### PR TITLE
feat: mirror crown router in Rust

### DIFF
--- a/NEOABZU/crown/src/lib.rs
+++ b/NEOABZU/crown/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use std::collections::HashMap;
 
 fn select_store(archetype: &str) -> &str {
     match archetype.to_lowercase().as_str() {
@@ -30,75 +31,290 @@ fn route_decision(
     validator: Option<PyObject>,
     documents: Option<PyObject>,
 ) -> PyResult<Py<PyDict>> {
-    if let Some(val) = validator {
-        let res = val
+    if let Ok(hb_mod) = PyModule::import(py, "monitoring.chakra_heartbeat") {
+        if let Ok(cls) = hb_mod.getattr("ChakraHeartbeat") {
+            let hb = cls.call0()?;
+            hb.call_method0("check_alerts")?;
+            let status: String = hb.call_method0("sync_status")?.extract()?;
+            if status != "Great Spiral" {
+                if let Ok(bus) = PyModule::import(py, "agents.event_bus") {
+                    let meta = PyDict::new(py);
+                    meta.set_item("status", "out_of_sync")?;
+                    let _ = bus
+                        .getattr("emit_event")?
+                        .call1(("chakra_heartbeat", "chakra_down", meta));
+                }
+                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "chakras out of sync",
+                ));
+            }
+        }
+    }
+
+    let mut throughput: Option<PyObject> = None;
+    let mut errors: Option<PyObject> = None;
+    if let Ok(prom) = PyModule::import(py, "prometheus_client") {
+        if let Ok(counter) = prom.getattr("Counter") {
+            throughput = counter
+                .call1((
+                    "narrative_throughput_total",
+                    "Narrative events processed",
+                    ("service",),
+                ))
+                .ok()
+                .map(|o| o.into_py(py));
+            errors = counter
+                .call1((
+                    "service_errors_total",
+                    "Number of errors encountered",
+                    ("service",),
+                ))
+                .ok()
+                .map(|o| o.into_py(py));
+        }
+    }
+    if let Some(tc) = throughput.as_ref() {
+        let _ = tc
             .as_ref(py)
-            .call_method("validate_action", ("crown", text), None)?;
-        let compliant = res
-            .get_item("compliant")
-            .and_then(|v| v.extract::<bool>())
-            .unwrap_or(false);
-        if !compliant {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "ethical violation",
-            ));
+            .call_method1("labels", ("crown",))
+            .and_then(|l| l.call_method0("inc"));
+    }
+
+    let outcome = (|| -> PyResult<Py<PyDict>> {
+        if let Some(val) = validator {
+            let res = val
+                .as_ref(py)
+                .call_method("validate_action", ("crown", text), None)?;
+            let compliant = res
+                .get_item("compliant")
+                .and_then(|v| v.extract::<bool>())
+                .unwrap_or(false);
+            if !compliant {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "ethical violation",
+                ));
+            }
+        }
+
+        let docs = match documents {
+            Some(d) => d,
+            None => {
+                let module = PyModule::import(py, "agents.nazarick.document_registry")?;
+                let cls = module.getattr("DocumentRegistry")?;
+                let registry = cls.call0()?;
+                registry.call_method0("get_corpus")?.into_py(py)
+            }
+        };
+
+        let orch_obj = match orchestrator {
+            Some(o) => o,
+            None => {
+                let module = PyModule::import(py, "rag.orchestrator")?;
+                let cls = module.getattr("MoGEOrchestrator")?;
+                cls.call0()?.into_py(py)
+            }
+        };
+
+        let result_obj = if std::env::var("INTERNAL_MODEL_PROTOCOL")
+            .ok()
+            .as_deref()
+            == Some("mcp")
+        {
+            match PyModule::import(py, "mcp.gateway") {
+                Ok(mcp) => {
+                    let payload = PyDict::new(py);
+                    payload.set_item("text", text)?;
+                    payload.set_item("emotion_data", emotion_data)?;
+                    payload.set_item("documents", &docs)?;
+                    let json = PyModule::import(py, "json")?;
+                    let payload_json = json.getattr("dumps")?.call1((payload,))?;
+                    let invoke = mcp.getattr("invoke_model")?;
+                    let asyncio = PyModule::import(py, "asyncio")?;
+                    let coro = invoke.call1(("orchestrator_route", payload_json))?;
+                    match asyncio.getattr("run")?.call1((coro,)) {
+                        Ok(resp) => {
+                            let any = resp
+                                .get_item("result")
+                                .unwrap_or_else(|_| PyDict::new(py).into());
+                            any.into_py(py)
+                        },
+                        Err(_) => {
+                            let kwargs = PyDict::new(py);
+                            kwargs.set_item("text_modality", false)?;
+                            kwargs.set_item("voice_modality", false)?;
+                            kwargs.set_item("music_modality", false)?;
+                            kwargs.set_item("documents", &docs)?;
+                            orch_obj
+                                .as_ref(py)
+                                .call_method("route", (text, emotion_data), Some(kwargs))?
+                                .into_py(py)
+                        }
+                    }
+                }
+                Err(_) => {
+                    let kwargs = PyDict::new(py);
+                    kwargs.set_item("text_modality", false)?;
+                    kwargs.set_item("voice_modality", false)?;
+                    kwargs.set_item("music_modality", false)?;
+                    kwargs.set_item("documents", &docs)?;
+                    orch_obj
+                        .as_ref(py)
+                        .call_method("route", (text, emotion_data), Some(kwargs))?
+                        .into_py(py)
+                }
+            }
+        } else {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("text_modality", false)?;
+            kwargs.set_item("voice_modality", false)?;
+            kwargs.set_item("music_modality", false)?;
+            kwargs.set_item("documents", &docs)?;
+            orch_obj
+                .as_ref(py)
+                .call_method("route", (text, emotion_data), Some(kwargs))?
+                .into_py(py)
+        };
+        let result: &PyDict = result_obj.as_ref(py).downcast::<PyDict>()?;
+
+        let emotion: String = emotion_data
+            .get_item("emotion")?
+            .and_then(|v| v.extract::<String>().ok())
+            .unwrap_or_else(|| "neutral".to_string());
+
+        let decider = PyModule::import(py, "crown_decider")?;
+        let opts: &PyDict = decider
+            .getattr("decide_expression_options")?
+            .call1((&emotion,))?
+            .downcast::<PyDict>()?;
+
+        let soul_state: Option<String> = PyModule::import(py, "emotional_state")
+            .ok()
+            .and_then(|m| m.getattr("get_soul_state").ok())
+            .and_then(|f| f.call0().ok())
+            .and_then(|v| v.extract().ok());
+
+        let (chakra_reg, records) = if let Ok(reg_mod) = PyModule::import(py, "memory.chakra_registry") {
+            if let Ok(cls) = reg_mod.getattr("ChakraRegistry") {
+                if let Ok(reg) = cls.call0() {
+                    let kwargs = PyDict::new(py);
+                    let filter = PyDict::new(py);
+                    filter.set_item("type", "expression_decision")?;
+                    filter.set_item("emotion", &emotion)?;
+                    kwargs.set_item("filter", filter)?;
+                    kwargs.set_item("k", 20)?;
+                    let recs = reg
+                        .call_method("search", ("crown", ""), Some(kwargs))
+                        .ok();
+                    (Some(reg.into_py(py)), recs)
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        let mut backend_weights: HashMap<String, f64> = HashMap::new();
+        if let Some(tts) = opts.get_item("tts_backend")? {
+            backend_weights.insert(tts.extract()?, 1.0);
+        }
+        let mut avatar_weights: HashMap<String, f64> = HashMap::new();
+        if let Some(style) = opts.get_item("avatar_style")? {
+            avatar_weights.insert(style.extract()?, 1.0);
+        }
+        if let Some(recs) = records {
+            for rec in recs.iter()? {
+                let r: &PyDict = rec?.downcast()?;
+                let weight = if let (Some(soul), Some(rec_soul)) = (
+                    soul_state.as_ref(),
+                    r.get_item("soul_state")?.and_then(|v| v.extract::<String>().ok()),
+                ) {
+                    if rec_soul == *soul { 2.0 } else { 1.0 }
+                } else {
+                    1.0
+                };
+                if let Ok(Some(b_any)) = r.get_item("tts_backend") {
+                    if let Ok(b) = b_any.extract::<String>() {
+                        *backend_weights.entry(b).or_insert(0.0) += weight;
+                    }
+                }
+                if let Ok(Some(a_any)) = r.get_item("avatar_style") {
+                    if let Ok(a) = a_any.extract::<String>() {
+                        *avatar_weights.entry(a).or_insert(0.0) += weight;
+                    }
+                }
+            }
+        }
+
+        let tts_backend = backend_weights
+            .iter()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(k, _)| k.clone())
+            .unwrap_or_default();
+        let avatar_style = avatar_weights
+            .iter()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(k, _)| k.clone())
+            .unwrap_or_default();
+
+        let rust_memory = PyModule::import(py, "memory.bundle")
+            .and_then(|m| m.getattr("MemoryBundle"))
+            .and_then(|c| c.call0())
+            .and_then(|b| {
+                b.call_method0("initialize")?;
+                b.call_method1("query", (text,))
+            })
+            .ok();
+
+        let core_output = PyModule::import(py, "neoabzu_core")
+            .and_then(|m| m.getattr("evaluate_py"))
+            .and_then(|f| f.call1((text,)))
+            .ok();
+
+        let decision = PyDict::new(py);
+        if let Some(model) = result.get_item("model")? {
+            decision.set_item("model", model)?;
+        }
+        decision.set_item("tts_backend", &tts_backend)?;
+        decision.set_item("avatar_style", &avatar_style)?;
+        if let Some(aura) = opts.get_item("aura")? {
+            decision.set_item("aura", aura)?;
+        }
+        if let Some(mem) = rust_memory {
+            decision.set_item("memory", mem)?;
+        }
+        if let Some(core) = core_output {
+            decision.set_item("core", core)?;
+        }
+        if let Some(reg) = chakra_reg {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("type", "expression_decision")?;
+            kwargs.set_item("emotion", &emotion)?;
+            kwargs.set_item("tts_backend", &tts_backend)?;
+            kwargs.set_item("avatar_style", &avatar_style)?;
+            if let Some(soul) = soul_state {
+                kwargs.set_item("soul_state", soul)?;
+            }
+            let _ = reg
+                .as_ref(py)
+                .call_method("record", ("crown", text, "crown_router"), Some(kwargs));
+        }
+
+        Ok(decision.into_py(py))
+    })();
+
+    if outcome.is_err() {
+        if let Some(ec) = errors {
+            let _ = ec
+                .as_ref(py)
+                .call_method1("labels", ("crown",))
+                .and_then(|l| l.call_method0("inc"));
         }
     }
 
-    let docs = match documents {
-        Some(d) => d,
-        None => {
-            let module = PyModule::import(py, "agents.nazarick.document_registry")?;
-            let cls = module.getattr("DocumentRegistry")?;
-            let registry = cls.call0()?;
-            registry.call_method0("get_corpus")?.into_py(py)
-        }
-    };
-
-    let orch_obj = match orchestrator {
-        Some(o) => o,
-        None => {
-            let module = PyModule::import(py, "rag.orchestrator")?;
-            let cls = module.getattr("MoGEOrchestrator")?;
-            cls.call0()?.into_py(py)
-        }
-    };
-
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("text_modality", false)?;
-    kwargs.set_item("voice_modality", false)?;
-    kwargs.set_item("music_modality", false)?;
-    kwargs.set_item("documents", docs)?;
-    let result_obj = orch_obj
-        .as_ref(py)
-        .call_method("route", (text, emotion_data), Some(kwargs))?;
-    let result: &PyDict = result_obj.downcast::<PyDict>()?;
-
-    let emotion = emotion_data.get_item("emotion").ok().flatten();
-    let none = py.None();
-    let emotion = match emotion {
-        Some(v) => v,
-        None => none.as_ref(py),
-    };
-    let decider = PyModule::import(py, "crown_decider")?;
-    let opts: &PyDict = decider
-        .getattr("decide_expression_options")?
-        .call1((emotion,))?
-        .downcast::<PyDict>()?;
-    let decision = PyDict::new(py);
-    if let Some(model) = result.get_item("model")? {
-        decision.set_item("model", model)?;
-    }
-    if let Some(tts) = opts.get_item("tts_backend")? {
-        decision.set_item("tts_backend", tts)?;
-    }
-    if let Some(style) = opts.get_item("avatar_style")? {
-        decision.set_item("avatar_style", style)?;
-    }
-    if let Some(aura) = opts.get_item("aura")? {
-        decision.set_item("aura", aura)?;
-    }
-    Ok(decision.into_py(py))
+    outcome
 }
 
 #[pyfunction]

--- a/NEOABZU/crown/tests/python_parity.rs
+++ b/NEOABZU/crown/tests/python_parity.rs
@@ -1,0 +1,160 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+#[test]
+fn rust_matches_python_route_decision() {
+    Python::with_gil(|py| {
+        py.run(
+            r#"
+import types, sys, asyncio, json
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.called = False
+    def route(self, text, emotion_data, text_modality=False, voice_modality=False, music_modality=False, documents=None):
+        self.called = True
+        return {'model': 'test-model'}
+
+class DummyValidator:
+    def validate_action(self, agent, text):
+        return {'compliant': True}
+
+def decide_expression_options(emotion):
+    return {'tts_backend': 'tts', 'avatar_style': 'avatar', 'aura': 'blue'}
+
+def get_soul_state():
+    return 'calm'
+
+class DocumentRegistry:
+    def get_corpus(self):
+        return {'doc': 'value'}
+
+class ChakraHeartbeat:
+    def check_alerts(self):
+        pass
+    def sync_status(self):
+        return 'Great Spiral'
+
+def emit_event(actor, action, meta):
+    pass
+
+# stub modules
+crown_decider = types.ModuleType('crown_decider')
+crown_decider.decide_expression_options = decide_expression_options
+sys.modules['crown_decider'] = crown_decider
+
+emotional_state = types.ModuleType('emotional_state')
+emotional_state.get_soul_state = get_soul_state
+sys.modules['emotional_state'] = emotional_state
+
+agents = types.ModuleType('agents')
+event_bus = types.ModuleType('event_bus')
+event_bus.emit_event = emit_event
+agents.event_bus = event_bus
+sys.modules['agents'] = agents
+sys.modules['agents.event_bus'] = event_bus
+
+rag = types.ModuleType('rag')
+orchestrator = types.ModuleType('orchestrator')
+orchestrator.MoGEOrchestrator = DummyOrchestrator
+rag.orchestrator = orchestrator
+sys.modules['rag'] = rag
+sys.modules['rag.orchestrator'] = orchestrator
+
+INANNA_AI = types.ModuleType('INANNA_AI')
+ethical = types.ModuleType('ethical_validator')
+ethical.EthicalValidator = DummyValidator
+INANNA_AI.ethical_validator = ethical
+sys.modules['INANNA_AI'] = INANNA_AI
+sys.modules['INANNA_AI.ethical_validator'] = ethical
+
+doc_mod = types.ModuleType('agents.nazarick.document_registry')
+doc_mod.DocumentRegistry = DocumentRegistry
+sys.modules['agents.nazarick.document_registry'] = doc_mod
+
+monitoring = types.ModuleType('monitoring')
+chakra_mod = types.ModuleType('chakra_heartbeat')
+chakra_mod.ChakraHeartbeat = ChakraHeartbeat
+monitoring.chakra_heartbeat = chakra_mod
+sys.modules['monitoring'] = monitoring
+sys.modules['monitoring.chakra_heartbeat'] = chakra_mod
+
+prom = types.ModuleType('prometheus_client')
+class Counter:
+    def __init__(self,*a,**k):
+        pass
+    def labels(self,*a):
+        return self
+    def inc(self):
+        pass
+prom.Counter = Counter
+prom.REGISTRY = types.SimpleNamespace()
+sys.modules['prometheus_client'] = prom
+
+psutil = types.ModuleType('psutil')
+psutil.cpu_percent = lambda :0
+psutil.virtual_memory = lambda : types.SimpleNamespace(used=0)
+sys.modules['psutil'] = psutil
+
+neoabzu_memory = types.ModuleType('neoabzu_memory')
+neoabzu_memory.query_memory = lambda text: {}
+neoabzu_memory.broadcast_layer_event = lambda s: None
+sys.modules['neoabzu_memory'] = neoabzu_memory
+"#,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let py_router = PyModule::import(py, "crown_router").unwrap();
+        let rs_router = PyModule::import(py, "neoabzu_crown").unwrap();
+
+        let emotion = PyDict::new(py);
+        emotion.set_item("emotion", "joy").unwrap();
+
+        let py_dec: &PyDict = py_router
+            .getattr("route_decision")
+            .unwrap()
+            .call1(("hello", emotion))
+            .unwrap()
+            .downcast()
+            .unwrap();
+        let rs_dec: &PyDict = rs_router
+            .getattr("route_decision")
+            .unwrap()
+            .call1(("hello", emotion))
+            .unwrap()
+            .downcast()
+            .unwrap();
+
+        let model_py: String = py_dec.get_item("model").unwrap().unwrap().extract().unwrap();
+        let model_rs: String = rs_dec.get_item("model").unwrap().unwrap().extract().unwrap();
+        assert_eq!(model_py, model_rs);
+        let tts_py: String = py_dec
+            .get_item("tts_backend")
+            .unwrap()
+            .unwrap()
+            .extract()
+            .unwrap();
+        let tts_rs: String = rs_dec
+            .get_item("tts_backend")
+            .unwrap()
+            .unwrap()
+            .extract()
+            .unwrap();
+        assert_eq!(tts_py, tts_rs);
+        let avatar_py: String = py_dec
+            .get_item("avatar_style")
+            .unwrap()
+            .unwrap()
+            .extract()
+            .unwrap();
+        let avatar_rs: String = rs_dec
+            .get_item("avatar_style")
+            .unwrap()
+            .unwrap()
+            .extract()
+            .unwrap();
+        assert_eq!(avatar_py, avatar_rs);
+    });
+}

--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -10,7 +10,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | --- | --- | --- |
 | User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated |
-| Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | rewrite in Rust |
+| Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | mirrored in `neoabzu-crown` with PyO3 route bindings |
 | RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | initial Rust crate for vector retrieval |
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | rewrite in Rust |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -7,7 +7,7 @@ For narrative alignment and sacred terminology, consult [herojourney_engine.md](
 | Python Subsystem | Rust Crate | Bridge |
 | --- | --- | --- |
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |
-| `crown_router.py` | `neoabzu-crown` | Exposes routing functions via `crown_router_rs.py` wrapper. |
+| `crown_router.py` | `neoabzu-crown` | Rust crate now mirrors router routes and validations; `crown_router_rs.py` wraps PyO3 bindings. |
 | `rag/orchestrator.py` | `neoabzu-rag` | Provides retrieval utilities compatible with the RAG orchestrator. |
 | `core` lambda engine (`core/`) | `neoabzu-core` | Accessible through `neoabzu_memory.eval_core` and `neoabzu_memory.reduce_inevitable_core` for Crown Router and RAZAR. |
 


### PR DESCRIPTION
## Summary
- implement crown router parity in `neoabzu-crown` via PyO3
- add Python parity integration test
- document crown router parity in NEOABZU docs

## Testing
- `pre-commit run --files NEOABZU/crown/src/lib.rs NEOABZU/crown/tests/python_parity.rs NEOABZU/docs/feature_parity.md NEOABZU/docs/migration_crosswalk.md`
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`
- `cargo test -p neoabzu-crown` *(fails: undefined references to Python symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68c60c26ed8c832eba6efa7436c76dad