### PR TITLE
Document Stage B MCP heartbeat payload

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |
@@ -341,6 +340,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [connectors/CONNECTOR_INDEX.md](connectors/CONNECTOR_INDEX.md) | Connector Index | Canonical registry of ABZU's connectors. Each entry lists the purpose, version, primary service endpoints, linked age... | `../../connectors/avatar_broadcast.py`, `../../connectors/mcp_gateway_example.py`, `../../connectors/narrative_mcp.py`, `../../connectors/neo_apsu_connector_template.py`, `../../connectors/primordials_api.py`, `../../connectors/primordials_mcp.py`, `../../connectors/signal_bus.py`, `../../connectors/webrtc_connector.py`, `../../narrative_api.py`, `../../operator_api.py`, `../../razar/crown_handshake.py`, `../../razar/crown_link.py`, `../../server.py`, `../../tools/bot_discord.py`, `../../tools/bot_telegram.py` |
 | [connectors/README.md](connectors/README.md) | Connector Overview | Guidelines for modules that bridge Spiral OS to external services. The live registry of available connectors lives in... | - |
 | [connectors/mcp_capability_payload.md](connectors/mcp_capability_payload.md) | MCP Capability Payload | The Neo-APSU connector template exchanges capabilities with the MCP gateway during the `/handshake` ritual. The paylo... | - |
+| [connectors/mcp_heartbeat_payload.md](connectors/mcp_heartbeat_payload.md) | Stage B Heartbeat Payload | The Neo-APSU Stage B rehearsal emits a canonical heartbeat payload through the MCP `/heartbeat` endpoint. The templat... | `../../connectors/neo_apsu_connector_template.py` |
 | [connectors/mcp_migration.md](connectors/mcp_migration.md) | MCP Migration Guide | This guide explains how to convert existing API connectors to the **Model Context Protocol (MCP)**. | - |
 | [contribution_guide.md](contribution_guide.md) | Contribution Guide | Thank you for considering a contribution! | - |
 | [contributor_checklist.md](contributor_checklist.md) | Contributor Checklist | This checklist distills mandatory practices for ABZU contributors. | - |

