### PR TITLE
Add memory load proof CLI and update Stage B docs

### DIFF
--- a/docs/monitoring/RAZAR.md
+++ b/docs/monitoring/RAZAR.md
@@ -104,6 +104,30 @@ fields `memory_layers`, `memory_init_duration`, `memory_init_ready`, and
 `scripts/bootstrap_memory.py`, and `scripts/bootstrap_world.py` when proving a
 10 k-item audit to operations.
 
+### Memory load proof telemetry
+
+Operators attach a dedicated load proof to Stage B packages using
+`python scripts/memory_load_proof.py <fixture>`. The CLI writes latency
+percentiles (P50/P95/P99) and the replayed record counts to
+`logs/memory_load_proof.jsonl`, while `record_memory_init_metrics` refreshes the
+`razar_memory_init_*` gauges under the supplied `--metrics-source` label.
+
+1. Produce (or request) a 10 k-record JSONL fixture where each line contains a
+   `query` field. Store it alongside prior audits under
+   `data/memory/load_proofs/`.
+2. Run the CLI with Stage B labels. Example:
+
+   ```bash
+   python scripts/memory_load_proof.py data/memory/load_proofs/stageb_fixture.jsonl \
+     --metrics-source stageb-readiness --warmup 25
+   ```
+
+3. Export `monitoring/boot_metrics.prom` and the appended JSON log for review.
+
+**Acceptance thresholds** for the audit remain `p95 ≤ 0.120 s` and
+`p99 ≤ 0.180 s`. Any non-ready layers or replay failures must be documented in the
+operations log with remediation notes before sign-off.
+
 ### Navigation Notes for the New Architect
 
 1. From the Grafana home page, open **Dashboards → RAZAR Failover Observability**.

--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -177,7 +177,7 @@ documents:
       scope: RAZAR agent workflows and deployment.
   docs/The_Absolute_Protocol.md:
     commit: worktree
-    sha256: 1f9a998157722855567ffb40b3f101fee815cfecd6befe2e938385a01183b7d2
+    sha256: 3983518de637d4e290ec5f493f343c611d277465621ea6e224832192b304a6db
     summary:
       insight: Stage B MCP rehearsals now reference `OperatorMCPAdapter` and the
         shared smoke script to verify connector rotation logs.

