### PR TITLE
feat(ci): add rust checks and doc reference validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
       - name: Verify crate references
         run: python scripts/verify_crate_refs.py
 
+  doc-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify documentation references
+        run: python scripts/verify_doc_refs.py
+
   blueprint-refs:
     runs-on: ubuntu-latest
     steps:
@@ -326,6 +336,36 @@ PY
 
       - name: Validate API schemas
         run: python scripts/validate_api_schemas.py
+
+  rust-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: cargo test
+        run: cargo test --workspace --all-features
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run targeted pre-commit
+        run: |
+          files=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD -- '*.rs' 'Cargo.toml' 'Cargo.lock')
+          if [ -n "$files" ]; then
+            pre-commit run --files $files
+          fi
 
   rust-python-integration:
     runs-on: ubuntu-latest

--- a/docs/CI_GUIDE.md
+++ b/docs/CI_GUIDE.md
@@ -1,0 +1,24 @@
+# CI Guide
+
+This guide outlines how ABZU's continuous integration checks run and how to replicate them locally.
+
+## Rust checks
+
+The CI pipeline validates Rust code with:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+## Pre-commit hooks
+
+Run `pre-commit run --files <modified files>` before committing. This repository also requires:
+
+- `pre-commit run verify-onboarding-refs`
+
+## Registration checks
+
+- New Rust crates must appear in `docs/system_blueprint.md` and related doctrine.
+- New documentation files must be listed in `docs/INDEX.md`.
+
+For a summary of workflow jobs, see [CI Overview](CI_OVERVIEW.md).

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -227,6 +226,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ALBEDO_LAYER.md](ALBEDO_LAYER.md) | Albedo Layer | Albedo is a personality layer that shapes responses through a four-phase alchemical cycle. | - |
 | [Albedo_GUIDE.md](Albedo_GUIDE.md) | Albedo Guide | - | - |
 | [BLUEPRINT_EXPORT.md](BLUEPRINT_EXPORT.md) | Blueprint Export | This snapshot lists major documentation assets with links that can be pinned to a specific commit. For general contri... | - |
+| [CI_GUIDE.md](CI_GUIDE.md) | CI Guide | This guide outlines how ABZU's continuous integration checks run and how to replicate them locally. | - |
 | [CI_OVERVIEW.md](CI_OVERVIEW.md) | CI Overview | This guide summarizes the repository's continuous integration workflow. | - |
 | [CONTRIBUTOR_GUIDE.md](CONTRIBUTOR_GUIDE.md) | Contributor Guide | An overview of commit message conventions for contributors. | - |
 | [CONTRIBUTOR_HANDBOOK.md](CONTRIBUTOR_HANDBOOK.md) | Contributor Handbook | This handbook helps new contributors get set up, understand the repository layout, and work through common developmen... | - |


### PR DESCRIPTION
## Summary
- add CI job to enforce doc index registration
- run cargo fmt, clippy, test, and targeted pre-commit in CI
- document CI expectations in `docs/CI_GUIDE.md`

## Testing
- `python tools/doc_indexer.py`
- `python scripts/verify_doc_refs.py`
- `pre-commit run verify-onboarding-refs`
- `pre-commit run --files scripts/verify_doc_refs.py .github/workflows/ci.yml docs/CI_GUIDE.md docs/INDEX.md` *(fails: unrecognized pytest args; missing monitoring endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e1a55e8832ea0e939d71dedfc69