### PR TITLE
Update memory readiness terminology

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -1262,7 +1262,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/check_memory_layers.py",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": [
         "__future__",
         "memory",
@@ -3041,7 +3041,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/init_memory_layers.py",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": [
         "__future__",
         "memory",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -223,6 +223,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../agents/nazarick/victim_character.md](../agents/nazarick/victim_character.md) | victim_character.md | - | - |
 | [../agents/nazarick/zohar-zero_character.md](../agents/nazarick/zohar-zero_character.md) | zohar-zero_character.md | - | - |
 | [../benchmarks/README.md](../benchmarks/README.md) | Benchmarks | Run `make bench` to execute all benchmarks. Results are written to `data/benchmarks`. | - |
+| [../coverage.mmd](../coverage.mmd) | coverage.mmd | - | - |
 | [../data/biosignals/README.md](../data/biosignals/README.md) | Biosignal Acquisition Guidelines | This directory hosts anonymized biosignal samples used by the Nazarick Narrative System. | - |
 | [ABSOLUTE_MILESTONES.md](ABSOLUTE_MILESTONES.md) | Absolute Milestones | This timeline captures notable releases and planned work. Each entry links to the relevant specification and pull req... | - |
 | [ABZU_DEPLOYMENT.md](ABZU_DEPLOYMENT.md) | ABZU Deployment | This guide outlines the environment preparation, boot order, and rollback steps for deploying ABZU. | - |
@@ -377,16 +378,16 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [figures/agent_relations.mmd](figures/agent_relations.mmd) | Crown, Nazarick, and operator interaction diagram | Version: v1.0.0 Last updated: 2025-09-08 | - |
 | [figures/chakra_architecture.mmd](figures/chakra_architecture.mmd) | chakra_architecture.mmd | - | - |
 | [figures/heartbeat_self_healing.mmd](figures/heartbeat_self_healing.mmd) | heartbeat_self_healing.mmd | - | - |
-| [figures/layer_init_broadcast.mmd](figures/layer_init_broadcast.mmd) | Layer initialization broadcast diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/layer_init_broadcast.mmd](figures/layer_init_broadcast.mmd) | Layer initialization broadcast diagram | Version: v1.1.0 Last updated: 2025-10-07 | - |
 | [figures/layer_init_query_flow.mmd](figures/layer_init_query_flow.mmd) | layer_init_query_flow.mmd | - | - |
-| [figures/memory_bundle.mmd](figures/memory_bundle.mmd) | Memory bundle initialization and query aggregation diagram | Version: v1.1.0 Last updated: 2025-09-07 | - |
+| [figures/memory_bundle.mmd](figures/memory_bundle.mmd) | Memory bundle initialization and query aggregation diagram | Version: v1.2.0 Last updated: 2025-10-07 | - |
 | [figures/memory_layer_flow.mmd](figures/memory_layer_flow.mmd) | Memory layer flow diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
 | [figures/nazarick_agents_chart.mmd](figures/nazarick_agents_chart.mmd) | nazarick_agents_chart.mmd | - | - |
 | [figures/nazarick_crown_razar_integration.mmd](figures/nazarick_crown_razar_integration.mmd) | nazarick_crown_razar_integration.mmd | - | - |
 | [figures/nazarick_ui_pipeline.mmd](figures/nazarick_ui_pipeline.mmd) | nazarick_ui_pipeline.mmd | - | - |
-| [figures/operator_query_sequence.mmd](figures/operator_query_sequence.mmd) | Operator query sequence diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/operator_query_sequence.mmd](figures/operator_query_sequence.mmd) | Operator query sequence diagram | Version: v1.1.0 Last updated: 2025-10-07 | - |
 | [figures/pyo3_interfaces.mmd](figures/pyo3_interfaces.mmd) | pyo3_interfaces.mmd | - | - |
-| [figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd) | Query memory aggregation diagram | Version: v1.0.0 Last updated: 2025-09-05 | - |
+| [figures/query_memory_aggregation.mmd](figures/query_memory_aggregation.mmd) | Query memory aggregation diagram | Version: v1.1.0 Last updated: 2025-10-07 | - |
 | [figures/razar_crown_kimicho_flow.mmd](figures/razar_crown_kimicho_flow.mmd) | razar_crown_kimicho_flow.mmd | - | - |
 | [figures/rust_crate_boundaries.mmd](figures/rust_crate_boundaries.mmd) | rust_crate_boundaries.mmd | - | - |
 | [figures/system_tear_matrix.mmd](figures/system_tear_matrix.mmd) | system_tear_matrix.mmd | - | - |
