### PR TITLE
feat: scaffold nazarick console skeleton

### DIFF
--- a/nazarick-console/backend/Cargo.toml
+++ b/nazarick-console/backend/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nazarick-console-backend"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+[workspace]

--- a/nazarick-console/backend/src/main.rs
+++ b/nazarick-console/backend/src/main.rs
@@ -1,0 +1,93 @@
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Path, Query,
+    },
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use futures::{SinkExt, StreamExt};
+use std::{collections::HashMap, net::SocketAddr, time::Duration};
+use tokio::sync::broadcast;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let (tx, _) = broadcast::channel::<String>(100);
+
+    // periodic chakra pulse
+    tokio::spawn({
+        let tx = tx.clone();
+        async move {
+            let mut freq: f32 = 1.0;
+            loop {
+                let _ = tx.send(format!("chakra:{freq}"));
+                freq += 0.1;
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    });
+
+    // synthetic log stream
+    tokio::spawn({
+        let tx = tx.clone();
+        async move {
+            let mut n = 0u64;
+            loop {
+                let _ = tx.send(format!("log:agent{0}:entry {0}", n % 3));
+                n += 1;
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }
+    });
+
+    let app = Router::new().route(
+        "/ws/:agent",
+        get({
+            let tx = tx.clone();
+            move |ws: WebSocketUpgrade,
+                  Path(agent): Path<String>,
+                  Query(params): Query<HashMap<String, String>>| {
+                ws_handler(ws, agent, params.get("token").cloned(), tx.clone())
+            }
+        }),
+    );
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3001));
+    println!("listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    agent: String,
+    token: Option<String>,
+    tx: broadcast::Sender<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if token.as_deref() != Some("demo") {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(ws.on_upgrade(move |socket| websocket(socket, agent, tx)))
+}
+
+async fn websocket(stream: WebSocket, agent: String, tx: broadcast::Sender<String>) {
+    let (mut sender, mut receiver) = stream.split();
+    let mut rx = tx.subscribe();
+
+    let send_task = tokio::spawn(async move {
+        while let Ok(msg) = rx.recv().await {
+            if sender.send(Message::Text(msg)).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    while let Some(Ok(Message::Text(text))) = receiver.next().await {
+        let _ = tx.send(format!("log:{agent}:{text}"));
+    }
+
+    send_task.abort();
+}

--- a/nazarick-console/frontend/app.js
+++ b/nazarick-console/frontend/app.js
@@ -1,0 +1,30 @@
+const agent = 'agent1';
+const token = 'demo';
+const socket = new WebSocket(`ws://localhost:3001/ws/${agent}?token=${token}`);
+
+socket.onmessage = (ev) => {
+  const log = document.getElementById('chat-log');
+  log.textContent += ev.data + '\n';
+  if (ev.data.startsWith('chakra:')) {
+    const freq = parseFloat(ev.data.split(':')[1]);
+    pulse(freq);
+  }
+};
+
+function pulse(freq) {
+  const orb = document.getElementById('chakra');
+  orb.style.opacity = 0.2 + (freq % 1) * 0.8;
+}
+
+document.getElementById('send-btn').onclick = () => {
+  const input = document.getElementById('chat-input');
+  socket.send(input.value);
+  input.value = '';
+};
+
+document.getElementById('command').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    socket.send(`/cmd ${e.target.value}`);
+    e.target.value = '';
+  }
+});

--- a/nazarick-console/frontend/index.html
+++ b/nazarick-console/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Nazarick Console</title>
+  <style>
+    body { font-family: sans-serif; }
+    #chakra { width:100px; height:100px; border-radius:50%; background:#222; margin:20px auto; transition:opacity 0.2s; }
+    #chat-log { height:150px; border:1px solid #ccc; overflow-y:auto; padding:5px; }
+  </style>
+</head>
+<body>
+  <div id="chakra"></div>
+  <div id="chat-log"></div>
+  <input id="chat-input" placeholder="message" />
+  <button id="send-btn">Send</button>
+  <input id="command" placeholder="command" />
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `nazarick-console` backend exposing websocket endpoint with auth and log streaming
- basic frontend with chat, chakra pulse, and command palette

## Testing
- `cargo check --manifest-path nazarick-console/backend/Cargo.toml`
- `pre-commit run verify-onboarding-refs`
- `pre-commit run --files nazarick-console/backend/Cargo.toml nazarick-console/backend/src/main.rs nazarick-console/frontend/index.html nazarick-console/frontend/app.js` *(fails: KeyboardInterrupt during environment install)*

------
https://chatgpt.com/codex/tasks/task_e_68c739020874832e9ec31636d93bc366