### PR TITLE
Document Air Star in RAZAR delegation cascade

### DIFF
--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -70,14 +70,16 @@ remote delegation ladder. The orchestrator packages the aggregated
 `logs/razar_ai_invocations.json` history and current heartbeat telemetry before
 handing the brief to each specialist so downstream agents inherit the same
 context the Crown attempted to resolve. The default chain is
-**Crown → Kimi-cho → Kimi 2 → rStar** and follows the
+**Crown → Kimi-cho → K2 Coder → Air Star → rStar** and follows the
 [Alpha v0.1 escalation doctrine](The_Absolute_Protocol.md#alpha-v01-escalation-doctrine):
 
 1. **Kimi-cho** – applies Kimicho's repair heuristics to pursue lightweight,
    context-preserving fixes before invoking remote synthesis.
 2. **Kimi 2 (K2 Coder)** – escalates stubborn issues through the PyO3 bridge,
    synthesizing code-first patches when Kimi-cho reports persistent faults.
-3. **rStar** – final automation stop for recalcitrant bugs, generating
+3. **Air Star** – bridges K2 Coder and rStar with cross-file planning and
+   validation to keep the repair lane synchronized with upstream context.
+4. **rStar** – final automation stop for recalcitrant bugs, generating
    high-assurance patches before the mission returns to operator review.
 
 Thresholds, ordering, and service credentials for this cascade live in
@@ -89,12 +91,14 @@ secret, so pipelines must inject these keys at launch.
 [system_blueprint.md#configurable-crown-escalation-chain](system_blueprint.md#configurable-crown-escalation-chain)
 for the component-level escalation diagram and
 [system_blueprint.md#remote-agent-failover-configuration](system_blueprint.md#remote-agent-failover-configuration)
-for the configuration contract and roster normalization rules. Shared context and
-logging mechanics for this ladder are documented in
+for the configuration contract and roster normalization rules. Cross-navigate via
+[RAZAR Escalation Runbook – Escalation Ladder and Threshold Controls](runbooks/razar_escalation.md#escalation-ladder-and-threshold-controls)
+for the operator playbook that keeps these settings aligned during incidents.
+Shared context and logging mechanics for this ladder are documented in
 [RAZAR Agent – Shared Failure Context](RAZAR_AGENT.md#shared-failure-context) and
 [RAZAR Agent – Invocation Log Format](RAZAR_AGENT.md#invocation-log-format).
 Operational responders follow the [RAZAR Escalation
-Runbook](runbooks/razar_escalation.md) for the thresholds, log triage commands,
+Runbook](runbooks/razar_escalation.md#context-and-log-triage) for the thresholds, log triage commands,
 metrics, and rollback flow that keep the delegation history intact during an
 incident.
 


### PR DESCRIPTION
## Summary
- document the full Crown → Kimi-cho → K2 Coder → Air Star → rStar handoff in the blueprint spine
- add an explicit Air Star stage with supporting context in the RAZAR delegation ladder list
- link the ladder to the matching sections in system_blueprint.md and the RAZAR escalation runbook for easier cross-navigation

## Testing
- `pre-commit run --files docs/blueprint_spine.md`
- `pre-commit run verify-onboarding-refs`
- `python scripts/validate_docs.py`
- `python scripts/verify_docs_up_to_date.py`


------
https://chatgpt.com/codex/tasks/task_e_68caa5b2a200832e90f92b839d0c423c