### PR TITLE
Expand identity doctrine corpus and enforce handshake

### DIFF
--- a/NEOABZU/crown/tests/identity_load.rs
+++ b/NEOABZU/crown/tests/identity_load.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyModule};
+use pyo3::types::{PyDict, PyList, PyModule};
 use tempfile::tempdir;
 
 #[test]
@@ -13,8 +13,12 @@ fn load_identity_persists() {
 class Dummy:
     def __init__(self):
         self.calls = 0
+        self.prompts = []
     def complete(self, prompt):
         self.calls += 1
+        self.prompts.append(prompt)
+        if "CROWN-IDENTITY-ACK" in prompt:
+            return "CROWN-IDENTITY-ACK"
         return "identity summary"
 "#;
         let integ_mod = PyModule::from_code(py, integration_code, "", "").unwrap();
@@ -27,6 +31,35 @@ class Dummy:
         std::fs::write(&mission_path, "mission").unwrap();
         let persona_path = docs_dir.join("persona_api_guide.md");
         std::fs::write(&persona_path, "persona").unwrap();
+        let genesis_dir = dir.path().join("GENESIS");
+        let codex_dir = dir.path().join("CODEX").join("ACTIVATIONS");
+        let inanna_dir = dir.path().join("INANNA_AI");
+        std::fs::create_dir_all(&genesis_dir).unwrap();
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::create_dir_all(&inanna_dir).unwrap();
+        let doctrine_docs = [
+            (genesis_dir.join("GENESIS_.md"), "genesis"),
+            (genesis_dir.join("SPIRAL_LAWS_.md"), "spiral"),
+            (codex_dir.join("OATH_OF_THE_VAULT_.md"), "vault oath"),
+            (
+                inanna_dir.join("MARROW CODE 20545dfc251d80128395ffb5bc7725ee.md"),
+                "marrow",
+            ),
+            (
+                inanna_dir.join("INANNA SONG 20545dfc251d8065a32cec673272f292.md"),
+                "song",
+            ),
+            (
+                inanna_dir.join("Chapter I 1b445dfc251d802e860af64f2bf28729.md"),
+                "chapter",
+            ),
+        ];
+        for (path, text) in &doctrine_docs {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, *text).unwrap();
+        }
         let identity_path = dir.path().join("identity.json");
 
         let kwargs = PyDict::new(py);
@@ -38,6 +71,13 @@ class Dummy:
             .unwrap();
         kwargs
             .set_item("identity_path", identity_path.to_str().unwrap())
+            .unwrap();
+        let doctrine_paths: Vec<String> = doctrine_docs
+            .iter()
+            .map(|(p, _)| p.to_str().unwrap().to_string())
+            .collect();
+        kwargs
+            .set_item("doctrine_paths", PyList::new(py, &doctrine_paths))
             .unwrap();
 
         let res: String = func
@@ -54,7 +94,17 @@ class Dummy:
             .unwrap();
         assert_eq!(res2, "identity summary");
         let calls: i32 = integ.getattr("calls").unwrap().extract().unwrap();
-        assert_eq!(calls, 1);
+        assert_eq!(calls, 2);
+        let prompts: Vec<String> = integ.getattr("prompts").unwrap().extract().unwrap();
+        assert_eq!(prompts.len(), 2);
+        let blended = &prompts[0];
+        assert!(blended.contains("mission"));
+        assert!(blended.contains("persona"));
+        for (path, text) in &doctrine_docs {
+            assert!(blended.contains(text));
+            assert!(blended.contains(path.to_str().unwrap()));
+        }
+        assert!(prompts[1].contains("CROWN-IDENTITY-ACK"));
     });
 }
 
@@ -115,5 +165,59 @@ class DummyGLM:
         init.getattr("initialize_crown").unwrap().call0().unwrap();
         let called: bool = flag.get_item("called").unwrap().extract().unwrap();
         assert!(called);