@@ -410,7 +411,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [memory_cortex.md](memory_cortex.md) | Cortex Memory Search | The `memory.cortex` module stores spiral decisions as JSON lines under `data/cortex_memory_spiral.jsonl`. Each entry... | - |
 | [memory_emotion.md](memory_emotion.md) | Memory and Emotion APIs | This document outlines the public interfaces for the in-memory vector store and emotion state utilities. | - |
 | [memory_layer.md](memory_layer.md) | Deprecated | See [Memory Layers Guide](memory_layers_GUIDE.md). | - |
-| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.0.9 **Last updated:** 2025-09-30 | - |
+| [memory_layers_GUIDE.md](memory_layers_GUIDE.md) | Memory Layers Guide | **Version:** v1.1.0 **Last updated:** 2025-10-07 | - |
 | [migration_crosswalk.md](migration_crosswalk.md) | Migration Crosswalk | For legacy edge cases, see the [Python legacy audit](python_legacy_audit.md). | - |
 | [migration_playbooks/crown.md](migration_playbooks/crown.md) | Crown Migration Playbook | - | - |
 | [migration_playbooks/razar.md](migration_playbooks/razar.md) | RAZAR Migration Playbook | - | - |
@@ -521,6 +522,10 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [world_bootstrap.md](world_bootstrap.md) | World Bootstrap | Guidelines for seeding and cloning world configurations. | - |
 | [../floor_client/README.md](../floor_client/README.md) | Floor Client | This folder contains the React interface for Floor channels. | - |
 | [../guides/visual_customization.md](../guides/visual_customization.md) | Avatar Visual Customization | This guide outlines how to turn a 2D concept image into the 3D model used by the video engine. | - |
