### PR TITLE
docs: document kimicho fallback in crown routing

### DIFF
--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -11,7 +11,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated via `neoabzu_persona` |
 | Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | fully ported in Rust |
-| Kimicho Fallback | Provides fallback code generation when the Crown Router cannot reach K2 Coder | `neoabzu-kimicho` crate exposes `fallback_k2` via PyO3 `neoabzu_kimicho` binding |
+| Kimicho Fallback | Provides fallback code generation when the Crown Router cannot reach K2 Coder | `kimicho` crate exposes `fallback_k2` via PyO3 `neoabzu_kimicho` bridge |
 | RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator merges memory and connector results (parity achieved) |
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` counts word and bigram frequencies and integrates with Crown Router |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -10,7 +10,7 @@ For module-specific quirks and bugs, see the [Python legacy audit](../../docs/py
 | --- | --- | --- |
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |
 | `crown_router.py` | `neoabzu-crown` | Fully ported; Python module is a thin stub over the Rust crate. |
-| legacy fallback subsystem (`razar/boot_orchestrator.py`) | `neoabzu-kimicho` | PyO3 module `neoabzu_kimicho` exposes `init_kimicho` and `fallback_k2` for Crown routing failover. |
+| legacy Python fallback subsystem (`razar/boot_orchestrator.py`) | `kimicho` | PyO3 module `neoabzu_kimicho` exposes `init_kimicho` and `fallback_k2` for Crown routing failover. |
 | `rag/orchestrator.py` | `neoabzu-rag` | `MoGEOrchestrator` aggregates memory and connector results via PyO3. |
 | `core` lambda engine (`core/`) | `neoabzu-core` | Accessible through `neoabzu_memory.eval_core` and `neoabzu_memory.reduce_inevitable_core` for Crown Router and RAZAR. |
 | `system coordination` (`metrics`, `tracing`, `caching`) | `neoabzu-crown` | Shared instrumentation and caches mirror ABZU coordination. |


### PR DESCRIPTION
## Summary
- note Kimicho's fallback codegen role in Crown Router feature parity matrix
- crosswalk legacy Python fallback subsystem to Rust `kimicho` crate via PyO3 bridge

## Testing
- `pre-commit run --files NEOABZU/docs/feature_parity.md NEOABZU/docs/migration_crosswalk.md`
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea2c2a0c832e99f26de90b376a37