### PR TITLE
feat: adaptive routing and narrative logs

### DIFF
--- a/connectors/heart_mediator.py
+++ b/connectors/heart_mediator.py
@@ -1,0 +1,19 @@
+"""Heart mediator routing Head↔Base communications."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from typing import Dict
+
+from .signal_bus import publish
+
+
+def mediate_head_base(head_msg: str, base_msg: str) -> Dict[str, str]:
+    """Relay messages between Head and Base via the Heart channel."""
+    payload = {"head": head_msg, "base": base_msg}
+    publish("heart:coordination", payload, 0)
+    return payload
+
+
+__all__ = ["mediate_head_base"]

--- a/operator_api.py
+++ b/operator_api.py
@@ -28,6 +28,7 @@ from fastapi import (
 
 from agents.operator_dispatcher import OperatorDispatcher
 from agents.interaction_log import log_agent_interaction
+from bana import narrative as bana_narrative
 from agents.task_orchestrator import run_mission
 from fastapi.responses import HTMLResponse
 from servant_model_manager import (
@@ -65,6 +66,10 @@ def _log_command(entry: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, default=repr) + "\n")
+    try:
+        bana_narrative.emit("operator", "decision", entry, target_agent="bana")
+    except Exception:  # pragma: no cover - narrative errors
+        logger.exception("failed to emit operator decision")
 
 
 async def broadcast_event(event: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary
- track servant pulse metrics for latency and failure rates and adapt K2 routing
- log operator decisions into Bana narratives and display routing metrics in console
- add heart mediator for head↔base coordination

## Testing
- `pre-commit run --files crown_prompt_orchestrator.py operator_api.py servant_model_manager.py src/cli/console_interface.py connectors/heart_mediator.py` *(fails: Confirm onboarding reading; missing instrumentation references; docs out of date)*
- `pre-commit run verify-onboarding-refs`
- `pytest tests/test_kimi_k2_servant.py::test_invoke_kimi_k2 -q` *(fails: ModuleNotFoundError: neoabzu_chakrapulse)*

------
https://chatgpt.com/codex/tasks/task_e_68c748bbc120832ea32bd751e921827e