--- a/scripts/memory_load_proof.py
+++ b/scripts/memory_load_proof.py
@@ -1,0 +1,321 @@
+"""Run a memory load proof against a 10k-record fixture.
+
+This CLI initializes :class:`memory.bundle.MemoryBundle`, replays queries
+from a JSONL fixture, records latency percentiles, and exports memory
+initialization metrics for Stage B readiness reviews.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Sequence
+
+
+# Ensure the repository root is importable when the script is executed via a
+# relative path such as ``python scripts/memory_load_proof.py``.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+from memory.bundle import MemoryBundle
+from monitoring.boot_metrics import (  # noqa: E402  (delayed import)
+    MemoryInitMetricValues,
+    record_memory_init_metrics,
+    summarize_memory_statuses,
+)
+
+logger = logging.getLogger("memory.load_proof")
+
+
+@dataclass(frozen=True)
+class LoadProofResult:
+    """Aggregate results from a load-proof execution."""
+
+    dataset: Path
+    total_records: int
+    queries_executed: int
+    init_duration_s: float
+    p50_latency_s: float
+    p95_latency_s: float
+    p99_latency_s: float
+    layer_total: int
+    layer_ready: int
+    layer_failed: int
+    query_failures: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Replay memory queries from a JSONL fixture and export latency "
+            "percentiles for Stage B readiness."
+        )
+    )
+    parser.add_argument(
+        "dataset",
+        type=Path,
+        help="Path to the JSONL fixture containing memory queries.",
+    )
+    parser.add_argument(
+        "--query-field",
+        default="query",
+        help=(
+            "JSON key holding the query text. Fallbacks: 'prompt' and 'text' "
+            "when the preferred field is missing."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional limit on the number of records to replay.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Number of warm-up queries executed before timing begins.",
+    )
+    parser.add_argument(
+        "--metrics-source",
+        default="memory-load-proof",
+        help=(
+            "Source label applied to razar_memory_init_* gauges. Defaults to "
+            "'memory-load-proof'."
+        ),
+    )
+    parser.add_argument(
+        "--metrics-output",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path for the Prometheus textfile exporter. When omitted "
+            "the default boot metrics path is used."
+        ),
+    )
+    parser.add_argument(
+        "--log-path",
+        type=Path,
+        default=Path("logs/memory_load_proof.jsonl"),
+        help="JSONL file that receives the per-run summary.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging for troubleshooting.",
+    )
+    return parser.parse_args()
+
+
+def _load_records(path: Path) -> Iterator[dict[str, object]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                yield json.loads(text)
+            except json.JSONDecodeError as exc:  # pragma: no cover - logging only
+                logger.warning(
+                    "Skipping malformed JSON on line %s: %s", line_number, exc
+                )
+
+
+def _extract_query(record: dict[str, object], preferred: str) -> str | None:
+    candidates = [preferred, "prompt", "text"]
+    for key in candidates:
+        if key in record:
+            value = record[key]
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+    return None
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    clipped = sorted(values)
+    rank = (percentile / 100.0) * (len(clipped) - 1)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return clipped[int(rank)]
+    weight = rank - lower
+    return clipped[lower] + (clipped[upper] - clipped[lower]) * weight
+
+
+def _record_metrics(
+    *,
+    source: str,
+    duration_s: float,
+    statuses: dict[str, object],
+    output_path: Path | None,
+) -> tuple[int, int, int]:
+    total, ready, failed = summarize_memory_statuses(statuses)
+    record_memory_init_metrics(
+        MemoryInitMetricValues(
+            duration_seconds=duration_s,
+            layer_total=float(total),
+            layer_ready=float(ready),
+            layer_failed=float(failed),
+            source=source,
+            error=failed > 0,
+        ),
+        output_path=output_path,
+    )
+    return total, ready, failed
+
+
+def run_load_proof(args: argparse.Namespace) -> LoadProofResult:
+    bundle = MemoryBundle()
+
+    start_init = time.perf_counter()
+    statuses = bundle.initialize()
+    init_duration = time.perf_counter() - start_init
+
+    layer_total, layer_ready, layer_failed = _record_metrics(
+        source=args.metrics_source,
+        duration_s=init_duration,
+        statuses=statuses,
+        output_path=args.metrics_output,
+    )
+
+    records_iter = _load_records(args.dataset)
+    queries: list[str] = []
+    for record in records_iter:
+        query = _extract_query(record, args.query_field)
+        if query is None:
+            continue
+        queries.append(query)
+        if args.limit is not None and len(queries) >= args.limit:
+            break
+
+    if not queries:
+        raise ValueError(
+            "No queries extracted from dataset. Check the --query-field option."
+        )
+
+    warmup = max(min(args.warmup, max(len(queries) - 1, 0)), 0)
+    if warmup:
+        for query in queries[:warmup]:
+            try:
+                bundle.query(query)
+            except Exception:  # pragma: no cover - warmup best effort
+                logger.exception("Warm-up query failed: %s", query)
+
+    timed_queries = queries[warmup:] if warmup < len(queries) else queries
+
+    latencies: list[float] = []
+    query_failures = 0
+    for query in timed_queries:
+        start_query = time.perf_counter()
+        try:
+            result = bundle.query(query)
+        except Exception:  # pragma: no cover - logged and counted
+            elapsed = time.perf_counter() - start_query
+            latencies.append(elapsed)
+            query_failures += 1
+            logger.exception("Query execution failed: %s", query)
+            continue
+
+        elapsed = time.perf_counter() - start_query
+        latencies.append(elapsed)
+
+        failed_layers = result.get("failed_layers") if isinstance(result, dict) else []
+        if failed_layers:
+            query_failures += 1
+
+    p50 = _percentile(latencies, 50)
+    p95 = _percentile(latencies, 95)
+    p99 = _percentile(latencies, 99)
+
+    return LoadProofResult(
+        dataset=args.dataset,
+        total_records=len(queries),
+        queries_executed=len(timed_queries),
+        init_duration_s=init_duration,
+        p50_latency_s=p50,
+        p95_latency_s=p95,
+        p99_latency_s=p99,
+        layer_total=layer_total,
+        layer_ready=layer_ready,
+        layer_failed=layer_failed,
+        query_failures=query_failures,
+    )
+
+
+def _append_log(result: LoadProofResult, log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "dataset": str(result.dataset),
+        "total_records": result.total_records,
+        "queries_executed": result.queries_executed,
+        "init_duration_s": round(result.init_duration_s, 6),
+        "latency_p50_s": round(result.p50_latency_s, 6),
+        "latency_p95_s": round(result.p95_latency_s, 6),
+        "latency_p99_s": round(result.p99_latency_s, 6),
+        "layer_total": result.layer_total,
+        "layer_ready": result.layer_ready,
+        "layer_failed": result.layer_failed,
+        "query_failures": result.query_failures,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload))
+        handle.write("\n")
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+    result = run_load_proof(args)
+    _append_log(result, args.log_path)
+
+    logger.info(
+        "Load proof complete: dataset=%s records=%s p95=%.3fms p99=%.3fms",
+        result.dataset,
+        result.total_records,
+        result.p95_latency_s * 1000,
+        result.p99_latency_s * 1000,
+    )
+
+    summary = {
+        "dataset": str(result.dataset),
+        "total_records": result.total_records,
+        "queries_timed": result.queries_executed,
+        "init_duration_s": round(result.init_duration_s, 6),
+        "latency_p50_s": round(result.p50_latency_s, 6),
+        "latency_p95_s": round(result.p95_latency_s, 6),
+        "latency_p99_s": round(result.p99_latency_s, 6),
+        "layers": {
+            "total": result.layer_total,
+            "ready": result.layer_ready,
+            "failed": result.layer_failed,
+        },
+        "query_failures": result.query_failures,
+    }
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add a memory load proof CLI that replays JSONL fixtures through `MemoryBundle`, records latency percentiles, and emits boot metrics
- document the Stage B load proof workflow and acceptance thresholds in the memory layers and RAZAR monitoring guides
- refresh the onboarding confirmation hash for `docs/The_Absolute_Protocol.md`

## Testing
- `pre-commit run --files scripts/memory_load_proof.py docs/memory_layers_GUIDE.md docs/monitoring/RAZAR.md onboarding_confirm.yml` *(fails: capture-failing-tests, pytest-cov, verify-docs-up-to-date, verify-chakra-monitoring, verify-self-healing)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68cef13fe260832e998c1ca7ec69eeb2