### PR TITLE
Pause non-stage components and restrict coverage enforcement

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -115,7 +115,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -146,7 +146,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -166,7 +166,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -191,7 +191,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -213,7 +213,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -261,7 +261,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -300,7 +300,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -340,7 +340,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -361,7 +361,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -435,7 +435,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -455,7 +455,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -494,7 +494,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -520,7 +520,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -545,7 +545,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -568,7 +568,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -594,7 +594,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -619,7 +619,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -650,7 +650,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -685,7 +685,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -718,7 +718,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -751,7 +751,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -786,7 +786,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -816,7 +816,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -840,7 +840,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -902,7 +902,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -960,7 +960,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -979,7 +979,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1003,7 +1003,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1032,7 +1032,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1060,7 +1060,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1081,7 +1081,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1104,7 +1104,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1128,7 +1128,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1155,7 +1155,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1173,7 +1173,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1194,7 +1194,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1214,7 +1214,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1232,7 +1232,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1253,7 +1253,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1274,7 +1274,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1293,7 +1293,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1313,7 +1313,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1333,7 +1333,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1354,7 +1354,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1375,7 +1375,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1396,7 +1396,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1434,7 +1434,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1457,7 +1457,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1480,7 +1480,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1514,7 +1514,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1534,7 +1534,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1556,7 +1556,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1583,7 +1583,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1604,7 +1604,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1645,7 +1645,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1683,7 +1683,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1727,7 +1727,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1761,7 +1761,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1781,7 +1781,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -1808,7 +1808,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1830,7 +1830,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1870,7 +1870,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1905,7 +1905,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1929,7 +1929,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -1955,7 +1955,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2006,7 +2006,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2024,7 +2024,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2042,7 +2042,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2065,7 +2065,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2086,7 +2086,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2119,7 +2119,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2147,7 +2147,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2169,7 +2169,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2202,7 +2202,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2230,7 +2230,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2245,7 +2245,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2287,7 +2287,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2318,7 +2318,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2338,7 +2338,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2363,7 +2363,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2390,7 +2390,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2416,7 +2416,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2439,7 +2439,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2461,7 +2461,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2482,7 +2482,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2502,7 +2502,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2521,7 +2521,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2539,7 +2539,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2573,7 +2573,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2596,7 +2596,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2628,7 +2628,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2657,7 +2657,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2681,7 +2681,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2712,7 +2712,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2733,7 +2733,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2772,7 +2772,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2815,7 +2815,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2837,7 +2837,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2856,7 +2856,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2881,7 +2881,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2901,7 +2901,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -2924,7 +2924,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2951,7 +2951,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2974,7 +2974,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -2996,7 +2996,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3032,7 +3032,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3054,7 +3054,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3074,7 +3074,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3091,7 +3091,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3114,7 +3114,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3133,7 +3133,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3163,7 +3163,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3185,7 +3185,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3208,7 +3208,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3233,7 +3233,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3253,7 +3253,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3274,7 +3274,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3381,7 +3381,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3401,7 +3401,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3430,7 +3430,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3464,7 +3464,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3489,7 +3489,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3512,7 +3512,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3537,7 +3537,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3568,7 +3568,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3603,7 +3603,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3637,7 +3637,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3662,7 +3662,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3685,7 +3685,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -3710,7 +3710,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3730,7 +3730,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3764,7 +3764,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3796,7 +3796,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3825,7 +3825,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3877,7 +3877,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3919,7 +3919,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3941,7 +3941,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -3972,7 +3972,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4017,7 +4017,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4039,7 +4039,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "CLI crate without lib.rs; add dedicated tests to stabilize",
       "adr": null
     },
@@ -4059,7 +4059,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4078,7 +4078,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4104,7 +4104,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4125,7 +4125,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4159,7 +4159,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4179,7 +4179,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4199,7 +4199,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4223,7 +4223,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4244,7 +4244,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4269,7 +4269,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4292,7 +4292,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4309,7 +4309,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4328,7 +4328,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4348,7 +4348,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4367,7 +4367,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4388,7 +4388,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4415,7 +4415,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4435,7 +4435,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4465,7 +4465,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4485,7 +4485,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4509,7 +4509,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4546,7 +4546,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4572,7 +4572,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4590,7 +4590,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4610,7 +4610,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4636,7 +4636,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4659,7 +4659,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4681,7 +4681,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4699,7 +4699,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4722,7 +4722,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4747,7 +4747,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4769,7 +4769,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4792,7 +4792,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4817,7 +4817,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4837,7 +4837,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -4864,7 +4864,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4895,7 +4895,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4926,7 +4926,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -4957,7 +4957,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5029,7 +5029,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5104,7 +5104,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5126,7 +5126,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5154,7 +5154,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5184,7 +5184,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5235,7 +5235,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5256,7 +5256,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5281,7 +5281,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5315,7 +5315,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5336,7 +5336,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5355,7 +5355,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5376,7 +5376,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5400,7 +5400,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5423,7 +5423,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5453,7 +5453,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5475,7 +5475,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5504,7 +5504,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5529,7 +5529,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5553,7 +5553,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5573,7 +5573,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5594,7 +5594,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5643,7 +5643,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5685,7 +5685,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5709,7 +5709,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5729,7 +5729,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5747,7 +5747,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -5775,7 +5775,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5804,7 +5804,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5828,7 +5828,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5906,7 +5906,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5938,7 +5938,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5967,7 +5967,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -5989,7 +5989,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6017,7 +6017,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6037,7 +6037,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6059,7 +6059,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6082,7 +6082,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6130,7 +6130,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6152,7 +6152,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6172,7 +6172,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6203,7 +6203,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6227,7 +6227,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6254,7 +6254,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6275,7 +6275,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6297,7 +6297,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6317,7 +6317,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6338,7 +6338,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6360,7 +6360,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6382,7 +6382,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6403,7 +6403,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6437,7 +6437,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6463,7 +6463,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6499,7 +6499,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6524,7 +6524,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6546,7 +6546,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6570,7 +6570,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6622,7 +6622,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6646,7 +6646,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6667,7 +6667,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6709,7 +6709,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6731,7 +6731,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6752,7 +6752,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6776,7 +6776,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6797,7 +6797,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6821,7 +6821,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6922,7 +6922,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -6943,7 +6943,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6965,7 +6965,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -6986,7 +6986,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7008,7 +7008,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7030,7 +7030,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7050,7 +7050,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7074,7 +7074,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7096,7 +7096,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7117,7 +7117,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7151,7 +7151,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7178,7 +7178,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7197,7 +7197,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7221,7 +7221,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7244,7 +7244,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7268,7 +7268,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7291,7 +7291,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7326,7 +7326,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     },
@@ -7359,7 +7359,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7376,7 +7376,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "experimental",
+      "status": "deprecated",
       "issues": "No tests found",
       "adr": null
     },
@@ -7402,7 +7402,7 @@
       "metrics": {
         "coverage": 0.0
       },
-      "status": "active",
+      "status": "deprecated",
       "issues": "No known issues",
       "adr": null
     }


### PR DESCRIPTION
## Summary
- mark every non-Stage component entry in `component_index.json` as deprecated so only the spiral memory modules remain active
- gate coverage enforcement in `scripts/export_coverage.py` behind an explicit Stage A allowlist so paused components are ignored

## Testing
- pre-commit run --files component_index.json scripts/export_coverage.py *(fails: Stage A test coverage remains below the 90% threshold)*
- scripts/run_alpha_gate.sh *(fails: razar failover test and subsequent coverage export error)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3f571a38832e9e758b360730bbd0