### PR TITLE
test: assert K2 coder error path in Kimicho fallback

### DIFF
--- a/NEOABZU/k2coder/tests/fallback.rs
+++ b/NEOABZU/k2coder/tests/fallback.rs
@@ -29,6 +29,6 @@ fn crown_failure_switches_to_k2_coder() {
 #[test]
 fn crown_failure_reports_error_when_k2_unreachable() {
     init_kimicho(Some("http://127.0.0.1:1".to_string()));
-    let result = fallback_k2("fn main() {}");
-    assert!(result.is_err());
+    let err = fallback_k2("fn main() {}").expect_err("request should fail");
+    assert!(err.to_string().contains("K2 request failed"));
 }


### PR DESCRIPTION
## Summary
- assert K2 request failure in Kimicho fallback

## Testing
- `pre-commit run --files NEOABZU/k2coder/tests/fallback.rs`
- `pre-commit run verify-onboarding-refs`
- `cargo test -p k2coder` *(fails: linking with `cc` failed: undefined reference to `PyErr_Print`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e5bab1c8832ea737d2d53b37f336