### PR TITLE
feat: add tracing hooks and kimicho integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,18 @@ jobs:
       - name: Verify system blueprint references
         run: python scripts/verify_blueprint_refs.py
 
+  crate-docs-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Ensure blueprint docs and tests updated
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_blueprints_and_tests.py
+
   validate-components:
     runs-on: ubuntu-latest
     steps:
@@ -382,6 +394,8 @@ PY
           override: true
       - name: Build Rust workspace
         run: cargo build --manifest-path NEOABZU/Cargo.toml --workspace --lib
+      - name: Run NEOABZU tests
+        run: cargo test --manifest-path NEOABZU/Cargo.toml --workspace
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/NEOABZU/kimicho/Cargo.toml
+++ b/NEOABZU/kimicho/Cargo.toml
@@ -12,3 +12,12 @@ pyo3 = { version = "0.21", features = ["extension-module"] }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 once_cell = "1.19"
 serde_json = "1.0"
+tracing = { version = "0.1", optional = true }
+neoabzu-instrumentation = { path = "../../instrumentation", optional = true }
+
+[features]
+default = []
+tracing = ["dep:tracing", "dep:neoabzu-instrumentation"]
+
+[dev-dependencies]
+httpmock = "0.6"

--- a/NEOABZU/kimicho/tests/razor_integration.rs
+++ b/NEOABZU/kimicho/tests/razor_integration.rs
@@ -1,0 +1,32 @@
+use httpmock::prelude::*;
+use pyo3::prelude::*;
+
+#[test]
+fn razor_can_call_kimicho_fallback() {
+    Python::with_gil(|py| {
+        let server = MockServer::start();
+        let _m = server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{\"text\":\"pong\"}");
+        });
+
+        let code = format!(
+            "import neoabzu_kimicho as k\n"
+            "k.init_kimicho('{url}')\n"
+            "def invoke():\n"
+            "    return k.fallback_k2('ping')\n",
+            url = server.url("/")
+        );
+        let razor = PyModule::from_code(py, &code, "", "razor_agent").unwrap();
+        let res: String = razor
+            .getattr("invoke")
+            .unwrap()
+            .call0()
+            .unwrap()
+            .extract()
+            .unwrap();
+        assert_eq!(res, "pong");
+    });
+}

--- a/crown/Cargo.toml
+++ b/crown/Cargo.toml
@@ -11,5 +11,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 pyo3 = { version = "0.21", features = ["extension-module"] }
 neoabzu-memory = { path = "../NEOABZU/memory" }
-tracing = "0.1"
-neoabzu-instrumentation = { path = "../instrumentation" }
+
+tracing = { version = "0.1", optional = true }
+neoabzu-instrumentation = { path = "../instrumentation", optional = true }
+
+[features]
+default = []
+tracing = ["dep:tracing", "dep:neoabzu-instrumentation"]

--- a/crown/src/lib.rs
+++ b/crown/src/lib.rs
@@ -1,10 +1,11 @@
 use neoabzu_memory::MemoryBundle;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+#[cfg(feature = "tracing")]
 use tracing::instrument;
 
 #[pyfunction]
