### PR TITLE
feat(rag): merge memory and connector results

### DIFF
--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -11,7 +11,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated via `neoabzu_persona` |
 | Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | rewrite in Rust |
-| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator aggregates memory and connector results |
+| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator merges memory and connector results (parity achieved) |
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` counts word frequencies and integrates with Crown Router |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |
 | System Coordination | Metrics, tracing, and caching align cross-subsystem orchestration | parity achieved |

--- a/NEOABZU/rag/tests/merge.rs
+++ b/NEOABZU/rag/tests/merge.rs
@@ -1,0 +1,31 @@
+use neoabzu_rag::merge_documents;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+#[test]
+fn combines_memory_and_connector_lists() {
+    Python::with_gil(|py| {
+        let mem_doc = PyDict::new(py);
+        mem_doc.set_item("text", "abc").unwrap();
+        let memory = PyList::new(py, [mem_doc]);
+
+        let conn_doc = PyDict::new(py);
+        conn_doc.set_item("text", "ext").unwrap();
+        let connectors = PyList::new(py, [conn_doc]);
+
+        let merged = merge_documents(py, "abc", memory, Some(connectors), 2).unwrap();
+        let texts: Vec<String> = merged
+            .iter()
+            .map(|d| {
+                d.as_ref(py)
+                    .get_item("text")
+                    .unwrap()
+                    .unwrap()
+                    .extract()
+                    .unwrap()
+            })
+            .collect();
+        assert!(texts.contains(&"abc".to_string()));
+        assert!(texts.contains(&"ext".to_string()));
+    });
+}

--- a/NEOABZU/rag/tests/orchestrator.rs
+++ b/NEOABZU/rag/tests/orchestrator.rs
@@ -38,7 +38,17 @@ def fetch(q):
         let kwargs = PyDict::new(py);
         kwargs.set_item("connectors", connectors).unwrap();
         let result = orchestrator
-            .route(py, "abc", emotion, Some(kwargs))
+            .route(
+                py,
+                "abc",
+                emotion,
+                None,
+                true,
+                false,
+                false,
+                None,
+                Some(kwargs),
+            )
             .unwrap();
         let docs_any = result.as_ref(py).get_item("documents").unwrap().unwrap();
         let docs: &PyList = docs_any.downcast().unwrap();

--- a/docs/feature_parity.md
+++ b/docs/feature_parity.md
@@ -6,4 +6,4 @@ Tracks Rust reimplementations of key Python subsystems.
 | --- | --- | --- |
 | Persona API | `neoabzu_persona_layers` | Mirrors `INANNA_AI/personality_layers` with basic responses. |
 | Crown Router | `neoabzu_crown` | Replaces `crown_router.py` with validation, `MoGEOrchestrator` calls, and telemetry parity. |
-| RAG Orchestrator | `neoabzu_rag` | Retrieves and ranks memory records via `MemoryBundle`. |
+| RAG Orchestrator | `neoabzu_rag` | Merges memory records and external connector results via `MemoryBundle`. |

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -674,7 +674,7 @@ Performance-critical services are gradually migrating to Rust crates within NEOA
 - `neoabzu_rag` – retrieval helpers.
 - `neoabzu_insight` – reasoning engine wired into the crown router.
 
-The RAG orchestrator is feature-complete, blending internal memory with external connectors for retrieval. The workspace mirrors existing Python APIs to permit side-by-side validation during the transition.
+The RAG orchestrator is feature-complete, merging memory bundle and external connector results through a dedicated merge routine. The workspace mirrors existing Python APIs via PyO3 wrappers to permit side-by-side validation during the transition.
 See the [Migration Crosswalk](../NEOABZU/docs/migration_crosswalk.md) for mappings between Python subsystems and their Rust counterparts.
 
 ## Chakra-Aligned Architecture


### PR DESCRIPTION
## Summary
- merge memory bundle and external connector results through new `merge_documents`
- expose orchestrator wrappers matching `rag.orchestrator` API
- document feature parity and blueprint updates

## Testing
- `cargo test --manifest-path NEOABZU/rag/Cargo.toml`
- `pre-commit run --files NEOABZU/rag/src/lib.rs NEOABZU/rag/tests/orchestrator.rs NEOABZU/rag/tests/merge.rs docs/feature_parity.md NEOABZU/docs/feature_parity.md docs/system_blueprint.md` *(skipped: verify-chakra-monitoring, verify-self-healing)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c68c31eb04832ea7fab8ac32cd463e