### PR TITLE
Add coverage badge generation and bundle html reports

### DIFF
--- a/scripts/export_coverage.py
+++ b/scripts/export_coverage.py
@@ -41,6 +41,23 @@ def main() -> None:
         ],
         check=True,
     )
+    subprocess.run(
+        [
+            PYTHON,
+            "-m",
+            "coverage",
+            "html",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "coverage-badge",
+            "-o",
+            str(REPO_ROOT / "coverage.svg"),
+        ],
+        check=True,
+    )
     with COVERAGE_JSON.open("r", encoding="utf-8") as fh:
         coverage_payload = json.load(fh)
 

--- a/scripts/run_alpha_gate.sh
+++ b/scripts/run_alpha_gate.sh
@@ -346,6 +346,13 @@ run_tests() {
     if [[ -f "$ROOT_DIR/coverage.mmd" ]]; then
         cp "$ROOT_DIR/coverage.mmd" "$LOG_DIR/coverage.mmd"
     fi
+    if [[ -f "$ROOT_DIR/coverage.svg" ]]; then
+        cp "$ROOT_DIR/coverage.svg" "$LOG_DIR/coverage.svg"
+    fi
+    if [[ -d "$ROOT_DIR/htmlcov" ]]; then
+        rm -rf "$LOG_DIR/htmlcov"
+        cp -R "$ROOT_DIR/htmlcov" "$LOG_DIR/"
+    fi
     if [[ -f "$REPLAY_SUMMARY" ]]; then
         cp "$REPLAY_SUMMARY" "$LOG_DIR/crown_replay_summary.json"
     fi


### PR DESCRIPTION
## Summary
- extend the coverage export helper to also render the HTML coverage report and badge artifacts
- bundle the generated coverage badge and HTML report directory inside each alpha gate log archive

## Testing
- `pre-commit run --files scripts/export_coverage.py scripts/run_alpha_gate.sh` *(fails: repository hooks `capture-failing-tests`, `pytest-cov`, and `verify-docs-up-to-date` fail in the current tree)*
- `scripts/run_alpha_gate.sh --skip-build --skip-health` *(fails: existing integration and vector memory tests fail under default configuration, preventing coverage generation)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4807efec832e90f1b4185f50a482