### PR TITLE
Document Rust doctrine requirements

### DIFF
--- a/NEOABZU/docs/onboarding.md
+++ b/NEOABZU/docs/onboarding.md
@@ -14,8 +14,17 @@ NEOABZU migrates core ABZU capabilities into a lean Rust foundation while preser
 - [Blueprint Spine](../../docs/blueprint_spine.md)
 - [System Blueprint](../../docs/system_blueprint.md)
 - [The Absolute Protocol](../../docs/The_Absolute_Protocol.md)
+- [Rust Doctrine](rust_doctrine.md) – Rust style, testing, and tooling canon
 - [OROBOROS Engine](OROBOROS_Engine.md)
 - [OROBOROS Lexicon](OROBOROS_Lexicon.md)
 - [Fusion Engine](../fusion/src/lib.rs)
 - [Numeric Utilities](../numeric/src/lib.rs)
 - [QNL Tier I Glyph Library](QNL_Library.md) – Sumerian lexicon
+
+## Rust Contribution Checklist
+
+When working on Neo-ABZU Rust crates, follow the guardrails summarized in the [Rust Doctrine](rust_doctrine.md):
+
+- Mirror the naming, module layout, and API boundaries specified there so crates align with ABZU's wider style guides.
+- Run `cargo fmt --check`, `cargo clippy`, and `cargo test` before sending changes for review; fix all reported issues instead of suppressing them.
+- Record doctrine updates in companion documentation such as the [Absolute Protocol](../../docs/The_Absolute_Protocol.md) and ensure `docs/doctrine_index.md` stays accurate.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -267,7 +267,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [SOCIAL_INVESTOR_ONE_PAGER.md](SOCIAL_INVESTOR_ONE_PAGER.md) | ABZU: Social Investor One-Pager | --- | - |
 | [SOUL_CODE.md](SOUL_CODE.md) | RFA7D Soul Core | The **RFA7D** core represents a seven‑dimensional grid of complex numbers. It serves as the energetic "soul" that INA... | - |
 | [TESTING_REPORT.md](TESTING_REPORT.md) | Testing Report | Summary of recent test results with links to logs and affected components. | `../agents/guardian.py`, `../agents/razar/boot_orchestrator.py`, `../razar/crown_handshake.py` |
-| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.102 **Last updated:** 2025-10-08 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/signal_bus.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py`, `../scripts/verify_blueprint_refs.py` |
+| [The_Absolute_Protocol.md](The_Absolute_Protocol.md) | The Absolute Protocol | **Version:** v1.0.103 **Last updated:** 2025-10-12 | `../agents/guardian.py`, `../connectors/__init__.py`, `../connectors/signal_bus.py`, `../connectors/webrtc_connector.py`, `../scripts/validate_ignition.py`, `../scripts/verify_blueprint_refs.py` |
 | [VAST_DEPLOYMENT.md](VAST_DEPLOYMENT.md) | Vast.ai Deployment | This guide explains how to run the SPIRAL_OS tools on a Vast.ai server. | - |
 | [VISION.md](VISION.md) | Vision | - | - |
 | [WISH_BOX_CHARTER.md](WISH_BOX_CHARTER.md) | Wish Box Charter | - | - |

--- a/docs/KEY_DOCUMENTS.md
+++ b/docs/KEY_DOCUMENTS.md
@@ -49,6 +49,7 @@ graph LR
 | [API Reference](api_reference.md) | API endpoints and schemas | Quarterly |
 | [Operator Protocol](operator_protocol.md) | Operator interaction rules | Quarterly |
 | [Neo-ABZU Onboarding](../NEOABZU/docs/onboarding.md) | Orientation for cross-project work | Quarterly |
+| [Rust Doctrine](../NEOABZU/docs/rust_doctrine.md) | Naming, testing, and tooling canon for Neo-ABZU Rust crates | Quarterly |
 | [OROBOROS Lexicon](../NEOABZU/docs/OROBOROS_Lexicon.md) | Canonical Sumerian glyph correspondences | Quarterly |
 | [Hero Journey Engine](../NEOABZU/docs/herojourney_engine.md) | Reduction stages mapped to mythic narrative | Quarterly |
 | [Sumerian 33‑Word Lexicon](../NEOABZU/docs/SUMERIAN_33WORDS.md) | Sacred vocabulary of 33 primordial concepts | Quarterly |

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -1,7 +1,7 @@
 # The Absolute Protocol
 
-**Version:** v1.0.102
-**Last updated:** 2025-10-08
+**Version:** v1.0.103
+**Last updated:** 2025-10-12
 
 ## How to Use This Protocol
 This document consolidates ABZU's guiding rules. Review it before contributing to follow required workflows and standards. Every contributor must propose operator-facing improvements alongside system enhancements to honor the operator-first principle. See [Contributor Checklist](contributor_checklist.md) for a quick summary of the triple-reading rule, error index updates, and test requirements. Declare a top-level `__version__` for each module, connector, and service. Every pull request and commit message must include a change-justification statement formatted as "I did X on Y to obtain Z, expecting behavior B" per the [Contributor Guide](CONTRIBUTOR_GUIDE.md#commit-message-format). Agent guides must include sections for **Vision**, **Module Overview**, **Workflow**, **Architecture Diagram**, **Requirements**, **Deployment**, **Config Schemas**, **Version History**, **Cross-links**, **Example Runs**, **Persona & Responsibilities**, and **Component & Link**.
@@ -30,11 +30,11 @@ Components ported from Python to Rust must:
 
 ### Rust Contribution Doctrine
 
-Rust crates and services must follow the canon described in [NEOABZU/docs/rust_doctrine.md](../NEOABZU/docs/rust_doctrine.md). Align naming, module layout, and formatting with repository-wide expectations in [CODE_STYLE.md](../CODE_STYLE.md) and coordinate documentation updates through the [Documentation Protocol](documentation_protocol.md).
+Rust crates and services must stay aligned with the canon codified in [NEOABZU/docs/rust_doctrine.md](../NEOABZU/docs/rust_doctrine.md). Use this summary as a quick-reference when staging Neo-ABZU changes:
 
-- **Coding style.** Mirror the module and API structure outlined in the Rust doctrine while matching the cross-language conventions captured in [CODE_STYLE.md](../CODE_STYLE.md).
-- **Tooling.** Run `cargo fmt --check` and `cargo clippy` locally or through pre-commit before pushing changes; resolve reported warnings rather than suppressing them.
-- **Testing.** Execute `cargo test` for each workspace crate and keep suites deterministic as required in the Rust doctrine, reporting outcomes alongside the repository coverage expectations in [Coverage & Testing Requirements](#coverage--testing-requirements).
+- **Style & structure.** Follow the naming and module layout rules in the Rust doctrine while mirroring the cross-language conventions documented in [CODE_STYLE.md](../CODE_STYLE.md). Keep public APIs in `lib.rs`, reserve binaries for `main.rs`, and share common utilities through dedicated core crates.
+- **Testing discipline.** Run `cargo test` for every workspace crate before submitting changes. Tests must remain deterministic, offline, and mapped to the coverage guardrails described in [Coverage & Testing Requirements](#coverage--testing-requirements).
+- **Tooling & linting.** Format code with `cargo fmt --check` and lint with `cargo clippy` via pre-commit or local execution, resolving issues instead of suppressing them so doctrine standards remain intact.
 
 Rust updates that touch operator-facing workflows must also refresh relevant entries in [doctrine_index.md](doctrine_index.md) so the checksum registry remains accurate.
 

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -81,4 +81,5 @@
 | IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-14T10:20:56+02:00 |
 | docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `4eb5f46f5e2cc2702c9faa2cbdf2ee93589e55bac0b377e24a2cd1a300a1e2fa` | 2025-10-10T00:00:00+00:00 |
 | docs/runbooks/razar_escalation.md |  | `9242f4ee751e5a04d3229ae406a2e523c3f0ed0dbfa1a0b0f6b984d0a9452202` | 2025-10-10T00:00:00+00:00 |
-| docs/The_Absolute_Protocol.md | v1.0.102 | `f635aa6baca3c33bec494436d88cdd22956778c112538ed8b72ff57888591646` | 2025-10-08T00:00:00+00:00 |
+| docs/The_Absolute_Protocol.md | v1.0.103 | `a035ba68e80378e7255b0bc3f4b7dd30b07915774a3fd43c1236d13fea8f9fa2` | 2025-10-12T00:00:00+00:00 |
+| NEOABZU/docs/rust_doctrine.md |  | `f5ba02df33694dd469c31ccdedaf8e1af51d3882cc051d5e6a8088ea8586a77b` | 2025-10-12T00:00:00+00:00 |


### PR DESCRIPTION
## Summary
- expand the Rust Contribution Doctrine in The Absolute Protocol with explicit style, testing, and tooling expectations linked to the Neo-ABZU doctrine
- register the Rust doctrine as canonical by updating the doctrine index, key documents list, and regenerated docs index
- extend the Neo-ABZU onboarding guide with a rust-specific checklist and reference to the doctrine

## Testing
- pre-commit run --files docs/The_Absolute_Protocol.md docs/doctrine_index.md docs/KEY_DOCUMENTS.md
- pre-commit run --files NEOABZU/docs/onboarding.md

------
https://chatgpt.com/codex/tasks/task_e_68c9f09ead5c832e9b4a7ea6bfc13fd8