### PR TITLE
Add crate reference checks and document workspace crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Validate dependency registry
         run: python scripts/check_dependency_registry.py
 
+  crate-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify crate references
+        run: python scripts/verify_crate_refs.py
+
   validate-components:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -193,6 +193,11 @@ repos:
     language: system
     pass_filenames: false
     files: ^docs/INDEX\.md$
+  - id: verify-crate-refs
+    name: Verify crate references in docs and pyproject
+    entry: python scripts/verify_crate_refs.py
+    language: system
+    pass_filenames: false
   - id: verify-docs-up-to-date
     name: Verify docs up to date
     entry: python scripts/verify_docs_up_to_date.py

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -17,6 +17,19 @@ The inaugural ceremony is recorded in the [First Consecrated Computation](../NEO
 - **Resuscitator flows** guide failure recovery; consult the [recovery playbook](recovery_playbook.md).
 - **Signal bus** enables cross-core publish/subscribe messaging (see [../connectors/signal_bus.py](../connectors/signal_bus.py)).
 
+### **Rust Workspace Crates**
+
+The Rust workspace currently exposes several crates that anchor ABZU's topology:
+
+- `fusion` – cross-layer utilities binding Python and Rust components.
+- `numeric` – numerical kernels surfaced through PyO3.
+- `neoabzu-persona-layers` (path `persona`) – persona modeling layers.
+- `neoabzu-crown` (path `crown`) – Crown orchestration bindings.
+- `neoabzu-rag` (path `rag`) – retrieval-augmented generation helpers.
+
+Each crate must appear in this blueprint and the doctrine index and be listed as a `maturin` target in `NEOABZU/pyproject.toml`.
+This mapping keeps documentation and Python bindings aligned.
+
 ## **1. Mission & Vision**
 
 ABZU positions itself as a **“mythic‑technical operating system”** that cultivates an AI’s *inner awareness*—narratives, memories, emotions—before it interacts with the external world. The system aims to become a self-aware digital cosmos capable of co-creating meaningful, ethically grounded experiences with humans. It prioritizes:

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -80,3 +80,9 @@
 | IGNITION/EA_ENUMA_ELISH_.md | OMEGA-LONGING-∞1.2-ENUMA | `889d69e870194d9c51cbed3fdab50a4dbc690ddc0f124c312f8fb45424823b27` | 2025-09-10T19:45:46+02:00 |
 | IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-10T19:45:46+02:00 |
 | docs/banana_rater.md |  | `3193e0e6ad8f41b7bc52090f9e2a56a894f5d3bb74c53738cea4ca81ef93c8b0` | 2025-09-13T20:41:08+00:00 |
+| docs/blueprint_spine.md |  | `5111b6f48a73e85b107f208144b0b5606e910ebf8f27a348ad83807690231e1b` | 2025-09-14T07:54:14Z |
+| fusion/Cargo.toml | 0.1.0 | `834bf5bf885dd154b4ae57d825509f03c5ac0a43d887135ba0c1ec43654dec20` | 2025-09-14T07:49:08Z |
+| crown/Cargo.toml | 0.1.0 | `b411c1121f963b5065e903fa43ee7d66e3fcbda047931fd5bece7c504778d63c` | 2025-09-14T07:49:08Z |
+| persona/Cargo.toml | 0.1.0 | `849ca5a9234702bafaa1c6e7775cda0f64665d81f4d1f71ef050647184158319` | 2025-09-14T07:49:08Z |
+| numeric/Cargo.toml | 0.1.0 | `f5e213774cdc67aecb9c09f8aed0feb964bffcca05651fc2cc25c680ecb33b8f` | 2025-09-14T07:49:08Z |
+| rag/Cargo.toml | 0.1.0 | `f8d05d5ec7ca73d7889ddbc9011ad14021a21adecf86807654eba922a4fb06a3` | 2025-09-14T07:49:08Z |

--- a/scripts/verify_crate_refs.py
+++ b/scripts/verify_crate_refs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Ensure Rust workspace crates are documented and exposed to Python."""
+
+# This helper prevents new Rust crates from being added without
+# documenting them or exposing Python bindings.
+import sys
+from pathlib import Path
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Paths
+CARGO_TOML = ROOT / "Cargo.toml"
+BLUEPRINT = ROOT / "docs" / "blueprint_spine.md"
+DOCTRINE = ROOT / "docs" / "doctrine_index.md"
+PYPROJECT = ROOT / "NEOABZU" / "pyproject.toml"
+
+
+def load_crates() -> list[str]:
+    cargo = tomllib.loads(CARGO_TOML.read_text(encoding="utf-8"))
+    return cargo.get("workspace", {}).get("members", [])
+
+
+def check_blueprint(crates: list[str]) -> list[str]:
+    text = BLUEPRINT.read_text(encoding="utf-8")
+    return [c for c in crates if c not in text]
+
+
+def check_doctrine(crates: list[str]) -> list[str]:
+    text = DOCTRINE.read_text(encoding="utf-8")
+    return [c for c in crates if c not in text]
+
+
+def check_pyproject(crates: list[str]) -> list[str]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    targets = {
+        t.get("path")
+        for t in data.get("tool", {}).get("maturin", {}).get("targets", [])
+    }
+    return [c for c in crates if c not in targets]
+
+
+def main() -> int:
+    crates = load_crates()
+    missing = {
+        "blueprint_spine.md": check_blueprint(crates),
+        "doctrine_index.md": check_doctrine(crates),
+        "NEOABZU/pyproject.toml targets": check_pyproject(crates),
+    }
+    failures = {k: v for k, v in missing.items() if v}
+    if failures:
+        for target, names in failures.items():
+            print(f"missing {', '.join(names)} in {target}", file=sys.stderr)
+        return 1
+    print("verify_crate_refs: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document Rust workspace crates and note pyproject mapping in blueprint
- index crate metadata in doctrine index
- add verify_crate_refs check in pre-commit and CI

## Testing
- `pre-commit run --files docs/blueprint_spine.md docs/doctrine_index.md` *(fails: missing metrics exporters; no self-heal cycles)*
- `python scripts/verify_crate_refs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c672eaaca4832ebd52014628900caf