### PR TITLE
Add Kimicho K2 coder fallback integration tests

### DIFF
--- a/NEOABZU/Cargo.toml
+++ b/NEOABZU/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["core", "memory", "vector", "fusion", "persona", "crown", "rag", "numeric", "narrative", "insight", "kimicho"]
+members = ["core", "memory", "vector", "fusion", "persona", "crown", "rag", "numeric", "narrative", "insight", "kimicho", "k2coder"]
 resolver = "2"

--- a/NEOABZU/k2coder/Cargo.toml
+++ b/NEOABZU/k2coder/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "k2coder"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+neoabzu-kimicho = { path = "../kimicho" }

--- a/NEOABZU/k2coder/src/lib.rs
+++ b/NEOABZU/k2coder/src/lib.rs
@@ -1,0 +1,1 @@
+//! Placeholder crate hosting K2 Coder integration tests.

--- a/NEOABZU/k2coder/tests/fallback.rs
+++ b/NEOABZU/k2coder/tests/fallback.rs
@@ -1,0 +1,34 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use neoabzu_kimicho::{fallback_k2, init_kimicho};
+
+#[test]
+fn crown_failure_switches_to_k2_coder() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let body = r#"{\"text\":\"k2 diff\"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(), body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    init_kimicho(Some(format!("http://{}", addr)));
+    let out = fallback_k2("fn main() {}").expect("fallback succeeded");
+    assert_eq!(out, "k2 diff");
+}
+
+#[test]
+fn crown_failure_reports_error_when_k2_unreachable() {
+    init_kimicho(Some("http://127.0.0.1:1".to_string()));
+    let result = fallback_k2("fn main() {}");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- add k2coder test crate with Kimicho fallback integration tests
- include k2coder in NEOABZU workspace

## Testing
- `pre-commit run --files NEOABZU/Cargo.toml NEOABZU/Cargo.lock NEOABZU/k2coder/Cargo.toml NEOABZU/k2coder/src/lib.rs NEOABZU/k2coder/tests/fallback.rs` *(fails: Run cargo fmt and clippy, Verify environment prerequisites, Capture failing pytest cases, Run tests with coverage, Verify crate references in docs and pyproject, Verify system blueprint crate references, Verify docs up to date)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c6b44ded94832ebb7727c2fd6e7066