### PR TITLE
feat(rag): orchestrate multi-source retrieval

### DIFF
--- a/NEOABZU/docs/feature_parity.md
+++ b/NEOABZU/docs/feature_parity.md
@@ -12,7 +12,7 @@ For the narrative driver and lexicon grounding the engine, see [herojourney_engi
 | Persona API | Normalizes user intents and forwards requests to the Crown Router【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L42-L43】 | migrated via `neoabzu_persona` |
 | Crown Router | Coordinates system-level actions and delegates to RAG Orchestrator【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L45-L46】 | fully ported in Rust with native orchestrator and validator bindings; RAZAR integration parity verified |
 | Kimicho Fallback | Provides fallback code generation when the Crown Router cannot reach K2 Coder | `kimicho` crate exposes `fallback_k2` via PyO3 `neoabzu_kimicho` bridge; legacy `kimicho.py` retired |
-| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator merges memory and connector results with plugin connectors and ranking strategies (parity achieved) |
+| RAG Orchestrator | Dispatches queries to memory bundle and external sources【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L52】 | Rust orchestrator aggregates memory and connector retrievals with plugin connectors and ranking strategies (parity achieved) |
 | Insight Engine | Performs higher-order reasoning and returns insights via Persona API【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L54-L58】 | `neoabzu-insight` now computes semantic embeddings with per-word similarity scores, exposing advanced reasoning hooks for the Crown Router |
 | Memory Bundle | Cortex, Emotional, Mental, Spiritual, and Narrative layers for unified storage【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L48-L49】【F:docs/ABZU_SUBSYSTEM_OVERVIEW.md†L72-L76】 | reuse |
 | System Coordination | Metrics, tracing, and caching align cross-subsystem orchestration | parity achieved |

--- a/NEOABZU/docs/migration_crosswalk.md
+++ b/NEOABZU/docs/migration_crosswalk.md
@@ -11,7 +11,7 @@ For module-specific quirks and bugs, see the [Python legacy audit](../../docs/py
 | `memory` layers (`memory/`, `vector_memory.py`) | `neoabzu-memory` | PyO3 module `neoabzu_memory` bundles cortex, vector, spiral, emotional, mental, spiritual, and narrative layers. |
 | `crown_router.py` | `neoabzu-crown` | Fully ported; Python module is a thin stub over the Rust crate with native `MoGEOrchestrator` bindings and optional `EthicalValidator` gating. RAZAR parity tests ensure legacy behavior. |
 | legacy `kimicho.py` fallback subsystem (invoked by `razar/boot_orchestrator.py`) | `kimicho` | PyO3 module `neoabzu_kimicho` exposes `init_kimicho` and `fallback_k2` for Crown routing failover. |
-| `rag/orchestrator.py` | `neoabzu-rag` | `MoGEOrchestrator` aggregates memory and connector results via PyO3. |
+| `rag/orchestrator.py` | `neoabzu-rag` | `MoGEOrchestrator` aggregates memory and connector results with optional ranking via PyO3. |
 | `core` lambda engine (`core/`) | `neoabzu-core` | Accessible through `neoabzu_memory.eval_core` and `neoabzu_memory.reduce_inevitable_core` for Crown Router and RAZAR. |
 | `system coordination` (`metrics`, `tracing`, `caching`) | `neoabzu-crown` | Shared instrumentation and caches mirror ABZU coordination. |
 | `insight_compiler.py` | `neoabzu-insight` | Insight engine counts word and bigram frequencies for Crown Router. |

--- a/NEOABZU/rag/src/orchestrator.rs
+++ b/NEOABZU/rag/src/orchestrator.rs
@@ -1,0 +1,60 @@
+use neoabzu_memory::MemoryBundle;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict, PyList};
+
+/// Core retrieval orchestrator.
+///
+/// Gathers documents from the [`MemoryBundle`] and optional connector plugins,
+/// tagging each item with its source and applying an optional ranking
+/// strategy. Mirrors the behaviour of the Python ``rag.orchestrator`` module.
+pub struct Orchestrator;
+
+impl Orchestrator {
+    pub fn retrieve(
+        py: Python<'_>,
+        question: &str,
+        connectors: Option<&PyList>,
+        ranker: Option<&PyAny>,
+        top_n: usize,
+    ) -> PyResult<Vec<Py<PyDict>>> {
+        let mut bundle = MemoryBundle::new();
+        bundle.initialize(py)?;
+        let q_dict = bundle.query(py, question)?;
+        let data = q_dict.as_ref(py);
+        let vector_any = data
+            .get_item("vector")?
+            .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyKeyError, _>("vector"))?;
+        let memory_list: &PyList = vector_any.downcast()?;
+
+        let mut connector_accum: Vec<Py<PyDict>> = Vec::new();
+        if let Some(conn_list) = connectors {
+            for conn in conn_list.iter() {
+                let callable: &PyAny = if conn.hasattr("retrieve")? {
+                    conn.getattr("retrieve")?
+                } else {
+                    conn
+                };
+                if !callable.is_callable() {
+                    continue;
+                }
+                let fetched = callable.call1((question,))?;
+                let items: &PyList = fetched.downcast()?;
+                for item in items.iter() {
+                    if let Ok(meta) = item.downcast::<PyDict>() {
+                        connector_accum.push(meta.into());
+                    }
+                }
+            }
+        }
+
+        let connector_list = PyList::new(py, connector_accum);
+        crate::merge_documents(
+            py,
+            question,
+            memory_list,
+            Some(connector_list),
+            top_n,
+            ranker,
+        )
+    }
+}

