### PR TITLE
Ensure coverage export refreshes badge and verifies htmlcov output

### DIFF
--- a/scripts/export_coverage.py
+++ b/scripts/export_coverage.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INDEX_PATH = REPO_ROOT / "component_index.json"
 COVERAGE_JSON = REPO_ROOT / "coverage.json"
 COVERAGE_MMD = REPO_ROOT / "coverage.mmd"
+COVERAGE_SVG = REPO_ROOT / "coverage.svg"
 PYTHON = sys.executable
 ACTIVE_STATUSES = {"active"}
 STAGE_A_COMPONENT_IDS = {
@@ -48,6 +49,26 @@ def main() -> None:
             "coverage",
             "html",
             "--fail-under=0",
+        ],
+        check=True,
+    )
+
+    htmlcov_dir = REPO_ROOT / "htmlcov"
+    if not htmlcov_dir.is_dir():
+        raise RuntimeError(
+            "Coverage HTML directory htmlcov/ missing; rerun coverage html."
+        )
+
+    if COVERAGE_SVG.exists():
+        COVERAGE_SVG.unlink()
+
+    subprocess.run(
+        [
+            PYTHON,
+            "-m",
+            "coverage_badge",
+            "-o",
+            str(COVERAGE_SVG),
         ],
         check=True,
     )


### PR DESCRIPTION
## Summary
- ensure the coverage export script removes any stale coverage.svg before creating a new badge
- verify that htmlcov/ exists after generating HTML reports and raise a clear error when it is missing

## Testing
- python -m pre_commit run --files scripts/export_coverage.py *(fails: repo hooks enforce full test coverage and docs currency outside this change)*
- scripts/run_alpha_gate.sh --skip-build --skip-health


------
https://chatgpt.com/codex/tasks/task_e_68ce47ca5e58832e88195163d3f5d8d4