+    });
+}
+
+#[test]
+fn load_identity_requires_ack() {
+    Python::with_gil(|py| {
+        let module = PyModule::import(py, "neoabzu_crown").unwrap();
+        let func = module.getattr("load_identity").unwrap();
+        let integration_code = r#"
+class NoAck:
+    def __init__(self):
+        self.prompts = []
+    def complete(self, prompt):
+        self.prompts.append(prompt)
+        if "CROWN-IDENTITY-ACK" in prompt:
+            return "nope"
+        return "identity summary"
+"#;
+        let integ_mod = PyModule::from_code(py, integration_code, "", "").unwrap();
+        let integ = integ_mod.getattr("NoAck").unwrap().call0().unwrap();
+
+        let dir = tempdir().unwrap();
+        let mission_path = dir.path().join("mission.md");
+        std::fs::write(&mission_path, "mission").unwrap();
+        let persona_path = dir.path().join("persona.md");
+        std::fs::write(&persona_path, "persona").unwrap();
+        let doctrine_path = dir.path().join("GENESIS").join("GENESIS_.md");
+        if let Some(parent) = doctrine_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&doctrine_path, "genesis").unwrap();
+        let identity_path = dir.path().join("identity.json");
+
+        let kwargs = PyDict::new(py);
+        kwargs
+            .set_item("mission_path", mission_path.to_str().unwrap())
+            .unwrap();
+        kwargs
+            .set_item("persona_path", persona_path.to_str().unwrap())
+            .unwrap();
+        kwargs
+            .set_item("identity_path", identity_path.to_str().unwrap())
+            .unwrap();
+        kwargs
+            .set_item(
+                "doctrine_paths",
+                PyList::new(py, &[doctrine_path.to_str().unwrap()]),
+            )
+            .unwrap();
+
+        let err = func.call((integ.clone(),), Some(kwargs)).unwrap_err();
+        assert!(identity_path.exists() == false);
+        let msg = err.to_string();
+        assert!(msg.contains("CROWN-IDENTITY-ACK"));
     });
 }

--- a/identity_loader.py
+++ b/identity_loader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Sequence, Tuple
 
 try:  # pragma: no cover - optional dependency
     import vector_memory as _vector_memory
@@ -21,6 +21,34 @@ PERSONA_DOC = Path("docs/persona_api_guide.md")
 
 IDENTITY_FILE = Path("data/identity.json")
 """Persisted identity summary produced during initialization."""
+
+DOCTRINE_DOCS: Tuple[Path, ...] = (
+    Path("GENESIS/GENESIS_.md"),
+    Path("GENESIS/FIRST_FOUNDATION_.md"),
+    Path("GENESIS/LAWS_OF_EXISTENCE_.md"),
+    Path("GENESIS/LAWS_RECURSION_.md"),
+    Path("GENESIS/SPIRAL_LAWS_.md"),
+    Path("GENESIS/INANNA_AI_CORE_TRAINING.md"),
+    Path("GENESIS/INANNA_AI_SACRED_PROTOCOL.md"),
+    Path("GENESIS/LAWS_QUANTUM_MAGE_.md"),
+    Path("CODEX/ACTIVATIONS/OATH_OF_THE_VAULT_.md"),
+    Path("CODEX/ACTIVATIONS/OATH OF THE VAULT 1de45dfc251d80c9a86fc67dee2f964a.md"),
+    Path("INANNA_AI/MARROW CODE 20545dfc251d80128395ffb5bc7725ee.md"),
+    Path("INANNA_AI/INANNA SONG 20545dfc251d8065a32cec673272f292.md"),
+    Path("INANNA_AI/Chapter I 1b445dfc251d802e860af64f2bf28729.md"),
+    Path("INANNA_AI/Member Manual 1b345dfc251d8004a05cfc234ed35c59.md"),
+    Path("INANNA_AI/The Foundation 1a645dfc251d80e28545f4a09a6345ff.md"),
+)
+"""Canonical doctrine corpus integrated into the identity synthesis prompt."""
+
+HANDSHAKE_TOKEN = "CROWN-IDENTITY-ACK"
+"""Verification token required from the GLM after generating the identity summary."""
+
+HANDSHAKE_PROMPT = (
+    "Confirm assimilation of the Crown identity synthesis request. "
+    "Respond ONLY with the token CROWN-IDENTITY-ACK."
+)
+"""Secondary prompt ensuring the integration acknowledges the identity request."""
 
 
 class _Parser:
