### PR TITLE
feat: add kimicho K2 fallback

### DIFF
--- a/NEOABZU/Cargo.toml
+++ b/NEOABZU/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["core", "memory", "vector", "fusion", "persona", "crown", "rag", "numeric", "narrative", "insight"]
+members = ["core", "memory", "vector", "fusion", "persona", "crown", "rag", "numeric", "narrative", "insight", "kimicho"]
 resolver = "2"

--- a/NEOABZU/kimicho/Cargo.toml
+++ b/NEOABZU/kimicho/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "neoabzu-kimicho"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "neoabzu_kimicho"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["extension-module"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+once_cell = "1.19"
+serde_json = "1.0"

--- a/NEOABZU/kimicho/src/lib.rs
+++ b/NEOABZU/kimicho/src/lib.rs
@@ -1,0 +1,48 @@
+// Patent pending – see PATENTS.md
+//! Kimicho fallback client delegating code generation to K2 Coder.
+
+use once_cell::sync::Lazy;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use std::sync::Mutex;
+
+static ENDPOINT: Lazy<Mutex<String>> = Lazy::new(|| {
+    Mutex::new(
+        std::env::var("KIMI_K2_URL").unwrap_or_else(|_| "http://localhost:8004".to_string()),
+    )
+});
+
+/// Initialize Kimicho with an optional endpoint override.
+#[pyfunction]
+pub fn init_kimicho(endpoint: Option<String>) {
+    if let Some(ep) = endpoint {
+        *ENDPOINT.lock().expect("lock poisoned") = ep;
+    }
+}
+
+/// Call the K2 Coder service and return its response text.
+#[pyfunction]
+pub fn fallback_k2(prompt: &str) -> PyResult<String> {
+    let endpoint = ENDPOINT.lock().expect("lock poisoned").clone();
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(&endpoint)
+        .json(&serde_json::json!({ "prompt": prompt }))
+        .send()
+        .map_err(|e| PyRuntimeError::new_err(format!("K2 request failed: {e}")))?;
+    let text = resp
+        .text()
+        .map_err(|e| PyRuntimeError::new_err(format!("K2 request failed: {e}")))?;
+    let value = serde_json::from_str::<serde_json::Value>(&text)
+        .ok()
+        .and_then(|v| v.get("text").and_then(|s| s.as_str().map(|s| s.to_string())))
+        .unwrap_or(text);
+    Ok(value)
+}
+
+#[pymodule]
+fn neoabzu_kimicho(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(init_kimicho, m)?)?;
+    m.add_function(wrap_pyfunction!(fallback_k2, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `neoabzu-kimicho` crate providing K2 Coder fallback logic
- expose `init_kimicho` and `fallback_k2` for PyO3 integration
- register `kimicho` in workspace members

## Testing
- `pre-commit run --files NEOABZU/kimicho/Cargo.toml NEOABZU/kimicho/src/lib.rs NEOABZU/Cargo.toml` *(fails: rust-fmt-clippy, missing python packages, pytest errors, verify-crate-refs)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c6b022faac832e9baea9ecfce032ef