### PR TITLE
Document vector gRPC setup

### DIFF
--- a/NEOABZU/Reignition.md
+++ b/NEOABZU/Reignition.md
@@ -58,24 +58,19 @@ computational stability.
 
 ## Vector Service Deployment
 
-Run the gRPC service with:
-
-```bash
-cargo run -p neoabzu-vector --bin server
-```
-
-The server expects a JSON list of texts referenced by
-`NEOABZU_VECTOR_STORE`:
+Run the gRPC service (binding to `0.0.0.0:50051`) with:
 
 ```bash
 export NEOABZU_VECTOR_STORE=tests/data/store.json
 cargo run -p neoabzu-vector --bin server
 ```
 
-Each entry is embedded at startup and stored in memory. Metrics counters
-`neoabzu_vector_init_total` and `neoabzu_vector_search_total` track RPC
-usage, and invalid requests surface gRPC errors (e.g. missing store,
-zero `top_n`, or searches before initialization).
+The `NEOABZU_VECTOR_STORE` environment variable should point to a JSON
+array of strings. Each entry is embedded at startup and stored in
+memory. Metrics counters `neoabzu_vector_init_total` and
+`neoabzu_vector_search_total` track RPC usage, and invalid requests
+surface gRPC errors (e.g. missing store, zero `top_n`, or searches
+before initialization).
 
 Python callers may connect using `neoabzu.vector.VectorClient`:
 

--- a/NEOABZU/vector/README.md
+++ b/NEOABZU/vector/README.md
@@ -12,3 +12,20 @@ Rust vector operations for Neo-ABZU.
   ```bash
   cargo build --release --no-default-features --features python-extension
   ```
+
+- **Serve gRPC endpoints** over Tonic:
+  ```bash
+  export NEOABZU_VECTOR_STORE=tests/data/store.json
+  cargo run -p neoabzu-vector --bin server
+  ```
+  The server embeds each string in the JSON array and exposes `Init` and
+  `Search` RPCs on `0.0.0.0:50051`.
+
+- **Call from Python** using the bundled helpers:
+  ```python
+  from neoabzu.vector import VectorClient
+
+  with VectorClient("http://localhost:50051") as client:
+      client.init()
+      results = client.search("hello", 2)
+  ```

--- a/docs/feature_parity.md
+++ b/docs/feature_parity.md
@@ -7,3 +7,4 @@ Tracks Rust reimplementations of key Python subsystems.
 | Persona API | `neoabzu_persona_layers` | Mirrors `INANNA_AI/personality_layers` with basic responses. |
 | Crown Router | `neoabzu_crown` | Replaces `crown_router.py` with validation, `MoGEOrchestrator` calls, and telemetry parity. |
 | RAG Orchestrator | `neoabzu_rag` | Merges memory records and external connector results via `MemoryBundle`. |
+| Vector Service | `neoabzu_vector` | Tonic gRPC `Init`/`Search` with in-memory embeddings and Python client helpers. |


### PR DESCRIPTION
## Summary
- clarify how to launch the neoabzu-vector gRPC server and connect from Python
- note Init/Search service in feature parity matrix
- expand Reignition guidance with env configuration details

## Testing
- `pre-commit run --files NEOABZU/Reignition.md NEOABZU/vector/README.md docs/feature_parity.md`
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`
- `cargo test -p neoabzu-vector`
- `pytest -o addopts="" vector/tests/test_grpc_python.py`


------
https://chatgpt.com/codex/tasks/task_e_68c69368726c832eaa4a66d299e6ffa2