### PR TITLE
Stop generating coverage badge artifacts

### DIFF
--- a/scripts/export_coverage.py
+++ b/scripts/export_coverage.py
@@ -51,14 +51,6 @@ def main() -> None:
         ],
         check=True,
     )
-    subprocess.run(
-        [
-            "coverage-badge",
-            "-o",
-            str(REPO_ROOT / "coverage.svg"),
-        ],
-        check=True,
-    )
     with COVERAGE_JSON.open("r", encoding="utf-8") as fh:
         coverage_payload = json.load(fh)
 

--- a/scripts/run_alpha_gate.sh
+++ b/scripts/run_alpha_gate.sh
@@ -384,9 +384,6 @@ run_tests() {
     if [[ -f "$ROOT_DIR/coverage.mmd" ]]; then
         cp "$ROOT_DIR/coverage.mmd" "$LOG_DIR/coverage.mmd"
     fi
-    if [[ -f "$ROOT_DIR/coverage.svg" ]]; then
-        cp "$ROOT_DIR/coverage.svg" "$LOG_DIR/coverage.svg"
-    fi
     if [[ -d "$ROOT_DIR/htmlcov" ]]; then
         rm -rf "$LOG_DIR/htmlcov"
         cp -R "$ROOT_DIR/htmlcov" "$LOG_DIR/"


### PR DESCRIPTION
## Summary
- remove the `coverage-badge` invocation so `scripts/export_coverage.py` only refreshes the JSON and Mermaid coverage artifacts
- stop the alpha gate from copying `coverage.svg`, matching the new set of exported coverage files

## Testing
- python scripts/export_coverage.py *(fails: coverage thresholds are unmet when no prior coverage data is available)*
- python -m pre_commit run --files scripts/export_coverage.py scripts/run_alpha_gate.sh *(fails: repository hooks modify unrelated artifacts and enforce stale documentation indexes)*

------
https://chatgpt.com/codex/tasks/task_e_68cddd2c87f4832ebb9cc2b2b788c3bb