### PR TITLE
Guard heartbeat when MCP disabled

### DIFF
--- a/connectors/neo_apsu_connector_template.py
+++ b/connectors/neo_apsu_connector_template.py
@@ -212,6 +212,10 @@ async def handshake(
 
 async def send_heartbeat(payload: dict[str, Any]) -> None:
     """Emit heartbeat telemetry to maintain alignment."""
+
+    if not _USE_MCP:
+        raise RuntimeError("MCP is not enabled")
+
     async with httpx.AsyncClient() as client:
         resp = await client.post(f"{_MCP_URL}/heartbeat", json=payload, timeout=5.0)
         resp.raise_for_status()

--- a/tests/connectors/test_neo_apsu_connector_template.py
+++ b/tests/connectors/test_neo_apsu_connector_template.py
@@ -155,3 +155,14 @@ def test_handshake_raises_after_exhausting_retries(
 
     with pytest.raises(RuntimeError, match="authentication failed"):
         asyncio.run(_run())
+
+
+def test_send_heartbeat_requires_mcp_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Heartbeat emission is blocked when MCP is disabled."""
+
+    monkeypatch.setattr(connector, "_USE_MCP", False)
+
+    with pytest.raises(RuntimeError, match="MCP is not enabled"):
+        asyncio.run(connector.send_heartbeat({"status": "ok"}))


### PR DESCRIPTION
## Summary
- raise a RuntimeError from `send_heartbeat` when MCP support is disabled
- add a unit test that verifies the heartbeat guard logic

## Testing
- `pre-commit run --files connectors/neo_apsu_connector_template.py tests/connectors/test_neo_apsu_connector_template.py` *(fails: command not found in container)*
- `python -m pytest tests/connectors/test_neo_apsu_connector_template.py` *(unable to complete due to heavy optional dependencies imported from conftest)*

------
https://chatgpt.com/codex/tasks/task_e_68cecdfbcc24832e8c29315e46366c97