### PR TITLE
docs: add doctrine references to narrative guides

### DIFF
--- a/docs/narrative_engine_GUIDE.md
+++ b/docs/narrative_engine_GUIDE.md
@@ -34,3 +34,7 @@ pytest tests/narrative_engine/test_biosignal_pipeline.py
 |---------|------|-------|
 | 0.7.0 | 2025-09-20 | Added Bana narrative emission and Inanna bridge flow. |
 | 0.6.0 | 2025-09-16 | Clarified architecture and dataset schema. |
+
+## Doctrine References
+- [Doctrine Index](doctrine_index.md)
+- [The Absolute Protocol](The_Absolute_Protocol.md)

--- a/docs/narrative_framework.md
+++ b/docs/narrative_framework.md
@@ -17,3 +17,7 @@ stack.
 
 This flow provides a reproducible path from physiological signals to the
 stories and scenes operators observe.
+
+## Doctrine References
+- [Doctrine Index](doctrine_index.md)
+- [The Absolute Protocol](The_Absolute_Protocol.md)


### PR DESCRIPTION
## Summary
- append Doctrine References sections in narrative_framework.md and narrative_engine_GUIDE.md
- link to doctrine_index.md and The_Absolute_Protocol.md
- doc-indexer confirmed docs/INDEX.md up to date

## Testing
- `pre-commit run doc-indexer --files docs/narrative_framework.md docs/narrative_engine_GUIDE.md docs/INDEX.md`
- `SKIP=verify-chakra-monitoring,verify-self-healing,pytest-cov,verify-crate-refs,verify-blueprint-refs,verify-docs-up-to-date pre-commit run --files docs/narrative_framework.md docs/narrative_engine_GUIDE.md`
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72ff80e40832ea9d75c96ebada89b