+| [../logs/alpha_gate/20250918T221655Z/coverage.mmd](../logs/alpha_gate/20250918T221655Z/coverage.mmd) | coverage.mmd | - | - |
+| [../logs/alpha_gate/20250919T220647Z/coverage.mmd](../logs/alpha_gate/20250919T220647Z/coverage.mmd) | coverage.mmd | - | - |
+| [../logs/alpha_gate/20250919T221803Z/coverage.mmd](../logs/alpha_gate/20250919T221803Z/coverage.mmd) | coverage.mmd | - | - |
+| [../logs/alpha_gate/20250920T065519Z/coverage.mmd](../logs/alpha_gate/20250920T065519Z/coverage.mmd) | coverage.mmd | - | - |
 | [../monitoring/README.md](../monitoring/README.md) | Monitoring | This stack launches Prometheus, Grafana, Node Exporter, cAdvisor, and an NVIDIA GPU exporter. Metrics include CPU, me... | - |
 | [../monitoring/copresence_dashboard.md](../monitoring/copresence_dashboard.md) | Copresence Dashboard | This Grafana dashboard surfaces real‑time copresence signals for operators. It focuses on boot health, narrative flow... | - |
 | [../monitoring/metrics_catalog.md](../monitoring/metrics_catalog.md) | Metrics Catalog | \| Metric \| Type \| Labels \| Description \| Dashboard \| \| --- \| --- \| --- \| --- \| --- \| \| `service_boot_duration_seconds... | - |

--- a/docs/component_index.md
+++ b/docs/component_index.md
@@ -391,7 +391,7 @@ Generated automatically. Lists each Python and Rust file with its description an
 | `scripts/check_env.py` | Python | Fail if required tools or packages are missing. | None |
 | `scripts/check_key_documents.py` | Python | Verify that key documents exist. | yaml |
 | `scripts/check_mcp_connectors.py` | Python | Verify connectors use MCP instead of raw HTTP endpoints. | None |
-| `scripts/check_memory_layers.py` | Python | Verify memory layers respond with seeded data. | memory |
+| `scripts/check_memory_layers.py` | Python | Verify memory layers respond with ready bootstrap data. | memory |
 | `scripts/check_neoabzu_onboarding.py` | Python | Ensure onboarding_confirm.yml updated when NEOABZU code changes. | None |
 | `scripts/check_no_binaries.py` | Python | Fail if any staged files are detected as binary. | None |
 | `scripts/check_placeholders.py` | Python | Fail if files contain TODO or FIXME placeholders. | None |
@@ -411,7 +411,7 @@ Generated automatically. Lists each Python and Rust file with its description an
 | `scripts/ingest_ethics.py` | Python | Reindex ethics corpus files into the Chroma vector store. | INANNA_AI |
 | `scripts/ingest_music_books.py` | Python | Ingest music theory books into the vector memory. | pdfplumber, unstructured |
 | `scripts/ingest_sample_events.py` | Python | Ingest sample events into each memory layer and verify retrieval. | memory |
-| `scripts/init_memory_layers.py` | Python | Seed cortex, emotional, mental, spiritual and narrative stores. | memory |
+| `scripts/init_memory_layers.py` | Python | Bootstrap cortex, emotional, mental, spiritual and narrative stores. | memory |
 | `scripts/list_layers.py` | Python | Print configured personality layers and whether they are enabled. | yaml |
 | `scripts/log_intent.py` | Python | Append commit intent entries to the change ledger. | None |
 | `scripts/manage_servants.py` | Python | No description | requests |

--- a/docs/figures/layer_init_broadcast.mmd
+++ b/docs/figures/layer_init_broadcast.mmd
@@ -1,11 +1,17 @@
 %% Layer initialization broadcast diagram
-%% Version: v1.0.0
-%% Last updated: 2025-09-05
+%% Version: v1.1.0
+%% Last updated: 2025-10-07
 graph TD
-    MB[MemoryBundle.initialize] --> EB[(EventBus: memory)]
-    EB --> Cortex[Cortex]
-    EB --> Emotional[Emotional]
-    EB --> Mental[Mental]
-    EB --> Spiritual[Spiritual]
-    EB --> Narrative[Narrative]
+    MB[MemoryBundle.initialize] -- layer_init<br/>ready · skipped · error --> EB[(EventBus: memory)]
+    EB -->|cortex: ready| Cortex[Cortex]
+    EB -->|emotional: ready| Emotional[Emotional]
+    EB -->|mental: skipped| Mental[Mental]
+    EB -->|spiritual: ready| Spiritual[Spiritual]
+    EB -->|narrative: ready/error| Narrative[Narrative]
+    classDef ready stroke:#24d05a,fill:#e9fcef,color:#0c3b1c;
+    classDef skipped stroke:#f5a623,fill:#fff5e6,color:#5a3d07;
+    classDef error stroke:#f04747,fill:#fdeaea,color:#5a0a0a;
+    class Cortex,Emotional,Spiritual ready;
+    class Mental skipped;
+    class Narrative error;
 

--- a/docs/figures/layer_init_query_flow.mmd
+++ b/docs/figures/layer_init_query_flow.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-    layer_init[(layer_init)] --> Cortex
+    layer_init[(layer_init<br/>ready · skipped · error)] --> Cortex
     layer_init --> Emotional
     layer_init --> Mental
     layer_init --> Spiritual
@@ -17,4 +17,5 @@ flowchart LR
     Spiritual --> Aggregate
     Narrative --> Aggregate
 
-    Aggregate --> OperatorAgent[Operator Agent]
+    Aggregate --> StatusMap[Status map + failed_layers]
+    StatusMap --> OperatorAgent[Operator Agent]

--- a/docs/figures/memory_bundle.mmd
+++ b/docs/figures/memory_bundle.mmd
@@ -1,6 +1,6 @@
 %% Memory bundle initialization and query aggregation diagram
-%% Version: v1.1.0
-%% Last updated: 2025-09-07
+%% Version: v1.2.0
+%% Last updated: 2025-10-07
 flowchart LR
     subgraph Init[Layer Initialization]
         MBInit[MemoryBundle.initialize] --> Bus[(EventBus: memory)]
@@ -9,6 +9,11 @@ flowchart LR
         Bus --> Mental[Mental]
         Bus --> Spiritual[Spiritual]
         Bus --> Narrative[Narrative]
+    end
+    subgraph Legend[Status Legend]
+        Ready[ready → canonical layer online]
+        Skipped[skipped → Python fallback engaged]
+        Error[error → initialization failed]
     end
     subgraph Query[Query Aggregation]
         Caller[Caller] --> MBQuery[MemoryBundle.query]

--- a/docs/figures/operator_query_sequence.mmd
+++ b/docs/figures/operator_query_sequence.mmd
@@ -1,6 +1,6 @@
 %% Operator query sequence diagram
-%% Version: v1.0.0
-%% Last updated: 2025-09-05
+%% Version: v1.1.0
+%% Last updated: 2025-10-07
 sequenceDiagram
     participant UI as Arcade UI
     participant API as /query_memory
@@ -10,6 +10,6 @@ sequenceDiagram
     UI->>API: submit query
     API->>MB: query_memory
     MB->>L: fan out
-    L-->>MB: results
-    MB-->>API: aggregate
+    L-->>MB: results + status (ready/skipped/error)
+    MB-->>API: aggregate + failed_layers
     API-->>UI: respond

--- a/docs/figures/query_memory_aggregation.mmd
+++ b/docs/figures/query_memory_aggregation.mmd
@@ -1,6 +1,6 @@
 %% Query memory aggregation diagram
-%% Version: v1.0.0
-%% Last updated: 2025-09-05
+%% Version: v1.1.0
+%% Last updated: 2025-10-07
 graph TD
     Caller[Caller] --> MB[MemoryBundle.query]
     MB --> QM[query_memory]
@@ -10,6 +10,12 @@ graph TD
     Cortex --> QM
     Vector --> QM
     Spiral --> QM
+    QM --> Failed[failed_layers ← error statuses]
     QM --> MB
     MB --> Caller
+    subgraph Legend[Status Legend]
+        Ready[ready → include results]
+        SkippedLegend[skipped → empty responses]
+        ErrorLegend[error → add to failed_layers]
+    end
 

--- a/docs/memory_architecture.md
+++ b/docs/memory_architecture.md
@@ -35,7 +35,7 @@ Ready-made helpers are available for spinning up the storage back ends:
 - [deployment/sqlite/bootstrap_memory_dbs.sh](../deployment/sqlite/bootstrap_memory_dbs.sh)
   creates SQLite files for file‑based stores.
 - [scripts/init_memory_layers.py](../scripts/init_memory_layers.py) and
-  [scripts/init_memory_layers.sh](../scripts/init_memory_layers.sh) seed all
+  [scripts/init_memory_layers.sh](../scripts/init_memory_layers.sh) bootstrap all
   layers with example records.
 
 ## Layer overview
@@ -77,7 +77,7 @@ bash scripts/init_memory_layers.sh
 python scripts/init_memory_layers.py
 ```
 
