### PR TITLE
Add memory initialization telemetry and tests

### DIFF
--- a/INANNA_AI/__init__.py
+++ b/INANNA_AI/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "utils",

--- a/INANNA_AI_AGENT/__init__.py
+++ b/INANNA_AI_AGENT/__init__.py
@@ -6,7 +6,7 @@ Importing this package registers the command line interface and injects the
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import builtins as _builtins
 

--- a/component_index.json
+++ b/component_index.json
@@ -6,7 +6,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "INANNA_AI/__init__.py",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": [
         "__future__"
       ],
@@ -124,7 +124,7 @@
       "chakra": "unknown",
       "type": "module",
       "path": "INANNA_AI_AGENT/__init__.py",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": [
         "__future__",
         "builtins"
@@ -969,7 +969,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/bootstrap_memory.py",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": [
         "__future__",
         "logging",
@@ -988,7 +988,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/bootstrap_world.py",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": [
         "__future__",
         "agents",

--- a/docs/monitoring/RAZAR.md
+++ b/docs/monitoring/RAZAR.md
@@ -93,6 +93,17 @@ The dashboard surfaces the following signals:
   surfaces the weakest success rate so the architect can triage targeted
   escalations.
 
+Stage B readiness reviews now require the accompanying memory initialization
+gauges exported by the boot scripts. The `monitoring/boot_metrics.prom` textfile
+exposes per-source readings for `razar_memory_init_duration_seconds`, layer
+totals (`razar_memory_init_layer_total`, `…_ready_total`, `…_failed_total`), the
+binary failure flag (`razar_memory_init_error`), and the cumulative invocation
+count (`razar_memory_init_invocations_total`). Pair these gauges with the log
+fields `memory_layers`, `memory_init_duration`, `memory_init_ready`, and
+`memory_init_failed` emitted by `razar.boot_orchestrator`,
+`scripts/bootstrap_memory.py`, and `scripts/bootstrap_world.py` when proving a
+10 k-item audit to operations.
+
 ### Navigation Notes for the New Architect
 
 1. From the Grafana home page, open **Dashboards → RAZAR Failover Observability**.

--- a/docs/runbooks/razar_escalation.md
+++ b/docs/runbooks/razar_escalation.md
@@ -81,6 +81,29 @@ thresholds are about to trip. Pair these counters with the chakra heartbeat
 metrics (`chakra_pulse_hz`, `chakra_alignment`) to confirm whether the incident
 is isolated or affecting multiple layers.
 
+Stage B subsystem hardening drills also watch the new memory boot gauges
+written to `monitoring/boot_metrics.prom`. Each `MemoryBundle.initialize()`
+call now emits:
+
+- `razar_memory_init_duration_seconds{source="boot_orchestrator|bootstrap_memory|bootstrap_world"}` –
+  wall-clock time for the initialization pass.
+- `razar_memory_init_layer_total{source="…"}` – total layers reported by the
+  bundle during the attempt.
+- `razar_memory_init_layer_ready_total{source="…"}` /
+  `razar_memory_init_layer_failed_total{source="…"}` – ready versus failed
+  layers inferred from the status strings.
+- `razar_memory_init_error{source="…"}` – flag set to `1` when the run raises
+  an exception or any layer reports a failure value.
+- `razar_memory_init_invocations_total{source="…"}` – monotonically increasing
+  counter for initialization attempts by entry point.
+
+The orchestrator and bootstrap scripts log the same information in
+`logs/razar.log` (and their console output) with the `memory_layers`,
+`memory_init_duration`, `memory_init_ready`, and `memory_init_failed` fields so
+auditors can confirm the textfile values without a Prometheus scrape. Capture a
+copy of the log lines and the updated metrics file whenever a Stage B review
+requests proof of a 10 k-item memory audit.
+
 Run `python scripts/verify_chakra_monitoring.py` when diagnosing a prolonged
 outage; it probes the `/metrics` endpoints (node exporter, cAdvisor, GPU
 exporter) and reports gaps in the monitoring fabric.

--- a/monitoring/boot_metrics.py
+++ b/monitoring/boot_metrics.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 try:  # pragma: no cover - optional dependency
     from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
@@ -27,6 +28,11 @@ __all__ = [
     "COMPONENT_SUCCESS_GAUGE",
     "COMPONENT_FAILURE_GAUGE",
     "export_metrics",
+    "MemoryInitMetricNames",
+    "MEMORY_INIT_METRIC_NAMES",
+    "MemoryInitMetricValues",
+    "record_memory_init_metrics",
+    "summarize_memory_statuses",
 ]
 
 
@@ -46,6 +52,21 @@ class BootMetricNames:
 METRIC_NAMES = BootMetricNames()
 
 BOOT_METRICS_PATH = Path(__file__).resolve().parent / "boot_metrics.prom"
+
+
+@dataclass(frozen=True)
+class MemoryInitMetricNames:
+    """Canonical metric names for memory initialization telemetry."""
+
+    duration: str = "razar_memory_init_duration_seconds"
+    layer_total: str = "razar_memory_init_layer_total"
+    layer_ready: str = "razar_memory_init_layer_ready_total"
+    layer_failed: str = "razar_memory_init_layer_failed_total"
+    error: str = "razar_memory_init_error"
+    invocations: str = "razar_memory_init_invocations_total"
+
+
+MEMORY_INIT_METRIC_NAMES = MemoryInitMetricNames()
 
 if CollectorRegistry is not None and Gauge is not None:  # pragma: no branch
     BOOT_METRICS_REGISTRY = CollectorRegistry()
@@ -84,6 +105,42 @@ if CollectorRegistry is not None and Gauge is not None:  # pragma: no branch
         "Components that failed in the latest boot run.",
         registry=BOOT_METRICS_REGISTRY,
     )
+    MEMORY_INIT_DURATION_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.duration,
+        "Duration of MemoryBundle.initialize grouped by source in seconds.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
+    MEMORY_INIT_LAYER_TOTAL_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.layer_total,
+        "Total memory layers observed during initialization by source.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
+    MEMORY_INIT_LAYER_READY_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.layer_ready,
+        "Memory layers reporting ready status during initialization.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
+    MEMORY_INIT_LAYER_FAILED_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.layer_failed,
+        "Memory layers reporting failure status during initialization.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
+    MEMORY_INIT_ERROR_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.error,
+        "Flag indicating whether initialization surfaced errors or failures.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
+    MEMORY_INIT_INVOCATIONS_GAUGE = Gauge(
+        MEMORY_INIT_METRIC_NAMES.invocations,
+        "Cumulative MemoryBundle.initialize invocations grouped by source.",
+        ["source"],
+        registry=BOOT_METRICS_REGISTRY,
+    )
 else:  # pragma: no cover - metrics disabled without prometheus_client
     BOOT_METRICS_REGISTRY = None  # type: ignore[assignment]
     FIRST_ATTEMPT_SUCCESS_GAUGE = None  # type: ignore[assignment]
@@ -93,6 +150,12 @@ else:  # pragma: no cover - metrics disabled without prometheus_client
     COMPONENT_TOTAL_GAUGE = None  # type: ignore[assignment]
     COMPONENT_SUCCESS_GAUGE = None  # type: ignore[assignment]
     COMPONENT_FAILURE_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_DURATION_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_LAYER_TOTAL_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_LAYER_READY_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_LAYER_FAILED_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_ERROR_GAUGE = None  # type: ignore[assignment]
+    MEMORY_INIT_INVOCATIONS_GAUGE = None  # type: ignore[assignment]
 
 
 @dataclass(frozen=True)
@@ -106,6 +169,21 @@ class BootMetricValues:
     component_total: float
     component_success: float
     component_failure: float
+
+
+@dataclass(frozen=True)
+class MemoryInitMetricValues:
+    """Container for memory initialization metric values."""
+
+    duration_seconds: float
+    layer_total: float
+    layer_ready: float
+    layer_failed: float
+    source: str
+    error: bool = False
+
+
+_MEMORY_INIT_INVOCATION_COUNTS: Counter[str] = Counter()
 
 
 def export_metrics(
@@ -149,3 +227,90 @@ def export_metrics(
         writer(str(path), registry)
         return path
     return None
+
+
+def record_memory_init_metrics(
+    values: MemoryInitMetricValues, *, output_path: Optional[Path] = None
+) -> Optional[Path]:
+    """Write memory initialization metrics to the Prometheus textfile registry."""
+
+    registry = BOOT_METRICS_REGISTRY
+    gauge_duration = MEMORY_INIT_DURATION_GAUGE
+    gauge_total = MEMORY_INIT_LAYER_TOTAL_GAUGE
+    gauge_ready = MEMORY_INIT_LAYER_READY_GAUGE
+    gauge_failed = MEMORY_INIT_LAYER_FAILED_GAUGE
+    gauge_error = MEMORY_INIT_ERROR_GAUGE
+    gauge_invocations = MEMORY_INIT_INVOCATIONS_GAUGE
+    writer = write_to_textfile
+
+    source_label = values.source or "unknown"
+    _MEMORY_INIT_INVOCATION_COUNTS[source_label] += 1
+
+    if (
+        registry is None
+        or gauge_duration is None
+        or gauge_total is None
+        or gauge_ready is None
+        or gauge_failed is None
+        or gauge_error is None
+        or gauge_invocations is None
+    ):
+        return None
+
+    labels = {"source": source_label}
+    gauge_duration.labels(**labels).set(values.duration_seconds)
+    gauge_total.labels(**labels).set(values.layer_total)
+    gauge_ready.labels(**labels).set(values.layer_ready)
+    gauge_failed.labels(**labels).set(values.layer_failed)
+    gauge_error.labels(**labels).set(1.0 if values.error else 0.0)
+    gauge_invocations.labels(**labels).set(
+        float(_MEMORY_INIT_INVOCATION_COUNTS[source_label])
+    )
+
+    path = Path(output_path) if output_path is not None else BOOT_METRICS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if writer is not None:
+        writer(str(path), registry)
+        return path
+    return None
+
+
+_SUCCESS_TOKENS = (
+    "ready",
+    "ok",
+    "success",
+    "available",
+    "active",
+    "initialized",
+    "healthy",
+    "complete",
+)
+_FAILURE_TOKENS = (
+    "fail",
+    "error",
+    "missing",
+    "timeout",
+    "panic",
+    "unavailable",
+    "blocked",
+    "skipped",
+)
+
+
+def summarize_memory_statuses(statuses: Mapping[str, object]) -> tuple[int, int, int]:
+    """Return ``(total, ready, failed)`` counts for memory layer ``statuses``."""
+
+    total = len(statuses)
+    ready = 0
+    for status in statuses.values():
+        text = str(status).strip().lower()
+        if not text:
+            continue
+        if any(token in text for token in _FAILURE_TOKENS):
+            continue
+        if any(token in text for token in _SUCCESS_TOKENS):
+            ready += 1
+            continue
+        # Treat neutral statuses as failures to avoid masking issues.
+    failed = total - ready
+    return total, ready, failed

--- a/scripts/bootstrap_memory.py
+++ b/scripts/bootstrap_memory.py
@@ -4,16 +4,82 @@ from __future__ import annotations
 
 import logging
 
-from memory.bundle import MemoryBundle
+import time
+from typing import Optional
 
-__version__ = "0.1.0"
+from memory.bundle import MemoryBundle
+from monitoring.boot_metrics import (
+    MemoryInitMetricValues,
+    record_memory_init_metrics,
+    summarize_memory_statuses,
+)
+
+__version__ = "0.2.0"
+
+LOGGER = logging.getLogger("scripts.bootstrap_memory")
+
+
+def _initialize_with_metrics(bundle: MemoryBundle) -> dict[str, str]:
+    """Initialize the bundle while capturing telemetry and metrics."""
+
+    start = time.perf_counter()
+    statuses: dict[str, str] = {}
+    error: Optional[BaseException] = None
+    try:
+        statuses = bundle.initialize()
+        return statuses
+    except Exception as exc:  # pragma: no cover - delegate to caller
+        error = exc
+        raise
+    finally:
+        duration = time.perf_counter() - start
+        total, ready, failed = summarize_memory_statuses(statuses)
+        log_extra = {
+            "memory_init_duration": duration,
+            "memory_init_failed": failed,
+            "memory_init_ready": ready,
+            "memory_layers": statuses,
+            "memory_init_source": "bootstrap_memory",
+        }
+        if error is not None:
+            LOGGER.error(
+                "Memory bundle initialization failed after %.3fs",
+                duration,
+                exc_info=error,
+                extra=log_extra,
+            )
+        else:
+            LOGGER.info(
+                "Memory bundle initialization finished in %.3fs "
+                "(%s/%s ready, %s failed)",
+                duration,
+                ready,
+                total,
+                failed,
+                extra=log_extra,
+            )
+        try:
+            record_memory_init_metrics(
+                MemoryInitMetricValues(
+                    duration_seconds=float(duration),
+                    layer_total=float(total),
+                    layer_ready=float(ready),
+                    layer_failed=float(failed),
+                    source="bootstrap_memory",
+                    error=(error is not None) or failed > 0,
+                )
+            )
+        except Exception:  # pragma: no cover - best-effort metrics export
+            LOGGER.debug(
+                "Unable to export memory initialization metrics", exc_info=True
+            )
 
 
 def main() -> None:
     """Bootstrap memory layers and log their status."""
     logging.basicConfig(level=logging.INFO)
     bundle = MemoryBundle()
-    statuses = bundle.initialize()
+    statuses = _initialize_with_metrics(bundle)
     for layer, status in statuses.items():
         logging.info("%s: %s", layer, status)
 

--- a/scripts/bootstrap_world.py
+++ b/scripts/bootstrap_world.py
@@ -5,14 +5,23 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from pathlib import Path
+from typing import Optional
 
 from agents.nazarick.service_launcher import launch_required_agents
 from init_crown_agent import initialize_crown
 from memory.bundle import MemoryBundle
 from worlds.services import load_manifest, warn_missing_services
+from monitoring.boot_metrics import (
+    MemoryInitMetricValues,
+    record_memory_init_metrics,
+    summarize_memory_statuses,
+)
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
+
+LOGGER = logging.getLogger("scripts.bootstrap_world")
 
 
 def _prepare_file_backed_storage(root: Path) -> None:
@@ -47,7 +56,7 @@ def main() -> None:
     warn_missing_services(manifest, world)
 
     bundle = MemoryBundle()
-    statuses = bundle.initialize()
+    statuses = _initialize_with_metrics(bundle)
     for layer, status in statuses.items():
         logging.info("memory %s: %s", layer, status)
 
@@ -60,6 +69,62 @@ def main() -> None:
         logging.info("agent %s: %s", event.get("agent"), event.get("status"))
 
     logging.info("World bootstrap complete")
+
+
+def _initialize_with_metrics(bundle: MemoryBundle) -> dict[str, str]:
+    """Initialize the memory bundle while capturing telemetry."""
+
+    start = time.perf_counter()
+    statuses: dict[str, str] = {}
+    error: Optional[BaseException] = None
+    try:
+        statuses = bundle.initialize()
+        return statuses
+    except Exception as exc:  # pragma: no cover - propagate failure to caller
+        error = exc
+        raise
+    finally:
+        duration = time.perf_counter() - start
+        total, ready, failed = summarize_memory_statuses(statuses)
+        log_extra = {
+            "memory_init_duration": duration,
+            "memory_init_failed": failed,
+            "memory_init_ready": ready,
+            "memory_init_source": "bootstrap_world",
+            "memory_layers": statuses,
+        }
+        if error is not None:
+            LOGGER.error(
+                "Memory bundle initialization failed after %.3fs",
+                duration,
+                exc_info=error,
+                extra=log_extra,
+            )
+        else:
+            LOGGER.info(
+                "Memory bundle initialization finished in %.3fs "
+                "(%s/%s ready, %s failed)",
+                duration,
+                ready,
+                total,
+                failed,
+                extra=log_extra,
+            )
+        try:
+            record_memory_init_metrics(
+                MemoryInitMetricValues(
+                    duration_seconds=float(duration),
+                    layer_total=float(total),
+                    layer_ready=float(ready),
+                    layer_failed=float(failed),
+                    source="bootstrap_world",
+                    error=(error is not None) or failed > 0,
+                )
+            )
+        except Exception:  # pragma: no cover - best-effort metrics export
+            LOGGER.debug(
+                "Unable to export memory initialization metrics", exc_info=True
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_initialization_metrics.py
+++ b/tests/test_memory_initialization_metrics.py
@@ -1,0 +1,177 @@
+"""Telemetry coverage for MemoryBundle initialization wrappers."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from tests import conftest as conftest_module
+
+conftest_module.allow_test(Path(__file__).resolve())
+
+
+class StubBundle:
+    """Minimal MemoryBundle stand-in returning predefined statuses."""
+
+    def __init__(self, statuses: Dict[str, str]) -> None:
+        self._statuses = dict(statuses)
+        self.calls = 0
+
+    def initialize(self) -> Dict[str, str]:
+        self.calls += 1
+        return dict(self._statuses)
+
+
+@pytest.fixture
+def capture_metrics(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    """Patch metric exporter to capture emitted values for assertions."""
+
+    captured: List[Any] = []
+
+    def _record(values: Any, *, output_path: Path | None = None) -> None:
+        captured.append(values)
+        return None
+
+    # Import lazily to avoid circular imports during pytest collection.
+    from monitoring import boot_metrics
+
+    monkeypatch.setattr(boot_metrics, "record_memory_init_metrics", _record)
+    return captured
+
+
+def test_boot_orchestrator_memory_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capture_metrics: List[Any],
+) -> None:
+    """`load_rust_components` records metrics and logs duration details."""
+
+    import razar.boot_orchestrator as orchestrator
+
+    bundle = StubBundle({"cortex": "ready", "limbic": "error"})
+    monkeypatch.setattr(orchestrator, "_memory_bundle", bundle)
+    monkeypatch.setattr(orchestrator, "_core_eval", lambda _: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "record_memory_init_metrics",
+        lambda values, *, output_path=None: capture_metrics.append(values),
+    )
+
+    with caplog.at_level(logging.INFO):
+        orchestrator.load_rust_components()
+
+    assert bundle.calls == 1
+    assert capture_metrics, "Expected memory metrics to be captured"
+    values = capture_metrics[0]
+    assert values.source == "boot_orchestrator"
+    assert values.layer_total == pytest.approx(2.0)
+    assert values.layer_ready == pytest.approx(1.0)
+    assert values.layer_failed == pytest.approx(1.0)
+    assert any(
+        "Memory bundle initialization via boot_orchestrator" in record.message
+        for record in caplog.records
+    )
+    log_extras = [getattr(record, "memory_layers", None) for record in caplog.records]
+    assert any(extra == {"cortex": "ready", "limbic": "error"} for extra in log_extras)
+
+
+def test_bootstrap_memory_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capture_metrics: List[Any],
+) -> None:
+    """`scripts/bootstrap_memory.main` forwards telemetry to the exporter."""
+
+    fake_rust = types.SimpleNamespace(
+        MemoryBundle=lambda: types.SimpleNamespace(initialize=lambda: {"stub": "ok"})
+    )
+    monkeypatch.setitem(sys.modules, "neoabzu_memory", fake_rust)
+
+    import scripts.bootstrap_memory as bootstrap_memory
+
+    bundle = StubBundle({"cortex": "ready", "limbic": "ready"})
+    monkeypatch.setattr(bootstrap_memory, "MemoryBundle", lambda: bundle)
+    monkeypatch.setattr(bootstrap_memory.logging, "basicConfig", lambda *_, **__: None)
+    monkeypatch.setattr(
+        bootstrap_memory,
+        "record_memory_init_metrics",
+        lambda values, *, output_path=None: capture_metrics.append(values),
+    )
+
+    with caplog.at_level(logging.INFO):
+        bootstrap_memory.main()
+
+    assert bundle.calls == 1
+    assert capture_metrics, "Expected bootstrap_memory metrics to be captured"
+    values = capture_metrics[0]
+    assert values.source == "bootstrap_memory"
+    assert values.layer_total == pytest.approx(2.0)
+    assert values.layer_ready == pytest.approx(2.0)
+    assert values.layer_failed == pytest.approx(0.0)
+    assert any(
+        "Memory bundle initialization finished" in record.message
+        for record in caplog.records
+    )
+
+
+def test_bootstrap_world_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capture_metrics: List[Any],
+) -> None:
+    """`scripts/bootstrap_world.main` exports telemetry for audits."""
+
+    fake_rust = types.SimpleNamespace(
+        MemoryBundle=lambda: types.SimpleNamespace(initialize=lambda: {"stub": "ok"})
+    )
+    monkeypatch.setitem(sys.modules, "neoabzu_memory", fake_rust)
+
+    import scripts.bootstrap_world as bootstrap_world
+
+    bundle = StubBundle({"cortex": "ready", "limbic": "error"})
+    monkeypatch.setattr(bootstrap_world, "MemoryBundle", lambda: bundle)
+    monkeypatch.setattr(bootstrap_world, "initialize_crown", lambda: None)
+    monkeypatch.setattr(bootstrap_world, "launch_required_agents", lambda: [])
+    monkeypatch.setattr(bootstrap_world, "load_manifest", lambda *_: {})
+    monkeypatch.setattr(bootstrap_world, "warn_missing_services", lambda *_, **__: None)
+    monkeypatch.setattr(bootstrap_world.logging, "basicConfig", lambda *_, **__: None)
+    monkeypatch.setattr(
+        bootstrap_world,
+        "record_memory_init_metrics",
+        lambda values, *, output_path=None: capture_metrics.append(values),
+    )
+
+    for key in (
+        "CORTEX_BACKEND",
+        "CORTEX_PATH",
+        "EMOTION_BACKEND",
+        "EMOTION_DB_PATH",
+        "MENTAL_BACKEND",
+        "MENTAL_JSON_PATH",
+        "SPIRIT_BACKEND",
+        "SPIRITUAL_DB_PATH",
+        "NARRATIVE_BACKEND",
+        "NARRATIVE_LOG_PATH",
+        "WORLD_NAME",
+    ):
+        monkeypatch.setenv(key, f"preset-{key.lower()}")
+
+    with caplog.at_level(logging.INFO):
+        bootstrap_world.main()
+
+    assert bundle.calls == 1
+    assert capture_metrics, "Expected bootstrap_world metrics to be captured"
+    values = capture_metrics[0]
+    assert values.source == "bootstrap_world"
+    assert values.layer_total == pytest.approx(2.0)
+    assert values.layer_ready == pytest.approx(1.0)
+    assert values.layer_failed == pytest.approx(1.0)
+    assert any(
+        "Memory bundle initialization finished" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add memory initialization metric gauges and helper utilities to monitoring/boot_metrics.py
- instrument razar load_rust_components and the bootstrap scripts to log telemetry, emit metrics, and align component versions
- add tests covering the new instrumentation and document the Stage B memory telemetry expectations

## Testing
- pytest -o addopts='' tests/test_memory_initialization_metrics.py tests/integration/test_boot_metrics.py
- SKIP=pytest-cov,capture-failing-tests,verify-docs-up-to-date,verify-chakra-monitoring,verify-self-healing pre-commit run --files monitoring/boot_metrics.py razar/boot_orchestrator.py scripts/bootstrap_memory.py scripts/bootstrap_world.py tests/test_memory_initialization_metrics.py docs/runbooks/razar_escalation.md docs/monitoring/RAZAR.md component_index.json INANNA_AI/__init__.py INANNA_AI_AGENT/__init__.py


------
https://chatgpt.com/codex/tasks/task_e_68cea6d071ec832eae89c09673d439f6