### PR TITLE
docs: audit python legacy modules

### DIFF
--- a/NEOABZU/crown/README.md
+++ b/NEOABZU/crown/README.md
@@ -1,0 +1,6 @@
+# neoabzu-crown
+
+Rust implementation of the Crown router.
+
+See the [Python legacy audit](../../docs/python_legacy_audit.md) for historical quirks the crate addresses.
+

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -4,6 +4,8 @@ This guide maps legacy Python subsystems to their Rust implementations in NEOABZ
 
 For narrative alignment and sacred terminology, consult [herojourney_engine.md](herojourney_engine.md) and [SUMERIAN_33WORDS.md](SUMERIAN_33WORDS.md).
 
+For module-specific quirks and bugs, see the [Python legacy audit](../../docs/python_legacy_audit.md).
+
 | Python Subsystem | Rust Crate | Bridge |
 | --- | --- | --- |
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |

--- a/NEOABZU/kimicho/README.md
+++ b/NEOABZU/kimicho/README.md
@@ -1,0 +1,6 @@
+# neoabzu-kimicho
+
+Rust crate providing Kimicho fallback logic.
+
+Consult the [Python legacy audit](../../docs/python_legacy_audit.md) for prior edge cases and bugs.
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -143,6 +143,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md](../MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md) | ✴ QNL_OS · Quantum Narrative Language Operating System | QNL (Quantum Narrative Language) is a symbolic, multidimensional grammar designed to transmute energy, data, emotion,... | - |
 | [../MUSIC_FOUNDATION/music_foundation.md](../MUSIC_FOUNDATION/music_foundation.md) | 🎵 Music Foundation — Theoretical & Mathematical Guide | This document outlines the theoretical and mathematical principles needed for INANNA_AI to interpret human music and... | - |
 | [../NEOABZU/Reignition.md](../NEOABZU/Reignition.md) | Reignition | NEOABZU ignites a fresh substrate for ABZU components. | - |
+| [../NEOABZU/crown/README.md](../NEOABZU/crown/README.md) | neoabzu-crown | Rust implementation of the Crown router. | - |
 | [../NEOABZU/docs/Bana Narrator vision.md](../NEOABZU/docs/Bana Narrator vision.md) | Bana Narrator vision.md | - | - |
 | [../NEOABZU/docs/OROBOROS_Engine.md](../NEOABZU/docs/OROBOROS_Engine.md) | OROBOROS_Engine.md | - | - |
 | [../NEOABZU/docs/OROBOROS_Lexicon.md](../NEOABZU/docs/OROBOROS_Lexicon.md) | OROBOROS_Lexicon.md | - | - |
@@ -159,6 +160,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../NEOABZU/docs/migration_crosswalk.md](../NEOABZU/docs/migration_crosswalk.md) | Migration Crosswalk | This guide maps legacy Python subsystems to their Rust implementations in NEOABZU. | - |
 | [../NEOABZU/docs/onboarding.md](../NEOABZU/docs/onboarding.md) | Onboarding | This Neo‑ABZU guide complements the [ABZU Onboarding Checklist](../../docs/onboarding/README.md); review and confirm... | - |
 | [../NEOABZU/docs/rust_doctrine.md](../NEOABZU/docs/rust_doctrine.md) | Rust Doctrine | This primer captures expectations for Rust code within NEOABZU. | - |
+| [../NEOABZU/kimicho/README.md](../NEOABZU/kimicho/README.md) | neoabzu-kimicho | Rust crate providing Kimicho fallback logic. | - |
 | [../NEOABZU/memory/README.md](../NEOABZU/memory/README.md) | neoabzu-memory | Neo-ABZU memory primitives. | - |
 | [../NEOABZU/rag/README.md](../NEOABZU/rag/README.md) | neoabzu-rag | Retrieval-augmented generation components for Neo-ABZU. | - |
 | [../NEOABZU/vector/README.md](../NEOABZU/vector/README.md) | neoabzu-vector | Rust vector operations for Neo-ABZU. | - |
@@ -397,7 +399,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
 | [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | - |
-| [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | \| Step \| Rust crate \| Remaining Python dependencies \| \|------\|------------\|--------------------------------\| \| Razor... | - |
+| [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md). | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
@@ -443,6 +445,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [project_plan.md](project_plan.md) | Project Plan | This project plan outlines quarter-level goals and owners for components currently scoring below 7. Refer to [roadmap... | - |
 | [protocol_compliance.md](protocol_compliance.md) | Protocol Compliance | This dashboard provides a high-level view of how major components align with repository protocols. | - |
 | [psychic_loop.md](psychic_loop.md) | Psychic Loop | `mirror_thresholds.json` and `insight_matrix.json` feed the self-reflection cycle that keeps the avatar aligned with... | - |
+| [python_legacy_audit.md](python_legacy_audit.md) | Python Legacy Audit | This audit lists known bugs and quirks in Python modules superseded by Rust crates. Each Rust implementation should v... | - |
 | [quarantine_log.md](quarantine_log.md) | Quarantine Log | Failed components are moved to the `quarantine/` directory and recorded below. | - |
 | [quick_start_non_technical.md](quick_start_non_technical.md) | Quick Start Guide (Non-Technical) | Follow these steps to get the system running with minimal setup. | - |
 | [rag_music_oracle.md](rag_music_oracle.md) | RAG Music Oracle | `rag_music_oracle.py` answers questions about songs by combining Retrieval Augmented Generation with basic audio emot... | - |

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -1,5 +1,7 @@
 # Migration Crosswalk
 
+For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
+
 | Step | Rust crate | Remaining Python dependencies |
 |------|------------|--------------------------------|
 | Razor init | `neoabzu_memory` | `razar/boot_orchestrator.py` |

--- a/docs/python_legacy_audit.md
+++ b/docs/python_legacy_audit.md
@@ -1,0 +1,15 @@
+# Python Legacy Audit
+
+This audit lists known bugs and quirks in Python modules superseded by Rust crates. Each Rust implementation should verify these cases are handled or documented.
+
+## crown_router.py
+
+- Repeated memory evaluations were uncached, introducing latency until caching was implemented.
+- Lacked tracing and telemetry; optional OpenTelemetry spans and broader instrumentation were added later.
+- Initialization produced no boot-time metric, hindering performance diagnostics.
+
+## kimicho.py
+
+- Fallback logic originally shipped without tracing hooks or integration tests, making failures opaque.
+- Early implementations omitted a K2 fallback path, leaving certain failure modes unhandled.
+


### PR DESCRIPTION
## Summary
- catalogued crown_router.py and kimicho.py issues in python_legacy_audit.md
- link legacy audit from migration crosswalk and crate READMEs
- regenerate docs index

## Testing
- `pre-commit run --files docs/python_legacy_audit.md docs/migration_crosswalk.md NEOABZU/docs/migration_crosswalk.md NEOABZU/crown/README.md NEOABZU/kimicho/README.md docs/INDEX.md` *(failed: connection refused to metrics exporters; no successful self-heal cycles in last 24h)*
- `pre-commit run verify-onboarding-refs`
- `python tools/doc_indexer.py`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6cffeb140832e89658a589eeab42b