--- a/docs/communication_interfaces.md
+++ b/docs/communication_interfaces.md
@@ -163,6 +163,9 @@ problems and surface recovery instructions. Lagging or missing beats surface
 alignment issues early and are mirrored in the dashboards described in the
 [System Blueprint](system_blueprint.md#heartbeat-propagation) and
 [Blueprint Spine](blueprint_spine.md#heartbeat-propagation-and-self-healing).
+For Stage B MCP rehearsals, reference the
+[Stage B Heartbeat Payload](connectors/mcp_heartbeat_payload.md) guide for the
+canonical Neo-APSU telemetry contract.
 
 ## Recovery Flows
 

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -22,7 +22,7 @@ refer to the [MCP Migration Guide](mcp_migration.md).
 | `avatar_broadcast` | broadcast avatar frames to Discord and Telegram | 0.1.0 | Bot token | Discord API, Telegram API | Discord, Telegram | experimental | [connectors/avatar_broadcast.py](../../connectors/avatar_broadcast.py) | N/A | N/A |
 | `signal_bus` | cross-connector publish/subscribe bus | 0.3.0 | N/A | Redis/Kafka | all connectors | experimental | [connectors/signal_bus.py](../../connectors/signal_bus.py) | [README.md](README.md) | N/A |
 | `mcp_gateway_example` | example MCP gateway connector | 0.2.0 | Configured | `POST /model/invoke` | internal models | experimental | [connectors/mcp_gateway_example.py](../../connectors/mcp_gateway_example.py) | [README.md](README.md) | N/A |
-| `neo_apsu_connector_template` | template for new connectors | 0.2.0 | Bearer | `POST /handshake`, `POST /heartbeat` | MCP gateway | experimental | [connectors/neo_apsu_connector_template.py](../../connectors/neo_apsu_connector_template.py) | [mcp_capability_payload.md](mcp_capability_payload.md) | N/A |
+| `neo_apsu_connector_template` | template for new connectors | 0.2.0 | Bearer | `POST /handshake`, `POST /heartbeat` | MCP gateway | experimental | [connectors/neo_apsu_connector_template.py](../../connectors/neo_apsu_connector_template.py) | [mcp_capability_payload.md](mcp_capability_payload.md) | [mcp_heartbeat_payload.schema.json](../../schemas/mcp_heartbeat_payload.schema.json) |
 
 ## MCP Migration Status
 

--- a/docs/connectors/mcp_heartbeat_payload.md
+++ b/docs/connectors/mcp_heartbeat_payload.md
@@ -1,0 +1,68 @@
+# Stage B Heartbeat Payload
+
+The Neo-APSU Stage B rehearsal emits a canonical heartbeat payload through the MCP
+`/heartbeat` endpoint. The template in
+[`connectors/neo_apsu_connector_template.py`](../../connectors/neo_apsu_connector_template.py)
+applies baseline metadata, validates overrides, and guarantees that the gateway
+receives the telemetry required by doctrine.
+
+## Canonical Fields
+
+| field | type | required | default | notes |
+| --- | --- | --- | --- | --- |
+| `chakra` | string | yes | `"neo"` | Must be a non-empty string. Custom values are accepted when present in the payload and are validated before emission. |
+| `cycle_count` | integer | yes | `0` | Must be a non-negative integer. Boolean values are rejected even when numerically castable. |
+| `context` | string | yes | `"stage-b-rehearsal"` | The connector locks heartbeat telemetry to the Stage B rehearsal context and will raise if any other value is supplied. |
+| `credential_expiry` | string (`date-time`) | yes | sourced from MCP session | Derived from the handshake response (`session.credential_expiry` or `session.expires_at`). A manual override may be provided, but the value must be a valid ISO-8601 timestamp. |
+| `emitted_at` | string (`date-time`) | yes | current UTC timestamp | Automatically set when omitted so the payload always carries an emission time in ISO-8601 `Z` form. |
+
+Additional telemetry fields—such as `status`, `latency_ms`, or channel-specific
+metadata—may be included. The schema allows extra properties so operators can
+extend diagnostics without breaking validation.
+
+## Override Rules
+
+1. **Defaults first.** `_prepare_heartbeat_payload` merges payload fields with the
+   canonical metadata so every heartbeat contains the baseline `chakra`,
+   `cycle_count`, and `context` values when operators provide partial updates.
+2. **Strict validation.** The helper enforces a non-empty string for `chakra`, a
+   non-negative integer for `cycle_count`, and a literal `stage-b-rehearsal`
+   context. Any mismatch raises before the HTTP request is attempted.
+3. **Credential expiry required.** The heartbeat must carry a `credential_expiry`
+   timestamp. The connector first inspects the handshake `session` object for a
+   `credential_expiry` or `expires_at` field and falls back to an explicit
+   override parameter. If neither is available the emission is aborted.
+4. **ISO-8601 timestamps.** Both `credential_expiry` and `emitted_at` are
+   normalised to `YYYY-MM-DDTHH:MM:SSZ`. Supplying naive datetimes or alternate
+   offsets causes validation to fail before telemetry is posted.
+
+These rules ensure that Stage B rehearsals advertise their authentication window
+and cycle alignment on every beat, allowing downstream monitors to catch drift
+immediately.
+
+## JSON Schema
+
+The Stage B heartbeat schema lives in
+[`schemas/mcp_heartbeat_payload.schema.json`](../../schemas/mcp_heartbeat_payload.schema.json)
+and mirrors the validation logic enforced by the connector. It models the
+required fields, ISO-8601 formats, and allows custom diagnostics via additional
+properties.
+
+## Sample Payload
+
+```json
+{
+  "chakra": "neo",
+  "cycle_count": 12,
+  "context": "stage-b-rehearsal",
+  "credential_expiry": "2025-12-01T00:00:00Z",
+  "emitted_at": "2025-11-15T12:00:00Z",
+  "status": "aligned",
+  "latency_ms": 83
+}
+```
+
+This example mirrors the payload emitted after a successful Stage B handshake
+where the gateway supplied the credential expiry timestamp. Custom diagnostic
+fields (`status`, `latency_ms`) ride alongside the canonical telemetry without
+violating the schema.

--- a/schemas/mcp_heartbeat_payload.schema.json
+++ b/schemas/mcp_heartbeat_payload.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://abzu.ai/schemas/mcp_heartbeat_payload.schema.json",
+  "title": "Neo-APSU Stage B Heartbeat Payload",
+  "description": "Canonical telemetry emitted by the Neo-APSU connector during Stage B rehearsals.",
+  "type": "object",
+  "required": [
+    "chakra",
+    "cycle_count",
+    "context",
+    "credential_expiry",
+    "emitted_at"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "chakra": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Signal origin chakra tag. Must be a non-empty string.",
+      "examples": ["neo", "solar"]
+    },
+    "cycle_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cycle alignment counter. Must be a non-negative integer.",
+      "examples": [0, 3, 42]
+    },
+    "context": {
+      "type": "string",
+      "const": "stage-b-rehearsal",
+      "description": "Stage context identifier. Stage B rehearsal is required.",
+      "examples": ["stage-b-rehearsal"]
+    },
+    "credential_expiry": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp describing when the MCP credential expires.",
+      "examples": ["2025-12-01T00:00:00Z"]
+    },
+    "emitted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp captured when the heartbeat was emitted.",
+      "examples": ["2025-11-15T12:00:00Z"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Stage B heartbeat payload guide detailing required telemetry fields and override behaviour
- publish the matching JSON schema and reference it from the Neo-APSU connector index entry
- cross-link Stage B heartbeat expectations from the heartbeat propagation guide for operator visibility

## Testing
- `pre-commit run --files docs/connectors/mcp_heartbeat_payload.md docs/connectors/CONNECTOR_INDEX.md docs/communication_interfaces.md schemas/mcp_heartbeat_payload.schema.json` *(fails: documentation index regeneration, environment package check, metrics/self-heal verifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68ced33bb2e0832eaa193637b37599f4