-#[instrument(skip(py))]
+#[cfg_attr(feature = "tracing", instrument(skip(py)))]
 fn route_query(py: Python<'_>, question: &str) -> PyResult<Py<PyDict>> {
     let mut bundle = MemoryBundle::new();
     bundle.initialize(py)?;
@@ -13,7 +14,7 @@ fn route_query(py: Python<'_>, question: &str) -> PyResult<Py<PyDict>> {
 
 #[pyfunction]
 #[pyo3(signature = (text, emotion_data, documents=None))]
-#[instrument(skip(py, emotion_data, documents))]
+#[cfg_attr(feature = "tracing", instrument(skip(py, emotion_data, documents)))]
 fn route_decision(
     py: Python<'_>,
     text: &str,
@@ -39,6 +40,7 @@ fn route_decision(
 
 #[pymodule]
 fn neoabzu_crown(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    #[cfg(feature = "tracing")]
     let _ = neoabzu_instrumentation::init_tracing("crown");
     m.add_function(wrap_pyfunction!(route_query, m)?)?;
     m.add_function(wrap_pyfunction!(route_decision, m)?)?;

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -13,3 +13,6 @@ This crosswalk outlines how memory layers connect to Crown during startup.
 - Integration tests validate the broadcast and the query path.
 - The Rust module also handles Crown routing formerly in `crown_router.py`, adding validation, orchestrator delegation, and telemetry hooks.
 - `neoabzu_kimicho` replaces the legacy `kimicho.py` fallback with a Rust client exposing `init_kimicho` and `fallback_k2`.
+- Both `neoabzu_crown` and `neoabzu_kimicho` expose an optional `tracing` feature
+  to emit spans through `neoabzu_instrumentation`.
+- Integration tests cover Razor→Crown and Razor→Kimicho paths.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,6 +27,14 @@ Each crate calls `init_tracing` in its Python module initializer so spans are
 emitted when the module loads. Apply the `#[instrument]` attribute to functions
 to capture arguments and emit spans.
 
+Razor, Crown, and Kimicho expose a `tracing` feature flag. Enable it at build
+time to wire in the hooks and emit spans:
+
+```bash
+cargo test -p neoabzu-crown --features tracing
+cargo test -p neoabzu-kimicho --features tracing
+```
+
 ## Exporting
 
 The default configuration exports spans to stdout. Configure the standard

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -1040,8 +1040,9 @@ Emerging modules include:
   [Scribe Narrative Engine](../NEOABZU/docs/Scribe_narrative_engine.md).
 - `numeric` – exposes PCA utilities through PyO3 bindings.
 
-`narrative` and `numeric` offer optional `tracing` and `opentelemetry`
-features that emit spans for diagnostics when enabled.
+`narrative`, `numeric`, `crown`, and `kimicho` expose optional `tracing`
+features that emit spans for diagnostics when enabled. `narrative` and
+`numeric` also integrate `opentelemetry` for external collectors.
 
 - Marks in‑development components with a warning and delays their startup
   until explicitly enabled.

--- a/scripts/check_blueprints_and_tests.py
+++ b/scripts/check_blueprints_and_tests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Fail CI when crates change without doc or test updates."""
+import os
+import subprocess
+import sys
+
+BASE = os.environ.get("GITHUB_BASE_REF", "main")
+
+changed = subprocess.check_output(
+    ["git", "diff", "--name-only", f"origin/{BASE}...HEAD"],
+    text=True,
+).splitlines()
+changed_set = set(changed)
+
+crate_paths = ("crown/", "NEOABZU/kimicho/")
+crate_changed = any(any(p.startswith(cp) for cp in crate_paths) for p in changed_set)
+
+docs_required = {"docs/system_blueprint.md", "docs/migration_crosswalk.md"}
+if crate_changed and not docs_required.issubset(changed_set):
+    sys.stderr.write(
+        "crate changes require system_blueprint.md and migration_crosswalk.md updates\n"
+    )
+    sys.exit(1)
+
+# If crate source files changed ensure a corresponding test file changed
+code_changes = [
+    p
+    for p in changed_set
+    if any(p.startswith(cp) for cp in crate_paths)
+    and p.endswith(".rs")
+    and "/tests/" not in p
+]
+if code_changes:
+    if not any(p.startswith(cp + "tests/") for p in changed_set for cp in crate_paths):
+        sys.stderr.write("crate changes require test updates\n")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add optional `tracing` feature to Crown and Kimicho crates
- document tracing configuration and update system blueprints
- enforce crate doc/test updates in CI and run NEOABZU tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml NEOABZU/kimicho/Cargo.toml NEOABZU/kimicho/src/lib.rs NEOABZU/kimicho/tests/razor_integration.rs crown/Cargo.toml crown/src/lib.rs docs/migration_crosswalk.md docs/observability.md docs/system_blueprint.md scripts/check_blueprints_and_tests.py docs/INDEX.md` *(fails: rust-fmt-clippy linking error, pytest-cov arg error, link check 404, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date, verify-chakra-monitoring, verify-self-healing)*
- `pre-commit run verify-onboarding-refs`
- `cargo test --workspace` *(fails: linking error for pyo3)*
- `cargo test --manifest-path NEOABZU/Cargo.toml --workspace` *(fails: crown compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6beaad4c0832e9f54154b6874fb61