### PR TITLE
Expose memory diagnostics from PyO3 binding

### DIFF
--- a/NEOABZU/memory/src/bin/memory_bootstrap.rs
+++ b/NEOABZU/memory/src/bin/memory_bootstrap.rs
@@ -5,10 +5,7 @@ fn main() -> PyResult<()> {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
         let mut bundle = MemoryBundle::new();
-        let statuses = bundle.initialize(py)?;
-        for (layer, status) in statuses.iter() {
-            println!("{}: {}", layer, status);
-        }
+        bundle.initialize(py)?;
         Ok(())
     })
 }

--- a/tests/test_neoabzu_bindings.py
+++ b/tests/test_neoabzu_bindings.py
@@ -24,8 +24,10 @@ def test_memory_bundle_initialize():
     memory = pytest.importorskip("neoabzu_memory")
     setup_event_bus()
     bundle = memory.MemoryBundle()
-    statuses = bundle.initialize()
-    assert "vector" in statuses
+    result = bundle.initialize()
+    assert "statuses" in result
+    assert "diagnostics" in result
+    assert "vector" in result["statuses"]
 
 
 def test_vector_search():


### PR DESCRIPTION
## Summary
- enrich `neoabzu_memory::MemoryBundle::initialize` to build a diagnostics payload alongside layer statuses and return both to Python callers
- surface the diagnostics through the Python wrapper, preserving the status map API and documenting the richer structure
- adjust bootstrap and unit tests to expect the structured initialize result and to assert fallback/error metadata

## Testing
- pytest tests/test_memory_bundle.py tests/test_neoabzu_bindings.py *(fails: repo enforces coverage >=90% across unrelated modules)*
- pre-commit run --files NEOABZU/memory/src/lib.rs NEOABZU/memory/src/bin/memory_bootstrap.rs memory/bundle.py tests/test_memory_bundle.py tests/test_neoabzu_bindings.py *(fails: clippy flags existing PyO3 deprecations in other crates; ensure-blueprint-sync and verify-docs-up-to-date require broader repo updates; pytest coverage gate <90%)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9d2b87b8832eb79e858b15472263