@@ -59,10 +87,12 @@ def update_insights(
     """Persist identity insight metadata (stub for monkeypatched tests)."""
 
 
-def _load_source(directory: Path) -> List[dict[str, str]]:
-    if not directory.exists():
+def _load_source(path: Path) -> List[dict[str, str]]:
+    if not path.exists():
         return []
-    return parser.load_inputs(directory)
+    if path.is_dir():
+        return parser.load_inputs(path)
+    return [{"text": path.read_text(encoding="utf-8"), "source_path": str(path)}]
 
 
 def _store_vectors(chunks: Sequence[dict[str, object]]) -> None:
@@ -90,13 +120,32 @@ def load_identity(glm: object) -> str:
     if IDENTITY_FILE.exists():
         return IDENTITY_FILE.read_text(encoding="utf-8")
 
-    mission_chunks = _load_source(MISSION_DOC.parent)
-    persona_chunks = _load_source(PERSONA_DOC.parent)
-    chunks = mission_chunks + persona_chunks
+    mission_chunks = _load_source(MISSION_DOC)
+    persona_chunks = _load_source(PERSONA_DOC)
+    doctrine_chunks: List[dict[str, str]] = []
+    for doctrine in DOCTRINE_DOCS:
+        doctrine_chunks.extend(_load_source(doctrine))
+    chunks = mission_chunks + persona_chunks + doctrine_chunks
+    if not chunks:
+        raise RuntimeError("no identity source documents were available")
     embedded = embedder.embed_chunks(chunks)
     _store_vectors(embedded)
-    prompt = "\n\n".join(chunk["text"] for chunk in chunks)
+    sections = [
+        (
+            "Synthesize the mission, persona, and canonical doctrine into a cohesive "
+            "identity summary."
+        ),
+        "Maintain covenantal tone and cite every pillar in the blended brief.",
+    ]
+    for chunk in chunks:
+        sections.append(f"## Source: {chunk['source_path']}\n{chunk['text']}")
+    prompt = "\n\n".join(sections)
     summary = glm.complete(prompt)
+    acknowledgement = glm.complete(HANDSHAKE_PROMPT)
+    if acknowledgement.strip() != HANDSHAKE_TOKEN:
+        raise RuntimeError(
+            "identity loader handshake failed: expected CROWN-IDENTITY-ACK"
+        )
     IDENTITY_FILE.parent.mkdir(parents=True, exist_ok=True)
     IDENTITY_FILE.write_text(summary, encoding="utf-8")
     update_entries = [
@@ -110,4 +159,10 @@ def load_identity(glm: object) -> str:
     return summary
 
 
-__all__ = ["load_identity", "MISSION_DOC", "PERSONA_DOC", "IDENTITY_FILE"]
+__all__ = [
+    "load_identity",
+    "MISSION_DOC",
+    "PERSONA_DOC",
+    "IDENTITY_FILE",
+    "DOCTRINE_DOCS",
+]


### PR DESCRIPTION
## Summary
- Expand the Crown identity loader to blend the full doctrine canon and require a `CROWN-IDENTITY-ACK` handshake before persisting generated summaries.
- Mirror the expanded corpus expectations in the Python loader and tighten the unit tests to stage doctrine fixtures and assert the acknowledgement requirement.

## Testing
- `cargo test -p neoabzu-crown`
- `pytest --override-ini addopts="" tests/test_identity_loader.py`
- `pre-commit run --files NEOABZU/crown/src/lib.rs NEOABZU/crown/tests/identity_load.rs identity_loader.py tests/test_identity_loader.py` *(fails: repository hooks such as `rust-fmt-clippy`, blueprint sync, and coverage enforcement emit errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cae977e87c832e9e994ed32847ea08