### PR TITLE
feat: add kimi2 and airstar agent escalation

### DIFF
--- a/config/razar_ai_agents.json
+++ b/config/razar_ai_agents.json
@@ -18,6 +18,22 @@
       }
     },
     {
+      "name": "kimi2",
+      "endpoint": "${KIMI2_ENDPOINT}",
+      "auth": {
+        "type": "bearer",
+        "token": "${KIMI2_TOKEN}"
+      }
+    },
+    {
+      "name": "airstar",
+      "endpoint": "${AIRSTAR_ENDPOINT}",
+      "auth": {
+        "type": "bearer",
+        "token": "${AIRSTAR_TOKEN}"
+      }
+    },
+    {
       "name": "rstar",
       "endpoint": "${RSTAR_ENDPOINT}",
       "auth": {


### PR DESCRIPTION
## Summary
- add Kimi2 and Air Star agent definitions
- escalate AI recovery through Kimi2 -> AirStar -> rStar
- auto-detect remote agents when invoking handovers

## Testing
- `pre-commit run --files config/razar_ai_agents.json razar/boot_orchestrator.py razar/ai_invoker.py` *(fails: confirm-reading, pytest-cov, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c7fbdd9314832e845b97838f8d7076