### PR TITLE
Normalize agent names for RAZAR handover

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -222,7 +222,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/ai_invoker.py",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": [
         "__future__",
         "agents",
@@ -831,7 +831,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/boot_orchestrator.py",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": [
         "__future__",
         "agents",

--- a/razar/ai_invoker.py
+++ b/razar/ai_invoker.py
@@ -37,7 +37,7 @@ def _active_agent(path: Path = AGENT_CONFIG_PATH) -> str | None:
         if isinstance(data, dict):
             active = data.get("active")
             if isinstance(active, str):
-                return active
+                return active.lower()
     except Exception:
         return None
     return None


### PR DESCRIPTION
## Summary
- normalize agent identifiers from `razar_ai_agents.json` so comparisons and history logging are case-insensitive
- ensure `razar.ai_invoker._active_agent` and component index entries match the lowercase handling
- add a regression test covering mixed-case agent configurations during escalation

## Testing
- `python -m pre_commit run --files razar/boot_orchestrator.py razar/ai_invoker.py tests/test_boot_orchestrator.py`
- `pytest tests/test_boot_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c84a80731c832e930698206e6c1b36