### PR TITLE
docs: reference narrative framework in protocol

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -261,7 +261,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.99 **Last updated:** 2025-09-14 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/signal_bus.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.100 **Last updated:** 2025-09-14 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/signal_bus.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,6 +1,6 @@
 # The Absolute Protocol
 
-**Version:** v1.0.99
+**Version:** v1.0.100
 **Last updated:** 2025-09-14
 
 ## How to Use This Protocol
@@ -668,6 +668,7 @@ Any component launched by Crown or RAZAR must document its activation lifecycle:
 
 Narrative modules must maintain traceability by:
 
+- Aligning narrative pathways with [narrative_framework.md](narrative_framework.md); contributors must consult this framework when modifying narrative pathways.
 - Declaring a `__version__` field in every narrative module.
 - Registering and hashing all datasets in [data_manifest.md](data_manifest.md).
 - Registering related connectors in [connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md).


### PR DESCRIPTION
## Summary
- reference `narrative_framework.md` in Narrative Feature Requirements and require contributors to consult it when altering narrative pathways
- bump Absolute Protocol version to v1.0.100
- update documentation index entry for The Absolute Protocol

## Testing
- `pre-commit run --files docs/The_Absolute_Protocol.md docs/INDEX.md` *(fails: missing metrics exporters; no successful self-heal cycles)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68c735301f5c832eac6466e29a7a970b