-3. Query individual stores to verify the seeded records:
+3. Query individual stores to verify the bootstrap records and confirm the bundle reports them as `ready`:
 
 ```bash
 # Cortex

--- a/scripts/check_memory_layers.py
+++ b/scripts/check_memory_layers.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Verify memory layers respond with seeded data.
+"""Verify memory layers respond with ready bootstrap data.
 
 Runs minimal queries against each layer. Raises ``RuntimeError``
-if any layer is empty or unavailable. Used to guard Albedo
+if any layer is empty or unavailable, mirroring the ``ready``
+state emitted by the Rust bundle. Used to guard Albedo
 initialisation before persona modules load.
 """
 from __future__ import annotations
@@ -21,7 +22,7 @@ os.environ.setdefault("MENTAL_JSON_PATH", str(DATA_DIR / "tasks.jsonl"))
 os.environ.setdefault("SPIRITUAL_DB_PATH", str(DATA_DIR / "ontology.db"))
 os.environ.setdefault("NARRATIVE_LOG_PATH", str(DATA_DIR / "story.log"))
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from memory.cortex import query_spirals
 from memory.emotional import fetch_emotion_history, get_connection as emotion_conn

--- a/tests/test_memory_bus.py
+++ b/tests/test_memory_bus.py
@@ -57,17 +57,17 @@ def test_broadcast_layer_event_emits():
 
     broadcast_layer_event(
         {
-            "cortex": "seeded",
-            "emotional": "seeded",
+            "cortex": "ready",
+            "emotional": "ready",
             "mental": "skipped",
-            "spiritual": "seeded",
-            "narrative": "seeded",
+            "spiritual": "ready",
+            "narrative": "ready",
         }
     )
 
     assert len(producer.events) == 1
     layers = producer.events[0].payload["layers"]
-    assert layers["cortex"] == "seeded"
+    assert layers["cortex"] == "ready"
     assert layers["mental"] == "skipped"
     set_event_producer(None)
 
@@ -337,10 +337,10 @@ def test_init_memory_layers_bootstrap_and_persist(tmp_path, monkeypatch):
 
     assert len(producer.events) == 1
     layer_events = producer.events[0].payload["layers"]
-    assert layer_events["cortex"] == "seeded"
-    assert layer_events["emotional"] == "seeded"
-    assert layer_events["spiritual"] == "seeded"
-    assert layer_events["narrative"] == "seeded"
+    assert layer_events["cortex"] == "ready"
+    assert layer_events["emotional"] == "ready"
+    assert layer_events["spiritual"] == "ready"
+    assert layer_events["narrative"] == "ready"
     assert "mental" in layer_events
 
     class Node:


### PR DESCRIPTION
## Summary
- document the Rust bundle's ready/skipped/error states in the memory layers guide and related architecture docs
- update component metadata, bootstrap scripts, and unit tests to emit and expect the new readiness values
- refresh memory bundle Mermaid diagrams and regenerate the documentation index to align with the revised terminology

## Testing
- pre-commit run --files docs/component_index.md docs/figures/layer_init_broadcast.mmd docs/figures/layer_init_query_flow.mmd docs/figures/memory_bundle.mmd docs/figures/operator_query_sequence.mmd docs/figures/query_memory_aggregation.mmd docs/memory_architecture.md docs/memory_layers_GUIDE.md scripts/check_memory_layers.py scripts/init_memory_layers.py tests/test_memory_bus.py component_index.json docs/INDEX.md docs/testing/failure_inventory.md *(fails: coverage threshold not met, verify-docs-up-to-date requires unrelated updates, monitoring endpoints unavailable, and self-healing metrics absent)*
- PYTHONPATH=tests pytest tests/test_memory_bus.py *(fails: coverage threshold requirement with all tests skipped due to unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_68ce95054004832e91cfcfbc2d774fd1