### PR TITLE
feat: add telemetry hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +284,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +336,7 @@ dependencies = [
 name = "neoabzu-crown"
 version = "0.1.0"
 dependencies = [
+ "metrics",
  "neoabzu-instrumentation",
  "neoabzu-memory",
  "pyo3",
@@ -343,6 +378,7 @@ dependencies = [
 name = "neoabzu-rag"
 version = "0.1.0"
 dependencies = [
+ "metrics",
  "neoabzu-instrumentation",
  "neoabzu-memory",
  "pyo3",
@@ -917,6 +953,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/NEOABZU/Cargo.lock
+++ b/NEOABZU/Cargo.lock
@@ -1466,7 +1466,9 @@ dependencies = [
 name = "neoabzu-insight"
 version = "0.1.1"
 dependencies = [
+ "metrics",
  "pyo3",
+ "tracing",
 ]
 
 [[package]]

--- a/NEOABZU/insight/Cargo.toml
+++ b/NEOABZU/insight/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.21", features = ["extension-module"] }
+tracing = { version = "0.1", optional = true }
+metrics = "0.21"
 
 [features]
 default = []
+tracing = ["dep:tracing"]

--- a/crown/Cargo.toml
+++ b/crown/Cargo.toml
@@ -14,6 +14,7 @@ neoabzu-memory = { path = "../NEOABZU/memory" }
 
 tracing = { version = "0.1", optional = true }
 neoabzu-instrumentation = { path = "../instrumentation", optional = true }
+metrics = "0.21"
 
 [features]
 default = []

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -39,3 +39,23 @@ cargo test -p neoabzu-kimicho --features tracing
 
 The default configuration exports spans to stdout. Configure the standard
 OpenTelemetry environment variables to route data to an OTLP collector.
+
+## Shared configuration
+
+All crates share the same tracing and metrics setup. Initialize both telemetry
+systems during startup:
+
+```rust
+use neoabzu_instrumentation::init_tracing;
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing("demo-service")?;
+    PrometheusBuilder::new().install_recorder()?;
+    Ok(())
+}
+```
+
+With the recorder installed, counters and histograms emitted from Crown, RAG,
+Insight, and Vector become available at `http://localhost:9000/metrics`. Set
+`OTEL_EXPORTER_OTLP_ENDPOINT` to route spans to an external collector.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,3 +8,4 @@
 - Referenced chakra version tracking via [chakra_versions.json](chakra_versions.json) and documented bumps in [CHANGELOG.md](../CHANGELOG.md).
 - Enumerated chakra module versions (root 1.0.1, sacral 1.0.1, solar plexus 1.1.0, heart 1.0.1, throat 1.0.1, third eye 1.0.1, crown 1.0.1) in the manifest [chakra_versions.json](chakra_versions.json) tied to [chakra_koan_system.md](chakra_koan_system.md).
 - Security review: `pip-audit` found no vulnerabilities in Python dependencies, while `npm audit` reported two moderate issues in `floor_client`; `cargo-audit` installation failed, so Rust dependencies require follow-up.
+- Performance benchmarks: memory store `25995 adds/sec` with `0.0074s` search time; chat gateway `1,048,796 messages/sec`; LLM throughput `4092 tokens/sec`; query memory `398 qps` at `5.4ms` average latency.

--- a/rag/Cargo.toml
+++ b/rag/Cargo.toml
@@ -13,3 +13,4 @@ pyo3 = { version = "0.21", features = ["extension-module"] }
 neoabzu-memory = { path = "../NEOABZU/memory" }
 tracing = "0.1"
 neoabzu-instrumentation = { path = "../instrumentation" }
+metrics = "0.21"


### PR DESCRIPTION
## Summary
- add tracing and metrics counters to Crown, RAG, Insight, and Vector
- document shared tracing and metrics setup
- record latest benchmark results in release notes

## Testing
- `cargo test -p neoabzu-crown`
- `cargo test -p neoabzu-rag`
- `cargo test -p neoabzu-insight --manifest-path NEOABZU/Cargo.toml`
- `cargo test -p neoabzu-vector --manifest-path NEOABZU/Cargo.toml`
- `make bench`
- `pre-commit run --files Cargo.lock NEOABZU/Cargo.lock NEOABZU/insight/Cargo.toml NEOABZU/insight/src/lib.rs NEOABZU/vector/src/lib.rs crown/Cargo.toml crown/src/lib.rs docs/observability.md docs/release_notes.md rag/Cargo.toml rag/src/lib.rs` *(fails: markdown link, crate references, chakra monitoring, self healing, pytest-cov)*
- `pre-commit run verify-onboarding-refs` *(fails: rust fmt/clippy, verify-versions, check-env)*
- `python scripts/verify_docs_up_to_date.py` *(fails: outdated CODEX entries)*

------
https://chatgpt.com/codex/tasks/task_e_68c715bc8510832eb00e501a5b5bc668