--- a/NEOABZU/rag/tests/multi_source_ranking.rs
+++ b/NEOABZU/rag/tests/multi_source_ranking.rs
@@ -1,0 +1,84 @@
+use neoabzu_rag::MoGEOrchestrator;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyModule};
+
+fn setup(py: Python<'_>) {
+    let sys = py.import("sys").unwrap();
+    let modules: &PyDict = sys.getattr("modules").unwrap().downcast().unwrap();
+    let agents = PyModule::new(py, "agents").unwrap();
+    modules.set_item("agents", agents).unwrap();
+    let event_code = r#"
+events = []
+def emit_event(actor, action, metadata):
+    events.append((actor, action, metadata))
+"#;
+    let event_bus = PyModule::from_code(py, event_code, "", "event_bus").unwrap();
+    modules.set_item("agents.event_bus", event_bus).unwrap();
+    let vector_code = r#"
+def query_vectors(*a, **k):
+    return [{'text':'mem'}]
+"#;
+    let vector_mod = PyModule::from_code(py, vector_code, "", "vector_memory").unwrap();
+    modules.set_item("vector_memory", vector_mod).unwrap();
+}
+
+#[test]
+fn ranks_across_multiple_sources() {
+    Python::with_gil(|py| {
+        setup(py);
+        let conn1_code = r#"
+def fetch(q):
+    return [{'text': 'alpha'}]
+"#;
+        let conn2_code = r#"
+def fetch(q):
+    return [{'text': 'beta'}]
+"#;
+        let mod1 = PyModule::from_code(py, conn1_code, "", "conn1").unwrap();
+        let mod2 = PyModule::from_code(py, conn2_code, "", "conn2").unwrap();
+        let connectors = PyList::new(py, [mod1.getattr("fetch").unwrap(), mod2.getattr("fetch").unwrap()]);
+        let orch = MoGEOrchestrator::new();
+        let emotion = PyDict::new(py);
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("connectors", connectors).unwrap();
+        let result = orch
+            .route(
+                py,
+                "alpha",
+                emotion,
+                None,
+                true,
+                false,
+                false,
+                None,
+                Some(kwargs),
+            )
+            .unwrap();
+        let docs_any = result.as_ref(py).get_item("documents").unwrap().unwrap();
+        let docs: &PyList = docs_any.downcast().unwrap();
+        assert_eq!(docs.len(), 3);
+        let texts: Vec<String> = docs
+            .iter()
+            .map(|d| {
+                d.downcast::<PyDict>()
+                    .unwrap()
+                    .get_item("text")
+                    .unwrap()
+                    .unwrap()
+                    .extract()
+                    .unwrap()
+            })
+            .collect();
+        assert!(texts.contains(&"mem".to_string()));
+        assert!(texts.contains(&"alpha".to_string()));
+        assert!(texts.contains(&"beta".to_string()));
+        let first: &PyDict = docs[0].downcast().unwrap();
+        let first_text: String = first
+            .get_item("text")
+            .unwrap()
+            .unwrap()
+            .extract()
+            .unwrap();
+        assert_eq!(first_text, "alpha");
+    });
+}

