### PR TITLE
feat: embed-backed vector service with client tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/operator_onboarding.md` documents mission workflows with Mermaid diagrams and cross-links in `system_blueprint.md`.
 - `datpars` placeholder package with stub interfaces and `docs/datpars_overview.md`.
 - Documented Chakra Heartbeat Alignment for Nazarick agents with Mermaid mapping; cross-linked `chakra_metrics.md` and `ignition_blueprint.md`.
+- gRPC vector service loads embeddings from `NEOABZU_VECTOR_STORE`, tracks basic metrics, and exposes Python `VectorClient` helpers with end-to-end tests for `init` and `search`.
 - Wrapped `agents.event_bus.emit_event` and memory layer queries with OpenTelemetry spans.
 - Structured manual detailing chakra architecture, system components, memory bundle, and operator paths with Mermaid diagrams and doctrine cross-links.
 - Blueprint manual capturing vision, chakra architecture, operator console routes, memory bundle initialization, and dynamic ignition.

--- a/NEOABZU/Reignition.md
+++ b/NEOABZU/Reignition.md
@@ -64,14 +64,27 @@ Run the gRPC service with:
 cargo run -p neoabzu-vector --bin server
 ```
 
+The server expects a JSON list of texts referenced by
+`NEOABZU_VECTOR_STORE`:
+
+```bash
+export NEOABZU_VECTOR_STORE=tests/data/store.json
+cargo run -p neoabzu-vector --bin server
+```
+
+Each entry is embedded at startup and stored in memory. Metrics counters
+`neoabzu_vector_init_total` and `neoabzu_vector_search_total` track RPC
+usage, and invalid requests surface gRPC errors (e.g. missing store,
+zero `top_n`, or searches before initialization).
+
 Python callers may connect using `neoabzu.vector.VectorClient`:
 
 ```python
 from neoabzu.vector import VectorClient
 
-client = VectorClient("http://localhost:50051")
-client.init()
-results = client.search("hello", 2)
+with VectorClient("http://localhost:50051") as client:
+    client.init()
+    results = client.search("hello", 2)
 ```
 
 ## Contributor Guidelines

