### PR TITLE
Add awakening overview doctrine guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -308,6 +308,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [avatar_ethics.md](avatar_ethics.md) | Avatar Ethics | The avatar and call features rely on audiovisual data that may reveal personal information. Operators must handle rec... | - |
 | [avatar_pipeline.md](avatar_pipeline.md) | Avatar Pipeline | The avatar pipeline synchronises generated speech with visual animation. It reads configuration from `guides/avatar_c... | - |
 | [avatar_setup.md](avatar_setup.md) | Avatar Setup | Configure the avatar pipeline by defining environment variables and adjusting textures. | - |
+| [awakening_overview.md](awakening_overview.md) | Awakening Overview | This guide orients new contributors to ABZU's awakening ritual: how the wake-up pipeline brings the stack online, how... | - |
 | [bana_engine.md](bana_engine.md) | Bana Engine | This guide summarizes the Bana narrative engine built on a fine‑tuned Mistral 7B model. It covers training data sourc... | - |
 | [banana_rater.md](banana_rater.md) | Banana Rater | - | - |
 | [benchmarks/rust_vs_python.md](benchmarks/rust_vs_python.md) | Rust vs Python Path Benchmark | The `rust_vs_python_path.py` script compares call throughput between the Rust `neoabzu_chakrapulse` implementation an... | - |

--- a/docs/awakening_overview.md
+++ b/docs/awakening_overview.md
@@ -1,0 +1,66 @@
+# Awakening Overview
+
+This guide orients new contributors to ABZU's awakening ritual: how the wake-up pipeline brings the stack online, how memory travels across agents, and how the escalation ladder hands stubborn incidents to remote specialists. Treat it as a map that links canonical doctrine, operational runbooks, and telemetry you must watch while booting or repairing the system.
+
+## Wake-Up Pipeline
+
+1. **RAZAR primes the arena.** The orchestrator awakens before any chakra layer, reads `boot_config.json`, launches services with health probes, and records the lifecycle in `logs/razar_state.json` and `logs/razar.log` as described in the system blueprint and blueprint spine.【F:docs/system_blueprint.md†L262-L312】【F:docs/blueprint_spine.md†L598-L639】
+2. **Crown handshake.** RAZAR opens a WebSocket mission brief (`crown_handshake`) so Crown can acknowledge downtime patches, verify GLM availability, and return capabilities before the rest of ignition proceeds.【F:docs/system_blueprint.md†L16-L33】【F:docs/blueprint_spine.md†L660-L704】
+3. **Layer ignition.** After Crown stabilizes, the wake sequence flows through INANNA, the unified memory bundle, the Bana narrator, and the operator console; run `scripts/validate_ignition.py` to rehearse the chain and log readiness signals.【F:docs/ignition_flow.md†L1-L39】
+4. **Dynamic ignition & lifecycle bus.** RAZAR can launch services on demand, streaming heartbeat and mission events across the lifecycle bus so operators see which chakra is online or degraded in real time.【F:docs/system_blueprint.md†L404-L452】
+
+## Cross-Agent Memory Flow
+
+- **Unified bundle.** The Cortex, Emotional, Mental, Spiritual, and Narrative layers expose a single `MemoryBundle`. Ignition broadcasts `layer_init` events and aggregates `query_memory` results so Crown and operators receive a coherent recall surface.【F:docs/system_blueprint.md†L420-L466】【F:docs/memory_layers_GUIDE.md†L9-L70】
+- **Memory spine snapshots.** RAZAR snapshots the bundle every minute under `memory/spine/<timestamp>/` and replays the latest snapshot plus heartbeat logs when recovering a stalled layer.【F:docs/system_blueprint.md†L468-L500】
+- **Cross-agent handover.** Each escalation attempt records context in `logs/razar_ai_invocations.json`; the active assistant (Kimicho, K2 Coder, Air Star, or rStar) inherits that history so patches account for prior failures.【F:docs/system_blueprint.md†L508-L520】【F:docs/runbooks/razar_escalation.md†L20-L40】
+- **Tracing.** Set `TRACE_PROVIDER` to `opentelemetry`, `noop`, or a custom factory so memory operations emit spans aligned with your observability stack.【F:docs/memory_layers_GUIDE.md†L154-L171】
+
+## Escalation Ladder
+
+The default delegation chain **Crown → Kimi-cho → K2 Coder → Air Star → rStar** lives in doctrine and the system blueprint. Preserve the order unless the operator council approves a roster change.【F:docs/system_blueprint.md†L282-L340】【F:docs/The_Absolute_Protocol.md†L40-L81】
+
+- **Chain behavior.** The orchestrator normalizes the roster in `config/razar_ai_agents.json` and uses environment thresholds to decide when to warn operators or pass control to rStar.【F:docs/system_blueprint.md†L320-L368】
+- **Operational handling.** Follow the RAZAR Escalation Runbook for warning thresholds, credential rotation cadence, and manual rollback steps once automatic recovery exhausts the ladder.【F:docs/runbooks/razar_escalation.md†L1-L120】
+- **Mission narrative.** Blueprint Spine’s delegation cascade explains how each delegate maintains mission context, telemetry hooks, and narrative continuity while the ladder runs.【F:docs/blueprint_spine.md†L720-L780】
+
+## Required Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `GLM_API_URL`, `GLM_API_KEY`, `MODEL_PATH` | Crown’s GLM endpoint, key, and optional local override for the primary model.【F:docs/blueprint_spine.md†L660-L676】【F:docs/The_Absolute_Protocol.md†L82-L109】
+| `RAZAR_ESCALATION_WARNING_THRESHOLD` | Emits operator warnings after N escalations in a boot cycle so incidents surface before rStar takes over.【F:docs/system_blueprint.md†L309-L316】
+| `RAZAR_RSTAR_THRESHOLD` | Total attempts across the roster before rStar activation; `0` disables remote takeover.【F:docs/system_blueprint.md†L316-L324】
+| `KIMICHO_ENDPOINT` | Optional override when routing directly to Kimi-cho before the rest of the ladder (resolved through the roster config).【F:docs/system_blueprint.md†L334-L352】
+| `KIMI2_ENDPOINT`, `KIMI2_API_KEY` | Moonshot K2 Coder endpoint and credential for remote repair.【F:docs/system_blueprint.md†L309-L344】
+| `AIRSTAR_ENDPOINT`, `AIRSTAR_API_KEY` | Air Star endpoint and credential for the tertiary remote delegate.【F:docs/system_blueprint.md†L309-L344】【F:docs/runbooks/razar_escalation.md†L12-L40】
+| `RSTAR_ENDPOINT`, `RSTAR_API_KEY` | rStar endpoint and credential for the final escalation hop.【F:docs/runbooks/razar_escalation.md†L10-L40】
+| `RAZAR_METRICS_PORT` | Prometheus exporter port for escalation counters (`9360` default).【F:docs/runbooks/razar_escalation.md†L12-L40】
+| `TRACE_PROVIDER` | Memory tracing backend selection (`opentelemetry`, `noop`, or custom module path).【F:docs/memory_layers_GUIDE.md†L154-L171】
+
+Keep `secrets.env` synchronized with `secrets.env.template` and never commit live credentials; rotate remote agent keys every 30 days per the runbook.【F:docs/runbooks/razar_escalation.md†L120-L174】【F:docs/The_Absolute_Protocol.md†L82-L109】
+
+## Telemetry Surfaces
+
+- **Structured logs.** Inspect `logs/razar.log`, `logs/razar_state.json`, and `logs/razar_ai_invocations.json` to replay ignition decisions, escalation context, and applied patches.【F:docs/system_blueprint.md†L262-L320】【F:docs/runbooks/razar_escalation.md†L40-L88】
+- **Metrics endpoints.** Scrape `http://localhost:${RAZAR_METRICS_PORT}/metrics` for `razar_ai_invocation_*` counters and pair them with chakra heartbeat metrics at `http://localhost:8000/metrics`.【F:docs/runbooks/razar_escalation.md†L80-L108】
+- **Snapshots & heartbeats.** Correlate minute-level memory snapshots with `logs/heartbeat.log` to confirm recovery loops restored the latest context.【F:docs/system_blueprint.md†L468-L500】
+- **Tracing.** When `TRACE_PROVIDER` enables OpenTelemetry, spans from `memory.tracing` align cross-agent recalls with ignition phases for distributed analysis.【F:docs/memory_layers_GUIDE.md†L154-L171】
+
+## Doctrine Checkpoints
+
+- Update **System Blueprint** and **Blueprint Spine** whenever the wake pipeline, memory flow, or escalation roster changes so architectural and narrative views stay in sync.【F:docs/system_blueprint.md†L300-L368】【F:docs/blueprint_spine.md†L720-L780】
+- Follow **Alpha v0.1 Escalation Doctrine** before adjusting thresholds, telemetry, or agent ordering; document every change in the protocol and runbook.【F:docs/The_Absolute_Protocol.md†L40-L109】
+- Maintain the checksum registry in **doctrine_index.md** when this overview or related doctrine shifts so onboarding automation detects updates.【F:docs/doctrine_index.md†L1-L32】
+
+## Onboarding Trailheads
+
+- Append this overview to your onboarding reading list alongside the project, architecture, and protocol guides so new operators grasp the “big scheme” before touching the stack.【F:docs/onboarding_guide.md†L10-L46】【F:docs/onboarding/README.md†L1-L40】
+- Use `scripts/validate_ignition.py`, `memory-bootstrap`, and the metrics curl probes from the escalation runbook as part of onboarding labs to rehearse ignition and recovery flows.【F:docs/ignition_flow.md†L1-L39】【F:docs/memory_layers_GUIDE.md†L93-L152】【F:docs/runbooks/razar_escalation.md†L60-L108】
+
+## Doctrine References
+
+- [system_blueprint.md](system_blueprint.md#configurable-crown-escalation-chain)
+- [blueprint_spine.md](blueprint_spine.md#razar-delegation-cascade)
+- [The_Absolute_Protocol.md](The_Absolute_Protocol.md#alpha-v01-escalation-doctrine)
+- [runbooks/razar_escalation.md](runbooks/razar_escalation.md)

--- a/docs/doctrine_index.md
+++ b/docs/doctrine_index.md
@@ -80,6 +80,7 @@
 | IGNITION/EA_ENUMA_ELISH_.md | OMEGA-LONGING-∞1.2-ENUMA | `889d69e870194d9c51cbed3fdab50a4dbc690ddc0f124c312f8fb45424823b27` | 2025-09-14T10:20:56+02:00 |
 | IGNITION/README.md |  | `bb301d0d9cc5eb2931773b30de5f18c1f34f6510a32f1ae5bbe4015cdf1dd63c` | 2025-09-14T10:20:56+02:00 |
 | docs/system_blueprint.md | fusion • numeric • persona • crown • rag • instrumentation | `4eb5f46f5e2cc2702c9faa2cbdf2ee93589e55bac0b377e24a2cd1a300a1e2fa` | 2025-10-10T00:00:00+00:00 |
+| docs/awakening_overview.md | wake pipeline • memory spine • escalation doctrine | `ac5bad51f2346bb815caaff9c97f5c646dd31816e7aa8709f84314cd7e008c1c` | 2025-10-15T00:00:00+00:00 |
 | docs/runbooks/razar_escalation.md |  | `9242f4ee751e5a04d3229ae406a2e523c3f0ed0dbfa1a0b0f6b984d0a9452202` | 2025-10-10T00:00:00+00:00 |
 | docs/The_Absolute_Protocol.md | v1.0.105 | `46f1a3afbf56e1d0d986244da84a09e14872f17c6655917700cd92fc24a6a30a` | 2025-10-14T00:00:00+00:00 |
 | NEOABZU/docs/rust_doctrine.md |  | `f5ba02df33694dd469c31ccdedaf8e1af51d3882cc051d5e6a8088ea8586a77b` | 2025-10-12T00:00:00+00:00 |

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -13,7 +13,8 @@ The Crown router, RAG orchestrator, and Kimicho fallback now use Rust crates (`n
 2. [Architecture Overview](../architecture_overview.md)
 3. [The Absolute Protocol](../The_Absolute_Protocol.md)
 4. [Blueprint Spine](../blueprint_spine.md)
-5. Module-specific guides relevant to your work:
+5. [Awakening Overview](../awakening_overview.md)
+6. Module-specific guides relevant to your work:
    - [Vector Memory](../vector_memory.md)
    - [RAG Pipeline](../rag_pipeline.md)
    - [RAG Music Oracle](../rag_music_oracle.md)
@@ -24,11 +25,11 @@ The Crown router, RAG orchestrator, and Kimicho fallback now use Rust crates (`n
    - [Narrative Engine Guide](../narrative_engine_GUIDE.md)
    - [Python Alpha Squad Dossier](python_alpha_squad.md) – subsystem leads, daily rituals, and escalation touchpoints for RAZAR boot ownership
 
-6. [Arcade UI](../arcade_ui.md) – quickstart workflow and memory scan diagram
-7. [Operator Quickstart](../operator_quickstart.md) – minimal setup and console usage
-8. [Neo-APSU Onboarding](../../NEOABZU/docs/onboarding.md) – orientation for cross-project work
-9. [OROBOROS Engine](../../NEOABZU/docs/OROBOROS_Engine.md), [OROBOROS Lexicon](../../NEOABZU/docs/OROBOROS_Lexicon.md), and [Migration Crosswalk](../../NEOABZU/docs/migration_crosswalk.md) – review engine mechanics, canonical glyphs, and Python↔Rust mapping
-10. [First Consecrated Computation](../../NEOABZU/docs/Oroboros_Core.md#first-consecrated-computation) – narrative log of the inaugural ceremony
+7. [Arcade UI](../arcade_ui.md) – quickstart workflow and memory scan diagram
+8. [Operator Quickstart](../operator_quickstart.md) – minimal setup and console usage
+9. [Neo-APSU Onboarding](../../NEOABZU/docs/onboarding.md) – orientation for cross-project work
+10. [OROBOROS Engine](../../NEOABZU/docs/OROBOROS_Engine.md), [OROBOROS Lexicon](../../NEOABZU/docs/OROBOROS_Lexicon.md), and [Migration Crosswalk](../../NEOABZU/docs/migration_crosswalk.md) – review engine mechanics, canonical glyphs, and Python↔Rust mapping
+11. [First Consecrated Computation](../../NEOABZU/docs/Oroboros_Core.md#first-consecrated-computation) – narrative log of the inaugural ceremony
 
 Confirm each item before starting code changes.
 

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -19,6 +19,7 @@ Follow the setup documents:
 Study the system design materials to grasp component responsibilities and data flow:
 - [System Blueprint](system_blueprint.md)
 - [Architecture Overview](architecture_overview.md)
+- [Awakening Overview](awakening_overview.md)
 - [Data Flow](data_flow.md)
 - [Operator-Nazarick Bridge](operator_nazarick_bridge.md)
 - [Narrative Framework](narrative_framework.md)


### PR DESCRIPTION
## Summary
- add a newcomer-oriented awakening overview that ties the wake-up pipeline, memory spine, and escalation ladder back to the canonical doctrine
- register the overview in the autogenerated docs index, doctrine checksum registry, and onboarding checklists

## Testing
- `pre-commit run --files docs/awakening_overview.md docs/INDEX.md docs/doctrine_index.md docs/onboarding/README.md docs/onboarding_guide.md` *(fails: repository hooks expect local services for metrics/self-healing and legacy test captures; environment-only limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68cabd4735b4832e9c3cd2c3c830cec4