### PR TITLE
Handle missing agent credentials during escalation

### DIFF
--- a/razar/boot_orchestrator.py
+++ b/razar/boot_orchestrator.py
@@ -533,7 +533,11 @@ def _handle_ai_result(
     failure_tracker[name] = count
     if not _should_escalate(count):
         return
-    active_agent, sequence, lookup = _load_agent_state()
+    try:
+        active_agent, sequence, lookup = _load_agent_state()
+    except ai_invoker.AgentCredentialError as exc:
+        LOGGER.warning("Skipping remote escalation for %s: %s", name, exc)
+        return
     if active_agent is not None:
         active_agent = active_agent.lower()
     sequence = [agent.lower() for agent in sequence]


### PR DESCRIPTION
## Summary
- guard `_handle_ai_result` against missing remote agent credentials so escalation is skipped gracefully
- default remote agent secrets in the boot orchestrator tests and add a regression that verifies local retries when credentials are absent

## Testing
- `pre-commit run --files razar/boot_orchestrator.py tests/test_boot_orchestrator.py` *(fails: confirm-reading gate, capture-failing-tests coverage run, verify-docs freshness requirements)*
- `pytest tests/test_boot_orchestrator.py` *(fails: repository-level coverage threshold 80% for entire project)*

------
https://chatgpt.com/codex/tasks/task_e_68cab9a5e60c832e84612e8276ed1794