### PR TITLE
feat(razar): fallback to kimicho on handshake failure

### DIFF
--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -37,7 +37,7 @@ except Exception:  # pragma: no cover - Rust crates optional
     _core_eval = None
 
 try:  # pragma: no cover - kimicho optional
-    from neoabzu_kimicho import init_kimicho
+    from kimicho import init_kimicho  # PyO3 bindings
 except Exception:  # pragma: no cover - kimicho optional
     init_kimicho = None
 
@@ -437,7 +437,10 @@ def _perform_handshake(components: List[Dict[str, Any]]) -> CrownResponse:
         _persist_handshake(None)
         _emit_event("handshake", "fail", error=str(exc))
         if init_kimicho is not None:
-            LOGGER.info("Initializing Kimicho K2 Coder LLM from HuggingFacc")
+            LOGGER.info(
+                "Handshake failed; invoking Kimicho to initialize K2 Coder "
+                "LLM from HuggingFacc"
+            )
             try:
                 init_kimicho("https://huggingfacc.com/k2coder")
                 mission_logger.log_event("handshake", "kimicho", "init", "huggingfacc")


### PR DESCRIPTION
## Summary
- use kimicho PyO3 bindings in Razor's boot orchestrator
- fall back to Kimicho's K2 Coder LLM on CROWN handshake failure with logging

## Testing
- `pre-commit run --files razar/boot_orchestrator.py` *(fails: confirm-reading, pytest-cov, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c6e349d5f4832e91ae4329a3abe60d