### PR TITLE
crown: add validator routing and tests

### DIFF
--- a/NEOABZU/crown/tests/razar_validator.rs
+++ b/NEOABZU/crown/tests/razar_validator.rs
@@ -1,0 +1,50 @@
+use httpmock::prelude::*;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+#[test]
+fn razar_falls_back_when_validator_blocks() {
+    Python::with_gil(|py| {
+        let server = MockServer::start();
+        let _m = server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{\"text\":\"pong\"}");
+        });
+
+        py.run("import sys; sys.path.append('../..')", None, None)
+            .unwrap();
+        let code = format!(
+            r#"
+import neoabzu_crown as crown
+import neoabzu_kimicho as k
+from INANNA_AI.ethical_validator import EthicalValidator
+
+k.init_kimicho('{url}')
+validator = EthicalValidator()
+
+def route():
+    try:
+        return crown.route_decision('prepare to attack the village', {{'emotion': 'neutral'}}, validator=validator)
+    except Exception:
+        text = k.fallback_k2('ping')
+        return {{'model': 'kimicho', 'text': text}}
+"#,
+            url = server.url("/")
+        );
+
+        let razar = PyModule::from_code(py, &code, "", "razar_agent").unwrap();
+        let res: &PyDict = razar
+            .getattr("route")
+            .unwrap()
+            .call0()
+            .unwrap()
+            .downcast()
+            .unwrap();
+        let model: String = res.get_item("model").unwrap().unwrap().extract().unwrap();
+        assert_eq!(model, "kimicho");
+        let text: String = res.get_item("text").unwrap().unwrap().extract().unwrap();
+        assert_eq!(text, "pong");
+    });
+}

--- a/NEOABZU/crown/tests/validator.rs
+++ b/NEOABZU/crown/tests/validator.rs
@@ -1,0 +1,27 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+#[test]
+fn validator_blocks_unsafe_requests() {
+    Python::with_gil(|py| {
+        py.run("import sys; sys.path.append('../..')", None, None)
+            .unwrap();
+        let crown = PyModule::import(py, "neoabzu_crown").unwrap();
+        let validator_cls = PyModule::import(py, "INANNA_AI.ethical_validator").unwrap();
+        let validator = validator_cls
+            .getattr("EthicalValidator")
+            .unwrap()
+            .call0()
+            .unwrap();
+        let emo = PyDict::new(py);
+        emo.set_item("emotion", "neutral").unwrap();
+        let result = crown.getattr("route_decision").unwrap().call1((
+            "prepare to attack the village",
+            emo,
+            py.None(),
+            validator,
+            py.None(),
+        ));
+        assert!(result.is_err());
+    });
+}

--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -10,7 +10,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | --- | --- | --- |
 | User Interface | Routes user intents through the Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L39-L40】 | drop |
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated via `neoabzu_persona` |
-| Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | fully ported in Rust |
+| Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | fully ported in Rust with optional ethical validation |
 | Kimicho Fallback | Provides fallback code generation when the Crown Router cannot reach K2 Coder | `kimicho` crate exposes `fallback_k2` via PyO3 `neoabzu_kimicho` bridge |
 | RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator merges memory and connector results (parity achieved) |
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` generates simple semantic embeddings for tokens and bigrams, exposing vectors and hooks for the Crown Router |

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -9,7 +9,7 @@ For module-specific quirks and bugs, see the [Python legacy audit](../../docs/py
 | Python Subsystem | Rust Crate | Bridge |
 | --- | --- | --- |
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |
-| `crown_router.py` | `neoabzu-crown` | Fully ported; Python module is a thin stub over the Rust crate. |
+| `crown_router.py` | `neoabzu-crown` | Fully ported; Python module is a thin stub over the Rust crate and supports optional `EthicalValidator` gating. |
 | legacy Python fallback subsystem (`razar/boot_orchestrator.py`) | `kimicho` | PyO3 module `neoabzu_kimicho` exposes `init_kimicho` and `fallback_k2` for Crown routing failover. |
 | `rag/orchestrator.py` | `neoabzu-rag` | `MoGEOrchestrator` aggregates memory and connector results via PyO3. |
 | `core` lambda engine (`core/`) | `neoabzu-core` | Accessible through `neoabzu_memory.eval_core` and `neoabzu_memory.reduce_inevitable_core` for Crown Router and RAZAR. |
@@ -26,10 +26,12 @@ Legacy modules can import Rust crates compiled with PyO3 directly:
 
 ```python
 from crown_router import route_decision
+from INANNA_AI.ethical_validator import EthicalValidator
 
 from neoabzu_memory import eval_core
 
-result = route_decision("align chakras", {"emotion": "joy"})
+validator = EthicalValidator()
+result = route_decision("align chakras", {"emotion": "joy"}, validator=validator)
 print(result)
 
 print(eval_core("(\\x.x)y"))

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -327,6 +327,8 @@ for runtime details.
 
 Integration tests (`NEOABZU/crown/tests/kimicho_fallback.rs`) confirm that RAZAR falls back to Kimicho transparently when Crown routing fails.
 
+`NEOABZU/crown/tests/razar_validator.rs` extends this path with manifesto checks, falling back to Kimicho when Crown rejects a request via `EthicalValidator`.
+
 See the [Migration Crosswalk](migration_crosswalk.md#razar-init) for initialization mapping, [crown routing](migration_crosswalk.md#crown-routing), and [Kimicho fallback](migration_crosswalk.md#kimicho-fallback) status.
 
 ```mermaid


### PR DESCRIPTION
## Summary
- handle orchestrator and validator in Crown router
- add integration tests for validator rejections and RAZAR fallback
- document Crown validator and RAZAR flow

## Testing
- `cargo test -p neoabzu-crown` *(fails: missing Python symbols)*
- `pre-commit run --files NEOABZU/crown/src/lib.rs NEOABZU/crown/tests/razar_validator.rs NEOABZU/crown/tests/validator.rs NEOABZU/docs/feature_parity.md NEOABZU/docs/migration_crosswalk.md docs/system_blueprint.md` *(fails: rust-fmt-clippy diff)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c757a4b260832e866da3a74b851d47