--- a/docs/feature_parity.md
+++ b/docs/feature_parity.md
@@ -9,5 +9,5 @@ Tracks Rust reimplementations of key Python subsystems.
 | Numeric Kernels | `neoabzu_numeric` | [system_blueprint.md#triadic-stack](system_blueprint.md#triadic-stack) | PCA and cosine similarity utilities via PyO3. |
 | Persona API | `neoabzu_persona` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Tracks persona state and loads profile data. |
 | Crown Router | `neoabzu_crown` | [system_blueprint.md#operator-razar-crown-flow](system_blueprint.md#operator-razar-crown-flow) | Direct PyO3 interface with validation, `MoGEOrchestrator` calls, and telemetry parity. |
-| RAG Orchestrator | `neoabzu_rag` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Merges memory records and external connector results via `MemoryBundle`. |
+| RAG Orchestrator | `neoabzu_rag` | [The_Absolute_Protocol.md#doctrine-reference-requirements](The_Absolute_Protocol.md#doctrine-reference-requirements) | Aggregates memory and connector retrievals with pluggable ranking strategies via `MemoryBundle`. |
 | Insight Engine | `neoabzu_insight` | [ABZU_SUBSYSTEM_OVERVIEW.md#crown-router--insight-engine](ABZU_SUBSYSTEM_OVERVIEW.md#crown-router--insight-engine) | Semantic embeddings and similarity analysis exposed to Crown via PyO3. |

--- a/docs/migration_crosswalk.md
+++ b/docs/migration_crosswalk.md
@@ -43,8 +43,8 @@ For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md).
 - [x] Doctrine references: [System Blueprint](system_blueprint.md)
 
 ### RAG retrieval
-- [ ] Port complete
-- [ ] Required tests: `NEOABZU/rag/tests/orchestrator.rs`
+- [x] Port complete
+- [x] Required tests: `NEOABZU/rag/tests/orchestrator.rs`, `NEOABZU/rag/tests/multi_source_ranking.rs`
 - [x] Documentation references: [Spiral RAG Pipeline](rag_pipeline.md#migration-crosswalk)
 - [x] Doctrine references: [The Absolute Protocol](The_Absolute_Protocol.md#migration-crosswalk-references)
 

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -729,7 +729,7 @@ Performance-critical services are gradually migrating to Rust crates within NEOA
 
 The `neoabzu_fusion` crate merges invariants from symbolic and numeric layers to maintain triadic stack coherence. See the [Migration Crosswalk](migration_crosswalk.md#fusion-invariants) for migration details and legacy Python references.
 
-The RAG orchestrator is feature-complete, merging memory bundle and external connector results through a dedicated merge routine. The workspace mirrors existing Python APIs via PyO3 wrappers to permit side-by-side validation during the transition.
+The RAG orchestrator is feature-complete, merging memory bundle and external connector results through a dedicated merge and ranking routine. The workspace mirrors existing Python APIs via PyO3 wrappers to permit side-by-side validation during the transition.
 See the [Migration Crosswalk](migration_crosswalk.md) for mappings between Python subsystems and their Rust counterparts.
 
 ## Chakra-Aligned Architecture


### PR DESCRIPTION
## Summary
- implement Orchestrator to aggregate memory and connector results with ranking
- expose orchestrator via PyO3 and add multi-source ranking test
- document RAG orchestrator in feature parity, migration crosswalk, and system blueprint

## Testing
- `cargo fmt --package neoabzu-rag -- --check`
- `cargo clippy --manifest-path NEOABZU/rag/Cargo.toml`
- `cargo test --manifest-path NEOABZU/rag/Cargo.toml`
- `python scripts/verify_docs_up_to_date.py`
- `pre-commit run --files NEOABZU/rag/src/lib.rs NEOABZU/rag/src/orchestrator.rs NEOABZU/rag/tests/multi_source_ranking.rs docs/feature_parity.md docs/migration_crosswalk.md docs/system_blueprint.md NEOABZU/docs/feature_parity.md NEOABZU/docs/migration_crosswalk.md` *(fails: rust-fmt-clippy, verify-versions, check-env, verify-crate-refs, verify-blueprint-refs, verify-docs-up-to-date, verify-chakra-monitoring, verify-self-healing, pytest-cov)*

------
https://chatgpt.com/codex/tasks/task_e_68c819cdfe00832e95a61184e7f2d937