### PR TITLE
Add health probes and monitoring alerts to boot orchestrator

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -836,7 +836,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/boot_orchestrator.py",
-      "version": "0.2.11",
+      "version": "0.3.0",
       "dependencies": [
         "__future__",
         "agents",


### PR DESCRIPTION
## Summary
- add environment-configurable health probe scheduling, alert destinations, and state file locking to the boot orchestrator
- implement monitoring helpers for webhook/email notifications, configuration rollback, and a periodic probe loop that surfaces repeated escalations
- update AI escalation handling and the boot sequence to register processes, trigger periodic probes, emit monitoring alerts, and restore safe defaults on failure
- bump the component index entry for the boot orchestrator to v0.3.0

## Testing
- python -m compileall ABZU/razar/boot_orchestrator.py
- ruff check razar/boot_orchestrator.py
- pre-commit run --files razar/boot_orchestrator.py component_index.json *(fails: coverage threshold and repository documentation index are already stale)*

------
https://chatgpt.com/codex/tasks/task_e_68c9674e3814832e840d9f2aaa575cff