### PR TITLE
Track Crown identity fingerprint in handshake

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -1755,7 +1755,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "razar/crown_handshake.py",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": [
         "__future__",
         "dataclasses",
@@ -1775,7 +1775,8 @@
         "tests/ignition/test_full_stack.py",
         "tests/integration/test_full_flows.py",
         "tests/integration/test_razar_failover.py",
-        "tests/test_failover_integration.py"
+        "tests/test_failover_integration.py",
+        "tests/razar/test_crown_handshake_identity.py"
       ],
       "metrics": {},
       "status": "active",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
+| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/NEOABZU_spine.md
+++ b/docs/NEOABZU_spine.md
@@ -11,9 +11,11 @@ Genesis and INANNA doctrine corpus listed in
 are embedded into vector and corpus memory with metadata tags so routing
 queries can recover the same ethical baseline, the GLM produces a summary, and
 the resulting identity is persisted at `data/identity.json` so subsequent
-invocations reuse the cached context. Initialization halts when the GLM fails
-to return the `CROWN-IDENTITY-ACK` token, guaranteeing acknowledgement of the
-blend.
+invocations reuse the cached context. Initialization now also publishes
+`CROWN_IDENTITY_FINGERPRINT` (SHA-256 digest plus modification timestamp) so
+mission-brief transcripts and downstream services can confirm which identity
+imprint authorized the boot. Initialization halts when the GLM fails to return
+the `CROWN-IDENTITY-ACK` token, guaranteeing acknowledgement of the blend.
 
 ### Doctrine References
 - [system_blueprint.md#razar–crown–kimi-cho-migration](system_blueprint.md#razar–crown–kimi-cho-migration)

--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -55,6 +55,8 @@ Alpha v0.1 establishes the canonical remote delegation ladder for the Crown and 
 Commits that alter architecture—whether Python services, Rust crates, or orchestration manifests—must land with synchronized documentation updates. Always:
 
 - Revise [system_blueprint.md](system_blueprint.md), [blueprint_spine.md](blueprint_spine.md), and [NEOABZU_spine.md](NEOABZU_spine.md) so diagrams and mission narratives track the new structure.
+- When Crown identity handling changes, document the new `CROWN_IDENTITY_FINGERPRINT` semantics anywhere handshake transcripts or
+  audit procedures reference `data/identity.json`, including runbooks and awakening guides.
 - Synchronize [SECURITY.md](SECURITY.md#remote-agent-credentials) when RAZAR
   remote invocation rules change, including updates to the `KIMI2_API_KEY`,
   `AIRSTAR_API_KEY`, and `RSTAR_API_KEY` policies.

--- a/docs/awakening_overview.md
+++ b/docs/awakening_overview.md
@@ -5,7 +5,7 @@ This guide orients new contributors to ABZU's awakening ritual: how the wake-up 
 ## Wake-Up Pipeline
 
 1. **RAZAR primes the arena.** The orchestrator awakens before any chakra layer, reads `boot_config.json`, launches services with health probes, and records the lifecycle in `logs/razar_state.json` and `logs/razar.log` as described in the system blueprint and blueprint spine.【F:docs/system_blueprint.md†L262-L312】【F:docs/blueprint_spine.md†L598-L639】
-2. **Crown handshake.** RAZAR opens a WebSocket mission brief (`crown_handshake`) so Crown can acknowledge downtime patches, verify GLM availability, and return capabilities before the rest of ignition proceeds.【F:docs/system_blueprint.md†L16-L33】【F:docs/blueprint_spine.md†L660-L704】
+2. **Crown handshake.** RAZAR opens a WebSocket mission brief (`crown_handshake`) so Crown can acknowledge downtime patches, verify GLM availability, and return capabilities before the rest of ignition proceeds. The resulting transcript in `logs/razar_crown_dialogues.json` records an `identity_fingerprint` with the SHA-256 digest and timestamp of `data/identity.json` so operators can confirm which identity imprint booted the session.【F:docs/system_blueprint.md†L16-L33】【F:docs/blueprint_spine.md†L660-L704】
 3. **Layer ignition.** After Crown stabilizes, the wake sequence flows through INANNA, the unified memory bundle, the Bana narrator, and the operator console; run `scripts/validate_ignition.py` to rehearse the chain and log readiness signals.【F:docs/ignition_flow.md†L1-L39】
 4. **Dynamic ignition & lifecycle bus.** RAZAR can launch services on demand, streaming heartbeat and mission events across the lifecycle bus so operators see which chakra is online or degraded in real time.【F:docs/system_blueprint.md†L404-L452】
 

--- a/docs/blueprint_spine.md
+++ b/docs/blueprint_spine.md
@@ -50,7 +50,7 @@ The inaugural ceremony is recorded in the [First Consecrated Computation](../NEO
 - **Signal bus** enables cross-core publish/subscribe messaging (see [../connectors/signal_bus.py](../connectors/signal_bus.py)).
 - **OS Guardian** now brokers host-level automation with allowlisted commands and auditable safeguards; see [os_guardian.md](os_guardian.md) and policy references in [os_guardian_permissions.md](os_guardian_permissions.md).
 - **Neoabzu crates** bumped to **v0.1.2** with verified PyO3 bindings via `NEOABZU/pyproject.toml`.
-- **Identity loader** reimplemented in Rust; Crown initialization writes mission and persona summary to `data/identity.json` and seeds vector/corpus memory with an identity embedding so routing queries can recall the servant baseline.
+- **Identity loader** reimplemented in Rust; Crown initialization writes mission and persona summary to `data/identity.json` and seeds vector/corpus memory with an identity embedding so routing queries can recall the servant baseline. The boot cycle now surfaces a `CROWN_IDENTITY_FINGERPRINT` (SHA-256 digest plus mtime) for that file so audit trails link each mission brief acknowledgement to the exact identity imprint.
 - **Blueprint governance** requires architecture commits to update [system_blueprint.md](system_blueprint.md), [The_Absolute_Protocol.md](The_Absolute_Protocol.md#architecture-change-doctrine), [NEOABZU_spine.md](NEOABZU_spine.md), and the indexes [index.md](index.md) / [INDEX.md](INDEX.md) so ceremonial and operational guides remain in lockstep.
 
 ### **Rust Workspace Crates**

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ Curated starting points for understanding and operating the project. For an exha
 
 ## Orientation
 - [ABZU Project Declaration](project_mission_vision.md) – deployments must reach a living state
-- [Blueprint Spine](blueprint_spine.md) – mission overview, Operator ↔ RAZAR/Crown flow, identity embedding feed, Crown confirms load handshake, memory bundle, and ignition map
-- [System Blueprint](system_blueprint.md) – chakra layers, Operator ↔ RAZAR/Crown flow, identity embedding pipeline, handshake enforcement, dynamic ignition, and operator UI
+- [Blueprint Spine](blueprint_spine.md) – mission overview, Operator ↔ RAZAR/Crown flow, identity embedding feed, Crown confirms load handshake, identity fingerprint export, memory bundle, and ignition map
+- [System Blueprint](system_blueprint.md) – chakra layers, Operator ↔ RAZAR/Crown flow, identity embedding pipeline, `CROWN_IDENTITY_FINGERPRINT` publishing, handshake enforcement, dynamic ignition, and operator UI
 - [System Overview](system_overview.md) – mission, triadic stack, chakra agents, memory bundle, and avatar stack
 - [ABZU Blueprint](ABZU_blueprint.md) – high-level narrative for recreating the system with chakra and heartbeat roles
 - [Repository Blueprint](repository_blueprint.md) – mission, architecture, and memory bundle overview

--- a/docs/runbooks/razar_escalation.md
+++ b/docs/runbooks/razar_escalation.md
@@ -38,6 +38,12 @@ rStar see every previous failure, patch attempt, and rejection.
 
 Operators should triage incidents with the following artifacts:
 
+- **Crown handshake transcripts** (`logs/razar_crown_dialogues.json`). Each
+  `crown` entry now appends an `identity_fingerprint` object that captures the
+  SHA-256 digest and last-modified timestamp of `data/identity.json` so you can
+  verify which identity summary the acknowledgement came from during
+  post-incident review.
+
 ```bash
 # Recent orchestration state changes and component failures
 tail -n 50 logs/razar.log

--- a/docs/system_blueprint.md
+++ b/docs/system_blueprint.md
@@ -32,7 +32,7 @@ Contributors must propose operator-facing improvements alongside system enhancem
 - **ChakraPulse bus** distributes heartbeat pulses; see [chakrapulse_spec.md](chakrapulse_spec.md) for message schema.
 - **Per-agent avatars** render through the [avatar pipeline](avatar_pipeline.md) for synchronized sessions.
 - **Crown Router** now flows through the Rust crate [`neoabzu_crown`](../NEOABZU/crown/src/lib.rs), delivering built-in validation, orchestrator delegation, and telemetry hooks.
-- **Identity loader** migrated to Rust; Crown boot summarizes mission and persona into `data/identity.json` and seeds vector/corpus memory with an identity embedding for downstream retrieval.
+- **Identity loader** migrated to Rust; Crown boot summarizes mission and persona into `data/identity.json` and seeds vector/corpus memory with an identity embedding for downstream retrieval. Each boot now emits a `CROWN_IDENTITY_FINGERPRINT` payload containing the SHA-256 digest and modification timestamp of that file so downstream audits can correlate handshake transcripts with the active identity imprint.
 - **Resuscitator flows** streamline rollback and restart procedures; see the [recovery playbook](recovery_playbook.md).
 - **Signal bus** enables cross-core pub/sub messaging (see [../connectors/signal_bus.py](../connectors/signal_bus.py)).
 - **Neoabzu crates** released at **v0.1.2**; CI now enforces PyO3 exposure and `cargo check` on workspace crates.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -177,7 +177,7 @@ documents:
       scope: RAZAR agent workflows and deployment.
   docs/The_Absolute_Protocol.md:
     commit: worktree
-    sha256: cc7dacaa0d330ef4044e5188563260504c3f2d2f59c6a24e7c38b8ade75e144a
+    sha256: c5e546f5b8f25e260991e45565f6084cd88ff931fc52ec6f254df7384be78688
     summary:
       insight: Use the PR checklist to synchronize versions, connectors, and document
         summaries while keeping coverage high and removing placeholders before commit.

--- a/tests/razar/test_crown_handshake_identity.py
+++ b/tests/razar/test_crown_handshake_identity.py
@@ -1,0 +1,74 @@
+"""Regression coverage for propagating the identity fingerprint."""
+
+from __future__ import annotations
+
+import json
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from tests.conftest import allow_test
+
+allow_test(__file__)
+
+from razar.crown_handshake import CrownHandshake
+
+
+class _StubConnection:
+    """Minimal async context manager that mimics a websocket connection."""
+
+    def __init__(self, reply: Dict[str, Any]) -> None:
+        self._reply = reply
+        self.sent_payload: str | None = None
+
+    async def __aenter__(self) -> "_StubConnection":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def send(self, payload: str) -> None:
+        self.sent_payload = payload
+
+    async def recv(self) -> str:
+        return json.dumps(self._reply)
+
+
+def test_identity_fingerprint_written_to_transcript(monkeypatch, tmp_path):
+    """Ensure the handshake persists the fingerprint in logs and responses."""
+
+    mission_brief = {
+        "priority_map": {"fusion": 1},
+        "current_status": {"fusion": "green"},
+        "open_issues": [],
+    }
+    mission_path = tmp_path / "brief.json"
+    mission_path.write_text(json.dumps(mission_brief))
+
+    transcript_path = tmp_path / "transcript.json"
+
+    fingerprint_payload = {
+        "sha256": "abc123",
+        "modified": "2024-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setenv("CROWN_IDENTITY_FINGERPRINT", json.dumps(fingerprint_payload))
+
+    reply_body = {"ack": "CROWN-ACK", "capabilities": ["stasis"], "downtime": {}}
+    connection = _StubConnection(reply_body)
+
+    def _fake_connect(url: str) -> _StubConnection:
+        assert url == "ws://example.com/crown"
+        return connection
+
+    monkeypatch.setattr(
+        "razar.crown_handshake.websockets",
+        SimpleNamespace(connect=_fake_connect),
+    )
+
+    handshake = CrownHandshake("ws://example.com/crown", transcript_path)
+    response = asyncio.run(handshake.perform(str(mission_path)))
+
+    assert response.identity_fingerprint == fingerprint_payload
+
+    transcript = json.loads(transcript_path.read_text())
+    assert transcript[-1]["message"]["identity_fingerprint"] == fingerprint_payload


### PR DESCRIPTION
## Summary
- compute and publish a CROWN identity fingerprint after the loader writes data/identity.json, exposing the value via an environment variable and state file
- include the fingerprint in razar/crown_handshake transcripts and CrownResponse payloads, updating the component index and documenting the new field across runbooks and blueprints
- add regression coverage ensuring the handshake propagates the fingerprint from the environment into the response and transcript

## Testing
- `pytest --override-ini addopts='' tests/razar/test_crown_handshake_identity.py`
- `pre-commit run --files init_crown_agent.py razar/crown_handshake.py tests/razar/test_crown_handshake_identity.py docs/runbooks/razar_escalation.md docs/awakening_overview.md docs/system_blueprint.md docs/blueprint_spine.md docs/NEOABZU_spine.md onboarding_confirm.yml component_index.json docs/INDEX.md` *(fails: blueprint/doc-sync hooks require broader updates and repository monitoring hooks cannot reach local exporters)*

------
https://chatgpt.com/codex/tasks/task_e_68caf22c5b40832ebbf24a89d963947e