### PR TITLE
docs: enforce doctrine reference blocks across architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,16 @@ jobs:
       - name: Verify system blueprint references
         run: python scripts/verify_blueprint_refs.py
 
+  doctrine-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify doctrine references
+        run: python scripts/verify_doctrine_refs.py
+
   crate-docs-tests:
     runs-on: ubuntu-latest
     steps:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -353,7 +353,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [development_workflow.md](development_workflow.md) | Development Workflow | This page outlines the recommended steps for contributing to ABZU. | - |
 | [diagnostics.md](diagnostics.md) | Diagnostic Scripts and Self-Healing Plan | This guide outlines the diagnostic scripts and the self-healing mechanisms used to keep Spiral OS operational. | - |
 | [docker_build_audio_tools.md](docker_build_audio_tools.md) | Docker Image with Audio Tools | This project provides a Docker image that bundles the audio utilities **FFmpeg** and **SoX**. The `Dockerfile` instal... | - |
-| [doctrine_index.md](doctrine_index.md) | Doctrine Index | \| File \| Version \| Checksum \| Last Updated \| \| --- \| --- \| --- \| --- \| \| CODEX/ACTIVATIONS/OATH OF THE VAULT 1de45dfc... | - |
+| [doctrine_index.md](doctrine_index.md) | Doctrine Index | Every canonical document now requires a `Doctrine References` section linking back to this index. Use these links to... | - |
 | [documentation_protocol.md](documentation_protocol.md) | Documentation Protocol | Standard workflow for updating documentation and guides. | - |
 | [emotional_memory_matrix.md](emotional_memory_matrix.md) | Emotional Memory Matrix | The emotional memory matrix interconnects the various JSON files that store conversation history and affect metrics.... | - |
 | [environment_setup.md](environment_setup.md) | Environment Setup | - | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -27,6 +27,17 @@ Components ported from Python to Rust must:
 - Update [doctrine_index.md](doctrine_index.md) with the component's checksum and note its place in the APSU sequence.
 - Document where the component sits in the APSU sequence and link to relevant diagrams such as [blueprint_spine.md](blueprint_spine.md) or [system_blueprint.md](system_blueprint.md#razor–crown–kimi-cho-migration).
 
+### Doctrine Reference Requirements
+
+All architecture or protocol documents must include a **Doctrine References** section that links back to canonical doctrine paths. This ensures new material stays traceable to its source rules.
+
+**Example**
+
+```markdown
+### Doctrine References
+- [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) – illustrates the path for operator directives.
+```
+
 ### Environment Preparation
 Set up the local environment before running tools or tests:
 

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -1,5 +1,7 @@
 # Doctrine Index
 
+Every canonical document now requires a `Doctrine References` section linking back to this index. Use these links to trace provenance for new architectural rules.
+
 | File | Version | Checksum | Last Updated |
 | --- | --- | --- | --- |
 | CODEX/ACTIVATIONS/OATH OF THE VAULT 1de45dfc251d80c9a86fc67dee2f964a.md |  | `d46a551d4e1fb1b3e056bf14f051793e6faaa6191b268f84e3a0e054fe432c60` | 2025-09-13T01:34:31+02:00 |

--- a/docs/feature_parity.md
+++ b/docs/feature_parity.md
@@ -2,11 +2,11 @@
 
 Tracks Rust reimplementations of key Python subsystems.
 
-| Component | Rust crate | Notes |
-| --- | --- | --- |
-| Memory Bundle | `neoabzu_memory` | Initializes layered memory and routes multi‑layer queries. |
-| Fusion Engine | `neoabzu_fusion` | Selects invariants with highest inevitability gradient. |
-| Numeric Kernels | `neoabzu_numeric` | PCA and cosine similarity utilities via PyO3. |
-| Persona API | `neoabzu_persona` | Tracks persona state and loads profile data. |
-| Crown Router | `neoabzu_crown` | Direct PyO3 interface with validation, `MoGEOrchestrator` calls, and telemetry parity. |
-| RAG Orchestrator | `neoabzu_rag` | Merges memory records and external connector results via `MemoryBundle`. |
+| Component | Rust crate | Doctrine Reference | Notes |
+| --- | --- | --- | --- |
+| Memory Bundle | `neoabzu_memory` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | Initializes layered memory and routes multi‑layer queries. |
+| Fusion Engine | `neoabzu_fusion` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Selects invariants with highest inevitability gradient. |
+| Numeric Kernels | `neoabzu_numeric` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | PCA and cosine similarity utilities via PyO3. |
+| Persona API | `neoabzu_persona` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Tracks persona state and loads profile data. |
+| Crown Router | `neoabzu_crown` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | Direct PyO3 interface with validation, `MoGEOrchestrator` calls, and telemetry parity. |
+| RAG Orchestrator | `neoabzu_rag` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Merges memory records and external connector results via `MemoryBundle`. |

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -2,48 +2,55 @@
 
 For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 
-| Step | Rust crate | Remaining Python dependencies |
-|------|------------|--------------------------------|
-| Razor init | `neoabzu_memory` | `razar/boot_orchestrator.py` |
-| Crown routing | `neoabzu_crown` | — |
-| Fusion invariants | `neoabzu_fusion` | — |
-| Numeric embeddings | `neoabzu_numeric` | — |
-| Persona context | `neoabzu_persona` | — |
-| RAG retrieval | `neoabzu_rag` | `rag/orchestrator.py` |
-| Kimicho fallback | `neoabzu_kimicho` | — |
+| Step | Rust crate | Doctrine Reference | Remaining Python dependencies |
+|------|------------|--------------------|--------------------------------|
+| Razor init | `neoabzu_memory` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | `razar/boot_orchestrator.py` |
+| Crown routing | `neoabzu_crown` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | — |
+| Fusion invariants | `neoabzu_fusion` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | — |
+| Numeric embeddings | `neoabzu_numeric` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | — |
+| Persona context | `neoabzu_persona` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | — |
+| RAG retrieval | `neoabzu_rag` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | `rag/orchestrator.py` |
+| Kimicho fallback | `neoabzu_kimicho` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | — |
 
 ### Razor init
 - [x] Port complete
 - [x] Required tests: `tests/agents/razar/test_crown_handshake.py`
 - [ ] Documentation references: `docs/RAZAR_AGENT.md`
+- [ ] Doctrine references: `docs/system_blueprint.md`
 
 ### Crown routing
 - [ ] Port complete
 - [ ] Required tests: `NEOABZU/crown/tests/route_query.rs`
 - [ ] Documentation references: `docs/CROWN_OVERVIEW.md`
+- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
 
 ### Fusion invariants
 - [x] Port complete
 - [x] Required tests: `NEOABZU/fusion/tests/invariants.rs`
 - [ ] Documentation references: `docs/system_blueprint.md`
+- [ ] Doctrine references: `docs/system_blueprint.md`
 
 ### Numeric embeddings
 - [x] Port complete
 - [x] Required tests: `tests/test_numeric_cosine_similarity.py`
 - [ ] Documentation references: `docs/vector_memory.md`
+- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
 
 ### Persona context
 - [x] Port complete
 - [x] Required tests: `tests/test_personality_layers.py`
 - [ ] Documentation references: `docs/persona_api_guide.md`
+- [ ] Doctrine references: `docs/system_blueprint.md`
 
 ### RAG retrieval
 - [ ] Port complete
 - [ ] Required tests: `NEOABZU/rag/tests/orchestrator.rs`
 - [ ] Documentation references: `docs/rag_pipeline.md`
+- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
 
 ### Kimicho fallback
 - [ ] Port complete
 - [x] Required tests: `NEOABZU/kimicho/tests/razor_integration.rs`, `NEOABZU/crown/tests/kimicho_fallback.rs`
 - [ ] Documentation references: `docs/system_blueprint.md`
+- [ ] Doctrine references: `docs/system_blueprint.md`
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -33,6 +33,15 @@ Contributors must propose operator-facing improvements alongside system enhancem
 - **Resuscitator flows** streamline rollback and restart procedures; see the [recovery playbook](recovery_playbook.md).
 - **Signal bus** enables cross-core pub/sub messaging (see [../connectors/signal_bus.py](../connectors/signal_bus.py)).
 
+### Doctrine Reference Pattern
+
+Every architecture document must publish a **Doctrine References** block that links back to `doctrine_index.md` entries for touched components. This blueprint links to the operator flow as a template:
+
+```markdown
+### Doctrine References
+- [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements)
+```
+
 ### Origins & Awakening
 
 Origin texts like the Marrow Code and Inanna Song chart the Crown's ethical


### PR DESCRIPTION
## Summary
- require Doctrine References sections in architecture docs
- sync feature parity and migration crosswalk with doctrine links
- add CI job verifying doctrine references

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/system_blueprint.md docs/doctrine_index.md docs/feature_parity.md docs/migration_crosswalk.md .github/workflows/ci.yml docs/INDEX.md` *(fails: verify-versions, check-env, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date, verify-chakra-monitoring, verify-self-healing)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py` *(fails: many doctrine timestamps out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c70dc63388832e868e734a4e8611ff