### PR TITLE
Add alpha gate CI workflow and docs

### DIFF
--- a/.github/workflows/alpha_gate.yml
+++ b/.github/workflows/alpha_gate.yml
@@ -1,0 +1,92 @@
+name: Alpha Gate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  alpha-gate:
+    name: Run Alpha v0.1 gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PYTHONUNBUFFERED: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Restore pip cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'dev-requirements.txt', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: dist
+          key: ${{ runner.os }}-alpha-gate-dist-${{ hashFiles('pyproject.toml', 'setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-alpha-gate-dist-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          pip install build pytest
+
+      - name: Prepare mock connector endpoints
+        run: |
+          mkdir -p mock_connectors
+          echo 'ok' > mock_connectors/health
+          nohup python -m http.server 8000 --directory mock_connectors >mock_connectors/server.log 2>&1 &
+          echo $! > mock_connectors/server.pid
+
+      - name: Run Alpha gate
+        run: |
+          bash scripts/run_alpha_gate.sh --check-connectors
+
+      - name: Record gate success in changelog
+        if: success()
+        run: |
+          mkdir -p logs/alpha_gate
+          printf '\n### Alpha gate validation %s\n- workflow run: %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$GITHUB_RUN_ID" >> CHANGELOG.md
+          cp CHANGELOG.md logs/alpha_gate/CHANGELOG.md
+
+      - name: Upload Alpha gate logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-gate-logs
+          path: |
+            logs/alpha_gate/
+            mock_connectors/server.log
+          if-no-files-found: warn
+
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-gate-dist
+          path: dist/
+          if-no-files-found: warn
+
+      - name: Stop mock connector server
+        if: always()
+        run: |
+          if [ -f mock_connectors/server.pid ]; then
+            kill "$(cat mock_connectors/server.pid)" || true
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- GitHub Actions `Alpha Gate` workflow and `deployment/pipelines/alpha_gate.yml`
+  mirror, executing `scripts/run_alpha_gate.sh --check-connectors`, caching
+  build artifacts, and publishing `logs/alpha_gate/` with stamped changelog
+  notes for Alpha v0.1 readiness reviews.
 - Alpha v0.1 readiness workflow documented in `docs/releases/alpha_v0_1_workflow.md`
   with `scripts/run_alpha_gate.sh` automation covering packaging, health checks,
   and acceptance tests.

--- a/deployment/pipelines/alpha_gate.yml
+++ b/deployment/pipelines/alpha_gate.yml
@@ -1,0 +1,6 @@
+# Alpha Gate readiness pipeline executed via spiral-os pipeline deploy
+# Mirrors the CI workflow for Alpha v0.1 promotion validation.
+name: alpha-gate
+steps:
+  - run: scripts/run_alpha_gate.sh --check-connectors
+  - run: tar -czf logs/alpha_gate_artifacts.tgz logs/alpha_gate

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -57,7 +57,8 @@ These results indicate optional dependencies and system binaries are still missi
 ## Alpha v0.1 Readiness Gate
 - Workflow defined in [docs/releases/alpha_v0_1_workflow.md](releases/alpha_v0_1_workflow.md) covering packaging, mandatory health checks, and acceptance tests.
 - Automation available through `scripts/run_alpha_gate.sh` with optional connector sweeps and pytest argument passthrough.
-- Dry runs validate build artifact generation (`python -m build --wheel`) and Spiral OS / RAZAR acceptance coverage ahead of staging promotion.
+- GitHub Actions [`Alpha Gate`](../.github/workflows/alpha_gate.yml) runs on pushes to `main`, a weekly Monday 06:00 UTC schedule, and on-demand dispatch to gate release candidates. The job restores cached `dist/` wheels, starts mock connector probes, and publishes `logs/alpha_gate/` and build artifacts for review. Successful runs append a stamped entry to `CHANGELOG.md` inside the log bundle for audit trails.
+- Dry runs validate build artifact generation (`python -m build --wheel`) and Spiral OS / RAZAR acceptance coverage ahead of staging promotion. The same steps are codified in [`deployment/pipelines/alpha_gate.yml`](../deployment/pipelines/alpha_gate.yml) for local `spiral-os pipeline deploy` rehearsal.
 
 ## Deprecation Roadmap
 

--- a/docs/releases/alpha_v0_1_workflow.md
+++ b/docs/releases/alpha_v0_1_workflow.md
@@ -113,6 +113,32 @@ dry-run escalation drill during the health phase. The script exits with a
 non-zero status if any phase fails and writes consolidated logs to
 `logs/alpha_gate/` for review.
 
+## CI Integration
+
+- GitHub Actions workflow: `.github/workflows/alpha_gate.yml`.
+- Triggers: push events targeting `main`, weekly Monday 06:00 UTC schedule,
+  and manual `workflow_dispatch` runs when an operator wants to gate a
+  specific commit.
+- Environment preparation: restores cached `dist/` wheels, installs runtime and
+  test dependencies, and boots a lightweight mock connector server so
+  `--check-connectors` probes succeed in CI.
+- Artifacts: uploads `logs/alpha_gate/` (including the timestamped
+  `CHANGELOG.md` snippet) and the freshly built `dist/` wheel for auditing.
+- Pipeline mirror: `deployment/pipelines/alpha_gate.yml` enables `spiral-os
+  pipeline deploy deployment/pipelines/alpha_gate.yml` for local rehearsal.
+
+## Troubleshooting
+
+- Inspect the `alpha-gate-logs` artifact first; `build.log`,
+  `health_checks.log`, and `tests.log` include timestamped entries for each
+  phase.
+- Failures during connector probes usually mean the mock server was not
+  running. Re-run locally with `python -m http.server 8000` and create a `health`
+  file to mirror the CI setup before invoking the gate.
+- Packaging issues can be reproduced by running `python -m build --wheel`
+  directly; cached `dist/` artifacts are restored automatically on reruns but
+  are safe to delete if a rebuild is required.
+
 ## Version History
 
 - 2025-03-01: Initial workflow capturing alpha gate packaging, health checks,


### PR DESCRIPTION
## Summary
- add an Alpha Gate GitHub Actions workflow that runs the release gate with connector checks, caches build artifacts, and publishes logs and changelog notes
- publish a matching `deployment/pipelines/alpha_gate.yml` so operators can rehearse the gate locally
- document the workflow triggers, artifacts, and troubleshooting details in the Alpha v0.1 status and workflow guides, and record the automation in the changelog

## Testing
- /tmp/actionlint -color .github/workflows/alpha_gate.yml
- pre-commit run --files CHANGELOG.md docs/PROJECT_STATUS.md docs/releases/alpha_v0_1_workflow.md .github/workflows/alpha_gate.yml deployment/pipelines/alpha_gate.yml *(fails: repository hooks expect production services/metrics)*
- pre-commit run verify-onboarding-refs

------
https://chatgpt.com/codex/tasks/task_e_68ca1b47a6ec832e8f671ca74d7fe02c