### PR TITLE
docs: document narrative guides

### DIFF
--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -54,6 +54,8 @@ graph LR
 | [Sumerian 33‑Word Lexicon](../NEOABZU/docs/SUMERIAN_33WORDS.md) | Sacred vocabulary of 33 primordial concepts | Quarterly |
 | [Test Planning Guide](onboarding/test_planning.md) | Filing "Test Plan" issues defining scope, chakra, and coverage goals | Quarterly |
 | [Bana Engine](bana_engine.md) | Mistral 7B fine-tuning, event processing, and output paths | Quarterly |
+| [Narrative Framework](narrative_framework.md) | Maps biosignals to narrative orchestration pipeline | Quarterly |
+| [Narrative Engine Guide](narrative_engine_GUIDE.md) | Implementation guide for the biosignal-to-StoryEvent processing pipeline | Quarterly |
 | [Nazarick Narrative System](nazarick_narrative_system.md) | Biosignal→StoryEvent pipeline and memory hooks | Quarterly |
 | [Nazarick Core Architecture](../agents/nazarick/nazarick_core_architecture.md) | Observability framework and channel hierarchy | Quarterly |
 | [Nazarick Memory Blueprint](../agents/nazarick/nazarick_memory_blueprint.md) | Personality, memory, and communication design for agents | Quarterly |


### PR DESCRIPTION
## Summary
- register Narrative Framework and Narrative Engine Guide in key documents registry
- regenerate documentation index

## Testing
- `pre-commit run --files docs/KEY_DOCUMENTS.md docs/INDEX.md` *(fails: Missing Python packages: websockets; ImportError: No module named 'neoabzu_chakrapulse'; missing instrumentation in blueprint_spine.md; missing instrumentation in system_blueprint.md; verify-docs-up-to-date; verify-chakra-monitoring connection refused; verify-self-healing)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c737b5b0cc832ebb7ffc526df0072a