### PR TITLE
Add shared invocation logging and metrics instrumentation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/razar/metrics.py
+++ b/razar/metrics.py
@@ -1,0 +1,108 @@
+"""Lightweight Prometheus metrics for RAZAR AI handovers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from threading import Lock
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter, start_http_server
+except Exception:  # pragma: no cover - optional dependency
+    Counter = None  # type: ignore[assignment]
+    start_http_server = None  # type: ignore[assignment]
+
+LOGGER = logging.getLogger(__name__)
+
+_SUCCESS_COUNTER: Any = None
+_FAILURE_COUNTER: Any = None
+_RETRY_COUNTER: Any = None
+_LOCK = Lock()
+_INITIALIZED = False
+_SERVER_STARTED = False
+
+__all__ = ["init_metrics", "record_invocation"]
+
+
+def _resolve_port(port: int | None) -> int:
+    """Return the metrics port honoring the ``RAZAR_METRICS_PORT`` override."""
+
+    if port is not None:
+        return port
+
+    env_value = os.getenv("RAZAR_METRICS_PORT")
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            LOGGER.warning(
+                "Invalid RAZAR_METRICS_PORT=%s; defaulting to 9360", env_value
+            )
+    return 9360
+
+
+def init_metrics(port: int | None = None) -> bool:
+    """Initialise counters and expose them via an HTTP endpoint."""
+
+    global _INITIALIZED, _SERVER_STARTED
+    global _SUCCESS_COUNTER, _FAILURE_COUNTER, _RETRY_COUNTER
+    if Counter is None or start_http_server is None:
+        LOGGER.debug("prometheus_client not available; metrics disabled")
+        return False
+
+    with _LOCK:
+        if _INITIALIZED:
+            return _SERVER_STARTED
+
+        _SUCCESS_COUNTER = Counter(
+            "razar_ai_invocation_success_total",
+            "Count of AI handover attempts that produced a patch",
+            ["component"],
+        )
+        _FAILURE_COUNTER = Counter(
+            "razar_ai_invocation_failure_total",
+            "Count of AI handover attempts that produced no patch",
+            ["component"],
+        )
+        _RETRY_COUNTER = Counter(
+            "razar_ai_invocation_retries_total",
+            "Total retries performed across AI handover attempts",
+            ["component"],
+        )
+
+        port_value = _resolve_port(port)
+        started = False
+        try:
+            start_http_server(port_value)
+        except OSError as exc:  # pragma: no cover - platform dependent
+            LOGGER.warning(
+                "Could not start metrics server on port %s: %s", port_value, exc
+            )
+        else:
+            started = True
+            LOGGER.info("RAZAR metrics exposed on port %s", port_value)
+
+        _INITIALIZED = True
+        _SERVER_STARTED = started
+        return started
+
+
+def record_invocation(component: str, success: bool, *, retries: int = 0) -> None:
+    """Increment counters for a single handover attempt."""
+
+    success_counter = _SUCCESS_COUNTER
+    failure_counter = _FAILURE_COUNTER
+    retry_counter = _RETRY_COUNTER
+    if success_counter is None or failure_counter is None or retry_counter is None:
+        return
+
+    label = (component or "unknown").lower()
+    labels = {"component": label}
+    if success:
+        success_counter.labels(**labels).inc()
+    else:
+        failure_counter.labels(**labels).inc()
+
+    if retries > 0:
+        retry_counter.labels(**labels).inc(retries)

--- a/razar/utils/__init__.py
+++ b/razar/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Utility helpers shared across RAZAR modules."""
+
+from __future__ import annotations
+
+from .logging import append_invocation_event, load_invocation_history, log_invocation
+
+__all__ = [
+    "append_invocation_event",
+    "load_invocation_history",
+    "log_invocation",
+]

