### PR TITLE
feat: add rust orchestrator and insight engine

### DIFF
--- a/NEOABZU/Cargo.lock
+++ b/NEOABZU/Cargo.lock
@@ -621,6 +621,9 @@ dependencies = [
 name = "neoabzu-crown"
 version = "0.1.0"
 dependencies = [
+ "neoabzu-insight",
+ "neoabzu-memory",
+ "neoabzu-rag",
  "pyo3",
 ]
 

--- a/NEOABZU/crown/Cargo.toml
+++ b/NEOABZU/crown/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.21", features = ["extension-module"] }
+neoabzu-memory = { path = "../memory" }
+neoabzu-rag = { path = "../rag" }
+neoabzu-insight = { path = "../insight" }
 
 [features]
 default = []

--- a/NEOABZU/crown/tests/route_query.rs
+++ b/NEOABZU/crown/tests/route_query.rs
@@ -1,45 +1,32 @@
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyModule};
 
 #[test]
-fn test_route_query_selects_store() {
+fn test_route_query_uses_rust_retriever() {
     Python::with_gil(|py| {
-        py.run(
-            r#"
-import types, sys
-called = {}
-
-def fake_retrieve(q, top_n=5, collection="tech"):
-    called['store'] = collection
-    return []
-
-retriever = types.ModuleType('retriever')
-retriever.retrieve_top = fake_retrieve
-rag = types.ModuleType('rag')
-rag.retriever = retriever
-sys.modules['rag'] = rag
-sys.modules['rag.retriever'] = retriever
-"#,
-            None,
-            None,
-        )
-        .unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
+        let agents = PyModule::new(py, "agents").unwrap();
+        modules.set_item("agents", agents).unwrap();
+        let event_code = r#"
+ events = []
+ def emit_event(actor, action, metadata):
+     events.append((actor, action, metadata))
+"#;
+        let event_bus = PyModule::from_code(py, event_code, "", "event_bus").unwrap();
+        modules.set_item("agents.event_bus", event_bus).unwrap();
+        let vector_code = r#"
+ def query_vectors(*a, **k):
+     return [{'text':'abc'}]
+"#;
+        let vector_mod = PyModule::from_code(py, vector_code, "", "vector_memory").unwrap();
+        modules.set_item("vector_memory", vector_mod).unwrap();
 
         let module = PyModule::import(py, "neoabzu_crown").unwrap();
         let func = module.getattr("route_query").unwrap();
-        func.call1(("hello", "Sage")).unwrap();
-        let store: String = py
-            .eval("called['store']", None, None)
-            .unwrap()
-            .extract()
-            .unwrap();
-        assert_eq!(store, "tech");
-
-        func.call1(("hello", "Jester")).unwrap();
-        let store: String = py
-            .eval("called['store']", None, None)
-            .unwrap()
-            .extract()
-            .unwrap();
-        assert_eq!(store, "music");
+        let res: &PyList = func.call1(("hello", "Sage")).unwrap().downcast().unwrap();
+        let first: &PyDict = res.get_item(0).unwrap().downcast().unwrap();
+        let text: String = first.get_item("text").unwrap().unwrap().extract().unwrap();
+        assert_eq!(text, "abc");
     });
 }

--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -11,8 +11,8 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated via `neoabzu_persona` |
 | Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | rewrite in Rust |
-| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | initial Rust crate for vector retrieval |
-| Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | initial Rust crate `neoabzu-insight` wired into Crown Router |
+| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator aggregates memory and connector results |
+| Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` counts word frequencies and integrates with Crown Router |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |
 | System Coordination | Metrics, tracing, and caching align cross-subsystem orchestration | parity achieved |
 | Vector Search | Accelerates similarity lookups across memory layers【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | Rust crate `neoabzu_vector` exposed via gRPC |

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -8,10 +8,10 @@ For narrative alignment and sacred terminology, consult [herojourney_engine.md](
 | --- | --- | --- |
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |
 | `crown_router.py` | `neoabzu-crown` | Exposes routing functions via `crown_router_rs.py` wrapper. |
-| `rag/orchestrator.py` | `neoabzu-rag` | Provides retrieval utilities compatible with the RAG orchestrator. |
+| `rag/orchestrator.py` | `neoabzu-rag` | `MoGEOrchestrator` aggregates memory and connector results via PyO3. |
 | `core` lambda engine (`core/`) | `neoabzu-core` | Accessible through `neoabzu_memory.eval_core` and `neoabzu_memory.reduce_inevitable_core` for Crown Router and RAZAR. |
 | `system coordination` (`metrics`, `tracing`, `caching`) | `neoabzu-crown` | Shared instrumentation and caches mirror ABZU coordination. |
-| `insight_compiler.py` | `neoabzu-insight` | Provides `reason` routine for Crown Router via PyO3. |
+| `insight_compiler.py` | `neoabzu-insight` | Insight engine performs word-frequency analysis for Crown Router. |
 | `persona` intent layers (`INANNA_AI/personality_layers`) | `neoabzu-persona` | PyO3 module `neoabzu_persona` normalizes intents. |
 | `vector_memory.py` | `neoabzu-vector` | gRPC service `neoabzu_vector` exposes search APIs. |
 | `numeric` utilities (`numeric/`) | `neoabzu-numeric` | PyO3 module `neoabzu_numeric` accelerates math routines. |

--- a/NEOABZU/insight/src/lib.rs
+++ b/NEOABZU/insight/src/lib.rs
@@ -1,15 +1,24 @@
 // Patent pending – see PATENTS.md
 //! Insight reasoning routines for NeoABZU.
 
+use std::collections::HashMap;
+
 use pyo3::prelude::*;
 
-/// Reverse the provided text to simulate insight generation.
-pub fn analyze(text: &str) -> String {
-    text.chars().rev().collect()
+/// Generate basic insights by counting word frequencies within `text`.
+pub fn analyze(text: &str) -> Vec<(String, usize)> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for word in text.split_whitespace() {
+        let key = word.to_lowercase();
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    let mut pairs: Vec<(String, usize)> = counts.into_iter().collect();
+    pairs.sort_by(|a, b| b.1.cmp(&a.1));
+    pairs
 }
 
 #[pyfunction]
-fn reason(text: &str) -> PyResult<String> {
+fn reason(text: &str) -> PyResult<Vec<(String, usize)>> {
     Ok(analyze(text))
 }
 
@@ -24,7 +33,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_analyze_reverses_text() {
-        assert_eq!(analyze("abc"), "cba");
+    fn test_analyze_counts_words() {
+        let res = analyze("hi hi there");
+        assert_eq!(res[0], ("hi".to_string(), 2));
+        assert!(res.iter().any(|(w, c)| w == "there" && *c == 1));
     }
 }

--- a/NEOABZU/rag/tests/orchestrator.rs
+++ b/NEOABZU/rag/tests/orchestrator.rs
@@ -1,0 +1,60 @@
+use neoabzu_rag::MoGEOrchestrator;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyModule};
+
+fn setup(py: Python<'_>) {
+    let sys = py.import("sys").unwrap();
+    let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
+    let agents = PyModule::new(py, "agents").unwrap();
+    modules.set_item("agents", agents).unwrap();
+    let event_code = r#"
+events = []
+def emit_event(actor, action, metadata):
+    events.append((actor, action, metadata))
+"#;
+    let event_bus = PyModule::from_code(py, event_code, "", "event_bus").unwrap();
+    modules.set_item("agents.event_bus", event_bus).unwrap();
+    let vector_code = r#"
+def query_vectors(*a, **k):
+    return [{'text':'abc'}]
+"#;
+    let vector_mod = PyModule::from_code(py, vector_code, "", "vector_memory").unwrap();
+    modules.set_item("vector_memory", vector_mod).unwrap();
+}
+
+#[test]
+fn aggregates_memory_and_connector_results() {
+    Python::with_gil(|py| {
+        setup(py);
+        let conn_code = r#"
+def fetch(q):
+    return [{'text': 'ext'}]
+"#;
+        let conn_mod = PyModule::from_code(py, conn_code, "", "connector").unwrap();
+        let fetch = conn_mod.getattr("fetch").unwrap();
+        let connectors = PyList::new(py, [fetch]);
+        let orchestrator = MoGEOrchestrator::new();
+        let emotion = PyDict::new(py);
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("connectors", connectors).unwrap();
+        let result = orchestrator
+            .route(py, "abc", emotion, Some(kwargs))
+            .unwrap();
+        let docs_any = result.as_ref(py).get_item("documents").unwrap().unwrap();
+        let docs: &PyList = docs_any.downcast().unwrap();
+        let texts: Vec<String> = docs
+            .iter()
+            .map(|d| {
+                d.downcast::<PyDict>()
+                    .unwrap()
+                    .get_item("text")
+                    .unwrap()
+                    .unwrap()
+                    .extract()
+                    .unwrap()
+            })
+            .collect();
+        assert!(texts.contains(&"abc".to_string()));
+        assert!(texts.contains(&"ext".to_string()));
+    });
+}


### PR DESCRIPTION
## Summary
- replace Python RAG hooks with Rust equivalents and expose MoGEOrchestrator
- expand Insight engine to word-frequency analysis and wire into Crown
- update feature parity and migration crosswalk docs

## Testing
- `cargo test -p neoabzu-rag --manifest-path NEOABZU/Cargo.toml`
- `cargo test -p neoabzu-insight --manifest-path NEOABZU/Cargo.toml`
- `cargo test -p neoabzu-crown --manifest-path NEOABZU/Cargo.toml` (failed: missing Python symbols)
- `pre-commit run --files NEOABZU/rag/src/lib.rs NEOABZU/rag/tests/orchestrator.rs NEOABZU/crown/src/lib.rs NEOABZU/crown/Cargo.toml NEOABZU/crown/tests/route_query.rs NEOABZU/insight/src/lib.rs NEOABZU/docs/feature_parity.md NEOABZU/docs/migration_crosswalk.md` (failed: missing environment / formatting)
- `pre-commit run verify-onboarding-refs`

------
https://chatgpt.com/codex/tasks/task_e_68c67af1153c832eba8b6897e318e740