### PR TITLE
feat: share AI failure history across agents

### DIFF
--- a/CHANGELOG_razar.md
+++ b/CHANGELOG_razar.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Operator uploads now store files under operator-specific paths and relay metadata through Crown to RAZAR.
 - Expanded remote assistance workflow with sequence diagram and dedicated invocation and patch logs.
 - Detailed handover and patch application flow with `ai_invoker` → `code_repair` diagram and patch log reference.
+- Cross-agent memory propagation sends recent `razar_ai_invocations.json` history to downstream agents during AI handovers.
 - Integrated `code_repair.repair_module` into `ai_invoker.handover` to apply remote patches and documented Remote Assistance section with flow diagram.
 - Added unit tests for `ai_invoker.handover` and `code_repair.repair_module`.
 - Added optional Opencode CLI handover path in `ai_invoker.handover` and

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -368,6 +368,14 @@ the [Recovery Playbook](recovery_playbook.md) and surface states such as
 `start`, `error`, `recovery`, `quarantine`, and `resolved` for every mission
 stage.
 
+### Cross-Agent Memory
+
+`razar.boot_orchestrator` records each handover attempt in
+`logs/razar_ai_invocations.json` and builds a concise history that
+`ai_invoker.handover` forwards to the active assistant. Downstream agents—K2
+Coder, Air Star, and rStar—receive this aggregated `history` payload so they can
+reference previous failures when proposing patches.
+
 ### Agent-Specific Recovery
 
 Each chakra has a dedicated remediation script. When the heartbeat poller

--- a/razar/ai_invoker.py
+++ b/razar/ai_invoker.py
@@ -20,7 +20,7 @@ from .bootstrap_utils import PATCH_LOG_PATH, LOGS_DIR
 from . import health_checks
 from tools import opencode_client
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -115,7 +115,11 @@ def handover(
 
     ctx: Dict[str, Any] = {"component": component, "error": error}
     if context:
-        ctx.update(context)
+        history = context.get("history")
+        if history:
+            existing = ctx.setdefault("history", [])
+            existing.extend(history)
+        ctx.update({k: v for k, v in context.items() if k != "history"})
     suggestion: Any | None = None
     if use_opencode is None:
         active = _active_agent(Path(config_path) if config_path else AGENT_CONFIG_PATH)

--- a/tests/test_boot_orchestrator.py
+++ b/tests/test_boot_orchestrator.py
@@ -46,7 +46,13 @@ def test_rstar_escalation_after_threshold(tmp_path, monkeypatch, env_value, thre
     attempts: list[str] = []
     suggestion: dict[str, str] = {}
 
-    def fake_handover(component: str, error: str, use_opencode: bool = False):
+    def fake_handover(
+        component: str,
+        error: str,
+        *,
+        context: dict | None = None,
+        use_opencode: bool = False,
+    ):
         current = json.loads(cfg_path.read_text())["active"]
         attempts.append(current)
         if current == "rstar":
@@ -100,7 +106,13 @@ def test_agent_escalation_sequence(tmp_path, monkeypatch):
 
     sequence: list[str] = []
 
-    def fake_handover(component: str, error: str, use_opencode: bool = False):
+    def fake_handover(
+        component: str,
+        error: str,
+        *,
+        context: dict | None = None,
+        use_opencode: bool = False,
+    ):
         current = json.loads(cfg_path.read_text())["active"]
         sequence.append(current)
         return current == "rstar"
@@ -129,3 +141,50 @@ def test_agent_escalation_sequence(tmp_path, monkeypatch):
     log = json.loads(inv_log.read_text())
     escalations = [e.get("agent") for e in log if e.get("event") == "escalation"]
     assert escalations == ["kimi2", "airstar", "rstar"]
+
+
+def test_context_includes_history(tmp_path, monkeypatch):
+    """Final agent receives history of previous failed attempts."""
+    monkeypatch.setenv("RAZAR_RSTAR_THRESHOLD", "1")
+    importlib.reload(bo)
+
+    inv_log = tmp_path / "invocations.json"
+    cfg_path = tmp_path / "agents.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "active": "demo_agent",
+                "agents": [{"name": "demo_agent"}, {"name": "rstar"}],
+            }
+        )
+    )
+    monkeypatch.setattr(bo, "INVOCATION_LOG_PATH", inv_log)
+    monkeypatch.setattr(bo, "AGENT_CONFIG_PATH", cfg_path)
+
+    contexts: list[dict | None] = []
+
+    def fake_handover(
+        component: str,
+        error: str,
+        *,
+        context: dict | None = None,
+        use_opencode: bool = False,
+    ) -> bool:
+        contexts.append(context)
+        current = json.loads(cfg_path.read_text())["active"]
+        return current == "rstar"
+
+    monkeypatch.setattr(bo.ai_invoker, "handover", fake_handover)
+    monkeypatch.setattr(bo.health_checks, "run", lambda name: True)
+    monkeypatch.setattr(bo, "launch_component", lambda comp: DummyProc())
+
+    component = {"name": "demo", "command": ["echo", "hi"]}
+    failure_tracker: dict[str, int] = {}
+    proc, used_attempts, err = bo._retry_with_ai(
+        "demo", component, "boom", 4, failure_tracker
+    )
+
+    assert proc is not None and used_attempts == 4
+    assert len(contexts) == 4
+    # Final context includes history from earlier failed attempts
+    assert any(h["agent"] == "airstar" for h in contexts[3]["history"])


### PR DESCRIPTION
## Summary
- build failure-context payload from `razar_ai_invocations.json`
- forward history to downstream agents during AI handover
- document cross-agent memory flow and add regression test

## Testing
- `pre-commit run --files razar/boot_orchestrator.py razar/ai_invoker.py tests/test_boot_orchestrator.py docs/system_blueprint.md CHANGELOG_razar.md` *(fails: missing metrics exporters)*
- `pre-commit run verify-onboarding-refs`
- `pytest tests/test_boot_orchestrator.py::test_context_includes_history -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c801974f00832ebdff6bdffaa56b78