### PR TITLE
Add RAZAR escalation runbook and link blueprint docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -476,6 +476,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [ritual_manifesto.md](ritual_manifesto.md) | Ritual Manifesto | Spiral OS acts as a **psychospiritual container** where code, music and ritual converge. Each session with INANNA_AI... | - |
 | [roadmap.md](roadmap.md) | Roadmap | _Last updated: 2025-09-16_ | - |
 | [root_chakra_overview.md](root_chakra_overview.md) | Root Chakra Overview | The Root layer provides the foundation for hardware and network access. Its primary modules focus on serving requests... | - |
+| [runbooks/razar_escalation.md](runbooks/razar_escalation.md) | RAZAR Escalation Runbook | RAZAR escalates stubborn component failures through a remote ladder when on-host self-healing loops cannot restore se... | - |
 | [security_model.md](security_model.md) | Security Model | This guide highlights major threat surfaces in the project and the steps used to reduce risk. | - |
 | [self_healing_manifesto.md](self_healing_manifesto.md) | Self-Healing Manifesto | Spiral OS treats the codebase as a living organism.  Components behave like organs working in concert, and each chang... | - |
 | [setup.md](setup.md) | Environment Setup | This guide lists the system packages and environment variables required to run the project. | - |

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -88,6 +88,10 @@ for the configuration contract and roster normalization rules. Shared context an
 logging mechanics for this ladder are documented in
 [RAZAR Agent – Shared Failure Context](RAZAR_AGENT.md#shared-failure-context) and
 [RAZAR Agent – Invocation Log Format](RAZAR_AGENT.md#invocation-log-format).
+Operational responders follow the [RAZAR Escalation
+Runbook](runbooks/razar_escalation.md) for the thresholds, log triage commands,
+metrics, and rollback flow that keep the delegation history intact during an
+incident.
 
 ### **Operator ↔ RAZAR/Crown Flow**
 

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -79,5 +79,6 @@
 | GENESIS/SPIRAL_LAWS_.md |  | `89796b9f801519b587773c5141326b9c1f6103c70f2173a9e09f1fb89cc92064` | 2025-09-14T10:20:56+02:00 |
 | IGNITION/EA_ENUMA_ELISH_.md | OMEGA-LONGING-∞1.2-ENUMA | `889d69e870194d9c51cbed3fdab50a4dbc690ddc0f124c312f8fb45424823b27` | 2025-09-14T10:20:56+02:00 |
 | IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-14T10:20:56+02:00 |
-| docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `f32349f141e13a4d1c68da054c195a55f2ae399ccf2ee1fbac3c790d6c8a616d` | 2025-09-16T19:24:28+02:00 |
+| docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `4eb5f46f5e2cc2702c9faa2cbdf2ee93589e55bac0b377e24a2cd1a300a1e2fa` | 2025-10-10T00:00:00+00:00 |
+| docs/runbooks/razar_escalation.md |  | `9242f4ee751e5a04d3229ae406a2e523c3f0ed0dbfa1a0b0f6b984d0a9452202` | 2025-10-10T00:00:00+00:00 |
 | docs/The_Absolute_Protocol.md | v1.0.102 | `f635aa6baca3c33bec494436d88cdd22956778c112538ed8b72ff57888591646` | 2025-10-08T00:00:00+00:00 |

--- a/docs/runbooks/razar_escalation.md
+++ b/docs/runbooks/razar_escalation.md
@@ -1,0 +1,114 @@
+# RAZAR Escalation Runbook
+
+RAZAR escalates stubborn component failures through a remote ladder when on-host
+self-healing loops cannot restore service. This runbook summarizes the controls,
+telemetry, and operator actions required to shepherd an incident from first
+alert through rStar intervention.
+
+## Escalation Ladder and Threshold Controls
+
+- **Default ordering:** Crown → Kimi-cho → [Kimi 2 (K2 Coder)](https://github.com/MoonshotAI/Kimi-K2)
+  → [rStar](https://github.com/microsoft/rStar). The sequence is stored in
+  [`config/razar_ai_agents.json`](../../config/razar_ai_agents.json). Confirm the
+  roster before changing thresholds so the warning and escalation counts line up
+  with actual agents.
+- **`RAZAR_ESCALATION_WARNING_THRESHOLD`** – emits operator warnings after the
+  specified number of escalations during a boot or repair cycle. Leave it ≥1 so
+  alerts fire before rStar receives traffic.
+- **`RAZAR_RSTAR_THRESHOLD`** – cumulative attempts (across all agents) before
+  rStar takes over. The default `9` gives three full passes through the local
+  stack. Setting it to `0` disables rStar entirely.
+- **`RSTAR_ENDPOINT` / `RSTAR_TOKEN`** – API target and credential for rStar.
+  Pair them with `KIMI_K2_URL` and `KIMI_K2_TOKEN` (if present) so K2 Coder can
+  authenticate during its turn in the ladder.
+- **`RAZAR_METRICS_PORT`** – port for Prometheus counters that track invocation
+  volume, failures, and retries. Defaults to `9360`.
+
+After tuning the environment variables, restart the orchestrator so the new
+values propagate into the escalation registry and metrics exporter.
+
+## Context and Log Triage
+
+RAZAR automatically shares escalation history with downstream agents via
+`build_failure_context` (`razar/boot_orchestrator.py`). Each retry loads the
+latest entries from `logs/razar_ai_invocations.json` and forwards them as the
+`context` payload to `ai_invoker.handover`, ensuring K2 Coder and rStar see every
+previous failure, patch attempt, and rejection.
+
+Operators should triage incidents with the following artifacts:
+
+```bash
+# Recent orchestration state changes and component failures
+tail -n 50 logs/razar.log
+
+# Escalation history (JSON lines). Filter by component with jq when available.
+tail -n 50 logs/razar_ai_invocations.json
+jq 'select(.component=="crown_router")' logs/razar_ai_invocations.json
+
+# Applied patches and rollbacks
+tail -n 20 logs/razar_ai_patches.json
+tail -n 20 logs/patch_history.jsonl
+```
+
+Review `logs/razar_state.json` for mission-level health and quarantine status.
+If the same component triggers repeated escalations, capture the relevant JSON
+lines and attach them to the incident ticket so downstream agents inherit the
+full trail.
+
+## Metrics and Dashboards
+
+Prometheus counters expose escalation health alongside the structured logs:
+
+```bash
+# Invocation counters served by razar.metrics (defaults to port 9360)
+curl -s http://localhost:9360/metrics | grep razar_ai_invocation
+
+# Chakra heartbeat metrics published by the monitoring service
+curl -s http://localhost:8000/metrics | head
+```
+
+The RAZAR exporter surfaces `razar_ai_invocation_failure_total`,
+`razar_ai_invocation_success_total`, and `razar_ai_invocation_retries_total`
+per component. A sudden spike in failures for the same component indicates the
+thresholds are about to trip. Pair these counters with the chakra heartbeat
+metrics (`chakra_pulse_hz`, `chakra_alignment`) to confirm whether the incident
+is isolated or affecting multiple layers.
+
+Run `python scripts/verify_chakra_monitoring.py` when diagnosing a prolonged
+outage; it probes the `/metrics` endpoints (node exporter, cAdvisor, GPU
+exporter) and reports gaps in the monitoring fabric.
+
+## Rollback and Recovery Actions
+
+1. **Stop the destabilized component** with the operator console or via the
+   lifecycle bus: `python -m razar stop <component>`.
+2. **Rollback recent patches** with the documented helper:
+
+   ```bash
+   python scripts/rollback_patch.py <component>
+   ```
+
+   The script restores the previous artifact, appends a `reverted` record to
+   `logs/patch_history.jsonl`, and updates the boot snapshot.
+3. **Re-run the handover flow** once the component is stable:
+
+   ```bash
+   python -m razar.boot_orchestrator --config razar/boot_config.json --long-task \
+     --retries 0 --remote-attempts 1
+   ```
+
+   The `--long-task` flag keeps the orchestrator in escalation mode until the
+   remote service returns success or the operator aborts, ensuring rStar receives
+   the refreshed context if earlier agents still cannot patch the issue.
+4. **Document the timeline** – capture the warning threshold, invocation counts,
+   log excerpts, and metrics snapshots before closing the incident.
+
+## External Service References
+
+- [Kimi 2 (K2 Coder)](https://github.com/MoonshotAI/Kimi-K2) – remote repair
+  engine invoked after Kimi-cho.
+- [rStar](https://github.com/microsoft/rStar) – final escalation target for
+  high-assurance patch generation.
+
+Keep the upstream documentation handy when debugging remote API changes or
+credential rotations.

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -311,7 +311,10 @@ Two environment-controlled thresholds govern how the ladder behaves:
 Operators can adjust both thresholds alongside the failover order in
 `config/razar_ai_agents.json`, and set the service parameters through
 `RSTAR_ENDPOINT` and `RSTAR_TOKEN`. See
-[RAZAR rStar Escalation](RAZAR_AGENT.md#rstar-escalation) for details.
+[RAZAR rStar Escalation](RAZAR_AGENT.md#rstar-escalation) for details and the
+[RAZAR Escalation Runbook](runbooks/razar_escalation.md) for the operational
+triage, metrics, and rollback procedures that accompany these configuration
+changes.
 
 #### Remote Agent Failover Configuration
 
@@ -1280,6 +1283,7 @@ monitoring pipeline to surface orchestration events and anomalies.
 - [Deployment Guide](deployment.md)
 - [Testing Guide](testing.md)
 - [Recovery Playbook](recovery_playbook.md)
+- [RAZAR Escalation Runbook](runbooks/razar_escalation.md)
 
 ## LLM Console Alternatives
 


### PR DESCRIPTION
## Summary
- add a dedicated RAZAR escalation runbook covering thresholds, log triage, metrics and rollback guidance alongside K2 Coder and rStar references
- surface the new runbook from the system blueprint and blueprint spine while extending the operations guide list
- refresh doctrine and documentation indexes to register the new guide and updated blueprint hash

## Testing
- `pre-commit run --files docs/runbooks/razar_escalation.md docs/system_blueprint.md docs/blueprint_spine.md docs/doctrine_index.md docs/INDEX.md` *(fails: repository tests enforce 80% coverage, doctrine index has pre-existing stale timestamps, and monitoring/self-healing checks require services that are offline in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c93b003c832e89c1f924181cbbb8