### PR TITLE
Add deterministic handshake test for Crown transcript

### DIFF
--- a/tests/razar/conftest.py
+++ b/tests/razar/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures for RAZAR handshake tests."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+IDENTITY_SUMMARY_TEXT: Final[str] = (
+    "CROWN Identity Summary\n"
+    "======================\n"
+    "Designation: Crown Guardian\n"
+    "Focus: Stabilize mission chains, maintain operator channels.\n"
+    "Capabilities: triage, diagnostics, stabilization.\n"
+)
+
+# Freeze the modified timestamp so derived fingerprints remain deterministic.
+FIXED_IDENTITY_MTIME: Final[int] = 1_704_067_200  # 2024-01-01T00:00:00Z
+EXPECTED_IDENTITY_SHA256: Final[str] = hashlib.sha256(
+    IDENTITY_SUMMARY_TEXT.encode("utf-8")
+).hexdigest()
+EXPECTED_IDENTITY_MODIFIED: Final[str] = datetime.fromtimestamp(
+    FIXED_IDENTITY_MTIME, tz=timezone.utc
+).isoformat()
+
+
+@pytest.fixture
+def identity_summary_file(tmp_path: Path) -> Path:
+    """Write a deterministic identity summary for tests."""
+
+    path = tmp_path / "identity_summary.json"
+    path.write_text(IDENTITY_SUMMARY_TEXT, encoding="utf-8")
+    os.utime(path, (FIXED_IDENTITY_MTIME, FIXED_IDENTITY_MTIME))
+    return path
+
+
+@pytest.fixture
+def identity_fingerprint(identity_summary_file: Path) -> dict[str, str]:
+    """Return the expected fingerprint for the synthetic identity summary."""
+
+    digest = hashlib.sha256(identity_summary_file.read_bytes()).hexdigest()
+    # Guard against accidental fixture drift.
+    assert digest == EXPECTED_IDENTITY_SHA256
+    return {
+        "sha256": digest,
+        "modified": EXPECTED_IDENTITY_MODIFIED,
+    }
+
+
+__all__ = [
+    "identity_summary_file",
+    "identity_fingerprint",
+    "EXPECTED_IDENTITY_SHA256",
+    "EXPECTED_IDENTITY_MODIFIED",
+]

--- a/tests/razar/test_crown_handshake.py
+++ b/tests/razar/test_crown_handshake.py
@@ -1,0 +1,90 @@
+"""Integration coverage for the Crown handshake transcript."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from tests.conftest import allow_test
+
+allow_test(__file__)
+
+import pytest
+
+from razar.crown_handshake import CrownHandshake
+from tests.razar.conftest import (
+    EXPECTED_IDENTITY_MODIFIED,
+    EXPECTED_IDENTITY_SHA256,
+)
+
+
+class _StubWebSocket:
+    """Context manager that mimics a websocket connection."""
+
+    def __init__(self, reply: Dict[str, Any]) -> None:
+        self._reply = reply
+        self.sent_payload: dict[str, Any] | None = None
+
+    async def __aenter__(self) -> "_StubWebSocket":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def send(self, payload: str) -> None:
+        self.sent_payload = json.loads(payload)
+
+    async def recv(self) -> str:
+        return json.dumps(self._reply)
+
+
+@pytest.mark.usefixtures("identity_summary_file")
+def test_transcript_includes_fingerprint_and_capabilities(
+    monkeypatch,
+    tmp_path,
+    identity_fingerprint,
+):
+    """Verify the transcript contains the identity fingerprint and capabilities."""
+
+    mission_brief = {
+        "priority_map": {"core": 1},
+        "current_status": {"core": "green"},
+        "open_issues": [],
+    }
+    mission_path = tmp_path / "mission.json"
+    mission_path.write_text(json.dumps(mission_brief))
+
+    transcript_path = tmp_path / "dialogue.json"
+
+    reply_body = {
+        "ack": "CROWN-ACK",
+        "capabilities": ["triage", "diagnostics"],
+        "downtime": {},
+    }
+    connection = _StubWebSocket(reply_body)
+
+    def _fake_connect(url: str) -> _StubWebSocket:
+        assert url == "ws://unit-test"
+        return connection
+
+    monkeypatch.setenv("CROWN_IDENTITY_FINGERPRINT", json.dumps(identity_fingerprint))
+    monkeypatch.setattr(
+        "razar.crown_handshake.websockets",
+        SimpleNamespace(connect=_fake_connect),
+    )
+
+    handshake = CrownHandshake("ws://unit-test", transcript_path)
+    response = asyncio.run(handshake.perform(str(mission_path)))
+
+    assert response.capabilities == ["triage", "diagnostics"]
+    assert response.identity_fingerprint == identity_fingerprint
+    assert response.identity_fingerprint["sha256"] == EXPECTED_IDENTITY_SHA256
+    assert response.identity_fingerprint["modified"] == EXPECTED_IDENTITY_MODIFIED
+
+    assert connection.sent_payload == mission_brief
+
+    transcript = json.loads(transcript_path.read_text())
+    assert transcript[-1]["message"]["identity_fingerprint"] == identity_fingerprint
+    assert transcript[-1]["message"]["capabilities"] == ["triage", "diagnostics"]


### PR DESCRIPTION
## Summary
- add deterministic fixtures that write a synthetic Crown identity summary and expose the expected fingerprint hash for reuse
- add a Crown handshake regression test that stubs the websocket exchange, feeds a mission brief, and verifies the transcript records the fingerprint and capabilities

## Testing
- pytest tests/razar/test_crown_handshake.py --cov-fail-under=0
- PYTEST_ADDOPTS="--cov-fail-under=0" SKIP=verify-docs-up-to-date pre-commit run --files tests/razar/conftest.py tests/razar/test_crown_handshake.py


------
https://chatgpt.com/codex/tasks/task_e_68cb0b049734832ea13e868bec094ada