### PR TITLE
docs: add migration playbooks and protocol

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -401,6 +401,9 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
 | [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | - |
 | [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md). | - |
+| [migration_playbooks/crown.md](migration_playbooks/crown.md) | Crown Migration Playbook | - | - |
+| [migration_playbooks/razor.md](migration_playbooks/razor.md) | Razor Migration Playbook | - | - |
+| [migration_protocol.md](migration_protocol.md) | Migration Protocol | Guidelines for coordinating Python→Rust migrations across the codebase. | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |

--- a/docs/migration_playbooks/crown.md
+++ b/docs/migration_playbooks/crown.md
@@ -1,0 +1,17 @@
+# Crown Migration Playbook
+
+## Python→Rust Parity Checklist
+- Map Crown's Python orchestration flows to the `neoabzu_crown` crate.
+- Sync command interfaces and configuration schemas.
+- Verify APSU sequence alignment through [blueprint_spine.md](../blueprint_spine.md) and [system_blueprint.md](../system_blueprint.md).
+
+## Test Expectations
+- Run existing Crown Python tests alongside Rust integration tests.
+- Validate end-to-end mission routing under both implementations.
+- Merge only after CI and mission demos succeed.
+
+## Rollback Steps
+- Keep the Python Crown router available as an emergency path.
+- Re-enable Python and redeploy if Rust routing fails.
+- Log rollback actions and update the release notes.
+

--- a/docs/migration_playbooks/razor.md
+++ b/docs/migration_playbooks/razor.md
@@ -1,0 +1,17 @@
+# Razor Migration Playbook
+
+## Python→Rust Parity Checklist
+- Audit existing Python features and map each to the `neoabzu_razor` crate.
+- Align public APIs and configuration files.
+- Document APSU sequence placement referencing [blueprint_spine.md](../blueprint_spine.md) and [system_blueprint.md](../system_blueprint.md).
+
+## Test Expectations
+- Execute unit and integration tests for both Python and Rust paths.
+- Confirm cross-language regression tests pass before merging.
+- CI must report green across all gates.
+
+## Rollback Steps
+- Retain the last stable Python release behind a feature flag.
+- If Rust defects surface, revert to the Python module and redeploy.
+- Record rollback rationale in the component changelog.
+

--- a/docs/migration_protocol.md
+++ b/docs/migration_protocol.md
@@ -1,0 +1,19 @@
+# Migration Protocol
+
+Guidelines for coordinating Python→Rust migrations across the codebase.
+
+## Branching
+- Create feature branches using `migration/<module>` naming.
+- Rebase frequently on `main` to minimize drift.
+- Update [system_blueprint.md](system_blueprint.md) if architecture shifts.
+
+## Reviews
+- Require at least two maintainers to approve migrations.
+- Reference relevant playbooks in review descriptions.
+- Link to APSU sequence diagrams such as [blueprint_spine.md](blueprint_spine.md).
+
+## Release Gating
+- All migrations must pass unit, integration, and regression tests.
+- Documentation updates and index regeneration are mandatory.
+- Releases are gated on successful rollback validation and changelog entries.
+


### PR DESCRIPTION
## Summary
- add per-module migration playbooks for Razor and Crown
- document global migration protocol for Python→Rust efforts

## Testing
- `pre-commit run --files docs/migration_playbooks/razor.md docs/migration_playbooks/crown.md docs/migration_protocol.md docs/INDEX.md` *(fails: ModuleNotFoundError: No module named 'neoabzu_chakrapulse'; verify-crate-refs; verify-blueprint-refs; verify-docs-up-to-date)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py` *(reports many outdated documents)*

------
https://chatgpt.com/codex/tasks/task_e_68c73ad03d10832ea34027a0f4f40787