### PR TITLE
Adjust pytest coverage targets

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 pythonpath = src
-addopts = --cov=src --cov=agents --cov=start_spiral_os --cov=spiral_os --cov=spiral_memory --cov=spiral_vector_db --cov=vector_memory --cov-fail-under=90 --log-cli-level=INFO
+addopts = --cov=start_spiral_os --cov=spiral_os --cov=spiral_memory --cov=spiral_vector_db --cov=vector_memory --cov-fail-under=90 --log-cli-level=INFO
 filterwarnings =
     ignore:.*audioop.*:DeprecationWarning
     ignore:Couldn't find ffmpeg or avconv.*:RuntimeWarning


### PR DESCRIPTION
## Summary
- narrow pytest coverage configuration to Stage A critical modules

## Testing
- pre-commit run --files pytest.ini *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc66adda70832eb87d34de09492dfb