### PR TITLE
Add deterministic Crown replay capture workflow

### DIFF
--- a/crown/replay_scenarios.yaml
+++ b/crown/replay_scenarios.yaml
@@ -1,0 +1,82 @@
+# Crown replay scenarios for deterministic routing captures.
+# Each entry mirrors a Crown → servant path from the alpha v0.1 charter.
+scenarios:
+  - id: crown_glm_reflection
+    description: "Baseline GLM reflection without servant escalation."
+    prompt: |
+      Crown, offer a reflective meditation on how the mission doctrine guides
+      today's operator sync.
+    expected_model: glm
+    include_memory: false
+    seed: 1101
+    context:
+      - input: "Operator: confirm Crown identity assimilation transcript."
+      - input: "Crown: mission brief acknowledged; awaiting directives."
+
+  - id: crown_kimicho_guidance
+    description: "Technical triage escalated to the Kimicho servant."
+    prompt: |
+      Kimicho, diagnose this failure signature and outline a minimal patch.
+      Traceback: ValueError: ritual binding missing during activation stage.
+    expected_model: kimicho
+    include_memory: true
+    seed: 2102
+    memory:
+      spiral: "Ritual ledger flagged missing binding during prior rehearsal."
+      cortex:
+        - "Kimicho heuristic: prefer minimal code insertion before escalation."
+      vector:
+        - text: "Operator note: retain existing bindings when applying Kimicho patch."
+    context:
+      - input: "Operator: escalation requested for ritual binding fault."
+
+  - id: crown_kimi_k2_revision
+    description: "Kimicho relays to the K2 Coder servant for code-first repair."
+    prompt: |
+      K2 Coder, rewrite the failing binding so the activation ritual resolves
+      without additional side effects.
+    expected_model: kimi_k2
+    include_memory: true
+    seed: 3103
+    memory:
+      spiral: "Kimicho report: binding lookup requires explicit null-guard."
+      cortex:
+        - "Prior K2 Coder patch inserted guard rails for activation step."
+      vector:
+        - text: "Telemetry: activation ritual fails after three attempts without guard."
+    context:
+      - input: "Kimicho: escalation to K2 coder triggered after minimal patch attempt."
+
+  - id: crown_air_star_validation
+    description: "Air Star reviews cross-file impact before final escalation."
+    prompt: |
+      Air Star, evaluate the revised binding plan and stage validation notes for
+      the operator review packet.
+    expected_model: air_star
+    include_memory: true
+    seed: 4104
+    memory:
+      spiral: "K2 Coder patch introduces guard_path parameter."
+      cortex:
+        - "Air Star directive: cross-verify companion modules before merge."
+      vector:
+        - text: "Review log: ensure guard_path maintains ritual state machine invariants."
+    context:
+      - input: "K2 Coder: patch candidate ready; requesting Air Star validation."
+
+  - id: crown_rstar_finalization
+    description: "Final rStar escalation capturing the terminal remediation output."
+    prompt: |
+      rStar, synthesize the final remediation script so the ritual activation
+      completes even under degraded telemetry.
+    expected_model: rstar
+    include_memory: true
+    seed: 5105
+    memory:
+      spiral: "Air Star verdict: guard_path needs resilience hooks for telemetry gaps."
+      cortex:
+        - "rStar escalation protocol: include rollback stanza in final patch."
+      vector:
+        - text: "Operator directive: archive final remediation in Stage A evidence bundle."
+    context:
+      - input: "Air Star: handing final remediation to rStar with validation notes."

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/crown_invocation_guide.md
+++ b/docs/crown_invocation_guide.md
@@ -58,6 +58,17 @@ Each step is orchestrated by [`initialize_crown`](../init_crown_agent.py) and th
 - **Logs:** Review `logs/razar_crown_dialogues.json` for handshake transcripts and `logs/identity_refresh/` for doctrine regeneration history.
 - **Runbooks:** Pair this guide with [awakening_overview.md](awakening_overview.md) for the full wake pipeline and [blueprint_spine.md](blueprint_spine.md#razar-delegation-cascade) for narrative context across the delegation ladder.
 
+## Deterministic Replay Capture
+
+- Refresh the Stage A replay bundle with `python scripts/crown_capture_replays.py`. The helper reads the curated scenarios in
+  `crown/replay_scenarios.yaml`, exercises each Crown → servant hand-off through
+  `crown_prompt_orchestrator_async`, and records the routed model, emotion state, and
+  deterministic seed in `logs/crown_replays/`.
+- Audio/video surrogates are logged through `tools.session_logger`, and the script records
+  SHA-256 hashes for every capture. Re-running the command fails fast when the current outputs
+  diverge from the stored baseline, signalling operators to investigate doctrine or routing drift
+  before the alpha review board convenes.
+
 ## Doctrine References
 
 - [crown_manifest.md](crown_manifest.md)

--- a/docs/releases/alpha_v0_1_workflow.md
+++ b/docs/releases/alpha_v0_1_workflow.md
@@ -32,6 +32,15 @@ Alpha promotion requires a reproducible artifact bundle.
    ```
 3. Archive the generated wheel and supporting manifests under `release/` and
    cross-check signatures per [release_process.md](../release_process.md).
+4. Capture deterministic Crown replays for the Stage A evidence bundle:
+   ```bash
+   python scripts/crown_capture_replays.py
+   ```
+   The script validates the Crown → servant ladder defined in
+   `crown/replay_scenarios.yaml`, logs audio/video surrogates via
+   `tools.session_logger`, and writes hashed metadata to `logs/crown_replays/`.
+   Archive that directory with the other alpha gate artifacts so reviewers can
+   reproduce the routing traces.
 
 Successful packaging verifies that the project metadata and dependencies are in
 sync before health validation starts.


### PR DESCRIPTION
## Summary
- define five replay scenarios that cover the Crown → servant routing ladder called out in the alpha charter
- add a capture script that plays each scenario through the Crown prompt orchestrator, logs surrogate audio/video, and writes hashed metadata for regression checks
- document the replay refresh workflow for Stage A operators and fold the log bundle into the alpha gate artifact checklist

## Testing
- python -m pre_commit run --files crown/replay_scenarios.yaml scripts/crown_capture_replays.py docs/crown_invocation_guide.md docs/releases/alpha_v0_1_workflow.md -v *(fails: environment lacks websockets, metrics exporters, and blueprint/doc freshness checks)*

------
https://chatgpt.com/codex/tasks/task_e_68cb391653f8832eade5f84d2cab8e6f