--- a/razar/utils/logging.py
+++ b/razar/utils/logging.py
@@ -1,0 +1,268 @@
+"""Shared JSON-line logger for RAZAR AI invocation events."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Mapping
+
+from .. import metrics
+from ..bootstrap_utils import LOGS_DIR
+
+LOGGER = logging.getLogger(__name__)
+
+INVOCATION_LOG_PATH = LOGS_DIR / "razar_ai_invocations.json"
+
+_LOCK = RLock()
+_LEGACY_CONVERTED = False
+_AGENT_LOG_PATCHED = False
+_AGENT_LOG_FALLBACK: Callable[[Any, Mapping[str, Any]], None] | None = None
+
+__all__ = [
+    "INVOCATION_LOG_PATH",
+    "append_invocation_event",
+    "load_invocation_history",
+    "log_invocation",
+]
+
+
+def _isoformat(timestamp: float) -> str:
+    """Return an ISO-8601 string (UTC) for ``timestamp`` seconds."""
+
+    return (
+        datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_timestamp_string(value: str, fallback: float) -> float:
+    """Return a numeric timestamp parsed from ``value`` or ``fallback``."""
+
+    try:
+        return float(value)
+    except ValueError:
+        cleaned = value.strip()
+        if cleaned.endswith("Z"):
+            cleaned = cleaned[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(cleaned)
+        except ValueError:
+            return fallback
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.timestamp()
+
+
+def _stamp_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+    """Return ``entry`` with normalized timestamps and default status."""
+
+    record = dict(entry)
+    now = time.time()
+    timestamp = record.get("timestamp")
+    if isinstance(timestamp, (int, float)):
+        ts_value = float(timestamp)
+    elif isinstance(timestamp, str):
+        ts_value = _parse_timestamp_string(timestamp, now)
+        record["timestamp"] = ts_value
+    else:
+        ts_value = now
+        record["timestamp"] = ts_value
+
+    record.setdefault("timestamp_iso", _isoformat(ts_value))
+
+    if "patched" in record and "status" not in record:
+        patched_value = record.get("patched")
+        if isinstance(patched_value, bool):
+            record["status"] = "success" if patched_value else "failure"
+
+    return record
+
+
+def _ensure_legacy_conversion() -> None:
+    """Convert legacy list-based logs to JSON lines."""
+
+    global _LEGACY_CONVERTED
+    if _LEGACY_CONVERTED:
+        return
+
+    if not INVOCATION_LOG_PATH.exists():
+        _LEGACY_CONVERTED = True
+        return
+
+    try:
+        raw = INVOCATION_LOG_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        LOGGER.debug("Could not read %s: %s", INVOCATION_LOG_PATH, exc)
+        _LEGACY_CONVERTED = True
+        return
+
+    stripped = raw.lstrip()
+    if not stripped:
+        _LEGACY_CONVERTED = True
+        return
+
+    if stripped.startswith("["):
+        try:
+            records = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            LOGGER.warning(
+                "Failed to parse legacy invocation log %s: %s",
+                INVOCATION_LOG_PATH,
+                exc,
+            )
+            _LEGACY_CONVERTED = True
+            return
+
+        INVOCATION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with INVOCATION_LOG_PATH.open("w", encoding="utf-8") as handle:
+            for record in records:
+                if isinstance(record, dict):
+                    normalized = _stamp_entry(record)
+                    handle.write(json.dumps(normalized, sort_keys=True))
+                    handle.write("\n")
+        LOGGER.info("Converted legacy invocation log at %s", INVOCATION_LOG_PATH)
+
+    _LEGACY_CONVERTED = True
+
+
+def append_invocation_event(entry: Mapping[str, Any]) -> dict[str, Any]:
+    """Append ``entry`` to the invocation log and return the stored record."""
+
+    record = _stamp_entry(entry)
+    with _LOCK:
+        _ensure_legacy_conversion()
+        INVOCATION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with INVOCATION_LOG_PATH.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+    return record
+
+
+def _patch_agent_append_log() -> None:
+    """Redirect `agents.razar.ai_invoker._append_log` to JSON-line output."""
+
+    global _AGENT_LOG_PATCHED, _AGENT_LOG_FALLBACK
+    if _AGENT_LOG_PATCHED:
+        return
+    try:
+        from agents.razar import ai_invoker as agent_ai_invoker
+    except Exception:  # pragma: no cover - optional dependency
+        return
+
+    original = getattr(agent_ai_invoker, "_append_log", None)
+    if not callable(original):
+        return
+    if getattr(original, "__module__", "") == __name__:
+        _AGENT_LOG_PATCHED = True
+        return
+
+    _AGENT_LOG_FALLBACK = original
+
+    def _append_log_proxy(path: Any, entry: Mapping[str, Any]) -> None:
+        try:
+            target = Path(path)
+        except TypeError:
+            target = Path(str(path))
+        if target == INVOCATION_LOG_PATH:
+            append_invocation_event(entry)
+            return
+        fallback = _AGENT_LOG_FALLBACK
+        if fallback is not None:
+            fallback(path, entry)
+
+    agent_ai_invoker._append_log = _append_log_proxy  # type: ignore[attr-defined]
+    _AGENT_LOG_PATCHED = True
+
+
+def log_invocation(
+    component: str,
+    attempt: int,
+    error: str,
+    patched: bool,
+    *,
+    event: str | None = "attempt",
+    agent: str | None = None,
+    agent_original: str | None = None,
+    retries: int | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Record an AI handover attempt and update metrics."""
+
+    entry: dict[str, Any] = {
+        "component": component,
+        "attempt": int(attempt),
+        "error": error,
+        "patched": bool(patched),
+    }
+    if event is not None:
+        entry["event"] = event
+    if agent is not None:
+        entry["agent"] = agent
+    if agent_original is not None:
+        entry["agent_original"] = agent_original
+    if retries is not None:
+        entry["retries"] = retries
+    if extra:
+        entry.update(extra)
+
+    record = append_invocation_event(entry)
+
+    retry_count = retries if retries is not None else max(int(attempt) - 1, 0)
+    metrics.record_invocation(
+        component or "unknown", record["patched"], retries=retry_count
+    )
+
+    return record
+
+
+def load_invocation_history(
+    component: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return invocation records filtered by ``component``."""
+
+    with _LOCK:
+        _ensure_legacy_conversion()
+        if not INVOCATION_LOG_PATH.exists():
+            return []
+        try:
+            lines = INVOCATION_LOG_PATH.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            LOGGER.debug("Could not read %s: %s", INVOCATION_LOG_PATH, exc)
+            return []
+
+    entries: list[dict[str, Any]] = []
+    target = component.lower() if isinstance(component, str) else None
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        record = _stamp_entry(data)
+        if target is not None:
+            current = str(record.get("component", "")).lower()
+            if current != target:
+                continue
+        elif "component" not in record:
+            continue
+        entries.append(record)
+
+    entries.sort(key=lambda item: item.get("timestamp", 0.0))
+    if limit is not None and limit > 0:
+        entries = entries[-limit:]
+    return entries
+
+
+_patch_agent_append_log()

--- a/scripts/recovery_daemon.py
+++ b/scripts/recovery_daemon.py
@@ -6,35 +6,12 @@ import time
 from typing import Any, Dict, List
 
 from razar import ai_invoker, recovery_manager, health_checks
-from razar.bootstrap_utils import LOGS_DIR, STATE_FILE
+from razar.bootstrap_utils import STATE_FILE
+from razar.utils.logging import log_invocation
 
 __version__ = "0.2.0"
 
 LOGGER = logging.getLogger(__name__)
-
-INVOCATION_LOG_PATH = LOGS_DIR / "razar_ai_invocations.json"
-
-
-def _log_ai_invocation(component: str, attempt: int, error: str, patched: bool) -> None:
-    """Append AI handover attempt details to :data:`INVOCATION_LOG_PATH`."""
-    entry = {
-        "component": component,
-        "attempt": attempt,
-        "error": error,
-        "patched": patched,
-        "timestamp": time.time(),
-    }
-    records: List[Dict[str, Any]] = []
-    if INVOCATION_LOG_PATH.exists():
-        try:
-            records = json.loads(INVOCATION_LOG_PATH.read_text())
-            if not isinstance(records, list):
-                records = []
-        except json.JSONDecodeError:
-            records = []
-    records.append(entry)
-    INVOCATION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    INVOCATION_LOG_PATH.write_text(json.dumps(records, indent=2))
 
 
 def _load_events() -> List[Dict[str, Any]]:
@@ -56,7 +33,7 @@ def _handle_event(event: Dict[str, Any], *, max_attempts: int = 3) -> None:
     recovery_manager.request_shutdown(component)
     for attempt in range(1, max_attempts + 1):
         patched = ai_invoker.handover(component, error)
-        _log_ai_invocation(component, attempt, error, patched)
+        log_invocation(component, attempt, error, patched)
         if not patched:
             continue
         recovery_manager.resume(component)

--- a/tests/razar/test_long_task.py
+++ b/tests/razar/test_long_task.py
@@ -45,13 +45,14 @@ def test_long_task_retries_until_success(
     # Redirect file paths used by boot orchestrator
     monkeypatch.setattr(bo, "STATE_FILE", tmp_path / "state.json")
     monkeypatch.setattr(bo, "HISTORY_FILE", tmp_path / "history.json")
-    monkeypatch.setattr(bo, "INVOCATION_LOG_PATH", tmp_path / "invocations.json")
     monkeypatch.setattr(bo, "LONG_TASK_LOG_PATH", tmp_path / "long_task.json")
     monkeypatch.setattr(bo, "LOGS_DIR", tmp_path)
     monkeypatch.setattr(bo, "_perform_handshake", lambda comps: None)
     monkeypatch.setattr(bo, "launch_required_agents", lambda: None)
     monkeypatch.setattr(bo.doc_sync, "sync_docs", lambda: None)
-    monkeypatch.setattr(bo, "_log_ai_invocation", lambda *a, **k: None)
+    monkeypatch.setattr(bo, "log_invocation", lambda *a, **k: None)
+    monkeypatch.setattr(bo, "append_invocation_event", lambda *a, **k: None)
+    monkeypatch.setattr(bo.metrics, "init_metrics", lambda *a, **k: None)
     monkeypatch.setattr(bo.time, "sleep", lambda *a, **k: None)
 
     config = {

--- a/tests/razar/test_retry_with_ai.py
+++ b/tests/razar/test_retry_with_ai.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from pytest import MonkeyPatch
 
 import razar.boot_orchestrator as bo
+import razar.utils.logging as razar_logging
 
 
 class DummyProc(SimpleNamespace):
@@ -21,13 +22,18 @@ class DummyProc(SimpleNamespace):
         pass
 
 
+def configure_invocation_log(monkeypatch: MonkeyPatch, path: Path) -> None:
+    monkeypatch.setattr(razar_logging, "INVOCATION_LOG_PATH", path)
+    monkeypatch.setattr(razar_logging, "_LEGACY_CONVERTED", False)
+
+
 def test_retry_with_ai_applies_patch_and_relaunches(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Component restarts after Opencode patch and logs are updated."""
     patch_log = tmp_path / "patch_log.json"
     inv_log = tmp_path / "invocations.json"
-    monkeypatch.setattr(bo, "INVOCATION_LOG_PATH", inv_log)
+    configure_invocation_log(monkeypatch, inv_log)
     monkeypatch.setattr(bo.ai_invoker, "PATCH_LOG_PATH", patch_log)
 
     calls: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- introduce `razar.utils.logging` to persist AI handover events as JSON lines, load history, and shim the legacy agent logger
- expose Prometheus counters via `razar/metrics.py` and wire boot orchestrator/recovery daemon to the shared logger and metrics
- document the invocation log format and metrics endpoint in `docs/RAZAR_AGENT.md` while refreshing the docs index

## Testing
- `pre-commit run --files docs/RAZAR_AGENT.md razar/boot_orchestrator.py scripts/recovery_daemon.py tests/agents/razar/test_ai_invoker.py tests/razar/test_long_task.py tests/razar/test_remote_repair.py tests/razar/test_retry_with_ai.py tests/test_boot_orchestrator.py razar/metrics.py razar/utils/__init__.py razar/utils/logging.py docs/INDEX.md` *(fails: pytest-cov is configured with unsupported coverage flags, verify_docs_up_to_date sees stale upstream content, and monitoring/self-healing checks require live exporters)*

------
https://chatgpt.com/codex/tasks/task_e_68c948cc531c832e9b9220abf4d786ad