### PR TITLE
docs: crosslink migration references

### DIFF
--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -46,3 +46,8 @@ crown> {"upload": "ack"}
 ```
 
 For connector registration requirements, consult the [Connector Registry Protocol](The_Absolute_Protocol.md#connector-registry-protocol) and the [Connector Index](connectors/CONNECTOR_INDEX.md).
+
+### Migration Crosswalk
+
+Routing migration details are maintained in the [Migration Crosswalk](migration_crosswalk.md#crown-routing).
+

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -275,6 +275,10 @@ logs/mission_briefs/
 | basic_service   | `http://localhost:8000/healthz`       | `Health check failed for basic_service`   | Validate dependencies and restart the service.               |
 | complex_service | `/var/log/complex_service.log`        | `Health check failed for complex_service` | Inspect configuration or escalate repair to a remote agent. |
 
+### Migration Crosswalk
+
+Port status and legacy mappings for Razor initialization are tracked in the [Migration Crosswalk](migration_crosswalk.md#razor-init).
+
 ## Cross-links
 - [System Blueprint](system_blueprint.md)
 - [RAZAR Guide](RAZAR_GUIDE.md)

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -720,6 +720,12 @@ Capture learning at the end of each milestone:
 - **Action items:** 
 ```
 
+### Migration Crosswalk References
+
+- Crown routing: [Migration Crosswalk](migration_crosswalk.md#crown-routing)
+- Numeric embeddings: [Migration Crosswalk](migration_crosswalk.md#numeric-embeddings)
+- RAG retrieval: [Migration Crosswalk](migration_crosswalk.md#rag-retrieval)
+
 ## Protocol Change Process
 Updates to this protocol follow a lightweight governance model:
 

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -15,42 +15,42 @@ For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 ### Razor init
 - [x] Port complete
 - [x] Required tests: `tests/agents/razar/test_crown_handshake.py`
-- [ ] Documentation references: `docs/RAZAR_AGENT.md`
-- [ ] Doctrine references: `docs/system_blueprint.md`
+- [x] Documentation references: [RAZAR Agent](RAZAR_AGENT.md#migration-crosswalk)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
 
 ### Crown routing
 - [ ] Port complete
 - [ ] Required tests: `NEOABZU/crown/tests/route_query.rs`
-- [ ] Documentation references: `docs/CROWN_OVERVIEW.md`
-- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
+- [x] Documentation references: [CROWN Overview](CROWN_OVERVIEW.md#migration-crosswalk)
+- [x] Doctrine references: [The Absolute Protocol](The_Absolute_Protocol.md#migration-crosswalk-references)
 
 ### Fusion invariants
 - [x] Port complete
 - [x] Required tests: `NEOABZU/fusion/tests/invariants.rs`
-- [ ] Documentation references: `docs/system_blueprint.md`
-- [ ] Doctrine references: `docs/system_blueprint.md`
+- [x] Documentation references: [System Blueprint](system_blueprint.md#fusion-invariants)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md#fusion-invariants)
 
 ### Numeric embeddings
 - [x] Port complete
 - [x] Required tests: `tests/test_numeric_cosine_similarity.py`
-- [ ] Documentation references: `docs/vector_memory.md`
-- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
+- [x] Documentation references: [Vector Memory](vector_memory.md#migration-crosswalk)
+- [x] Doctrine references: [The Absolute Protocol](The_Absolute_Protocol.md#migration-crosswalk-references)
 
 ### Persona context
 - [x] Port complete
 - [x] Required tests: `tests/test_personality_layers.py`
-- [ ] Documentation references: `docs/persona_api_guide.md`
-- [ ] Doctrine references: `docs/system_blueprint.md`
+- [x] Documentation references: [Persona API Guide](persona_api_guide.md#migration-crosswalk)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md)
 
 ### RAG retrieval
 - [ ] Port complete
 - [ ] Required tests: `NEOABZU/rag/tests/orchestrator.rs`
-- [ ] Documentation references: `docs/rag_pipeline.md`
-- [ ] Doctrine references: `docs/The_Absolute_Protocol.md`
+- [x] Documentation references: [Spiral RAG Pipeline](rag_pipeline.md#migration-crosswalk)
+- [x] Doctrine references: [The Absolute Protocol](The_Absolute_Protocol.md#migration-crosswalk-references)
 
 ### Kimicho fallback
 - [ ] Port complete
 - [x] Required tests: `NEOABZU/kimicho/tests/razor_integration.rs`, `NEOABZU/crown/tests/kimicho_fallback.rs`
-- [ ] Documentation references: `docs/system_blueprint.md`
-- [ ] Doctrine references: `docs/system_blueprint.md`
+- [x] Documentation references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
 

--- a/docs/persona_api_guide.md
+++ b/docs/persona_api_guide.md
@@ -65,3 +65,8 @@ export PYTHONPATH=.
 
 The persona APIs only depend on ``PyYAML`` and ``jsonschema`` which are included
 in the base development requirements.
+
+### Migration Crosswalk
+
+Persona context porting is documented in the [Migration Crosswalk](migration_crosswalk.md#persona-context).
+

--- a/docs/rag_pipeline.md
+++ b/docs/rag_pipeline.md
@@ -75,3 +75,8 @@ from crown_query_router import route_query
 for rec in route_query("explain the ritual", "Sage"):
     print(rec["text"], rec.get("source_path"))
 ```
+
+### Migration Crosswalk
+
+RAG retrieval migration progress is tracked in the [Migration Crosswalk](migration_crosswalk.md#rag-retrieval).
+

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -327,6 +327,8 @@ for runtime details.
 
 Integration tests (`NEOABZU/crown/tests/kimicho_fallback.rs`) confirm that Razor falls back to Kimicho transparently when Crown routing fails.
 
+See the [Migration Crosswalk](migration_crosswalk.md#razor-init) for initialization mapping, [crown routing](migration_crosswalk.md#crown-routing), and [Kimicho fallback](migration_crosswalk.md#kimicho-fallback) status.
+
 ```mermaid
 {{#include figures/rust_crate_boundaries.mmd}}
 ```
@@ -404,6 +406,7 @@ graph TD
   - [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md) – memory layers and flows
   - [ALBEDO Layer](ALBEDO_LAYER.md) – persona modules and archetypal behavior hooks
   - [Persona API Guide](persona_api_guide.md) – conventions for persona profiles and hooks
+    - [Migration Crosswalk](migration_crosswalk.md#persona-context) – persona context porting status
   - [Nazarick Manifesto](nazarick_manifesto.md) – narrative charter governing personas
   - [Chat2DB Interface](chat2db.md) – bridge between the relational log and vector store
   - [Operator-Nazarick Bridge](operator_nazarick_bridge.md) – Vanna workflow, channel personas, and web console chat
@@ -704,8 +707,12 @@ Performance-critical services are gradually migrating to Rust crates within NEOA
 - `neoabzu_crown` – crown orchestration bindings.
 - `neoabzu_rag` – retrieval helpers.
 
+### Fusion Invariants
+
+The `neoabzu_fusion` crate merges invariants from symbolic and numeric layers to maintain triadic stack coherence. See the [Migration Crosswalk](migration_crosswalk.md#fusion-invariants) for migration details and legacy Python references.
+
 The RAG orchestrator is feature-complete, merging memory bundle and external connector results through a dedicated merge routine. The workspace mirrors existing Python APIs via PyO3 wrappers to permit side-by-side validation during the transition.
-See the [Migration Crosswalk](../NEOABZU/docs/migration_crosswalk.md) for mappings between Python subsystems and their Rust counterparts.
+See the [Migration Crosswalk](migration_crosswalk.md) for mappings between Python subsystems and their Rust counterparts.
 
 ## Chakra-Aligned Architecture
 

--- a/docs/vector_memory.md
+++ b/docs/vector_memory.md
@@ -57,3 +57,8 @@ restore_latest_snapshot()           # restore most recent snapshot
 `cluster_vectors(k)` groups stored embeddings into `k` clusters using FAISS when
 available, falling back to scikit-learn's `KMeans`. Each cluster summary contains
 the cluster index and number of members.
+
+### Migration Crosswalk
+
+Numeric embedding migration notes live in the [Migration Crosswalk](migration_crosswalk.md#numeric-embeddings).
+


### PR DESCRIPTION
## Summary
- cross-link migration sections in Razor agent, Crown overview, vector memory, persona API, and RAG pipeline docs
- expand system blueprint with fusion invariants and persona crosswalk references
- update migration crosswalk checklist with documentation links and traceability

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md docs/CROWN_OVERVIEW.md docs/vector_memory.md docs/persona_api_guide.md docs/rag_pipeline.md docs/system_blueprint.md docs/The_Absolute_Protocol.md docs/migration_crosswalk.md docs/INDEX.md` *(failed: ModuleNotFoundError: No module named 'neoabzu_chakrapulse'; missing metrics exporters)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py` *(failed: index timestamps out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c72c3a9a80832eb6fe0d3894e9d5df