### PR TITLE
Add sandboxed delegation for remote RAZAR agents

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -263,6 +263,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [RAZAR_GUIDE.md](RAZAR_GUIDE.md) | RAZAR Guide | - | - |
 | [README.md](README.md) | Documentation Index | The `docs` directory contains reference material for Spiral OS. | - |
 | [REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) | Repository Structure | The following table outlines the top-level layout of this repository. | - |
+| [SECURITY.md](SECURITY.md) | Security Overview | - | - |
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Overview
+
+## Remote Agent Credentials
+
+The RAZAR remediation pipeline can delegate failure analysis to several hosted
+agents. Each agent requires an API key that must be injected via environment
+variables at runtime. The loader in `razar/ai_invoker.py` automatically maps
+agent names to their corresponding secrets.
+
+| Agent name | Accepted secret variables | Notes |
+| ---------- | ------------------------- | ----- |
+| `kimi2`    | `KIMI2_API_KEY`, `KIMI2_TOKEN` | Standard MoonshotAI Kimi‑K2 deployment. |
+| `AiRstar` / `rStar` | `RSTAR_API_KEY`, `RSTAR_TOKEN`, `AIRSTAR_API_KEY`, `AIRSTAR_TOKEN` | `AiRstar` and `rStar` are aliases for the same Microsoft-hosted service. Either prefix is accepted. |
+
+Only one variable in each column is required; if multiple variables are set
+for the same agent the first populated value in the list is used. Secrets are
+never persisted to disk and are only forwarded to the active agent during the
+sandboxed invocation window.
+
+## Sandboxed Delegation
+
+All remote handovers now execute inside a constrained worker process. The
+sandbox enforces:
+
+- A CPU wall-clock timeout of 90 seconds for the external invocation.
+- Memory limits of approximately 512 MB to prevent runaway allocations.
+
+If the sandbox terminates the agent early—due to the timeout or resource
+limits—the failure is logged and the orchestrator falls back without applying
+untrusted patches.


### PR DESCRIPTION
## Summary
- add environment variable overrides for agent credentials so rStar/AiRstar and Kimi load secrets from dedicated keys
- sandbox remote agent delegation in a separate process with time and memory limits to prevent runaway execution
- document the required secrets and agent aliasing in docs/SECURITY.md and expose the page in the docs index

## Testing
- pre-commit run --files razar/ai_invoker.py docs/SECURITY.md *(fails: missing `websockets`, pytest args unsupported, monitoring endpoints unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c962405580832e9010c5fe8a7f676f