### PR TITLE
docs: add narrative onboarding references

### DIFF
--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -1,6 +1,6 @@
 # Developer Onboarding
 
-Quick links: [Development Checklist](development_checklist.md) | [Developer Etiquette](developer_etiquette.md) | [Documentation Protocol](documentation_protocol.md) | [Vision System](vision_system.md) | [Rust Doctrine](../NEOABZU/docs/rust_doctrine.md)
+Quick links: [Development Checklist](development_checklist.md) | [Developer Etiquette](developer_etiquette.md) | [Documentation Protocol](documentation_protocol.md) | [Vision System](vision_system.md) | [Rust Doctrine](../NEOABZU/docs/rust_doctrine.md) | [Narrative Framework](narrative_framework.md) | [Narrative Engine Guide](narrative_engine_GUIDE.md)
 
 ## Recent Changes
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -20,6 +20,8 @@ The Crown router, RAG orchestrator, and Kimicho fallback now use Rust crates (`n
    - [Vision System](../vision_system.md)
    - [Persona API Guide](../persona_api_guide.md)
    - [Spiral Cortex Terminal](../spiral_cortex_terminal.md)
+   - [Narrative Framework](../narrative_framework.md)
+   - [Narrative Engine Guide](../narrative_engine_GUIDE.md)
 
 6. [Arcade UI](../arcade_ui.md) – quickstart workflow and memory scan diagram
 7. [Operator Quickstart](../operator_quickstart.md) – minimal setup and console usage

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -21,6 +21,8 @@ Study the system design materials to grasp component responsibilities and data f
 - [Architecture Overview](architecture_overview.md)
 - [Data Flow](data_flow.md)
 - [Operator-Nazarick Bridge](operator_nazarick_bridge.md)
+- [Narrative Framework](narrative_framework.md)
+- [Narrative Engine Guide](narrative_engine_GUIDE.md)
 
 ## 4. Follow the Development Workflow
 Use the process documents to build and modify modules:

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -308,6 +308,22 @@ documents:
       key_rules: Use prescribed JSON logging format.
       purpose: Structured logging requirements.
       scope: Logging across modules.
+  docs/narrative_engine_GUIDE.md:
+    commit: 3c4f81b51eff75d5d5ccd63d732f954524296773
+    sha256: 3714db9071090d4c430ab986bd0e7b0bece10051277688d9bf0a8eb99fc69be7
+    summary:
+      insight: Provides setup and architecture for biosignal-driven narrative engine.
+      key_rules: Use documented ingestion and event structures.
+      purpose: Guide for deploying and extending narrative engine.
+      scope: Biosignal ingestion to memory persistence.
+  docs/narrative_framework.md:
+    commit: 3c4f81b51eff75d5d5ccd63d732f954524296773
+    sha256: 3774d01dff11be3df543c625cbd3e3c93fe1c23b880f1f6ee2189be87ef1ef4b
+    summary:
+      insight: Biosignals transform into narratives via defined stages.
+      key_rules: Align orchestration with framework stages.
+      purpose: Maps biosignal streams to narrative pipeline.
+      scope: Narrative orchestration across the stack.
   docs/nazarick_agents.md:
     commit: 18ad40926d0b92ad8e2bb4fbc93a9d5d650d73d9
     sha256: 9cfdb5732c777137ca29fe3796729c7a2fd3af751dddf6dca9faedd435c0321f


### PR DESCRIPTION
## Summary
- link narrative docs in onboarding checklist and guides
- record narrative doc hashes in onboarding confirmations

## Testing
- `pre-commit run --files docs/onboarding/README.md docs/onboarding_guide.md docs/developer_onboarding.md onboarding_confirm.yml` *(failed: Missing Python packages: websockets; ModuleNotFoundError: No module named 'neoabzu_chakrapulse'; missing instrumentation references; verify docs up to date; verify chakra monitoring; verify self healing)*
- `pre-commit run verify-onboarding-refs`

------
https://chatgpt.com/codex/tasks/task_e_68c736570768832ebe2efdde80024e05