### PR TITLE
Handle inherited pytest opts in alpha gate

### DIFF
--- a/tests/scripts/test_run_alpha_gate.py
+++ b/tests/scripts/test_run_alpha_gate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from tests.conftest import allow_test
+
+allow_test(__file__)
+
+
+def test_run_alpha_gate_rejects_pytest_addopts() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = {**os.environ, "PYTEST_ADDOPTS": "-k crown_replay_determinism"}
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/run_alpha_gate.sh",
+            "--skip-build",
+            "--skip-health",
+            "--skip-tests",
+        ],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode != 0
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "Alpha gate disallows pytest -k selectors" in combined_output


### PR DESCRIPTION
## Summary
- inspect PYTEST_ADDOPTS, PYTEST_OPTIONS, and PYTEST_ARGS before argument parsing so inherited pytest flags are flattened and validated alongside CLI extras
- tighten forbidden option detection to catch -k selectors in both separated and concatenated forms
- add an explicit smoke test that ensures the alpha gate script aborts when PYTEST_ADDOPTS supplies a forbidden -k selector

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/scripts/test_run_alpha_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68cdae3ea208832e8d68408a9e907bf5