### PR TITLE
feat: map agent chakras and expose pulse metrics

### DIFF
--- a/bana/narrative.py
+++ b/bana/narrative.py
@@ -14,6 +14,10 @@ from typing import Any, Dict, Optional
 from .event_structurizer import from_interaction
 from agents.event_bus import emit_event as bus_emit
 from memory import narrative_engine
+from albedo import Magnitude
+from albedo.state_machine import AlbedoStateMachine, EntityCategory
+
+_ALBEDO = AlbedoStateMachine()
 
 
 def emit(
@@ -35,6 +39,17 @@ def emit(
     metadata = dict(payload)
     if target_agent:
         metadata["target_agent"] = target_agent
+
+    # Integrate with Inanna's Albedo persona state machine
+    try:
+        trust = payload.get("trust")
+        category = payload.get("category")
+        if trust is not None and category is not None:
+            state = _ALBEDO.transition(Magnitude(int(trust)), EntityCategory(category))
+            metadata["albedo_state"] = state.value
+    except Exception:  # pragma: no cover - defensive
+        pass
+
     bus_emit(agent_id, event_type, metadata)
     return event
 

--- a/config/albedo_config.yaml
+++ b/config/albedo_config.yaml
@@ -1,3 +1,4 @@
+chakra: crown
 glm:
   endpoint: https://glm.example.com/glm41v_9b
   api_key: ${GLM_API_KEY}

--- a/config/razar_config.yaml
+++ b/config/razar_config.yaml
@@ -1,3 +1,4 @@
+chakra: throat
 dependencies: []
 enable_ai_handover: false
 ai_agent:

--- a/web_console/game_dashboard/chakraPulse.js
+++ b/web_console/game_dashboard/chakraPulse.js
@@ -78,6 +78,13 @@ export default function ChakraPulse() {
     ),
     React.createElement(
       'ul',
+      { className: 'metrics' },
+      Object.entries(chakras).map(([name, freq]) =>
+        React.createElement('li', { key: name }, `${name}: ${freq.toFixed(2)}Hz`)
+      )
+    ),
+    React.createElement(
+      'ul',
       { className: 'history' },
       history.map((t, i) => React.createElement('li', { key: i }, t))
     )

--- a/web_console/game_dashboard/chatThreads.js
+++ b/web_console/game_dashboard/chatThreads.js
@@ -1,0 +1,19 @@
+import React from 'https://esm.sh/react@18';
+import { BASE_URL } from '../main.js';
+
+export default function ChatThreads() {
+  const [threads, setThreads] = React.useState([]);
+
+  React.useEffect(() => {
+    fetch(`${BASE_URL}/agent/chat/threads`)
+      .then((r) => r.json())
+      .then((d) => setThreads(d.threads || []))
+      .catch(() => setThreads([]));
+  }, []);
+
+  return React.createElement(
+    'ul',
+    { id: 'chat-threads' },
+    threads.map((t, i) => React.createElement('li', { key: i }, t))
+  );
+}

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -7,6 +7,7 @@ import ChakraPulse from './chakraPulse.js';
 import AvatarRoom from './avatar_room/avatar_room.js';
 import ChakraStatusBoard from './chakraStatusBoard.js';
 import AgentStatusPanel from './agent_status_panel.js';
+import ChatThreads from './chatThreads.js';
 import MemoryPanel from './memory_panel/memory_panel.js';
 import ChakraStatusPanel from './chakra_status_panel/chakra_status_panel.js';
 import SelfHealingPanel from './self_healing_panel/self_healing_panel.js';
@@ -71,6 +72,7 @@ function GameDashboard() {
       React.createElement(ChakraStatusBoard),
       React.createElement(ChakraStatusPanel),
       React.createElement(AgentStatusPanel),
+      React.createElement(ChatThreads),
       React.createElement(ConnectorsPanel),
       React.createElement(MemoryPanel),
       React.createElement(SelfHealingPanel)

--- a/web_console/game_dashboard/index.html
+++ b/web_console/game_dashboard/index.html
@@ -15,6 +15,7 @@
     #chakra-pulse .orb { border-radius: 50%; position: relative; }
     #chakra-pulse .orb.aligned::after { content: ''; position: absolute; top: 50%; left: 50%; width: 4px; height: 4px; background: #FFFF00; border-radius: 50%; box-shadow: 0 0 8px #FFFF00; animation: particles 1s infinite; }
     #chakra-pulse .history { list-style: none; padding: 0; margin-top: 1rem; text-align: left; }
+    #chakra-pulse .metrics { list-style: none; padding: 0; margin-top: 1rem; text-align: left; }
     .resonance { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,255,0,0.2); pointer-events: none; animation: resonance 1s ease-out; }
     @keyframes pulse { from { transform: scale(0.9); } to { transform: scale(1.1); } }
     @keyframes particles { from { transform: translate(-50%, -50%) scale(1); opacity: 1; } to { transform: translate(-50%, -50%) scale(3); opacity: 0; } }
@@ -24,6 +25,7 @@
     #chakra-status-panel .orbs { display: flex; justify-content: center; gap: 0.5rem; }
     #chakra-status-panel .orb { border-radius: 50%; }
     #chakra-status-panel .components { list-style: none; padding: 0; margin-top: 0.5rem; text-align: left; }
+    #chat-threads { margin-top: 1rem; text-align: left; list-style: none; padding: 0; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- associate Albedo and RAZAR agents with their chakras
- propagate narrative events into Albedo's state machine
- surface ChakraPulse metrics and agent chat threads in dashboard

## Testing
- `pre-commit run --files config/albedo_config.yaml config/razar_config.yaml bana/narrative.py web_console/game_dashboard/chakraPulse.js web_console/game_dashboard/chatThreads.js web_console/game_dashboard/dashboard.js web_console/game_dashboard/index.html` *(fails: confirm-reading, pytest-cov, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date)*
- `pre-commit run verify-onboarding-refs`

------
https://chatgpt.com/codex/tasks/task_e_68c7465c39fc832e8eb76e8b455cb4e7