### PR TITLE
Persist Crown identity using RAG + insight pipeline

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -2922,7 +2922,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "init_crown_agent.py",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": [
         "INANNA_AI",
         "__future__",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -251,6 +252,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [LLM_MODELS.md](LLM_MODELS.md) | LLM Models | This document describes the language models used in SPIRAL_OS and how to download them. | - |
 | [MAINTENANCE.md](MAINTENANCE.md) | Maintenance | - | - |
 | [MISSION.md](MISSION.md) | Mission | - | - |
+| [NEOABZU_spine.md](NEOABZU_spine.md) | NEOABZU Spine | **Version:** v0.1.0 **Last updated:** 2025-10-05 | - |
 | [Nazarick_GUIDE.md](Nazarick_GUIDE.md) | Nazarick Guide | - | - |
 | [OROBOROS_Engine.md](OROBOROS_Engine.md) | OROBOROS Engine | The inaugural ceremony executed the expression `(♀ :: ∞) :: ∅`. | - |
 | [Oroboros_Core.md](Oroboros_Core.md) | Oroboros Core Reference | The interpreter associates glyph tokens with elemental metadata that flows through evaluation. | - |

--- a/docs/NEOABZU_spine.md
+++ b/docs/NEOABZU_spine.md
@@ -1,0 +1,19 @@
+# NEOABZU Spine
+
+**Version:** v0.1.0  
+**Last updated:** 2025-10-05
+
+## RAG + Insight Pipeline
+After Crown's LLM boots, `identity_loader.load_identity` runs a retrieval and
+insight pass over mission, vision, and persona documents. Chunks are embedded
+into vector memory, summarized by the GLM, and the resulting identity is
+persisted at `data/identity.json` so subsequent invocations reuse the cached
+context.
+
+### Doctrine References
+- [system_blueprint.md#razar–crown–kimi-cho-migration](system_blueprint.md#razar–crown–kimi-cho-migration)
+- [persona_api_guide.md](persona_api_guide.md)
+- [project_mission_vision.md](project_mission_vision.md)
+
+## Version History
+- v0.1.0 (2025-10-05): Documented identity spine pipeline.

--- a/identity_loader.py
+++ b/identity_loader.py
@@ -1,0 +1,66 @@
+"""Load and persist system identity using RAG and insight passes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+from INANNA_AI.glm_integration import GLMIntegration
+from rag import parser, embedder
+import vector_memory
+from insight_compiler import update_insights
+
+__version__ = "0.1.0"
+
+IDENTITY_FILE = Path("data/identity.json")
+MISSION_DOC = Path("docs/project_mission_vision.md")
+PERSONA_DOC = Path("docs/persona_api_guide.md")
+
+
+def _load_chunks(paths: Iterable[Path]) -> List[Dict[str, str]]:
+    """Return parsed chunks for the given document ``paths``."""
+    chunks: List[Dict[str, str]] = []
+    for doc in paths:
+        for item in parser.load_inputs(doc.parent):
+            if item.get("source_path") == str(doc):
+                chunks.append(item)
+    return chunks
+
+
+def load_identity(integration: GLMIntegration) -> str:
+    """Digest mission, vision, and persona docs and persist identity.
+
+    Uses the RAG parser and embedder to index the documents into vector
+    memory, then asks the provided ``integration`` for a summary which is
+    stored at :data:`IDENTITY_FILE` for reuse.
+    """
+    if IDENTITY_FILE.exists():
+        return IDENTITY_FILE.read_text(encoding="utf-8")
+
+    docs = [MISSION_DOC, PERSONA_DOC]
+    chunks = _load_chunks(docs)
+    embedded = embedder.embed_chunks(chunks)
+    texts = [c.get("text", "") for c in embedded]
+    metas = [{"source_path": c.get("source_path", "")} for c in embedded]
+    if texts:
+        vector_memory.add_vectors(texts, metas)
+    combined = "\n".join(texts)
+    summary = integration.complete(
+        "Summarize the mission, vision, and persona: \n" + combined
+    )
+    update_insights(
+        [
+            {
+                "intent": "identity_load",
+                "tone": "neutral",
+                "success": True,
+                "result": {"identity": summary},
+            }
+        ]
+    )
+    IDENTITY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    IDENTITY_FILE.write_text(summary, encoding="utf-8")
+    return summary
+
+
+__all__ = ["load_identity", "IDENTITY_FILE", "MISSION_DOC", "PERSONA_DOC"]

--- a/init_crown_agent.py
+++ b/init_crown_agent.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import os
@@ -15,6 +15,7 @@ import servant_model_manager as smm
 from env_validation import parse_servant_models
 from INANNA_AI import corpus_memory
 from INANNA_AI.glm_integration import GLMIntegration
+from identity_loader import load_identity
 
 try:  # pragma: no cover - optional dependency
     import vector_memory as _vector_memory
@@ -214,6 +215,7 @@ def initialize_crown() -> GLMIntegration:
     try:
         _verify_servant_health(cfg.get("servant_models", {}))
         _check_glm(integration)
+        load_identity(integration)
     except RuntimeError as exc:
         logger.error("%s", exc)
         raise SystemExit(1)

--- a/tests/test_identity_loader.py
+++ b/tests/test_identity_loader.py
@@ -1,0 +1,87 @@
+# mypy: ignore-errors
+"""Tests for the identity loading pipeline."""
+
+from types import SimpleNamespace
+
+import identity_loader as il
+import init_crown_agent as ic
+
+
+class DummyGLM:
+    def __init__(self):
+        self.calls = 0
+
+    def complete(self, prompt: str, *, quantum_context: str | None = None) -> str:
+        self.calls += 1
+        return "identity summary"
+
+
+def test_identity_loader_persists(tmp_path, monkeypatch):
+    mission = tmp_path / "docs" / "project_mission_vision.md"
+    persona = tmp_path / "docs" / "persona_api_guide.md"
+    mission.parent.mkdir(parents=True)
+    mission.write_text("mission", encoding="utf-8")
+    persona.write_text("persona", encoding="utf-8")
+
+    monkeypatch.setattr(il, "MISSION_DOC", mission)
+    monkeypatch.setattr(il, "PERSONA_DOC", persona)
+    ident_file = tmp_path / "identity.json"
+    monkeypatch.setattr(il, "IDENTITY_FILE", ident_file)
+
+    def fake_load_inputs(directory):
+        path = mission if directory == mission.parent else persona
+        return [{"text": path.read_text(), "source_path": str(path)}]
+
+    monkeypatch.setattr(il.parser, "load_inputs", fake_load_inputs)
+
+    def fake_embed_chunks(chunks):
+        return [
+            {"text": c["text"], "source_path": c["source_path"], "embedding": [1.0]}
+            for c in chunks
+        ]
+
+    monkeypatch.setattr(il.embedder, "embed_chunks", fake_embed_chunks)
+
+    flags = {}
+
+    def fake_add_vectors(texts, metas):
+        flags["add_vectors"] = True
+
+    monkeypatch.setattr(il.vector_memory, "add_vectors", fake_add_vectors)
+
+    def fake_update(entries):
+        flags["update"] = entries
+
+    monkeypatch.setattr(il, "update_insights", fake_update)
+
+    glm = DummyGLM()
+    out1 = il.load_identity(glm)
+    assert out1 == "identity summary"
+    assert ident_file.read_text() == "identity summary"
+    assert glm.calls == 1
+    assert flags.get("add_vectors")
+    assert "update" in flags
+
+    out2 = il.load_identity(glm)
+    assert out2 == "identity summary"
+    assert glm.calls == 1
+
+
+def test_initialize_triggers_identity(monkeypatch):
+    dummy_glm = DummyGLM()
+
+    monkeypatch.setattr(ic, "GLMIntegration", lambda *a, **k: dummy_glm)
+    monkeypatch.setattr(ic, "_init_memory", lambda cfg: None)
+    monkeypatch.setattr(ic, "_init_servants", lambda cfg: None)
+    monkeypatch.setattr(ic, "_verify_servant_health", lambda servants: None)
+    monkeypatch.setattr(ic, "_check_glm", lambda integration: None)
+
+    called = SimpleNamespace(flag=False)
+
+    def fake_load(integration):
+        called.flag = True
+
+    monkeypatch.setattr(ic, "load_identity", fake_load)
+
+    ic.initialize_crown()
+    assert called.flag


### PR DESCRIPTION
## Summary
- load mission, vision, and persona docs via RAG and GLM to cache identity
- invoke identity loader after Crown LLM boots
- document NEOABZU identity spine and add tests

## Testing
- `pre-commit run --files identity_loader.py init_crown_agent.py docs/NEOABZU_spine.md tests/test_identity_loader.py docs/INDEX.md component_index.json` *(fails: confirm-reading, doc-indexer, verify-versions, check-env, pytest-cov, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date, verify-chakra-monitoring, verify-self-healing)*
- `pre-commit run verify-onboarding-refs`
- `python scripts/verify_docs_up_to_date.py` *(reports outdated entries)*
- `pytest --override-ini="addopts=" tests/test_identity_loader.py` *(skipped: requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c80bfa9b5c832ea3c59d53cfa0f496