--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -15,7 +15,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` counts word frequencies and integrates with Crown Router |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |
 | System Coordination | Metrics, tracing, and caching align cross-subsystem orchestration | parity achieved |
-| Vector Search | Accelerates similarity lookups across memory layers【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | Rust crate `neoabzu_vector` exposed via gRPC |
+| Vector Search | Accelerates similarity lookups across memory layers【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | Rust crate `neoabzu_vector` exposes gRPC with in-memory embeddings, metrics, and Python client helpers |
 | Numeric Utilities | Provides fast math primitives | initial Rust crate `neoabzu_numeric` |
 | Fusion Engine | Merges symbolic and numeric invariants | initial Rust crate `neoabzu_fusion` |
 

--- a/NEOABZU/neoabzu/vector.py
+++ b/NEOABZU/neoabzu/vector.py
@@ -16,6 +16,10 @@ class VectorClient:
     """Simple gRPC client for the VectorService."""
 
     def __init__(self, target: str):
+        if target.startswith("http://"):
+            target = target[7:]
+        elif target.startswith("https://"):
+            target = target[8:]
         self._channel = grpc.insecure_channel(target)
         self._stub = vector_pb2_grpc.VectorServiceStub(self._channel)
 
@@ -25,6 +29,15 @@ class VectorClient:
     def search(self, text: str, top_n: int) -> vector_pb2.SearchResponse:
         req = vector_pb2.SearchRequest(text=text, top_n=top_n)
         return self._stub.Search(req)
+
+    def close(self) -> None:
+        self._channel.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
 
 
 __all__ = ["search", "VectorClient"]

--- a/NEOABZU/vector/Cargo.toml
+++ b/NEOABZU/vector/Cargo.toml
@@ -17,6 +17,11 @@ tracing-opentelemetry = { version = "0.23", optional = true }
 tonic = { version = "0.11", features = ["transport"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 prost = "0.12"
+metrics = "0.21"
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [features]
 default = ["pyo3/auto-initialize"]

--- a/NEOABZU/vector/src/server.rs
+++ b/NEOABZU/vector/src/server.rs
@@ -1,30 +1,76 @@
 use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
 
 use crate::proto::vector_service_server::{VectorService, VectorServiceServer};
 use crate::proto::{InitRequest, InitResponse, SearchRequest, SearchResponse, SearchResult};
+use metrics::{counter, gauge};
 use tonic::{transport::Server, Request, Response, Status};
 
-#[derive(Default)]
-pub struct VectorServer;
+fn embed(text: &str) -> Vec<f32> {
+    text.bytes().map(|b| b as f32 / 255.0).collect()
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let mag_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let mag_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (mag_a * mag_b + f32::EPSILON)
+}
+
+#[derive(Clone, Default)]
+pub struct VectorServer {
+    store: Arc<RwLock<Vec<(String, Vec<f32>)>>>,
+}
+
+impl VectorServer {
+    fn load_store(&self, texts: Vec<String>) {
+        let mut store = self.store.write().unwrap();
+        for t in texts {
+            store.push((t.clone(), embed(&t)));
+        }
+        gauge!("neoabzu_vector_store_size", store.len() as f64);
+    }
+}
 
 #[tonic::async_trait]
 impl VectorService for VectorServer {
     async fn init(&self, _request: Request<InitRequest>) -> Result<Response<InitResponse>, Status> {
+        counter!("neoabzu_vector_init_total", 1);
+        let path = std::env::var("NEOABZU_VECTOR_STORE")
+            .map_err(|_| Status::invalid_argument("NEOABZU_VECTOR_STORE not set"))?;
+        let data = std::fs::read_to_string(&path)
+            .map_err(|e| Status::internal(format!("failed to read store: {e}")))?;
+        let texts: Vec<String> = serde_json::from_str(&data)
+            .map_err(|e| Status::internal(format!("invalid store: {e}")))?;
+        self.load_store(texts);
+        let count = self.store.read().unwrap().len();
         Ok(Response::new(InitResponse {
-            message: "ok".to_string(),
+            message: format!("loaded {count}"),
         }))
     }
 
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>, Status> {
+        counter!("neoabzu_vector_search_total", 1);
         let req = request.into_inner();
-        let results = (0..req.top_n)
-            .map(|i| SearchResult {
-                text: format!("{}{}", req.text, i),
-                score: 1.0,
-                embedding: vec![0.0, 0.0],
+        if req.top_n == 0 {
+            return Err(Status::invalid_argument("top_n must be > 0"));
+        }
+        let store = self.store.read().unwrap();
+        if store.is_empty() {
+            return Err(Status::failed_precondition("store not initialized"));
+        }
+        let query_emb = embed(&req.text);
+        let mut results: Vec<SearchResult> = store
+            .iter()
+            .map(|(text, emb)| SearchResult {
+                text: text.clone(),
+                score: cosine_similarity(&query_emb, emb),
+                embedding: emb.clone(),
             })
             .collect();
-        Ok(Response::new(SearchResponse { results }))
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        let top = results.into_iter().take(req.top_n as usize).collect();
+        Ok(Response::new(SearchResponse { results: top }))
     }
 }
 

--- a/NEOABZU/vector/tests/grpc.rs
+++ b/NEOABZU/vector/tests/grpc.rs
@@ -1,10 +1,18 @@
 use neoabzu_vector::proto::vector_service_client::VectorServiceClient;
 use neoabzu_vector::proto::{InitRequest, SearchRequest};
 use neoabzu_vector::serve;
+use std::fs::File;
+use std::io::Write;
 use tokio::time::{sleep, Duration};
 
 #[tokio::test]
 async fn init_and_search() {
+    let dir = tempfile::tempdir().unwrap();
+    let store_path = dir.path().join("store.json");
+    let mut f = File::create(&store_path).unwrap();
+    f.write_all(b"[\"alpha\", \"beta\"]").unwrap();
+    std::env::set_var("NEOABZU_VECTOR_STORE", &store_path);
+
     let addr: std::net::SocketAddr = "127.0.0.1:50051".parse().unwrap();
     let server = tokio::spawn(async move {
         serve(addr).await.unwrap();
@@ -14,19 +22,26 @@ async fn init_and_search() {
     let endpoint = format!("http://{}", addr);
     let mut client = VectorServiceClient::connect(endpoint).await.unwrap();
 
+    assert!(client
+        .search(SearchRequest {
+            text: "alpha".into(),
+            top_n: 1,
+        })
+        .await
+        .is_err());
+
     let init = client.init(InitRequest {}).await.unwrap().into_inner();
-    assert_eq!(init.message, "ok");
+    assert!(init.message.contains("loaded"));
 
     let resp = client
         .search(SearchRequest {
-            text: "a".into(),
-            top_n: 2,
+            text: "alpha".into(),
+            top_n: 1,
         })
         .await
         .unwrap()
         .into_inner();
-    assert_eq!(resp.results.len(), 2);
-    assert_eq!(resp.results[0].text, "a0");
+    assert_eq!(resp.results[0].text, "alpha");
 
     server.abort();
 }

--- a/NEOABZU/vector/tests/test_grpc_python.py
+++ b/NEOABZU/vector/tests/test_grpc_python.py
@@ -1,0 +1,81 @@
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import grpc
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+import importlib.util
+import types
+
+neoabzu_vector = types.ModuleType("neoabzu_vector")
+neoabzu_vector.search = lambda text, top_n: [(text, 1.0)] * top_n
+sys.modules["neoabzu_vector"] = neoabzu_vector
+
+neoabzu_pkg = types.ModuleType("neoabzu")
+sys.modules["neoabzu"] = neoabzu_pkg
+
+for name in ["vector_pb2", "vector_pb2_grpc"]:
+    spec = importlib.util.spec_from_file_location(
+        f"neoabzu.{name}", ROOT / "neoabzu" / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    sys.modules[f"neoabzu.{name}"] = module
+    sys.modules[name] = module
+    setattr(neoabzu_pkg, name, module)
+
+spec = importlib.util.spec_from_file_location(
+    "neoabzu.vector", ROOT / "neoabzu" / "vector.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)  # type: ignore[arg-type]
+neoabzu_pkg.vector = module
+VectorClient = module.VectorClient
+
+
+@pytest.mark.component("vector")
+def test_grpc_end_to_end(tmp_path):
+    store = tmp_path / "store.json"
+    json.dump(["alpha", "beta"], store.open("w"))
+    env = os.environ.copy()
+    env["NEOABZU_VECTOR_STORE"] = str(store)
+    server = subprocess.Popen(
+        [
+            "cargo",
+            "run",
+            "-p",
+            "neoabzu-vector",
+            "--bin",
+            "server",
+        ],
+        env=env,
+        cwd=ROOT,
+    )
+    try:
+        import socket
+
+        for _ in range(60):
+            try:
+                with socket.create_connection(("localhost", 50051), timeout=1):
+                    break
+            except OSError:
+                time.sleep(1)
+        with VectorClient("http://localhost:50051") as client:
+            with pytest.raises(grpc.RpcError) as err:
+                client.search("alpha", 1)
+            assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+            init = client.init()
+            assert "loaded" in init.message
+
+            resp = client.search("alpha", 1)
+            assert resp.results[0].text == "alpha"
+    finally:
+        server.terminate()
+        server.wait()

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -66,7 +66,7 @@ documents:
       purpose: Maps reduction steps to a 12-stage heroic narrative.
       scope: Neo-ABZU narrative engine.
   NEOABZU/docs/migration_crosswalk.md:
-    sha256: 88ab3fcc4720dac1bc8cab7b28eb78b09efaa0a9fb93ae5a00307884b5c2a928
+    sha256: 14232e07153fa95a0b72da7e4bf2eb3fdfdd472703ace84b3bfdbdd4180d7475
     signed_by: onboarding-wizard
     summary:
       insight: neoabzu-memory crate bundles core memory layers.

--- a/persona/src/lib.rs
+++ b/persona/src/lib.rs
@@ -14,7 +14,9 @@ fn generate_response(layer: &str, text: &str) -> PyResult<String> {
     if PERSONALITIES.contains(&layer) {
         Ok(format!("[{layer}] {text}"))
     } else {
-        Err(PyErr::new::<pyo3::exceptions::PyValueError, _>("unknown layer"))
+        Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "unknown layer",
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- add embedding store, metrics, and error handling to VectorService
- expand Python VectorClient and add Rust/Python gRPC integration tests
- document vector service config and mark parity progress

## Testing
- `pre-commit run --files CHANGELOG.md NEOABZU/Reignition.md NEOABZU/docs/feature_parity.md NEOABZU/neoabzu/vector.py NEOABZU/vector/Cargo.toml NEOABZU/vector/src/server.rs NEOABZU/vector/tests/grpc.rs NEOABZU/vector/tests/test_grpc_python.py onboarding_confirm.yml persona/src/lib.rs` *(failed: Run cargo fmt and clippy)*
- `pre-commit run verify-onboarding-refs`
- `cargo test -p neoabzu-vector --manifest-path NEOABZU/Cargo.toml`
- `pytest -o addopts='' NEOABZU/vector/tests/test_grpc_python.py`


------
https://chatgpt.com/codex/tasks/task_e_68c681161318832eb9e84dee30b40748