### PR TITLE
Normalize agent casing and audit logging

### DIFF
--- a/razar/ai_invoker.py
+++ b/razar/ai_invoker.py
@@ -110,6 +110,8 @@ def _active_agent(path: Path = AGENT_CONFIG_PATH) -> str | None:
     """Return the normalized name of the active remote agent."""
 
     active, _definitions = load_agent_definitions(path)
+    if isinstance(active, str):
+        return active.lower()
     return active
 
 

--- a/tests/razar/test_ai_invoker.py
+++ b/tests/razar/test_ai_invoker.py
@@ -98,3 +98,27 @@ def test_handover_rolls_back_on_failed_check(monkeypatch, tmp_path: Path) -> Non
     assert module_path.read_text(encoding="utf-8") == "original"
     snaps = list(backups.iterdir())
     assert len(snaps) == 1
+
+
+def test_active_agent_normalization(tmp_path: Path) -> None:
+    """Active agent helper normalizes mixed-case configuration values."""
+
+    cfg = tmp_path / "agents.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "active": "KiMi2",
+                "agents": [
+                    {"name": "KiMi2"},
+                    {"name": "AirStar"},
+                    {"name": "RStar"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    active, definitions = ai_invoker.load_agent_definitions(cfg)
+    assert active == "kimi2"
+    assert [d.normalized for d in definitions] == ["kimi2", "airstar", "rstar"]
+    assert ai_invoker._active_agent(cfg) == "kimi2"

--- a/tests/test_boot_orchestrator.py
+++ b/tests/test_boot_orchestrator.py
@@ -244,6 +244,16 @@ def test_mixed_case_agent_config(tmp_path, monkeypatch):
     log = json.loads(inv_log.read_text())
     attempt_agents = [e.get("agent") for e in log if e.get("event") == "attempt"]
     assert attempt_agents == ["kimi2", "airstar", "rstar"]
+    attempt_originals = [
+        e.get("agent_original") for e in log if e.get("event") == "attempt"
+    ]
+    assert attempt_originals == ["KiMi2", "AirStar", "RStar"]
+    escalations = [
+        (e.get("agent"), e.get("agent_original"))
+        for e in log
+        if e.get("event") == "escalation"
+    ]
+    assert escalations == [("airstar", "AirStar"), ("rstar", "RStar")]
 
 
 def test_custom_agent_failover_chain(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- normalize agent casing in the AI invoker helper and boot orchestrator state loader
- persist normalized agent names while logging original casing for audit events
- expand mixed-case escalation tests and add coverage for `_active_agent`

## Testing
- SKIP=pytest-cov,verify-crate-refs,verify-docs-up-to-date pre-commit run --files razar/ai_invoker.py razar/boot_orchestrator.py tests/razar/test_ai_invoker.py tests/test_boot_orchestrator.py
- pytest --override-ini="addopts=--log-cli-level=INFO" tests/test_boot_orchestrator.py tests/razar/test_ai_invoker.py

------
https://chatgpt.com/codex/tasks/task_e_68c8797d55f0832e9f62c92282c90c4d