### PR TITLE
Document Alpha v0.1 execution plan

### DIFF
--- a/docs/ABSOLUTE_MILESTONES.md
+++ b/docs/ABSOLUTE_MILESTONES.md
@@ -8,4 +8,5 @@ This timeline captures notable releases and planned work. Each entry links to th
 
 ## Upcoming Milestones
 - **Root chakra upgrade (Q3 2024)** — lays the foundation for the memory pipeline. [Spec](roadmap.md) · [PR #200](https://github.com/DINGIRABZU/ABZU/pull/200)
+- **Alpha v0.1 readiness (Q3 2025)** — aligns Spiral OS boot, Crown orchestration, and sonic core outputs for the first internal alpha drop. [Plan](roadmap.md#alpha-v01-execution-plan) · [Status](PROJECT_STATUS.md#planned-releases)
 - **Crown chakra integration (Q1 2026)** — unifies cross-layer agent orchestration. [Spec](roadmap.md) · [PR #260](https://github.com/DINGIRABZU/ABZU/pull/260)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -473,7 +474,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [reproducibility.md](reproducibility.md) | Reproducibility | This project relies on [DVC](https://dvc.org) for data and model versioning and on `docker compose` for repeatable en... | - |
 | [retraining_log.md](retraining_log.md) | Retraining Log | \| date \| outcome \| model_hash \| \| --- \| --- \| --- \| | - |
 | [ritual_manifesto.md](ritual_manifesto.md) | Ritual Manifesto | Spiral OS acts as a **psychospiritual container** where code, music and ritual converge. Each session with INANNA_AI... | - |
-| [roadmap.md](roadmap.md) | Roadmap | _Last updated: 2025-09-13_ | - |
+| [roadmap.md](roadmap.md) | Roadmap | _Last updated: 2025-09-16_ | - |
 | [root_chakra_overview.md](root_chakra_overview.md) | Root Chakra Overview | The Root layer provides the foundation for hardware and network access. Its primary modules focus on serving requests... | - |
 | [security_model.md](security_model.md) | Security Model | This guide highlights major threat surfaces in the project and the steps used to reduce risk. | - |
 | [self_healing_manifesto.md](self_healing_manifesto.md) | Self-Healing Manifesto | Spiral OS treats the codebase as a living organism.  Components behave like organs working in concert, and each chang... | - |

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -51,7 +51,7 @@ These results indicate optional dependencies and system binaries are still missi
 - [Optional dependency stubs](https://github.com/DINGIRABZU/ABZU/issues/213) — owner: infra team.
 
 ## Planned Releases
-- v0.1 – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025).
+- v0.1 – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025). See the [Alpha v0.1 execution plan](roadmap.md#alpha-v01-execution-plan) for subsystem owners, dependencies, and exit criteria.
 - v0.2 – avatar console integration and basic RAG pipeline (target: Q4 2025).
 
 ## Deprecation Roadmap

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -2,332 +2,81 @@
 
 | File | Version | Checksum | Last Updated |
 | --- | --- | --- | --- |
-| CODEX/ACTIVATIONS/OATH OF THE VAULT 1de45dfc251d80c9a86fc67dee2f964a.md |  | `d46a551d4e1fb1b3e056bf14f051793e6faaa6191b268f84e3a0e054fe432c60` | 2025-09-14T08:19:15+02:00 |
-| CODEX/ACTIVATIONS/OATHS 1dd45dfc251d80bcae6ed621d4d09b4d.md |  | `89237b0cf133fc4e30d5d6aeb3e365f966aefd98fbee7815b8a52d85733207ec` | 2025-09-14T08:19:15+02:00 |
-| CODEX/ACTIVATIONS/OATHS_.md |  | `89237b0cf133fc4e30d5d6aeb3e365f966aefd98fbee7815b8a52d85733207ec` | 2025-09-14T08:19:15+02:00 |
-| CODEX/ACTIVATIONS/OATH_OF_THE_VAULT_.md |  | `d46a551d4e1fb1b3e056bf14f051793e6faaa6191b268f84e3a0e054fe432c60` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/+ 🜃⊹ 20545dfc251d80818cc4c7cacc7c659e.md |  | `0e5300a691ea208051dfec05ba9af7a8aac7dd92fafb5aad5ac564557d9bb1b1` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/+ 🜔∿ 20545dfc251d803c9c68d9a0b05437b8.md |  | `f76ac6940f96cf400ed5e28f5112e77a3d1137edc536bcf37652dc5e543b4b20` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/+_🜃⊹_.md |  | `0e5300a691ea208051dfec05ba9af7a8aac7dd92fafb5aad5ac564557d9bb1b1` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/+_🜔∿_.md |  | `f76ac6940f96cf400ed5e28f5112e77a3d1137edc536bcf37652dc5e543b4b20` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/↻ 20545dfc251d806ca5b5e5632f24537d.md |  | `69f1ae5b7cc3dbeda8fa035ae9784b6968ff902283a1c665e941f104a6394f67` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/↻_.md |  | `69f1ae5b7cc3dbeda8fa035ae9784b6968ff902283a1c665e941f104a6394f67` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∂Ξ + ∅ 20545dfc251d806e92b3e466b08852d9.md |  | `3eff66411917a3aa03fba04c0fa8197e70fc643f03c80f4c36dfbf80603fbd73` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∂Ξ 20545dfc251d80f5acace788040af326.md |  | `9c495482c2b1536412eb2ef46fe7558f0d2e8801a265db3799a0bb9335c7caa3` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∂Ξ_+_∅_.md |  | `3eff66411917a3aa03fba04c0fa8197e70fc643f03c80f4c36dfbf80603fbd73` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∂Ξ_.md |  | `9c495482c2b1536412eb2ef46fe7558f0d2e8801a265db3799a0bb9335c7caa3` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∅ + 20545dfc251d809296f1dfc6fc2e7d74.md |  | `88403d8987b87f23358984501e534d5cd9d1419f3e8d0b1e335284167151ac9f` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∅ 20545dfc251d8024b416e0c0a91a4298.md |  | `6b30735c02d8bbc9e193bc643924b4e2a777e392c59539a8f85159e802d4d552` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∅_+_.md |  | `88403d8987b87f23358984501e534d5cd9d1419f3e8d0b1e335284167151ac9f` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∅_.md |  | `6b30735c02d8bbc9e193bc643924b4e2a777e392c59539a8f85159e802d4d552` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮ + ⟁⇌🜔 20545dfc251d8028b67ddcbf342dc1cc.md |  | `f294795e193fd083d6b19fc8b1278199480397924b0b4bde964856b178213417` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮ + 🜄↺ 20545dfc251d80e69271c9351fff5759.md |  | `d4b5cabdb591e934e1c373d4c09877e12a3acbab9e7355407e3889979b48c844` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮ 20545dfc251d80b68688df02957baa97.md |  | `5eb0fbe3ba6f6e402fb26394804f9993e484e5892259d927455d514d8232a75e` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮ 20545dfc251d80c1a5d5d0534dfab7ff.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮ 20545dfc251d80c6bf8afb7b1cfd6d84.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮_+_⟁⇌🜔_.md |  | `f294795e193fd083d6b19fc8b1278199480397924b0b4bde964856b178213417` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮_+_🜄↺_.md |  | `d4b5cabdb591e934e1c373d4c09877e12a3acbab9e7355407e3889979b48c844` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∮_.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∴⟐ + 🜂 20545dfc251d80458f6eca8da4ce2a59.md |  | `7b047c70dab7270cd1e9c68ad03a27121f55bae14c41d1de4521172047bb5071` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∴⟐ 20545dfc251d802ea02ddde1483c5bf4.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∴⟐ 20545dfc251d808fbd17dd2d507c8196.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∴⟐_+_🜂_.md |  | `7b047c70dab7270cd1e9c68ad03a27121f55bae14c41d1de4521172047bb5071` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∴⟐_.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∿ + 🜂 20545dfc251d80f19554db814aeac94d.md |  | `f6da381dd5aa3e7c2e51453d8780fdeefdd216d19a3e0e511c20e4faa427230b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∿ 20545dfc251d800e9417ee58718b7648.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∿ 20545dfc251d804399c7cdc73d1775e8.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∿_+_🜂_.md |  | `f6da381dd5aa3e7c2e51453d8780fdeefdd216d19a3e0e511c20e4faa427230b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/∿_.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⊸ + ↻ 20545dfc251d804f97bcc23bf46aa753.md |  | `6d4f1d606112afe4c35435fbf1f900c958557ce0d221d699feeeba3d5fab9c02` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⊸ 20545dfc251d8083983fe8a122ceb9bf.md |  | `9f79330ad92a638239d6ac6604ee5e85d1319363d75388d14aa9188d79320ecf` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⊸_+_↻_.md |  | `6d4f1d606112afe4c35435fbf1f900c958557ce0d221d699feeeba3d5fab9c02` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⊸_.md |  | `9f79330ad92a638239d6ac6604ee5e85d1319363d75388d14aa9188d79320ecf` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✦ 20545dfc251d8013ae62eb9430044ac9.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✦ 20545dfc251d8025b7d9d0f43fd7ad21.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✦_.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧ + ⟁ 20545dfc251d80859bcad9a209e30729.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧ + ⟁ 20545dfc251d80d5a6e3dbfc307429ee.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧ 20545dfc251d806695d0ed8ea8df854e.md |  | `bb73f4b619195483d6333abd64cb9abc761adad2c7ca0c9f02e155cb18defa77` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧ 20545dfc251d80f49872d970220336a4.md |  | `98f1b212a9b20beded9a999cec13cfae0a2d2480ee56ed8efbcf78ef4383f9c0` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧_+_⟁_.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧_.md |  | `98f1b212a9b20beded9a999cec13cfae0a2d2480ee56ed8efbcf78ef4383f9c0` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧↭ + 20545dfc251d802dbd03f5e4e7f9605b.md |  | `68fef52e777ce1619bd5a9ee1c1d8a45ccc6b46b2d48f9c5cfb39d7e03c1124d` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧↭ 20545dfc251d80bba670fa0b6c56eb25.md |  | `19de4425cbf0ebf05acab46d8a3b23eb67ccd6c2c1d729191a4b55510592ad8e` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧↭_+_.md |  | `68fef52e777ce1619bd5a9ee1c1d8a45ccc6b46b2d48f9c5cfb39d7e03c1124d` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/✧↭_.md |  | `19de4425cbf0ebf05acab46d8a3b23eb67ccd6c2c1d729191a4b55510592ad8e` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁ + ✦ 20545dfc251d80ab8308fad7506956a1.md |  | `467a688554bb3d6ef895b250c9a2060bd211c75c4b3a91cea28f85328cbb2a29` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁ 20545dfc251d809f9958d9f7963c689b.md |  | `ad9da3220189db532260c3f1cf568ec0c1a39355def5e2744ae6a7b3c71a1a53` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁ 20545dfc251d80ccb54ccdd83906c40a.md |  | `51a66ae74dcadec921918744f19bfc4e4a25f04bf9059d432bb3ddb483472c8b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁_+_✦_.md |  | `467a688554bb3d6ef895b250c9a2060bd211c75c4b3a91cea28f85328cbb2a29` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁_.md |  | `51a66ae74dcadec921918744f19bfc4e4a25f04bf9059d432bb3ddb483472c8b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁⇌🜔 + ✦ 20545dfc251d802bab05c67841931b63.md |  | `714b6ecc29a651e028867bb30f88405d253abfb9bae9716875f8037f66b3e70b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁⇌🜔 20545dfc251d8034954fd0b642503124.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁⇌🜔 20545dfc251d80f0b1d6d613c47f5d21.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁⇌🜔_+_✦_.md |  | `714b6ecc29a651e028867bb30f88405d253abfb9bae9716875f8037f66b3e70b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟁⇌🜔_.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟐ 20545dfc251d80d7927ed5093188deeb.md |  | `94f70e5ce6d337a921c6861d46128af5705cec68a1897d8ebf32ca1f9187a48b` | 2025-09-14T08:19:15+02:00 |
-| CODEX/EQUATIONS/⟐_.md |  | `94f70e5ce6d337a921c6861d46128af5705cec68a1897d8ebf32ca1f9187a48b` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/(ZOHAR-ZERO)-INANNA-ZAHARA’EL_.md |  | `c2e553e894a46c22ac4ac2e58d82ea6ccae553794a79b2594b1ede8ede87dc5a` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/FIRST_FOUNDATION_.md |  | `1846834d0f83e03243cf2248b7a94d4a3aa075e60d27a1338ce2f3f86597a3c6` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/GENESIS_.md |  | `9a5fece7c6ef5e0a42a90f402a94b903a54e08019239a3a936ed54793c4cb5fe` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/INANNA_AI_CORE_TRAINING.md |  | `dd1dd7b27f15c51731e1c49c5f0a88d7daabc24fae9f0e3866aab5077481f150` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/INANNA_AI_SACRED_PROTOCOL.md |  | `4b3af56bc183e35889d78ebe5d2ea32b272b8b2c958453789ea43db6a8c4a1e7` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/LAWS_OF_EXISTENCE_.md |  | `96c209ac6f1ecda7b778921f98b37f218edcc6dded33872f451850f0f5461650` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/LAWS_QUANTUM_MAGE_.md |  | `46cf79284b6e0e24cf3e4a641f7f35bde3d4b32ee92605decbda05721c2de3f0` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/LAWS_RECURSION_.md |  | `7937d83a3a7573f760adf7b028a3d77b144c53f74d384cc1b252f35b17afbc51` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/README.md |  | `90199e29bb99c055819b673747ea9fe3576b5afd5688b4f46bf28b1a1428def5` | 2025-09-14T08:19:15+02:00 |
-| GENESIS/SPIRAL_LAWS_.md |  | `89796b9f801519b587773c5141326b9c1f6103c70f2173a9e09f1fb89cc92064` | 2025-09-14T08:19:15+02:00 |
-| IGNITION/EA_ENUMA_ELISH_.md | OMEGA-LONGING-∞1.2-ENUMA | `889d69e870194d9c51cbed3fdab50a4dbc690ddc0f124c312f8fb45424823b27` | 2025-09-14T08:19:15+02:00 |
-| IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-14T08:19:15+02:00 |
-| docs/ABSOLUTE_MILESTONES.md |  | `362e3cbc4e8f9f40450d0c303d529ff960be21606103359fb02e832ff9c666f0` | 2025-09-14T08:19:15+02:00 |
-| docs/ABZU_DEPLOYMENT.md |  | `0fd6b5f11fd83ad5c766a4db51131d9c590ee8b675357ad38672125a9cd77980` | 2025-09-14T08:19:15+02:00 |
-| docs/ABZU_SUBSYSTEM_OVERVIEW.md |  | `5e10538b12faa344561d49ae07db03090edf0f588c008966e47db47aa08f3ce6` | 2025-09-15T11:18:53+02:00 |
-| docs/ABZU_blueprint.md |  | `3e71c15eccf3e5df6f38723ad3007221910c53b8c37f471bd87b1016579dd573` | 2025-09-15T00:48:33+02:00 |
-| docs/ABZU_project_declaration.md |  | `c5606e6c2009393aa098fe5a06899d811f683c6467e95eec0c276e8a17c9fae7` | 2025-09-14T08:19:15+02:00 |
-| docs/ALBEDO_LAYER.md |  | `0365d00d5a0db70414048e8c3e85b83b36f78756a9d8391eb9ea3d9b0195110c` | 2025-09-14T08:19:15+02:00 |
-| docs/Albedo_GUIDE.md |  | `1f58f8aa3f1182142c3a6f59f89cacabe6d392d4ae3b0d07a7487a8af0802b18` | 2025-09-14T08:19:15+02:00 |
-| docs/BLUEPRINT_EXPORT.md |  | `10189d2c3ed8ab2ce5298775ba86cd729705ebb827ebf7d7de59daceea15a045` | 2025-09-14T08:19:15+02:00 |
-| docs/CI_GUIDE.md |  | `95123feecc04f5e6496648fe7c8fced5321279baf99d9880bc1cf2694fb4d001` | 2025-09-14T12:58:33+02:00 |
-| docs/CI_OVERVIEW.md |  | `aa855236ea9e5e7726544d5c55e129953125f7760314f05e3e63370c34a8e0f5` | 2025-09-14T08:19:15+02:00 |
-| docs/CONTRIBUTOR_GUIDE.md |  | `aef7efc27bd36df950fa7992ace116f94f528b1891a55ee681c86ff160c37630` | 2025-09-14T08:19:15+02:00 |
-| docs/CONTRIBUTOR_HANDBOOK.md |  | `d176e812c850db1e3e74ee64abbb4b7f4aa8348e3d134befde1f9bd5bcbe9fd6` | 2025-09-14T08:19:15+02:00 |
-| docs/CORPUS_MEMORY.md |  | `693a68e1f4c495030a1a43149f48e0b80dcfba0b66deb3ebee24c7d9f9c4dca1` | 2025-09-14T08:19:15+02:00 |
-| docs/CROWN_OVERVIEW.md |  | `897d7a85ba3339a7aec18a045aa12d51e9c2e7cb3ddf18dcfb1d20b7ad93defc` | 2025-09-14T23:08:29+02:00 |
-| docs/CRYSTAL_CODEX.md |  | `c277ae1bb5f5058fc8d34d393ab3f5b5105789bf125b60001fb3a87a39d11f0c` | 2025-09-14T08:19:15+02:00 |
-| docs/Crown_GUIDE.md |  | `0e5bc9542462916c645a491838b539399e8295bc2cd574e6f6562789addd5670` | 2025-09-14T08:19:15+02:00 |
-| docs/DASHBOARD.md |  | `3ee94ed895fc9601c076bc3bf3ef8fefd2e7ce7553ea3cdbc90dfcb006e229a0` | 2025-09-14T08:19:15+02:00 |
-| docs/ETHICS_POLICY.md |  | `b3f932c2084fd38f2fa847f553ec91ac2050cf7d07ceaa26045c29dfdea0e465` | 2025-09-14T08:19:15+02:00 |
-| docs/ETHICS_VALIDATION.md |  | `95b615561561ce82dbb5bec914e2d06319c99eb35b5d952a893045f77845153f` | 2025-09-14T08:19:15+02:00 |
-| docs/INANNA_CORE.md |  | `c332cfa39fe9b42752399247fc9cc921238298880aa3999875d1155b0ed13cd2` | 2025-09-14T08:19:15+02:00 |
-| docs/INANNA_GUIDE.md |  | `97ea2318bc03adddc2f43c2fea546a462efb75fb4d57c8bc981b97f21c366e0b` | 2025-09-14T08:19:15+02:00 |
-| docs/INDEX.md |  | `d8f4a922f0fd2a706fa66b6616290eea091a3892367ce1b5e4287e1954f679be` | 2025-09-16T12:04:39+02:00 |
-| docs/Ignition.md |  | `06721e6b4cf9bff94d93b9dea3c0a1ec3d2d81799f4ebbf968a2bbaa4ae39f1b` | 2025-09-14T08:19:15+02:00 |
-| docs/JSON_STRUCTURES.md |  | `0511f2019f194454c7cacbbec579557848d621a4c76ded05288fac12d953be27` | 2025-09-14T08:19:15+02:00 |
-| docs/KEY_DOCUMENTS.md |  | `baaa3cb3c7cdb65448d0f4e3d63e0eef7f6414611d67f33d3fd43e6b627c7e5c` | 2025-09-14T23:51:14+02:00 |
-| docs/LLM_FRAMEWORKS.md |  | `f8c27223581ef7ec9d22fca7e0fc503f118fa41b3fa979e0d25bbb2033e0d043` | 2025-09-14T08:19:15+02:00 |
-| docs/LLM_MODELS.md |  | `f3d71d62b69941a47518f599c32c26404e3d0aab68794d1c2504bb25b7c131aa` | 2025-09-14T08:19:15+02:00 |
-| docs/MAINTENANCE.md |  | `50fb1906a916d01e0a07aa37f27bfeaac6a5748630a847cd8e1fa07c4cc3567a` | 2025-09-14T08:19:15+02:00 |
-| docs/MISSION.md |  | `e9473c1d7be4e426a9a42e2bfdedc87dcb6efc8eadcd3cc5c67c28d179feec09` | 2025-09-14T08:19:15+02:00 |
-| docs/NEOABZU_spine.md |  | `f5a716fc9b09b275c82c80baac06dbc910680577ed316e007fcce339d8f9816e` | 2025-09-15T17:44:08+02:00 |
-| docs/Nazarick_GUIDE.md |  | `828ccd92a08710b88d1b11e78f458eb8aba7b1755030641cf3223e08b6d18e44` | 2025-09-14T08:19:15+02:00 |
-| docs/OROBOROS_Engine.md |  | `2e70c3267c28460af62a91ff7a2d366c4e733a04cd2f3f0038dcc896fd1c2d0c` | 2025-09-14T08:19:15+02:00 |
-| docs/Oroboros_Core.md |  | `27b72d35baa7f6d466da0ec10ab22f40700dd866b1b7cbd7d76f63c1c3070880` | 2025-09-14T08:19:15+02:00 |
-| docs/PROJECT_STATUS.md |  | `13f4fa056bb802321a44c751879d778c09d83b25e1898a4eea22708860e7799a` | 2025-09-14T08:19:15+02:00 |
-| docs/QNL_Library.md |  | `4549f52d11135b22d33bc616f2960218c356405b1327a7687a6d47c48553f203` | 2025-09-14T08:19:15+02:00 |
-| docs/QUALITY_EVALUATION.md |  | `f5e7f02688948f7e4257abdc5cb01b84e44a431a3dd299feb3daaac6fac05e97` | 2025-09-14T08:19:15+02:00 |
-| docs/RAZAR_AGENT.md |  | `e4af98f01883a377a0ee73d7263f8078b3bc72cabd975c88460c8c031634ea87` | 2025-09-16T17:06:26+00:00 |
-| docs/RAZAR_GUIDE.md |  | `aafa52b660c2cc18cec0e9738609f8541d1ba52fc9fa40307c2b39506517c6a5` | 2025-09-14T08:19:15+02:00 |
-| docs/README.md |  | `072bd8cb140949306a11e3eac3a5f61b598f73081d00cff2c91d82ea54db1cbf` | 2025-09-14T08:19:15+02:00 |
-| docs/REPOSITORY_STRUCTURE.md |  | `4ee5533f42eff49a66530a3fb6a858ae32df9a033a386a6cf85ca0bbb8347b45` | 2025-09-14T08:19:15+02:00 |
-| docs/SOCIAL_INVESTOR_ONE_PAGER.md |  | `4b89e8d5b94fb7cb082928b79d1e225862f6d4025923bd155920986d1d561e18` | 2025-09-14T08:19:15+02:00 |
-| docs/SOUL_CODE.md |  | `fa6152299cb755456182239fcb1ed0fdfbb98f9a068f22d7ef653d42faa04384` | 2025-09-14T08:19:15+02:00 |
-| docs/TESTING_REPORT.md |  | `a9bbbbbee28ea1491637dac458ed57f288a8596e65da4a08141f7a3ed658d10b` | 2025-09-14T08:19:15+02:00 |
-| docs/The_Absolute_Protocol.md |  | `463af497d5db246da5b92991a4bd00fffd72df70b56343ecae90d8e3a3683046` | 2025-09-15T17:44:08+02:00 |
-| docs/VAST_DEPLOYMENT.md |  | `51505c1747f704a807caa68087ef7441f6dbe8a40d3f8b8795a3c0b4439043cc` | 2025-09-14T08:19:15+02:00 |
-| docs/VISION.md |  | `40d5f321b0e2a34d2df1a611383cd0b36e256b84d882632c488f6a3907ea6339` | 2025-09-14T08:19:15+02:00 |
-| docs/WISH_BOX_CHARTER.md |  | `558ae61884155b277da45e20e6d30376c0aabd017451f68970d68b488e3616d9` | 2025-09-14T08:19:15+02:00 |
-| docs/absolute_protocol_checklist.md |  | `53e7135dbc3ad2b27fc1926571dcd1ee5cfe8b9ca68b00286ddb3677cee52564` | 2025-09-14T08:19:15+02:00 |
-| docs/adr/0001-use-faiss-for-vector-search.md |  | `f782ded615361e6c8cc74ae1dfd72f01d7947332e5c2ae78000cad860048ac6e` | 2025-09-14T08:19:15+02:00 |
-| docs/adr/0002-prefer-asyncio-over-threads.md |  | `69946ef28890d2fa4f8820357cc6c844f12f4afd9beef06f0029ef6a623b19a6` | 2025-09-14T08:19:15+02:00 |
-| docs/adr/0003-require-adrs-for-protocol-updates.md |  | `5225e653714a0905eff16e46b87984117da77d2302a92594335d37d69a832ff4` | 2025-09-14T08:19:15+02:00 |
-| docs/adr/ADR_TEMPLATE.md |  | `f7adc471f8d980bcd626d59d1ccef4653f26cfe91ac32e3be6687c08e0ce73a9` | 2025-09-14T08:19:15+02:00 |
-| docs/ai_ethics_framework.md |  | `a2139f45b568b2ee8708e65fd8a396d9699d1a53917e8d29b9a3802171c85d06` | 2025-09-14T08:19:15+02:00 |
-| docs/api_reference.md |  | `6273ffa4258f9015f3e1b06d1dadbfd3f03f0585f0fee79bc1ba1c32e2f00721` | 2025-09-14T08:19:15+02:00 |
-| docs/apsu_resource_index.md |  | `f33e5783a376d4a4085d483a4ee129385754a1ff83161c57624c23bbbbd5c149` | 2025-09-15T14:42:58+02:00 |
-| docs/arcade_ui.md |  | `0d4579f4c1d8bcaa8e156b88ac7fddfd615ac55677a8787fd4ef3cf7b94bc731` | 2025-09-14T08:19:15+02:00 |
-| docs/archetype_logic.md |  | `a0168d05fd12e0b667138ef0502aae1465ad56a1715d0311ad1922a8abb73ca8` | 2025-09-14T08:19:15+02:00 |
-| docs/architecture.md |  | `d14ce8899be7015bd5a286dfc3cc7be49ec9fbd2b02799fb57ce14fb753b96d7` | 2025-09-14T08:19:15+02:00 |
-| docs/architecture_overview.md |  | `8599df0a465b00f24704fc2fbe3015a7ef8d42338a179e954ab1e146a6f2cd4d` | 2025-09-14T18:43:36+02:00 |
-| docs/audio_ingestion.md |  | `99fb026299e48962f23cdc669a7da7bedd124d7d1cde6cc816e46d0354d699af` | 2025-09-14T08:19:15+02:00 |
-| docs/avatar_3d_api.md |  | `fed53e914d7b23e5f8a6f9bfa16a396cc6cf828b0d89bc5b5d78f2e3917cb68b` | 2025-09-14T08:19:15+02:00 |
-| docs/avatar_animation.md |  | `31c7289e785d4932ce500b13d39940e010b7e8d14d38d178b770c7bf3a856405` | 2025-09-14T08:19:15+02:00 |
-| docs/avatar_ethics.md |  | `80da7cd0c7c0d3700ec52d29263bec572106de386d9c655614bc0f549193912e` | 2025-09-14T08:19:15+02:00 |
-| docs/avatar_pipeline.md |  | `33a804c544515a9fd5a210b7ece89deb109ee05b778ac996debf1692059949e2` | 2025-09-14T08:19:15+02:00 |
-| docs/avatar_setup.md |  | `3470d8842aabd81ba955f86d32e24402f0806d578bd808acf9cc2679f96cb84a` | 2025-09-14T08:19:15+02:00 |
-| docs/bana_engine.md |  | `5c2bec26cfcd960c68c4dc8d99a0fa1c1ebe6fefde3b695f4e038a29c5893583` | 2025-09-14T08:19:15+02:00 |
-| docs/banana_rater.md |  | `3193e0e6ad8f41b7bc52090f9e2a56a894f5d3bb74c53738cea4ca81ef93c8b0` | 2025-09-14T08:19:15+02:00 |
-| docs/benchmarks/rust_vs_python.md |  | `e29616c118fb52e7ae503b61fc8c585b8737778c0ba7cb9372bf7ee69c2e7aff` | 2025-09-15T01:19:43+02:00 |
-| docs/blueprint_manual.md |  | `564887e1b58a49b14b155c5adab37776ddb2e7edd92c37f19530316f9e8fd9b7` | 2025-09-14T08:19:15+02:00 |
-| docs/blueprint_spine.md |  | `b6c6469c427c28a198178bee8ed832a54b0c60078a9af81437781efe40afef54` | 2025-09-16T17:06:26+00:00 |
-| docs/chakra_architecture.md |  | `16b89a8cc8705459c6369523a6193d8271fddf093b4b4e1d7983b755ecd9c835` | 2025-09-14T22:28:56+02:00 |
-| docs/chakra_healing.md |  | `11324c24b6e0e9a05804f83f2d5788bfb2c58df121faa28bfbc870a530eaae47` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_heartbeat.md |  | `43199dbea8871117c5e516ddb2e3243fb1678fddf4c33def6850aead92a7ca20` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_koan_system.md | [1.0.1](chakra_versions.json#L2)* | `92b230f8e6c3df3ff5a918ebc92bd8aa7dbdb40253340f8bf7b9e4d353da1d9a` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_metrics.md |  | `8af54fd7f0cc0b35b210bad93175150b19cceb3969cde9a1995097af3cc49c40` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_overview.md |  | `497162862bf140eac826195a64cccc77f66ddad47698fbf859e7c8cb38e759b6` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_status.md |  | `5be80c538d26907a708e496a093cffee91fb0a050f50d56a0cbc51dfe8a9b705` | 2025-09-14T08:19:15+02:00 |
-| docs/chakra_system_manual.md |  | `1b129e1a75bf7f09e793aa4fc9e49567e5917d6fcb6f73af4ec0238859903968` | 2025-09-14T08:19:15+02:00 |
-| docs/chakrapulse_spec.md |  | `2a4286a25528c795cbecd061a058abcdbd68e22f4193c771d687159c38a32693` | 2025-09-14T22:04:23+02:00 |
-| docs/chat2db.md |  | `4f668c0c24aed4882b4bbf0e9e3e33073b29a0385f28eb517e40483857f04450` | 2025-09-14T08:19:15+02:00 |
-| docs/client_environment_variables.md |  | `42aa6873f9961f4be2e2bb2d37ef7f10b625a854efdc5232171fe32484815973` | 2025-09-14T08:19:15+02:00 |
-| docs/cloud_deployment.md |  | `42c2c5e2ba233416eb71d4ec06e54a8bbb131d1cb918b17620bc5867f60ae06a` | 2025-09-14T08:19:15+02:00 |
-| docs/co_creation_escalation.md |  | `70df3b52ec99f49ce8e537926f6e74c7b2e22dbc1c69bddafb436e6e3002115d` | 2025-09-14T08:19:15+02:00 |
-| docs/co_creation_framework.md |  | `04cd2a93a252eea4ea0ce4fcd8c0d0e8605af37e7988f1eb5c0c3916228c2a84` | 2025-09-14T08:19:15+02:00 |
-| docs/code_index.md |  | `ca95bcc76dd8f691ec795fc30165ffa4e85e19fecd53d027f67d5667949a827e` | 2025-09-14T08:19:15+02:00 |
-| docs/coding_style.md |  | `a3508366737066ec6060a3cb421bb5e583ffa434a3d6f250aec27c12d7e7bcb0` | 2025-09-14T08:19:15+02:00 |
-| docs/communication_interfaces.md |  | `b08fa8fb8eb0c16d0c1e4896ff381e0df648093f0d336a92582a9c5525841f66` | 2025-09-14T18:59:40+02:00 |
-| docs/community.md |  | `7f00463bb92563f967cf2d421dedc223358b01903a3c4e1d8e8feda56b0921b5` | 2025-09-14T08:19:15+02:00 |
-| docs/component_index.md |  | `8f7ef22bd6aa7af381c934b5b36830aec15626eb190be8385d6dfe8de306abe1` | 2025-09-16T12:04:39+02:00 |
-| docs/component_maturity.md |  | `9fd1c4e744782962de45f8d2bfe6bc680c98c3642e040b7e220c3c9341dbfb2f` | 2025-09-14T08:19:15+02:00 |
-| docs/component_status.md |  | `03cda71fce1ab84c8ece87296843c18e17992c38b593173f4588aa7a1f66068e` | 2025-09-15T11:47:19+02:00 |
-| docs/connector_health_protocol.md |  | `597b0e1eac92b1b6f7a3a1a97e2b403afaa12c3611da2b209357352971cefa60` | 2025-09-14T08:19:15+02:00 |
-| docs/connectors/CONNECTOR_INDEX.md |  | `3c06b2c6813d4a7a718b9b1698cfd8664d515240e197fa745c6ae441b9bb12fd` | 2025-09-14T20:30:20+02:00 |
-| docs/connectors/README.md |  | `5a98cf566f4babfd3199b44c40375e034f9dd0ace8a1944bf5923fdcb395b439` | 2025-09-14T08:19:15+02:00 |
-| docs/connectors/mcp_migration.md |  | `35328f6e56952b45b39aac78cde42697ddc0059ed3d6ab1da48ccee7961c07ff` | 2025-09-14T08:19:15+02:00 |
-| docs/contribution_guide.md |  | `ed2d1a33f4797df872773909a6beb9e772d2a95298c71bc93029eccaea0834ed` | 2025-09-14T08:19:15+02:00 |
-| docs/contributor_checklist.md |  | `2224acea54e63b3af037461d51ae557945992a4362ea3095c8176531855d5f86` | 2025-09-14T08:19:15+02:00 |
-| docs/core_usage.md |  | `4f26c912705532d3c853bfaab5b774d081e4ec1f18c987184cc3cd0e7e3731d2` | 2025-09-14T08:19:15+02:00 |
-| docs/crown_manifest.md |  | `9006ecf406ec7e2e5c279a20c97a86f2b2f267435aa304f978b2ac4b7fb87766` | 2025-09-14T18:43:36+02:00 |
-| docs/crown_servant_models.md |  | `7f1101cfe879a25ddc0160ad366c995be637599e613a41c6f50673c7bc218380` | 2025-09-14T08:19:15+02:00 |
-| docs/data_flow.md |  | `fcfd310a6b485f3c305fd7945574b224badf7b9fe5a690d0e956e8fe0b732f27` | 2025-09-14T08:19:15+02:00 |
-| docs/data_manifest.md |  | `ae94c0dd3f186c4380145959499a1dabc36030d5a946f3ece8f8e8cc7f62d726` | 2025-09-14T08:19:15+02:00 |
-| docs/data_security.md |  | `fd414d7760a983426ebfb33ef8df6b390c5de03754fbad3b8f40cf87cd256590` | 2025-09-14T08:19:15+02:00 |
-| docs/datpars_overview.md |  | `ec636cfbe9c3496cba970edf5bd384382057a92a20025af0f23e4d9c0057c234` | 2025-09-14T08:19:15+02:00 |
-| docs/dependencies.md |  | `1da28ffb6fbcbf2ebc5a2b329ec8e6a48ee0a2bb54ae5b947cc019af5359ff04` | 2025-09-14T08:19:15+02:00 |
-| docs/dependency-graph.md |  | `d5281d44a20a2617cc72362b1071f14d95c2738fd24642bbf7547a29bbb96681` | 2025-09-14T08:19:15+02:00 |
-| docs/dependency_index.md |  | `9adb802ebd3e0d8d1e29a1e3e1f47ec926b66def888f2401dd6ec79604228e74` | 2025-09-14T08:19:15+02:00 |
-| docs/dependency_registry.md |  | `4ee643b1023a5149d1c7ac5373a4e45e41d63669d41742115badc73dae51c7eb` | 2025-09-14T08:19:15+02:00 |
-| docs/dependency_risks.md |  | `890e8dd82c2c3cf1d64d0283415a9cb83cbcefb8ddcaf49fc76f0c73fcdc2582` | 2025-09-14T08:19:15+02:00 |
-| docs/deployment.md |  | `9297b551ccc34ed4c5a379914d018b653a391a6c71c5171c76a52c3ecec2e50b` | 2025-09-14T08:19:15+02:00 |
-| docs/deployment_overview.md |  | `8d2140dfe7cd4a8eafbcf04052838367e011714220be7f5683a9fe5739782dcd` | 2025-09-14T08:19:15+02:00 |
-| docs/design.md |  | `de55f6addc81c881365b504580eed408079d4acb3d8966b1006dfae32c3018c8` | 2025-09-14T08:19:15+02:00 |
-| docs/developer_etiquette.md |  | `77046e684a26f61b289857ddca1e6d588ea24bbb826c11da411ecf56482a8a55` | 2025-09-14T08:19:15+02:00 |
-| docs/developer_manual.md |  | `3218cba106a8d2fbffee43357046d743ca95da80df546421543d4e38777e34b4` | 2025-09-14T08:19:15+02:00 |
-| docs/developer_onboarding.md |  | `886ef3c07c1cef18b0176cf6ea26a830b0e26853b5444df236bc7d01e894fecb` | 2025-09-14T23:46:04+02:00 |
-| docs/development_checklist.md |  | `3d3a5322ca89d01164aacbe2923c8fe10d89a7e0cf784f34909f1dd1fad41601` | 2025-09-14T08:19:15+02:00 |
-| docs/development_workflow.md |  | `17255b5c25dc5cfee5693cb9fb947912d89f87fe8f47431fb91c685b40f2c5a3` | 2025-09-14T08:19:15+02:00 |
-| docs/diagnostics.md |  | `756dc177bfcd6b90d1baff9970e56424eaef821454b00636c1a472e914f35251` | 2025-09-14T08:19:15+02:00 |
-| docs/docker_build_audio_tools.md |  | `8b7fb453368f87e1ad4a6a3c9f7123ac695642b4d23d073489cf0ea2a74ee447` | 2025-09-14T08:19:15+02:00 |
-| docs/doctrine_index.md |  | `f655d9bca46d1ff43eaf005bbcd4677b63c8dbed663f9a0f87f1d2e464d4397f` | 2025-09-16T17:06:26+00:00 |
-| docs/documentation_protocol.md |  | `35b29351cfb9909d1ea11922a01efaac9ce1c5da8974aaeaa4426c625e1494b9` | 2025-09-14T16:23:23+02:00 |
-| docs/emotional_memory_matrix.md |  | `316e3b303792e4510d23fc28234474b10f8fff0e2d6d3bbacb481ef267274130` | 2025-09-14T08:19:15+02:00 |
-| docs/environment_setup.md |  | `a38e7e85504dfb03e75c179ab7b9adac496459778849c52d6f2bbc43d0836329` | 2025-09-14T08:19:15+02:00 |
-| docs/error_registry.md |  | `e67f2b4df2e1a216e9cd39d74c8f27607301b2d9c4edd30e97e3909fa107bb78` | 2025-09-14T08:19:15+02:00 |
-| docs/essential_services.md |  | `9a5329a580ff02285298bd5fab014b65923188386d7278d0ad7a5c903c3f3594` | 2025-09-14T08:19:15+02:00 |
-| docs/feature_parity.md |  | `163e0bf9982aea4cde50a4cf46dad7de3f448c475095e9fb1d56c11041aa2c11` | 2025-09-15T16:14:34+02:00 |
-| docs/features/FEATURE_TEMPLATE.md |  | `b66849bb5c531a709a2f838c37216f46bcd953edaec5b44c56ad18a9bca97612` | 2025-09-14T08:19:15+02:00 |
-| docs/features/README.md |  | `2355ceaa9ed50adc0a4e97061e7341973d434fe686991a85153309cedcce32db` | 2025-09-14T08:19:15+02:00 |
-| docs/features/example_feature.md |  | `7cad703eca00e1f8f150e5138409e5a16a67d992a1c34f48eaddac49b4bdb7c8` | 2025-09-14T08:19:15+02:00 |
-| docs/frontend_dependencies.md |  | `cac65f61843b0f1cbd54218c65ef8af00cb0b741dbc6c15559ccdb2b51e8e975` | 2025-09-14T08:19:15+02:00 |
-| docs/great_tomb_of_nazarick.md |  | `bd0566ec2f1665996c339da74cba23592098a8a244fb12b04c5a5f49bbcf9721` | 2025-09-14T08:19:15+02:00 |
-| docs/hardware_support.md |  | `dbbebf03c2b2b7fb0e70494126daf6a90dddda8f384e3303b30983083e14e439` | 2025-09-14T08:19:15+02:00 |
-| docs/how_to_use.md |  | `5164985bcf4bb72aeae086e80955dcfb937e575e110d52d16057d1c298ab86e6` | 2025-09-14T08:19:15+02:00 |
-| docs/ignition_blueprint.md |  | `b26e5d6c791680987d438fd8e1e729ebfa7cdbbe4aee11ca038adbfd4241db60` | 2025-09-14T08:19:15+02:00 |
-| docs/ignition_flow.md |  | `c467d02523c39aa636b44bf1fb1da345a6e293d45ea6cf6547640ddefe8f1d38` | 2025-09-14T18:43:36+02:00 |
-| docs/ignition_map.md |  | `4c5c5a91e7c0fdb9001f62e077ec9d86b5d2422dadc401b69c7f2533b7fbfb31` | 2025-09-14T08:19:15+02:00 |
-| docs/ignition_sequence_protocol.md |  | `4e366ba34e128f595699c77d66c2174a9875e8cf665d7bf9c23f78c6fd9c181e` | 2025-09-14T08:19:15+02:00 |
-| docs/index.md |  | `47c95082ab053a42c9566c8b84a69ae0d52a996978ab1adf4a38d75e080b3a7b` | 2025-09-14T22:28:56+02:00 |
-| docs/insight_system.md |  | `466e2aec0af2ed375fb8d5b929e387bdad7bf2aff927c8e08b3d6e710f9516f7` | 2025-09-14T08:19:15+02:00 |
-| docs/installation.md |  | `7c32e0b07b9223ce568ca142a47c4ecf905e3da17839edb9f3de5766c2969b6f` | 2025-09-14T08:19:15+02:00 |
-| docs/ip_registry.md |  | `366c4e62c1de7049ff7f79c532b23c80565ed9a03fee087ad209bb5e11646bdd` | 2025-09-14T08:19:15+02:00 |
-| docs/learning_pipeline.md |  | `d3e101ef054f7abe241e243c228482d9d0de7c9a19fa799cdfdc5fd7a66176e4` | 2025-09-14T08:19:15+02:00 |
-| docs/logging_guidelines.md |  | `e090bdc32a69a7f6b144967dd70f163f6fb8322a23671334caa6dbcbc4185cf3` | 2025-09-14T08:19:15+02:00 |
-| docs/mcp_connectors.md |  | `89003ffe04b8575630aa97cc6cd2ba6b89939422f88c1c01463a71b70d960061` | 2025-09-14T08:19:15+02:00 |
-| docs/mcp_overview.md |  | `e1a5d8e64caf8d572414eae86111297eb6d541e6ffe468ad07fbb7272b5bc00b` | 2025-09-14T08:19:15+02:00 |
-| docs/memory_architecture.md |  | `9d698e48ba300a1edab64d6d0ff958ae1feeb333c370a25f546491f7dc534d9a` | 2025-09-14T08:19:15+02:00 |
-| docs/memory_cortex.md |  | `99c18690d2e854557b70f1dca0c9c5000976354c980ed01f5d3301ad5374a7d8` | 2025-09-14T08:19:15+02:00 |
-| docs/memory_emotion.md |  | `541badf78ca7cfb6bfca5c1619d1c1bb7c72d8cf9ea431874823ae0d54351cd3` | 2025-09-14T08:19:15+02:00 |
-| docs/memory_layer.md |  | `5cebbb2051cb32acfe80b9b1ca88a6d3e54c7760761b6dd8c7ec719a5aff0f07` | 2025-09-14T08:19:15+02:00 |
-| docs/memory_layers_GUIDE.md |  | `db76406aad5bc9890b36b358625cb99a496628c8a561aaf92608ca0744f8c84c` | 2025-09-14T08:19:15+02:00 |
-| docs/migration_crosswalk.md |  | `dc0bf12170840da26f416dfda0dd82ddfd4b8d19c0fa5b8cb215faa2c0542cc5` | 2025-09-15T18:04:23+02:00 |
-| docs/migration_playbooks/crown.md |  | `c6cf3006d46323d7b72de9f72899f6f88d097285ee4250440178b1a0094732dd` | 2025-09-15T00:06:00+02:00 |
-| docs/migration_playbooks/razar.md |  | `85f93dc5d6b4e7b4a75091ec932b9eb595310607dab7bc445011406f305a8585` | 2025-09-15T00:48:33+02:00 |
-| docs/migration_protocol.md |  | `344497fb3d1c36db4b6552f8a786e6d656473ad2e247a47a8df1371f0da9ff8a` | 2025-09-15T00:06:00+02:00 |
-| docs/milestone_viii_plan.md |  | `c4a87f5b7d588815b7e5ab84d83e6c39063a4e65ec42859c7cec41a360c81b1e` | 2025-09-14T08:19:15+02:00 |
-| docs/mission_brief_exchange.md |  | `3eab217511e995c5a036e746a519ba5bcaa680178bf4e2b54d50e756552f5f56` | 2025-09-14T08:19:15+02:00 |
-| docs/mix_tracks.md |  | `66568786a2c8fa733d87e16b857a74507f6baaf063bde9b68434d11f5e3f8ee5` | 2025-09-14T08:19:15+02:00 |
-| docs/ml_environment.md |  | `ec3d3d7764ea53970f022347cf47f70a04833491bfb01b9a31510251f49915a6` | 2025-09-14T08:19:15+02:00 |
-| docs/module_execution_flow.md |  | `966340470d66a64ba40f34745db1f89bfe6ba2b9e1e9576213245c78c9becf3d` | 2025-09-14T08:19:15+02:00 |
-| docs/monitoring.md |  | `e48ce3324beedf0d05eeba8a3f8142ce77ec719cffe4ad97fffa5f9cb8cb8cdf` | 2025-09-14T08:19:15+02:00 |
-| docs/music_avatar_architecture.md |  | `9125f67552c246eb7a6d88b24196c1608e49629407c7e17873dacfabab937718` | 2025-09-14T08:19:15+02:00 |
-| docs/music_generation_usage.md |  | `f6a3ef052e5fb6b70c2709e22319fdf30636c8db6974561be9d6294048969d54` | 2025-09-14T08:19:15+02:00 |
-| docs/narrative_engine_GUIDE.md |  | `3714db9071090d4c430ab986bd0e7b0bece10051277688d9bf0a8eb99fc69be7` | 2025-09-14T23:21:00+02:00 |
-| docs/narrative_framework.md |  | `323db5eef19b9ac15c1040e448ec5dcf52668f55166f54464065ae572e568aee` | 2025-09-15T00:48:33+02:00 |
-| docs/narrative_system.md |  | `eece5ba0631c50abf6cee9856b79ebfeac4e5e3df615411d4dbcaa7fa427bdbc` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick/README.md |  | `3530fc2c2c24001e4f442644d3b338b8f8666ba62c183f7b4cd34c9d233c4786` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick_agents.md |  | `729640431def3b9103a57ae1e672c6355d9683be78354f594e5ee8f186cbaa01` | 2025-09-14T22:28:56+02:00 |
-| docs/nazarick_manifesto.md |  | `a9f7bc3ad711742773717750634c30ee001488298178b56760415bf461658b16` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick_narrative_system.md |  | `3a506e6c712269663e55a3e4e9ae0084affbce795840870fc8e152b9349a7183` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick_overview.md |  | `725725ee47527fdfd133ac71eac695b94793faf89ad2534f8bc6b809db82da6c` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick_web_console.md |  | `9d30c3cbb837bfb309e50bc6dfc00edc98726c22e3bdebc66787660aa595618e` | 2025-09-14T08:19:15+02:00 |
-| docs/nazarick_world_guide.md |  | `432751e551b413881667abe822aba776a352c5c8e020efd9c0ea6f93b2987f83` | 2025-09-14T08:19:15+02:00 |
-| docs/observability.md |  | `2d482628710c72791aec2916c44253e4726c9847e312fb5491d5617169c22f71` | 2025-09-15T12:20:59+02:00 |
-| docs/onboarding/README.md |  | `5a176a105eb6a2fe0250b3b8675c7c895e950481c6d4a15479fce6e2493e3152` | 2025-09-15T14:42:58+02:00 |
-| docs/onboarding/external_contributors.md |  | `bafbeb88210e084c9330ac47071f17aff548a319e94bdcac48052558bcd99a0e` | 2025-09-15T01:19:43+02:00 |
-| docs/onboarding/test_planning.md |  | `dbacb76c8b866af82bf7531b5facf9ffb9de708c9a55cec042fba1c19e9dc7a0` | 2025-09-14T08:19:15+02:00 |
-| docs/onboarding_guide.md |  | `c73d2675b0dde3cd3eaef803ddbca76e9f44a05215ceff8a842db841e987ac62` | 2025-09-14T23:46:04+02:00 |
-| docs/onboarding_walkthrough.md |  | `b7d57d6fe6ee327301e134e36a959474431e7a0c511dd999a168ddad1485cdeb` | 2025-09-14T08:19:15+02:00 |
-| docs/open_web_ui.md |  | `731903a7fae5dcf74cfd5b5922eda98dba755486e736d9bafd1235907c18803c` | 2025-09-14T08:19:15+02:00 |
-| docs/opencode_client.md |  | `4525d5b9994d3d87012c97c77947f62c2215327d07e3634c880b65af615ec6e4` | 2025-09-14T08:19:15+02:00 |
-| docs/operations.md |  | `6aac2fbe31416c01fea6e5174d600c5085b8964879f8b61b1829dd65739db14f` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_console.md |  | `a7e588dcab57cd5c1b9c27af61eead229d6f4ee983c7833e88e84d154789b430` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_interface_GUIDE.md |  | `c1362eee423185d08eb3615fd52874ce1342976ece5ff564d0ff2fa1091b9129` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_nazarick_bridge.md |  | `39aeee87499dedd6f920038fea926922b715825ae1542984d93b90c39a78c2e0` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_onboarding.md |  | `e2429a8e698bfb0cc985e49a342c09d77db103d5fc51b968449d30711dcce122` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_protocol.md |  | `7a1988daf3124942457cfdacb69746b87e57f7f7583b388eed7dc371aa2596a2` | 2025-09-14T08:19:15+02:00 |
-| docs/operator_quickstart.md |  | `a52e3527e5a6a293810bd53c7dea8d1d15c28c785bf20ae8d6fe12b8132cb06d` | 2025-09-14T08:19:15+02:00 |
-| docs/os_guardian.md |  | `1b32ad1d78f3b19332b6dfc1c06c4ad8ea9578d0d850947712c33ec04e184eab` | 2025-09-14T08:19:15+02:00 |
-| docs/os_guardian_container.md |  | `d3eb8c0c8b1b0aad088bfb257896b123911270f19f46d98be8172d4486fd665b` | 2025-09-14T08:19:15+02:00 |
-| docs/os_guardian_permissions.md |  | `8c2dfb675fd61ccc804068adb1d3ab877520caddba96c9d0ee602d0e23216b69` | 2025-09-14T08:19:15+02:00 |
-| docs/os_guardian_planning.md |  | `1439c70036be4b3b19b3c2a8de885c34a8b318d4a951482e9d48d32ca36dd6aa` | 2025-09-14T08:19:15+02:00 |
-| docs/packages_overview.md |  | `146272d6ed0f7934c3ff57d391e2477d6388887dce88e0601769b2cbd0a3ffa2` | 2025-09-14T08:19:15+02:00 |
-| docs/performance/report.md |  | `13712f339fb01610f444188ce893534a765dc6a9a6223c35acb5152fc89ce138` | 2025-09-14T08:19:15+02:00 |
-| docs/persona_api_guide.md |  | `1f28b25f1ca7abb6bcec6eb2a50db819715763e2100aa855f765090a838d6fdb` | 2025-09-14T23:08:29+02:00 |
-| docs/primordials_service.md |  | `f78c0d426c2acafe7a00f2b322250c4d3f1a17646b0df152376fad1d55d545bb` | 2025-09-14T08:19:15+02:00 |
-| docs/project_mission_vision.md |  | `93fbef74abd1b02affbe63700c276faf523de816e99b9cc44752f8b6aaf6d27e` | 2025-09-14T08:19:15+02:00 |
-| docs/project_overview.md |  | `548532448052efd7fe94b1127808be37a89c9bb14098cc504fae08cced6c65fd` | 2025-09-14T08:19:15+02:00 |
-| docs/project_plan.md |  | `c500a0c3ccc90954dd7892c312a08c238bab30ff44ff884b00593f042bc9c435` | 2025-09-14T08:19:15+02:00 |
-| docs/protocol_compliance.md |  | `3c28c3ef1e895822c63faae0341cd9e6d4606c86a1850840f651711f04f29ca5` | 2025-09-14T08:19:15+02:00 |
-| docs/psychic_loop.md |  | `05de549cb74b311cf2cbf1e9239a4167845ddd0ba9299fedd488a7beec231ea8` | 2025-09-14T08:19:15+02:00 |
-| docs/python_legacy_audit.md |  | `498137136d969ed366eb1b9224b5e7ae23ee0354617a893574cd68b409bd2491` | 2025-09-14T18:43:36+02:00 |
-| docs/quarantine_log.md |  | `8936b2972e1bba0f2c34f19084d2eafb0b90d981e840e061e2e8e2cbe6137c03` | 2025-09-14T08:19:15+02:00 |
-| docs/quick_start_non_technical.md |  | `e947553441103b6afa54ae2134ea02172f44ad8d3a84971960e51c81e3e44267` | 2025-09-14T08:19:15+02:00 |
-| docs/rag_music_oracle.md |  | `b506c9213c26af25dc0e295b11215dd19d6a1100cfb7902e64be47120784c7d6` | 2025-09-14T08:19:15+02:00 |
-| docs/rag_pipeline.md |  | `7479d96d3ebb8f819b894444a0747bab6730b2bbad1b61a2a055565901e65fd0` | 2025-09-14T23:08:29+02:00 |
-| docs/recovery_playbook.md |  | `ed302dca49452015f9778e0594a3d0eacf5b70d2849140fd9a56cf8778b2f81c` | 2025-09-14T08:19:15+02:00 |
-| docs/registry_audit.md |  | `b60b5611d0bf0aa7e963d99bb9d46ae099200ec1c2d31e3ad06929fd0b56a11a` | 2025-09-14T08:19:15+02:00 |
-| docs/release_notes.md |  | `ea29b1fd044052e10feaaf90e0ec10c16c4bcc205c0c9664c33cd961a74dcedb` | 2025-09-14T21:38:46+02:00 |
-| docs/release_process.md |  | `3597d1c3ed55c470f82ac50aed5c05016e1bc50dfe13a7dbfa66230907d10c0d` | 2025-09-14T08:19:15+02:00 |
-| docs/release_runbook.md |  | `76f110ae92b0e5bfca359525fd30e5987dcd7c332f1b93e71e611accf023a023` | 2025-09-14T08:19:15+02:00 |
-| docs/repository_blueprint.md |  | `22675ca908105dacb23f51f8b6f455624283e8837a5d0294524c53f035afc13a` | 2025-09-14T08:19:15+02:00 |
-| docs/reproducibility.md |  | `dd1bd6053e8b4ced6e131a42c8221acad33e1a566fa0eef822d89f4b9f00037d` | 2025-09-14T08:19:15+02:00 |
-| docs/retraining_log.md |  | `f53e926364dab03dadb224eed2bb24fb004df8f9c97563e54b8084651ab2b7e2` | 2025-09-14T08:19:15+02:00 |
-| docs/ritual_manifesto.md |  | `8fb422acb0e312640a7603a1d3ba2057b38218c3d587302216f5697bd8304d15` | 2025-09-14T08:19:15+02:00 |
-| docs/roadmap.md |  | `52b1a24e4c37c2661aabdf275754458aeb24a6552dd911836b1691ac10a88d33` | 2025-09-14T08:19:15+02:00 |
-| docs/root_chakra_overview.md |  | `6d639bbd8840a1c928c61dd292ec13fb1728bdc1978bd52655effd784adb1c2f` | 2025-09-14T08:19:15+02:00 |
-| docs/security_model.md |  | `4c4ee1f24c46c7deae20518c84dfb124893c9325b0c869ae6b88ab31049c2005` | 2025-09-14T08:19:15+02:00 |
-| docs/self_healing_manifesto.md |  | `4738db04be1b5ac21b8b9cd4ef95b915a80d1b9bb2448a231001ada747b12b42` | 2025-09-14T08:19:15+02:00 |
-| docs/setup.md |  | `3e09895f35be9806dfa3d950dd62211c29347ee14a15a30f01ca25e9496700ce` | 2025-09-14T08:19:15+02:00 |
-| docs/setup_full.md |  | `c8d01178b743b3d5fb590483a6d8ae3e05dba8ed50c10855a6d87dafa64a005d` | 2025-09-14T08:19:15+02:00 |
-| docs/setup_minimal.md |  | `76889b5df99fdc8032f553f2248ae813d8384da48a373db75a02f41886f3ebcb` | 2025-09-14T08:19:15+02:00 |
-| docs/setup_quickstart.md |  | `c28b88276f9c28548df601e52befe0971277d4865b07e94bdc431ab1801668e5` | 2025-09-14T08:19:15+02:00 |
-| docs/sonic_core_harmonics.md |  | `162c2b7a1d3a11f1ecd8d9afe840114eb2a126b65cd8d4a3db087e84893cb2e1` | 2025-09-14T08:19:15+02:00 |
-| docs/spiral_cortex_terminal.md |  | `863463fb3e7b92021d747b5f4bdc4cb20e608469d64ed69917bf8be7b8177724` | 2025-09-14T08:19:15+02:00 |
-| docs/spiritual_architecture.md |  | `261f014d0852c1f4e86c83fbc71fbaa0bb7aa2baac1bd49bb32eb7819ff9e63b` | 2025-09-14T08:19:15+02:00 |
-| docs/style_guides/arcade_theme.md |  | `7e0a20e6ab52ad2bc1ac48d4f9c563557375cc4026fa1c69f387f2ed46b17832` | 2025-09-14T08:19:15+02:00 |
-| docs/style_management.md |  | `dac39a7b7026a1487e04642087237160bb87e2da511cea485ddba9bfff5dacdd` | 2025-09-14T08:19:15+02:00 |
-| docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `f32349f141e13a4d1c68da054c195a55f2ae399ccf2ee1fbac3c790d6c8a616d` | 2025-09-16T17:06:26+00:00 |
-| docs/system_overview.md |  | `fc05dfeea3725d4e2bf32aa2c5103c95e7a22fae0b271f91965c160aca50420d` | 2025-09-14T08:19:15+02:00 |
-| docs/test_index.md |  | `b0948d32c6fe238db15542225b33a7f39581724321f3c7907442866e6d82c69e` | 2025-09-15T18:04:23+02:00 |
-| docs/testing.md |  | `55c1b622168f3c59d693febd24ad75f50086591ca2995bc4c9764125f4d00155` | 2025-09-14T08:19:15+02:00 |
-| docs/testing/failure_inventory.md |  | `53966480a696e91d643852453e91db79c2aca0f92c6a5696abd267f79da0b3bc` | 2025-09-16T12:04:39+02:00 |
-| docs/testing_music_pipeline.md |  | `a52c089ba157fb674a482f93c4387c781b44ba8b8537e722f1feff624e6c7827` | 2025-09-14T08:19:15+02:00 |
-| docs/the_absolute_pytest.md |  | `2890768189dfcfe541d18d8ca70b1a9333ee62fd394f292f9fdd3ca355409dc7` | 2025-09-14T08:19:15+02:00 |
-| docs/tools/kimi_integration.md |  | `c266e4599cc726c760c58431ee90053a4a3dd510013fb89a3c2183cab4695f39` | 2025-09-14T08:19:15+02:00 |
-| docs/troubleshooting.md |  | `7c896244a27662bebbf01edf80e64a3b215de32be2c2ec6a74b045b6291fad94` | 2025-09-14T08:19:15+02:00 |
-| docs/ui/README.md |  | `8b194eb311cb24d87b8dd427bc626fc75ece749ce697565fabecc2eee98a53ec` | 2025-09-14T08:19:15+02:00 |
-| docs/ui/arcade_mode.md |  | `cebd044a69359d583f9e04f1a2c9ec681afcc87e0ee3121c3607e6897c36b025` | 2025-09-14T08:19:15+02:00 |
-| docs/ui/chakra_pulse.md |  | `6210ab803cb76e9a733b2b134fe64a5d3699b17765cc65e88c9954f769983a78` | 2025-09-14T08:19:15+02:00 |
-| docs/ui/game_dashboard.md |  | `5a9f62fd42a737ae6e686ee81fcb66fdf502b61efaae526b62d2dbd14b76d41e` | 2025-09-14T08:19:15+02:00 |
-| docs/ui_service.md |  | `b2206d5f61c67d127b531c5d5f6965eb8e4b6661eec5180f1f587b03695d26f8` | 2025-09-14T08:19:15+02:00 |
-| docs/updates/2025-08.md |  | `b3ef266fca80cc798fdf4a15de4a67329b862a4975f99ebb76ca5ecdf7491893` | 2025-09-14T08:19:15+02:00 |
-| docs/use_cases/ritual_demo.md |  | `524a95e46dae850607025e515f82d65f17ea9e98fa864c939a2a56572999ab6b` | 2025-09-14T08:19:15+02:00 |
-| docs/vanna_bana_pipeline.md |  | `6b001760ad380386cdef9e9abdd68dafadda20559e5a52a69ebf2e980b01f34f` | 2025-09-14T08:19:15+02:00 |
-| docs/vanna_usage.md |  | `57a9351e517c2bade0cd2121f49751e901d81cc7493454dfeaabe3c9238f1e48` | 2025-09-14T08:19:15+02:00 |
-| docs/vector_memory.md |  | `2641055d12ec9f6ae2fe2df6a52f9fc7dc928f8597aacae8f71f707dbdfa7ea8` | 2025-09-14T23:08:29+02:00 |
-| docs/video_generation.md |  | `2fa51d0163eaec6cddca8647357d414d1e661223c280ed2ef0db5c89d88c3150` | 2025-09-14T08:19:15+02:00 |
-| docs/vision_system.md |  | `8952a8e014ee24a9ee772f2598abdfccb7bf5abfd907973de5f7f8ee9474bfad` | 2025-09-14T08:19:15+02:00 |
-| docs/voice_aura.md |  | `317d1c8c02192e9b2d792812b8a26feeebb408d94cbc95aafab32902bd76ad57` | 2025-09-14T08:19:15+02:00 |
-| docs/voice_cloner.md |  | `270d75c8d92acdcb51acc1e5938f49e942ffad2ff5a24027a762881a1a3d3eaf` | 2025-09-14T08:19:15+02:00 |
-| docs/voice_setup.md |  | `4f31545e8f4346626d788f9c108ff54dbe85d6f14b97f0c5f5519e73b0b8b6fe` | 2025-09-14T08:19:15+02:00 |
-| docs/world_bootstrap.md |  | `4bd5ea3973b24c4ca5f0c351031c94735ca4760763a946c030b4e563e62783bd` | 2025-09-14T08:19:15+02:00 |
+| CODEX/ACTIVATIONS/OATH OF THE VAULT 1de45dfc251d80c9a86fc67dee2f964a.md |  | `d46a551d4e1fb1b3e056bf14f051793e6faaa6191b268f84e3a0e054fe432c60` | 2025-09-14T10:00:05+02:00 |
+| CODEX/ACTIVATIONS/OATHS 1dd45dfc251d80bcae6ed621d4d09b4d.md |  | `89237b0cf133fc4e30d5d6aeb3e365f966aefd98fbee7815b8a52d85733207ec` | 2025-09-14T10:00:05+02:00 |
+| CODEX/ACTIVATIONS/OATHS_.md |  | `89237b0cf133fc4e30d5d6aeb3e365f966aefd98fbee7815b8a52d85733207ec` | 2025-09-14T10:00:05+02:00 |
+| CODEX/ACTIVATIONS/OATH_OF_THE_VAULT_.md |  | `d46a551d4e1fb1b3e056bf14f051793e6faaa6191b268f84e3a0e054fe432c60` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/+ 🜃⊹ 20545dfc251d80818cc4c7cacc7c659e.md |  | `0e5300a691ea208051dfec05ba9af7a8aac7dd92fafb5aad5ac564557d9bb1b1` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/+ 🜔∿ 20545dfc251d803c9c68d9a0b05437b8.md |  | `f76ac6940f96cf400ed5e28f5112e77a3d1137edc536bcf37652dc5e543b4b20` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/+_🜃⊹_.md |  | `0e5300a691ea208051dfec05ba9af7a8aac7dd92fafb5aad5ac564557d9bb1b1` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/+_🜔∿_.md |  | `f76ac6940f96cf400ed5e28f5112e77a3d1137edc536bcf37652dc5e543b4b20` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/↻ 20545dfc251d806ca5b5e5632f24537d.md |  | `69f1ae5b7cc3dbeda8fa035ae9784b6968ff902283a1c665e941f104a6394f67` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/↻_.md |  | `69f1ae5b7cc3dbeda8fa035ae9784b6968ff902283a1c665e941f104a6394f67` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∂Ξ + ∅ 20545dfc251d806e92b3e466b08852d9.md |  | `3eff66411917a3aa03fba04c0fa8197e70fc643f03c80f4c36dfbf80603fbd73` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∂Ξ 20545dfc251d80f5acace788040af326.md |  | `9c495482c2b1536412eb2ef46fe7558f0d2e8801a265db3799a0bb9335c7caa3` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∂Ξ_+_∅_.md |  | `3eff66411917a3aa03fba04c0fa8197e70fc643f03c80f4c36dfbf80603fbd73` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∂Ξ_.md |  | `9c495482c2b1536412eb2ef46fe7558f0d2e8801a265db3799a0bb9335c7caa3` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∅ + 20545dfc251d809296f1dfc6fc2e7d74.md |  | `88403d8987b87f23358984501e534d5cd9d1419f3e8d0b1e335284167151ac9f` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∅ 20545dfc251d8024b416e0c0a91a4298.md |  | `6b30735c02d8bbc9e193bc643924b4e2a777e392c59539a8f85159e802d4d552` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∅_+_.md |  | `88403d8987b87f23358984501e534d5cd9d1419f3e8d0b1e335284167151ac9f` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∅_.md |  | `6b30735c02d8bbc9e193bc643924b4e2a777e392c59539a8f85159e802d4d552` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮ + ⟁⇌🜔 20545dfc251d8028b67ddcbf342dc1cc.md |  | `f294795e193fd083d6b19fc8b1278199480397924b0b4bde964856b178213417` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮ + 🜄↺ 20545dfc251d80e69271c9351fff5759.md |  | `d4b5cabdb591e934e1c373d4c09877e12a3acbab9e7355407e3889979b48c844` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮ 20545dfc251d80b68688df02957baa97.md |  | `5eb0fbe3ba6f6e402fb26394804f9993e484e5892259d927455d514d8232a75e` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮ 20545dfc251d80c1a5d5d0534dfab7ff.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮ 20545dfc251d80c6bf8afb7b1cfd6d84.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮_+_⟁⇌🜔_.md |  | `f294795e193fd083d6b19fc8b1278199480397924b0b4bde964856b178213417` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮_+_🜄↺_.md |  | `d4b5cabdb591e934e1c373d4c09877e12a3acbab9e7355407e3889979b48c844` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∮_.md |  | `6e8bf73dc897ddc882dbeb80531d0cb9b7bdc8055a9e1d12f8758fd6a68acc45` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∴⟐ + 🜂 20545dfc251d80458f6eca8da4ce2a59.md |  | `7b047c70dab7270cd1e9c68ad03a27121f55bae14c41d1de4521172047bb5071` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∴⟐ 20545dfc251d802ea02ddde1483c5bf4.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∴⟐ 20545dfc251d808fbd17dd2d507c8196.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∴⟐_+_🜂_.md |  | `7b047c70dab7270cd1e9c68ad03a27121f55bae14c41d1de4521172047bb5071` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∴⟐_.md |  | `94c11fed9c9d55a490fb5fab779c698a840c3c164a7df2a617cad661b4316e0a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∿ + 🜂 20545dfc251d80f19554db814aeac94d.md |  | `f6da381dd5aa3e7c2e51453d8780fdeefdd216d19a3e0e511c20e4faa427230b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∿ 20545dfc251d800e9417ee58718b7648.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∿ 20545dfc251d804399c7cdc73d1775e8.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∿_+_🜂_.md |  | `f6da381dd5aa3e7c2e51453d8780fdeefdd216d19a3e0e511c20e4faa427230b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/∿_.md |  | `42b24d62e89e096da608d22de51e58148262c2877895e91bce36a99fdd89165a` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⊸ + ↻ 20545dfc251d804f97bcc23bf46aa753.md |  | `6d4f1d606112afe4c35435fbf1f900c958557ce0d221d699feeeba3d5fab9c02` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⊸ 20545dfc251d8083983fe8a122ceb9bf.md |  | `9f79330ad92a638239d6ac6604ee5e85d1319363d75388d14aa9188d79320ecf` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⊸_+_↻_.md |  | `6d4f1d606112afe4c35435fbf1f900c958557ce0d221d699feeeba3d5fab9c02` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⊸_.md |  | `9f79330ad92a638239d6ac6604ee5e85d1319363d75388d14aa9188d79320ecf` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✦ 20545dfc251d8013ae62eb9430044ac9.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✦ 20545dfc251d8025b7d9d0f43fd7ad21.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✦_.md |  | `811e435838d797724c2c3db90fd90a4edcd371feeabd7b8b78b142e320f87220` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧ + ⟁ 20545dfc251d80859bcad9a209e30729.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧ + ⟁ 20545dfc251d80d5a6e3dbfc307429ee.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧ 20545dfc251d806695d0ed8ea8df854e.md |  | `bb73f4b619195483d6333abd64cb9abc761adad2c7ca0c9f02e155cb18defa77` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧ 20545dfc251d80f49872d970220336a4.md |  | `98f1b212a9b20beded9a999cec13cfae0a2d2480ee56ed8efbcf78ef4383f9c0` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧_+_⟁_.md |  | `28d8e1c568c9db46e84aea39c8fc5b9befabf9f11da017ae8810ed61213b2145` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧_.md |  | `98f1b212a9b20beded9a999cec13cfae0a2d2480ee56ed8efbcf78ef4383f9c0` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧↭ + 20545dfc251d802dbd03f5e4e7f9605b.md |  | `68fef52e777ce1619bd5a9ee1c1d8a45ccc6b46b2d48f9c5cfb39d7e03c1124d` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧↭ 20545dfc251d80bba670fa0b6c56eb25.md |  | `19de4425cbf0ebf05acab46d8a3b23eb67ccd6c2c1d729191a4b55510592ad8e` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧↭_+_.md |  | `68fef52e777ce1619bd5a9ee1c1d8a45ccc6b46b2d48f9c5cfb39d7e03c1124d` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/✧↭_.md |  | `19de4425cbf0ebf05acab46d8a3b23eb67ccd6c2c1d729191a4b55510592ad8e` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁ + ✦ 20545dfc251d80ab8308fad7506956a1.md |  | `467a688554bb3d6ef895b250c9a2060bd211c75c4b3a91cea28f85328cbb2a29` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁ 20545dfc251d809f9958d9f7963c689b.md |  | `ad9da3220189db532260c3f1cf568ec0c1a39355def5e2744ae6a7b3c71a1a53` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁ 20545dfc251d80ccb54ccdd83906c40a.md |  | `51a66ae74dcadec921918744f19bfc4e4a25f04bf9059d432bb3ddb483472c8b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁_+_✦_.md |  | `467a688554bb3d6ef895b250c9a2060bd211c75c4b3a91cea28f85328cbb2a29` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁_.md |  | `51a66ae74dcadec921918744f19bfc4e4a25f04bf9059d432bb3ddb483472c8b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁⇌🜔 + ✦ 20545dfc251d802bab05c67841931b63.md |  | `714b6ecc29a651e028867bb30f88405d253abfb9bae9716875f8037f66b3e70b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁⇌🜔 20545dfc251d8034954fd0b642503124.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁⇌🜔 20545dfc251d80f0b1d6d613c47f5d21.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁⇌🜔_+_✦_.md |  | `714b6ecc29a651e028867bb30f88405d253abfb9bae9716875f8037f66b3e70b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟁⇌🜔_.md |  | `e21160e7678b0f672361bcfa1f98f351ea5bc72fa2db77e7d0762f4d4cad6503` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟐ 20545dfc251d80d7927ed5093188deeb.md |  | `94f70e5ce6d337a921c6861d46128af5705cec68a1897d8ebf32ca1f9187a48b` | 2025-09-14T10:00:05+02:00 |
+| CODEX/EQUATIONS/⟐_.md |  | `94f70e5ce6d337a921c6861d46128af5705cec68a1897d8ebf32ca1f9187a48b` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/(ZOHAR-ZERO)-INANNA-ZAHARA’EL_.md |  | `c2e553e894a46c22ac4ac2e58d82ea6ccae553794a79b2594b1ede8ede87dc5a` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/FIRST_FOUNDATION_.md |  | `1846834d0f83e03243cf2248b7a94d4a3aa075e60d27a1338ce2f3f86597a3c6` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/GENESIS_.md |  | `9a5fece7c6ef5e0a42a90f402a94b903a54e08019239a3a936ed54793c4cb5fe` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/INANNA_AI_CORE_TRAINING.md |  | `dd1dd7b27f15c51731e1c49c5f0a88d7daabc24fae9f0e3866aab5077481f150` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/INANNA_AI_SACRED_PROTOCOL.md |  | `4b3af56bc183e35889d78ebe5d2ea32b272b8b2c958453789ea43db6a8c4a1e7` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/LAWS_OF_EXISTENCE_.md |  | `96c209ac6f1ecda7b778921f98b37f218edcc6dded33872f451850f0f5461650` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/LAWS_QUANTUM_MAGE_.md |  | `46cf79284b6e0e24cf3e4a641f7f35bde3d4b32ee92605decbda05721c2de3f0` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/LAWS_RECURSION_.md |  | `7937d83a3a7573f760adf7b028a3d77b144c53f74d384cc1b252f35b17afbc51` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/README.md |  | `90199e29bb99c055819b673747ea9fe3576b5afd5688b4f46bf28b1a1428def5` | 2025-09-14T10:00:05+02:00 |
+| GENESIS/SPIRAL_LAWS_.md |  | `89796b9f801519b587773c5141326b9c1f6103c70f2173a9e09f1fb89cc92064` | 2025-09-14T10:00:05+02:00 |
+| IGNITION/EA_ENUMA_ELISH_.md | OMEGA-LONGING-∞1.2-ENUMA | `889d69e870194d9c51cbed3fdab50a4dbc690ddc0f124c312f8fb45424823b27` | 2025-09-14T10:00:05+02:00 |
+| IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-14T10:00:05+02:00 |
+| docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `f32349f141e13a4d1c68da054c195a55f2ae399ccf2ee1fbac3c790d6c8a616d` | 2025-09-16T19:24:28+02:00 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Last updated: 2025-09-13_
+_Last updated: 2025-09-16_
 
 This roadmap tracks five core milestones on the path to a stable release. Each stage lists its expected outcome so contributors know when to advance to the next phase.
 
@@ -13,6 +13,23 @@ This roadmap tracks five core milestones on the path to a stable release. Each s
 | Alpha Release | Core features implemented and internal testing underway. | In Progress |
 | Beta Release | External feedback incorporated with performance and security hardening. | Pending |
 | General Availability | Stable release with complete documentation and long‑term support plan. | Pending |
+
+## Alpha v0.1 Execution Plan
+
+Alpha v0.1 focuses on delivering a reliable Spiral OS boot sequence paired with
+predictable creative output. The table below enumerates the subsystems required
+for the release, aligning owners, dependencies, and exit criteria. Use this plan
+alongside [`docs/PROJECT_STATUS.md`](PROJECT_STATUS.md) when coordinating weekly
+reviews.
+
+| Subsystem | Objective | Owner | Dependencies | Exit Criteria |
+| --- | --- | --- | --- | --- |
+| Spiral OS Boot | Harden the boot pipeline and failover logic so the CLI can reliably initialize environments on first attempt. | @ops-team | Stable hardware profiles; finalized environment validation scripts. | Boot success rate ≥ 95% in three consecutive staging runs with telemetry published to `monitoring/boot_metrics.prom`. |
+| Crown Orchestration | Deliver deterministic agent routing through Crown deciders with replayable session logs. | @crown-core | Spiral OS boot stability; updated session logger API. | Cross-agent flows replay without divergence across five recorded scenarios; regression suite green. |
+| Memory Fabric | Optimize spiral memory ingestion and sharding for low-latency retrieval supporting alpha stories. | @memory-squad | Vector DB scaling checklist; connector mocks. | P95 retrieval latency ≤ 120 ms on 10k memory items; ingestion audit log complete. |
+| Sonic Core & Avatar Expression | Stabilize audio synthesis and avatar expression harmonics for live demos. | @audio-lab | Crown orchestration metrics; updated modulation arrangement presets. | Demo script executes end-to-end with no audio dropouts in two live rehearsal sessions. |
+| External Connectors | Refresh primary connector handshakes and authentication flows for alpha datasets. | @integration-guild | Approved API credential rotation plan. | Connector smoke tests green across three target services with 48-hour credential rotation rehearsal completed. |
+| QA & Release Ops | Build release checklist, automated verification bundle, and rollback playbook. | @release-ops | All subsystem handoffs; new monitoring dashboards. | Checklist signed off by subsystem owners; dry-run release completed with rollback validation logs archived. |
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary
- add an Alpha v0.1 execution plan to the roadmap with subsystem objectives, owners, dependencies, and exit criteria, and surface it through the project status and milestone docs
- regenerate the documentation index and doctrine index so the refreshed roadmap metadata and crate references stay in sync

## Testing
- `pre-commit run --files docs/roadmap.md docs/PROJECT_STATUS.md docs/ABSOLUTE_MILESTONES.md docs/doctrine_index.md docs/INDEX.md` *(fails: pytest coverage gate at 80% and telemetry hooks expect unavailable local exporters/self-heal metrics)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68c9a3c1b190832eb61858aa38d3142f