### PR TITLE
chore: enforce release gates and document dependency audit

### DIFF
--- a/.github/workflows/release_checklist.yml
+++ b/.github/workflows/release_checklist.yml
@@ -22,10 +22,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r dev-requirements.txt
           pip install -e .
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: cargo test
+        run: cargo test --workspace --all-features
       - name: Verify docs index
         run: |
           python tools/doc_indexer.py
           git diff --exit-code docs/INDEX.md
+      - name: Validate docs
+        run: python scripts/validate_docs.py
       - name: Run tests with coverage
         run: pytest --cov --cov-fail-under=80
       - name: Verify environment specs unchanged

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -7,3 +7,4 @@
 - Added agent instructions and dependency group summaries to `CRYSTAL_CODEX.md`.
 - Referenced chakra version tracking via [chakra_versions.json](chakra_versions.json) and documented bumps in [CHANGELOG.md](../CHANGELOG.md).
 - Enumerated chakra module versions (root 1.0.1, sacral 1.0.1, solar plexus 1.1.0, heart 1.0.1, throat 1.0.1, third eye 1.0.1, crown 1.0.1) in the manifest [chakra_versions.json](chakra_versions.json) tied to [chakra_koan_system.md](chakra_koan_system.md).
+- Security review: `pip-audit` found no vulnerabilities in Python dependencies, while `npm audit` reported two moderate issues in `floor_client`; `cargo-audit` installation failed, so Rust dependencies require follow-up.


### PR DESCRIPTION
## Summary
- add cargo fmt/clippy/test and documentation validation to release checklist
- note security review results in release notes

## Testing
- `RUST_LOG=info cargo test -p neoabzu-vector --features opentelemetry -- --nocapture`
- `RUST_LOG=info cargo test -p neoabzu-rag -- --nocapture`
- `RUST_LOG=info cargo test -p neoabzu-insight -- --nocapture`
- `RUST_LOG=info cargo test -p neoabzu-crown -- --nocapture` *(fails: unresolved imports)*
- `python benchmarks/run_benchmarks.py`
- `pip-audit -r requirements.txt --progress-spinner off`
- `pip-audit -r dev-requirements.txt --progress-spinner off`
- `npm audit --audit-level=high --json`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `pre-commit run --files .github/workflows/release_checklist.yml docs/release_notes.md`
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c6f498db74832eb2fee321550deec5