### PR TITLE
Document alpha stage snapshots

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -51,7 +51,7 @@ These results indicate optional dependencies and system binaries are still missi
 - [Optional dependency stubs](https://github.com/DINGIRABZU/ABZU/issues/213) — owner: infra team.
 
 ## Planned Releases
-- v0.1 – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025). **Status:** Charter baseline approved in [alpha_v0_1_charter.md](alpha_v0_1_charter.md); subsystem execution tracked through the [Alpha v0.1 execution plan](roadmap.md#alpha-v01-execution-plan). Reference the [Python Alpha Squad dossier](onboarding/python_alpha_squad.md) for RAZAR boot ownership and daily reliability rituals feeding that plan.
+- v0.1 – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025). **Status:** Charter baseline approved in [alpha_v0_1_charter.md](alpha_v0_1_charter.md); subsystem execution tracked through the [Alpha v0.1 execution plan](roadmap.md#alpha-v01-execution-plan). Stage snapshots: **Stage A** focuses on Alpha gate automation readiness, **Stage B** locks subsystem hardening for sonic core, memory, and connectors, and **Stage C** synchronizes exit checklist, demo assets, and readiness signals. See the [Milestone Stages overview](roadmap.md#milestone-stages) for task-level detail. Reference the [Python Alpha Squad dossier](onboarding/python_alpha_squad.md) for RAZAR boot ownership and daily reliability rituals feeding that plan.
 - v0.2 – avatar console integration and basic RAG pipeline (target: Q4 2025). **Status:** Backlog shaping pending Alpha v0.1 exit criteria.
 
 ## Alpha v0.1 Readiness Gate

--- a/docs/alpha_v0_1_charter.md
+++ b/docs/alpha_v0_1_charter.md
@@ -80,3 +80,5 @@ current progress summarized in [PROJECT_STATUS.md](PROJECT_STATUS.md).
   [PROJECT_STATUS.md](PROJECT_STATUS.md#planned-releases) and
   [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md#upcoming-milestones) to reflect
   the milestone as complete and trigger the release checklist audit.
+
+Execution Ladder: Squads anchor planning to the Stage A/B/C roadmap track detailed in the [Milestone Stages overview](roadmap.md#milestone-stages). Before writing code, each squad must surface and review its next three tasks from that ladder to confirm ownership, dependencies, and readiness signals.


### PR DESCRIPTION
## Summary
- highlight Alpha v0.1 Stage A/B/C focus areas directly in the planned releases section
- document an execution ladder reminder in the charter so squads review the next three roadmap tasks before coding

## Testing
- `pre-commit run --files docs/PROJECT_STATUS.md docs/alpha_v0_1_charter.md` *(fails: verify_docs_up_to_date, verify-chakra-monitoring, verify-self-healing require repo-wide doctrine updates and running telemetry exporters unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb22638074832ea9b1f4663f9f3f32