### PR TITLE
Rename Razor crate to RAZAR

### DIFF
--- a/NEOABZU/Cargo.lock
+++ b/NEOABZU/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "neoabzu-razor"
+name = "neoabzu-razar"
 version = "0.1.0"
 dependencies = [
  "neoabzu-chakrapulse",

--- a/NEOABZU/Cargo.toml
+++ b/NEOABZU/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "kimicho",
     "k2coder",
     "chakrapulse",
-    "razor",
+    "razar",
     "inanna",
 ]
 resolver = "2"

--- a/NEOABZU/crown/tests/kimicho_fallback.rs
+++ b/NEOABZU/crown/tests/kimicho_fallback.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 #[test]
-fn razor_falls_back_to_kimicho_on_crown_error() {
+fn razar_falls_back_to_kimicho_on_crown_error() {
     Python::with_gil(|py| {
         let server = MockServer::start();
         let _m = server.mock(|when, then| {
@@ -14,21 +14,23 @@ fn razor_falls_back_to_kimicho_on_crown_error() {
         });
 
         let code = format!(
-            "import neoabzu_crown as crown\n" \
-            "import neoabzu_kimicho as k\n" \
-            "k.init_kimicho('{url}')\n" \
-            "crown.route_decision = lambda *a, **k: (_ for _ in ()).throw(RuntimeError('down'))\n" \
-            "def route():\n" \
-            "    try:\n" \
-            "        return crown.route_decision('ping', {'emotion':'joy'})\n" \
-            "    except Exception:\n" \
-            "        text = k.fallback_k2('ping')\n" \
-            "        return {'model':'kimicho', 'text': text}\n",
+            r#"
+import neoabzu_crown as crown
+import neoabzu_kimicho as k
+k.init_kimicho('{url}')
+crown.route_decision = lambda *a, **k: (_ for _ in ()).throw(RuntimeError('down'))
+def route():
+    try:
+        return crown.route_decision('ping', {'emotion':'joy'})
+    except Exception:
+        text = k.fallback_k2('ping')
+        return {{'model':'kimicho', 'text': text}}
+"#,
             url = server.url("/")
         );
 
-        let razor = PyModule::from_code(py, &code, "", "razor_agent").unwrap();
-        let res: &PyDict = razor
+        let razar = PyModule::from_code(py, &code, "", "razar_agent").unwrap();
+        let res: &PyDict = razar
             .getattr("route")
             .unwrap()
             .call0()
@@ -43,7 +45,7 @@ fn razor_falls_back_to_kimicho_on_crown_error() {
 }
 
 #[test]
-fn razor_falls_back_to_kimicho_when_crown_missing() {
+fn razar_falls_back_to_kimicho_when_crown_missing() {
     Python::with_gil(|py| {
         let server = MockServer::start();
         let _m = server.mock(|when, then| {
@@ -54,22 +56,24 @@ fn razor_falls_back_to_kimicho_when_crown_missing() {
         });
 
         let code = format!(
-            "import sys\n" \
-            "import neoabzu_kimicho as k\n" \
-            "k.init_kimicho('{url}')\n" \
-            "def route():\n" \
-            "    sys.modules.pop('neoabzu_crown', None)\n" \
-            "    try:\n" \
-            "        import neoabzu_crown as crown\n" \
-            "        return crown.route_decision('ping', {'emotion':'joy'})\n" \
-            "    except Exception:\n" \
-            "        text = k.fallback_k2('ping')\n" \
-            "        return {'model':'kimicho', 'text': text}\n",
+            r#"
+import sys
+import neoabzu_kimicho as k
+k.init_kimicho('{url}')
+def route():
+    sys.modules.pop('neoabzu_crown', None)
+    try:
+        import neoabzu_crown as crown
+        return crown.route_decision('ping', {'emotion':'joy'})
+    except Exception:
+        text = k.fallback_k2('ping')
+        return {{'model':'kimicho', 'text': text}}
+"#,
             url = server.url("/")
         );
 
-        let razor = PyModule::from_code(py, &code, "", "razor_agent").unwrap();
-        let res: &PyDict = razor
+        let razar = PyModule::from_code(py, &code, "", "razar_agent").unwrap();
+        let res: &PyDict = razar
             .getattr("route")
             .unwrap()
             .call0()

--- a/NEOABZU/crown/tests/razar_integration.rs
+++ b/NEOABZU/crown/tests/razar_integration.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 #[test]
-fn razor_can_call_rust_router() {
+fn razar_can_call_rust_router() {
     Python::with_gil(|py| {
         let sys = py.import("sys").unwrap();
         let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
@@ -35,17 +35,17 @@ def decide_expression_options(emotion):
         modules.set_item("crown_decider", decider).unwrap();
 
         py.run("import sys; sys.path.append('../..')", None, None).unwrap();
-        let razor_code = r#"
+        let razar_code = r#"
 import crown_router
 
 def route(text, emotion):
     return crown_router.route_decision(text, {'emotion': emotion})
 "#;
-        let razor_mod = PyModule::from_code(py, razor_code, "", "razor_agent").unwrap();
-        modules.set_item("razor_agent", razor_mod).unwrap();
+        let razar_mod = PyModule::from_code(py, razar_code, "", "razar_agent").unwrap();
+        modules.set_item("razar_agent", razar_mod).unwrap();
 
         let res: &PyDict = py
-            .eval("razor_agent.route('hi', 'joy')", None, None)
+            .eval("razar_agent.route('hi', 'joy')", None, None)
             .unwrap()
             .downcast()
             .unwrap();

--- a/NEOABZU/kimicho/tests/razar_integration.rs
+++ b/NEOABZU/kimicho/tests/razar_integration.rs
@@ -2,7 +2,7 @@ use httpmock::prelude::*;
 use pyo3::prelude::*;
 
 #[test]
-fn razor_can_call_kimicho_fallback() {
+fn razar_can_call_kimicho_fallback() {
     Python::with_gil(|py| {
         let server = MockServer::start();
         let _m = server.mock(|when, then| {
@@ -19,8 +19,8 @@ fn razor_can_call_kimicho_fallback() {
             "    return k.fallback_k2('ping')\n",
             url = server.url("/")
         );
-        let razor = PyModule::from_code(py, &code, "", "razor_agent").unwrap();
-        let res: String = razor
+        let razar = PyModule::from_code(py, &code, "", "razar_agent").unwrap();
+        let res: String = razar
             .getattr("invoke")
             .unwrap()
             .call0()

--- a/NEOABZU/razar/Cargo.toml
+++ b/NEOABZU/razar/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "neoabzu-razor"
+name = "neoabzu-razar"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "neoabzu_razor"
+name = "neoabzu_razar"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/NEOABZU/razar/src/lib.rs
+++ b/NEOABZU/razar/src/lib.rs
@@ -22,11 +22,11 @@ pub fn route(py: Python<'_>, text: &str, emotion: &str) -> PyResult<Py<PyDict>> 
 
 #[pyfunction]
 fn health_pulse() {
-    emit_pulse("razor", true);
+    emit_pulse("razar", true);
 }
 
 #[pymodule]
-fn neoabzu_razor(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn neoabzu_razar(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(route, m)?)?;
     m.add_function(wrap_pyfunction!(health_pulse, m)?)?;
     // ensure dependent modules load if available

--- a/NEOABZU/razar/tests/route.rs
+++ b/NEOABZU/razar/tests/route.rs
@@ -17,7 +17,7 @@ fn falls_back_to_kimicho_on_error() {
         let kimi = PyModule::from_code(py, kimi_code, "", "neoabzu_kimicho").unwrap();
         modules.set_item("neoabzu_kimicho", kimi).unwrap();
 
-        let binding = neoabzu_razor::route(py, "hi", "neutral").unwrap();
+        let binding = neoabzu_razar::route(py, "hi", "neutral").unwrap();
         let res: &PyDict = binding.as_ref(py).downcast().unwrap();
         let text: String = res.get_item("text").unwrap().unwrap().extract().unwrap();
         assert_eq!(text, "HI");

--- a/component_index.json
+++ b/component_index.json
@@ -4027,7 +4027,7 @@
         "NEOABZU/crown/tests/kimicho_fallback.rs",
         "NEOABZU/crown/tests/route_decision.rs",
         "NEOABZU/crown/tests/memory_query.rs",
-        "NEOABZU/crown/tests/razor_integration.rs",
+        "NEOABZU/crown/tests/razar_integration.rs",
         "NEOABZU/crown/tests/route_query.rs",
         "NEOABZU/crown/tests/insight.rs",
         "NEOABZU/crown/tests/legacy_parity.rs"
@@ -4116,7 +4116,7 @@
         "tracing"
       ],
       "tests": [
-        "NEOABZU/kimicho/tests/razor_integration.rs"
+        "NEOABZU/kimicho/tests/razar_integration.rs"
       ],
       "metrics": {
         "coverage": 1.0

--- a/docs/ABZU_blueprint.md
+++ b/docs/ABZU_blueprint.md
@@ -52,13 +52,13 @@ Crown brokers operator directives to Nazarick servants, who relay telemetry back
 {{#include figures/agent_relations.mmd}}
 ```
 
-### Razor–Crown–Kimi-cho Migration
+### RAZAR–Crown–Kimi-cho Migration
 
 ```mermaid
-{{#include figures/razor_crown_kimicho_flow.mmd}}
+{{#include figures/razar_crown_kimicho_flow.mmd}}
 ```
 
-*Figure: Mission traffic moves from Razor through the Rust-based Crown router to the Kimi-cho fallback, tracking migration progress.*
+*Figure: Mission traffic moves from RAZAR through the Rust-based Crown router to the Kimi-cho fallback, tracking migration progress.*
 
 ```mermaid
 {{#include figures/rust_crate_boundaries.mmd}}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -376,7 +376,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [figures/operator_query_sequence.mmd](figures/operator_query_sequence.mmd) | Operator query sequence diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
 | [figures/pyo3_interfaces.mmd](figures/pyo3_interfaces.mmd) | pyo3_interfaces.mmd | - | - |
 | [figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd) | Query memory aggregation diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
-| [figures/razor_crown_kimicho_flow.mmd](figures/razor_crown_kimicho_flow.mmd) | razor_crown_kimicho_flow.mmd | - | - |
+| [figures/razar_crown_kimicho_flow.mmd](figures/razar_crown_kimicho_flow.mmd) | razar_crown_kimicho_flow.mmd | - | - |
 | [figures/rust_crate_boundaries.mmd](figures/rust_crate_boundaries.mmd) | rust_crate_boundaries.mmd | - | - |
 | [figures/system_tear_matrix.mmd](figures/system_tear_matrix.mmd) | system_tear_matrix.mmd | - | - |
 | [frontend_dependencies.md](frontend_dependencies.md) | Frontend Dependencies | This page outlines the core libraries used by the `floor_client` interface. Refer to each project's documentation for... | - |
@@ -402,7 +402,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | - |
 | [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md). | - |
 | [migration_playbooks/crown.md](migration_playbooks/crown.md) | Crown Migration Playbook | - | - |
-| [migration_playbooks/razor.md](migration_playbooks/razor.md) | Razor Migration Playbook | - | - |
+| [migration_playbooks/razar.md](migration_playbooks/razar.md) | RAZAR Migration Playbook | - | - |
 | [migration_protocol.md](migration_protocol.md) | Migration Protocol | Guidelines for coordinating Python→Rust migrations across the codebase. | - |
 | [milestone_viii_plan.md](milestone_viii_plan.md) | Milestone VIII – Sonic Core & Avatar Expression Harmonics | This milestone strengthens the emotional flow between text, music and the on-screen avatar. It expands the Sonic Core... | - |
 | [mission_brief_exchange.md](mission_brief_exchange.md) | Mission Brief Exchange & Servant Routing | This guide outlines how RAZAR hands mission briefs to Crown, how failures escalate through `ai_invoker.handover`, and... | - |

--- a/docs/RAZAR_AGENT.md
+++ b/docs/RAZAR_AGENT.md
@@ -6,7 +6,7 @@ See [Agent Ecosystem & Relations](ABZU_blueprint.md#agent-ecosystem--relations) 
 
 RAZAR ↔ Crown ↔ Kimi2Code handoffs and recovery loops are diagrammed in the [Ignition Blueprint](ignition_blueprint.md).
 
-Razor now delegates crown routing and Kimicho fallback to the Rust crates `neoabzu_crown` and `neoabzu_kimicho`; the corresponding Python modules are stubs.
+RAZAR now delegates crown routing and Kimicho fallback to the Rust crates `neoabzu_crown` and `neoabzu_kimicho`; the corresponding Python modules are stubs.
 
 Mission brief exchange and servant routing are summarized in [Mission Brief Exchange & Servant Routing](mission_brief_exchange.md).
 
@@ -277,7 +277,7 @@ logs/mission_briefs/
 
 ### Migration Crosswalk
 
-Port status and legacy mappings for Razor initialization are tracked in the [Migration Crosswalk](migration_crosswalk.md#razor-init).
+Port status and legacy mappings for RAZAR initialization are tracked in the [Migration Crosswalk](migration_crosswalk.md#razar-init).
 
 ## Cross-links
 - [System Blueprint](system_blueprint.md)

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -25,7 +25,7 @@ Components ported from Python to Rust must:
 
 - Follow the [documentation protocol](documentation_protocol.md) to keep canonical references synchronized.
 - Update [doctrine_index.md](doctrine_index.md) with the component's checksum and note its place in the APSU sequence.
-- Document where the component sits in the APSU sequence and link to relevant diagrams such as [blueprint_spine.md](blueprint_spine.md) or [system_blueprint.md](system_blueprint.md#razor–crown–kimi-cho-migration).
+- Document where the component sits in the APSU sequence and link to relevant diagrams such as [blueprint_spine.md](blueprint_spine.md) or [system_blueprint.md](system_blueprint.md#razar–crown–kimi-cho-migration).
 
 ### Doctrine Reference Requirements
 

--- a/docs/figures/razar_crown_kimicho_flow.mmd
+++ b/docs/figures/razar_crown_kimicho_flow.mmd
@@ -1,6 +1,6 @@
 flowchart LR
     subgraph Python
-        R[Razor]
+        R[RAZAR]
     end
     subgraph Rust
         C[Crown]

--- a/docs/figures/rust_crate_boundaries.mmd
+++ b/docs/figures/rust_crate_boundaries.mmd
@@ -1,5 +1,5 @@
 flowchart TB
-    subgraph neoabzu_razor
+    subgraph neoabzu_razar
         R1[Orchestrator]
     end
     subgraph neoabzu_crown

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -4,7 +4,7 @@ For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 
 | Step | Rust crate | Doctrine Reference | Remaining Python dependencies |
 |------|------------|--------------------|--------------------------------|
-| Razor init | `neoabzu_memory` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | `razar/boot_orchestrator.py` |
+| RAZAR init | `neoabzu_memory` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | `razar/boot_orchestrator.py` |
 | Crown routing | `neoabzu_crown` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | — |
 | Fusion invariants | `neoabzu_fusion` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | — |
 | Numeric embeddings | `neoabzu_numeric` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | — |
@@ -12,11 +12,11 @@ For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 | RAG retrieval | `neoabzu_rag` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | `rag/orchestrator.py` |
 | Kimicho fallback | `neoabzu_kimicho` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | — |
 
-### Razor init
+### RAZAR init
 - [x] Port complete
 - [x] Required tests: `tests/agents/razar/test_crown_handshake.py`
 - [x] Documentation references: [RAZAR Agent](RAZAR_AGENT.md#migration-crosswalk)
-- [x] Doctrine references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md#razar–crown–kimi-cho-migration)
 
 ### Crown routing
 - [ ] Port complete
@@ -50,7 +50,7 @@ For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 
 ### Kimicho fallback
 - [ ] Port complete
-- [x] Required tests: `NEOABZU/kimicho/tests/razor_integration.rs`, `NEOABZU/crown/tests/kimicho_fallback.rs`
-- [x] Documentation references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
-- [x] Doctrine references: [System Blueprint](system_blueprint.md#razor-crown-kimi-cho-migration)
+- [x] Required tests: `NEOABZU/kimicho/tests/razar_integration.rs`, `NEOABZU/crown/tests/kimicho_fallback.rs`
+- [x] Documentation references: [System Blueprint](system_blueprint.md#razar–crown–kimi-cho-migration)
+- [x] Doctrine references: [System Blueprint](system_blueprint.md#razar–crown–kimi-cho-migration)
 

--- a/docs/migration_playbooks/razar.md
+++ b/docs/migration_playbooks/razar.md
@@ -1,7 +1,7 @@
-# Razor Migration Playbook
+# RAZAR Migration Playbook
 
 ## Python→Rust Parity Checklist
-- Audit existing Python features and map each to the `neoabzu_razor` crate.
+- Audit existing Python features and map each to the `neoabzu_razar` crate.
 - Align public APIs and configuration files.
 - Document APSU sequence placement referencing [blueprint_spine.md](../blueprint_spine.md) and [system_blueprint.md](../system_blueprint.md).
 

--- a/docs/narrative_framework.md
+++ b/docs/narrative_framework.md
@@ -11,7 +11,7 @@ stack.
    recall.【F:docs/bana_engine.md†L11-L17】
 3. **Inanna persona** – the bridge forwards Bana events into the Albedo persona
    for stylistic rendering and reflection before passing them downstream.
-4. **Razor orchestration** – structured narrative packets drive the wider
+4. **RAZAR orchestration** – structured narrative packets drive the wider
    experience pipeline, where an orchestrator routes descriptions and game
    directives into runtime systems for operator interaction.【F:NEOABZU/docs/Bana Narrator vision.md†L16-L37】
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ Each crate calls `init_tracing` in its Python module initializer so spans are
 emitted when the module loads. Apply the `#[instrument]` attribute to functions
 to capture arguments and emit spans.
 
-Razor, Crown, and Kimicho expose a `tracing` feature flag. Enable it at build
+RAZAR, Crown, and Kimicho expose a `tracing` feature flag. Enable it at build
 time to wire in the hooks and emit spans:
 
 ```bash

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -317,17 +317,17 @@ and retrieval requests, while `nazarick_agents` subscribe to mission updates and
 state changes. See the [Operations Guide](operations.md#heartbeat-polling-and-event-routing)
 for runtime details.
 
-### Razor–Crown–Kimi-cho Migration
+### RAZAR–Crown–Kimi-cho Migration
 
 ```mermaid
-{{#include figures/razor_crown_kimicho_flow.mmd}}
+{{#include figures/razar_crown_kimicho_flow.mmd}}
 ```
 
-*Figure: Events travel from the Python-based Razor orchestrator through the Rust Crown router to the Kimi-cho fallback, showing the current migration path.*
+*Figure: Events travel from the Python-based RAZAR orchestrator through the Rust Crown router to the Kimi-cho fallback, showing the current migration path.*
 
-Integration tests (`NEOABZU/crown/tests/kimicho_fallback.rs`) confirm that Razor falls back to Kimicho transparently when Crown routing fails.
+Integration tests (`NEOABZU/crown/tests/kimicho_fallback.rs`) confirm that RAZAR falls back to Kimicho transparently when Crown routing fails.
 
-See the [Migration Crosswalk](migration_crosswalk.md#razor-init) for initialization mapping, [crown routing](migration_crosswalk.md#crown-routing), and [Kimicho fallback](migration_crosswalk.md#kimicho-fallback) status.
+See the [Migration Crosswalk](migration_crosswalk.md#razar-init) for initialization mapping, [crown routing](migration_crosswalk.md#crown-routing), and [Kimicho fallback](migration_crosswalk.md#kimicho-fallback) status.
 
 ```mermaid
 {{#include figures/rust_crate_boundaries.mmd}}


### PR DESCRIPTION
## Summary
- rename `razor` crate and directory to `razar`
- update tests and docs to use new RAZAR naming
- switch workspace member and component references

## Testing
- `cargo clippy -p neoabzu-razar -p neoabzu-crown -p neoabzu-kimicho`
- `cargo test -p neoabzu-razar -p neoabzu-crown -p neoabzu-kimicho` *(fails: undefined references to Python symbols)*
- `pre-commit run --files NEOABZU/Cargo.lock NEOABZU/Cargo.toml NEOABZU/crown/tests/kimicho_fallback.rs NEOABZU/crown/tests/razar_integration.rs NEOABZU/kimicho/tests/razar_integration.rs NEOABZU/razar/Cargo.toml NEOABZU/razar/src/lib.rs NEOABZU/razar/tests/route.rs component_index.json docs/ABZU_blueprint.md docs/INDEX.md docs/RAZAR_AGENT.md docs/The_Absolute_Protocol.md docs/figures/razar_crown_kimicho_flow.mmd docs/figures/rust_crate_boundaries.mmd docs/migration_crosswalk.md docs/migration_playbooks/razar.md docs/narrative_framework.md docs/observability.md docs/system_blueprint.md` *(fails: missing metrics exporters, self-heal cycles)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c74170bd74832e8b3c6a0cb650420f