### PR TITLE
Add RAZAR failover dashboard and alerts

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -418,6 +418,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [mix_tracks.md](mix_tracks.md) | Mix Tracks | `audio/mix_tracks.py` combines multiple audio stems into a single track. The module accepts a JSON instruction file s... | - |
 | [ml_environment.md](ml_environment.md) | ML Environment Setup | This guide explains how to create an isolated Python environment and start Jupyter notebooks for experimenting with S... | - |
 | [module_execution_flow.md](module_execution_flow.md) | Module Execution Flow | Overview of key modules with their inputs, core processing, outputs, and error handling. Flowcharts summarize the exe... | - |
+| [monitoring/RAZAR.md](monitoring/RAZAR.md) | RAZAR Failover Monitoring | The RAZAR orchestrator exports detailed telemetry about AI handovers, retry loops, and cross-agent escalations. Prome... | - |
 | [monitoring.md](monitoring.md) | Monitoring | The application writes JSON-formatted logs to `logs/INANNA_AI.log`. The file rotates when it reaches roughly 10 MB, k... | - |
 | [music_avatar_architecture.md](music_avatar_architecture.md) | Music Avatar Architecture | The Crown agent can reflect on musical input by combining feature extraction with language model reasoning.  The `mus... | - |
 | [music_generation_usage.md](music_generation_usage.md) | Music Generation Usage | Generate audio from text prompts or ritual invocations. | - |

--- a/docs/monitoring/RAZAR.md
+++ b/docs/monitoring/RAZAR.md
@@ -1,0 +1,87 @@
+# RAZAR Failover Monitoring
+
+The RAZAR orchestrator exports detailed telemetry about AI handovers, retry
+loops, and cross-agent escalations. Prometheus scrapes these metrics from the
+`scripts/razar.metrics` endpoint while Grafana visualizes the data through the
+`monitoring/grafana/razar_failover.json` dashboard. This guide outlines the
+required setup and the alert thresholds that backstop the failover ladder.
+
+## Setup Steps
+
+1. **Enable metrics export.** Call `razar.metrics.init_metrics()` during service
+   startup (or launch `python -m razar.metrics`) so Prometheus can scrape the
+   counters and histograms on port `9360`. The exporter respects the
+   `RAZAR_METRICS_PORT` environment variable when the default port conflicts
+   with an existing service.
+2. **Expose the metrics endpoint.** Add the target to
+   `monitoring/prometheus.yml`:
+   ```yaml
+   - job_name: 'razar-metrics'
+     static_configs:
+       - targets: ['razar-metrics:9360']
+         labels:
+           chakra: crown
+   ```
+   Restart Prometheus (or run `docker compose up prometheus` inside
+   `monitoring/`) so the new job is loaded.
+3. **Import the Grafana dashboard.** Upload
+   `monitoring/grafana/razar_failover.json` via the Grafana UI or by copying the
+   file into `/var/lib/grafana/dashboards/`. The dashboard automatically
+   populates `component` and `agent` template variables using Prometheus
+   metadata.
+4. **Load alert rules.** Reference
+   `monitoring/alerts/razar_failover.yml` from the Prometheus alertmanager
+   configuration. When running the bundled docker-compose stack, mount the file
+   and restart the Prometheus container to activate the rules.
+5. **Verify the schema.** Execute `python scripts/ci_verify_dashboards.py` in CI
+   and locally to ensure dashboards remain well-formed before deploying.
+
+## Dashboard Panels
+
+The dashboard surfaces the following signals:
+
+- **Retry Attempts by Component** – stacked timeseries derived from
+  `razar_ai_invocation_retries_total` to show which component is consuming
+  retries per scrape window.
+- **Agent Success Rate** – percentage of successful handovers per component
+  calculated from `razar_ai_invocation_success_total` and
+  `razar_ai_invocation_failure_total`. Components falling below the 75% threshold
+  should trigger investigation.
+- **Retry Loop Duration (sum)** – cumulative seconds spent in the retry loop via
+  `razar_ai_retry_duration_seconds_sum`, highlighting components that are
+  approaching escalation.
+- **Retry Loop Iterations** – derivative of
+  `razar_ai_invocation_retries_total` to reveal how quickly retries are accruing
+  for each component.
+- **External Agent Latency** – moving average of
+  `razar_agent_call_duration_seconds` to track downstream agent responsiveness.
+- **Escalation Loop Warning** – stat panel that surfaces the largest retry-loop
+  duration in the last 30 minutes so operators can intervene before the loop
+  saturates.
+
+## Alert Thresholds
+
+| Alert | Expression | Threshold | Recommended Action |
+| --- | --- | --- | --- |
+| `RAZARExcessiveRetries` | `sum(increase(razar_ai_invocation_retries_total[5m])) by (component) > 10` | More than 10 retries in 5 minutes | Check the component log, confirm self-healing succeeds, and reseed mission context if necessary. |
+| `RAZARAgentSuccessRateLow` | Success rate below `0.75` for 10 minutes | Success rate < 75% | Validate external agent credentials, ensure upstream APIs are reachable, and review the [RAZAR Escalation Runbook](../runbooks/razar_escalation.md). |
+| `RAZAREscalationLoopStalled` | `sum(increase(razar_ai_retry_duration_seconds_sum[30m])) by (component) > 900` | >15 minutes spent inside the retry loop | Trigger operator escalation per the runbook and inspect `logs/operator_escalations.jsonl` for stuck events. |
+
+When alerts fire, document the outcome in `logs/operator_escalations.jsonl` so
+future cycles inherit context.
+
+## Runbooks and References
+
+- [RAZAR Escalation Runbook](../runbooks/razar_escalation.md)
+- [Co-creation Escalation Protocol](../co_creation_escalation.md)
+- [Monitoring Guide](../monitoring.md)
+
+## Automation and Validation
+
+CI executes `scripts/ci_verify_dashboards.py` to confirm that the Grafana
+JSON stays consistent with the expected schema. Run the script locally after
+editing dashboards or alert rules to catch formatting issues before committing.
+
+### Doctrine References
+- [system_blueprint.md#configurable-crown-escalation-chain](../system_blueprint.md#configurable-crown-escalation-chain)
+- [runbooks/razar_escalation.md](../runbooks/razar_escalation.md)

--- a/monitoring/alerts/razar_failover.yml
+++ b/monitoring/alerts/razar_failover.yml
@@ -1,0 +1,46 @@
+groups:
+  - name: razar-failover
+    rules:
+      - alert: RAZARExcessiveRetries
+        expr: sum(increase(razar_ai_invocation_retries_total[5m])) by (component) > 10
+        for: 5m
+        labels:
+          severity: warning
+          service: razar
+        annotations:
+          summary: "RAZAR retries elevated for {{ $labels.component }}"
+          description: |
+            {{ $labels.component }} attempted more than ten AI retries in the last five minutes.
+            Investigate the component log for repeated patch failures and confirm the failover ladder is still progressing.
+          runbook: docs/runbooks/razar_escalation.md
+      - alert: RAZARAgentSuccessRateLow
+        expr: |
+          sum(increase(razar_ai_invocation_success_total[15m])) by (component)
+            /
+          clamp_min(
+            sum(increase(razar_ai_invocation_success_total[15m])) by (component)
+            + sum(increase(razar_ai_invocation_failure_total[15m])) by (component),
+            1
+          ) < 0.75
+        for: 10m
+        labels:
+          severity: critical
+          service: razar
+        annotations:
+          summary: "RAZAR agent success rate below threshold for {{ $labels.component }}"
+          description: |
+            Success rate for {{ $labels.component }} fell below 75% for ten minutes.
+            Review the agent health status and confirm external dependencies are reachable before rerunning the handover.
+          runbook: docs/monitoring/RAZAR.md#alert-thresholds
+      - alert: RAZAREscalationLoopStalled
+        expr: sum(increase(razar_ai_retry_duration_seconds_sum[30m])) by (component) > 900
+        for: 15m
+        labels:
+          severity: critical
+          service: razar
+        annotations:
+          summary: "RAZAR escalation loop saturated for {{ $labels.component }}"
+          description: |
+            {{ $labels.component }} spent more than 15 minutes inside the retry loop.
+            Trigger the escalation runbook and confirm that the operator notification bus is processing events.
+          runbook: docs/runbooks/razar_escalation.md

--- a/monitoring/grafana/razar_failover.json
+++ b/monitoring/grafana/razar_failover.json
@@ -1,0 +1,185 @@
+{
+  "title": "RAZAR Failover Observability",
+  "uid": "razar-failover",
+  "tags": ["razar", "failover", "escalation"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "description": "Track AI handover retries, per-agent success rate, and escalation loops for the RAZAR orchestrator.",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "component",
+        "type": "query",
+        "label": "Component",
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(razar_ai_invocation_success_total, component)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*"
+      },
+      {
+        "name": "agent",
+        "type": "query",
+        "label": "External Agent",
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(razar_agent_call_duration_seconds_count, agent)",
+        "refresh": 2,
+        "sort": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Retry Attempts by Component",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(razar_ai_invocation_retries_total{component=~\"$component\"}[$__rate_interval])) by (component)",
+          "legendFormat": "{{component}}"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Agent Success Rate",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": 0},
+              {"color": "red", "value": 0.7},
+              {"color": "yellow", "value": 0.85},
+              {"color": "green", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(razar_ai_invocation_success_total{component=~\"$component\"}[15m])) by (component) / clamp_min(sum(increase(razar_ai_invocation_success_total{component=~\"$component\"}[15m])) by (component) + sum(increase(razar_ai_invocation_failure_total{component=~\"$component\"}[15m])) by (component), 1)",
+          "legendFormat": "{{component}}"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "table", "calcs": ["lastNotNull"], "placement": "bottom"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Retry Loop Duration (sum)",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {"unit": "s"},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(razar_ai_retry_duration_seconds_sum{component=~\"$component\"}[15m])) by (component)",
+          "legendFormat": "{{component}}"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Retry Loop Iterations",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {"unit": "short"},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(razar_ai_invocation_retries_total{component=~\"$component\"}[5m])) by (component)",
+          "legendFormat": "{{component}}"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "External Agent Latency",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {"unit": "s"},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(razar_agent_call_duration_seconds_sum{agent=~\"$agent\"}[5m])) by (agent) / clamp_min(sum(rate(razar_agent_call_duration_seconds_count{agent=~\"$agent\"}[5m])) by (agent), 1)",
+          "legendFormat": "{{agent}}"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Escalation Loop Warning",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 300},
+              {"color": "red", "value": 600}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max(sum(increase(razar_ai_retry_duration_seconds_sum{component=~\"$component\"}[30m])) by (component))",
+          "legendFormat": "Loop duration"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    }
+  ]
+}

--- a/scripts/ci_verify_dashboards.py
+++ b/scripts/ci_verify_dashboards.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+__version__ = "0.1.0"
+
+REQUIRED_PANEL_KEYS = {"type", "title", "targets"}
+REQUIRED_TARGET_KEYS = {"expr"}
+
+
+def _load_dashboard(path: Path) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON ({exc})") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: dashboard root must be a JSON object")
+    return data
+
+
+def _validate_dashboard(path: Path, data: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+
+    title = data.get("title")
+    if not isinstance(title, str) or not title.strip():
+        errors.append("missing or empty title")
+
+    panels = data.get("panels")
+    if not isinstance(panels, list) or not panels:
+        errors.append("panels must be a non-empty list")
+    else:
+        for idx, panel in enumerate(panels):
+            if not isinstance(panel, dict):
+                errors.append(f"panel[{idx}] must be a JSON object")
+                continue
+            missing_panel_keys = sorted(REQUIRED_PANEL_KEYS - panel.keys())
+            if missing_panel_keys:
+                errors.append(
+                    f"panel[{idx}] missing keys: {', '.join(missing_panel_keys)}"
+                )
+            targets = panel.get("targets")
+            if not isinstance(targets, list) or not targets:
+                errors.append(f"panel[{idx}].targets must be a non-empty list")
+                continue
+            for target_idx, target in enumerate(targets):
+                if not isinstance(target, dict):
+                    errors.append(
+                        f"panel[{idx}].targets[{target_idx}] must be a JSON object"
+                    )
+                    continue
+                missing_target_keys = sorted(REQUIRED_TARGET_KEYS - target.keys())
+                if missing_target_keys:
+                    errors.append(
+                        f"panel[{idx}].targets[{target_idx}] missing keys: {', '.join(missing_target_keys)}"
+                    )
+                expr = target.get("expr")
+                if not isinstance(expr, str) or not expr.strip():
+                    errors.append(
+                        f"panel[{idx}].targets[{target_idx}].expr must be a non-empty string"
+                    )
+
+    templating = data.get("templating")
+    if not isinstance(templating, dict):
+        errors.append("templating must be a JSON object containing dashboard variables")
+    else:
+        variables = templating.get("list")
+        if not isinstance(variables, list) or not variables:
+            errors.append("templating.list must be a non-empty list")
+        else:
+            names = {
+                item.get("name")
+                for item in variables
+                if isinstance(item, dict) and isinstance(item.get("name"), str)
+            }
+            if "component" not in names:
+                errors.append("templating.list must define a 'component' variable")
+
+    return errors
+
+
+def _iter_dashboards(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(p for p in root.rglob("*.json") if p.is_file())
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate Grafana dashboard JSON files so CI can catch schema regressions"
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "monitoring" / "grafana",
+        help="Directory containing dashboard JSON files",
+    )
+    args = parser.parse_args(argv)
+
+    dashboards = _iter_dashboards(args.root)
+    if not dashboards:
+        parser.error(f"no dashboards found under {args.root}")
+
+    total_errors = 0
+    for dashboard_path in dashboards:
+        try:
+            data = _load_dashboard(dashboard_path)
+        except ValueError as exc:
+            print(exc)
+            total_errors += 1
+            continue
+        errors = _validate_dashboard(dashboard_path, data)
+        for message in errors:
+            print(f"{dashboard_path}: {message}")
+        total_errors += len(errors)
+
+    if total_errors:
+        print(f"Validation failed with {total_errors} issue(s).")
+        return 1
+
+    print(f"Validated {len(dashboards)} dashboard(s) under {args.root}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated Grafana dashboard for RAZAR failover loops with retry, success-rate, latency, and escalation panels
- define Prometheus alert rules for retry spikes, per-agent success degradation, and stuck escalation loops
- document RAZAR monitoring setup and thresholds and add a CI helper to validate dashboard JSON

## Testing
- `pre-commit run --files monitoring/grafana/razar_failover.json monitoring/alerts/razar_failover.yml docs/monitoring/RAZAR.md` *(fails: doc age/monitoring hooks require live services)*
- `python scripts/ci_verify_dashboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9d6f7fc40832eae796597eb0e463b