### PR TITLE
Add nightly Stage B MCP drill automation

### DIFF
--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -34,3 +34,83 @@ jobs:
           name: pytest-results
           path: pytest.xml
           if-no-files-found: ignore
+
+  operator-mcp-stage-b:
+    name: Stage B operator MCP drill
+    runs-on: ubuntu-latest
+    env:
+      ABZU_USE_MCP: "1"
+      PYTHONPATH: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+      - name: Run Stage B smoke checks
+        run: |
+          set -eo pipefail
+          python scripts/stage_b_smoke.py --json | tee stage_b_smoke.json
+      - name: Validate rotation recency
+        run: |
+          python - <<'PY'
+          import json
+          import sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          from connectors.operator_mcp_adapter import ROTATION_WINDOW_HOURS
+
+          log_path = Path("logs") / "stage_b_rotation_drills.jsonl"
+          if not log_path.exists():
+              print(f"Rotation log missing: {log_path}")
+              sys.exit(1)
+
+          lines = [
+              json.loads(line)
+              for line in log_path.read_text(encoding="utf-8").splitlines()
+              if line.strip()
+          ]
+          if not lines:
+              print("Rotation log is empty")
+              sys.exit(1)
+
+          latest = lines[-1]
+          rotated_at_str = latest.get("rotated_at")
+          if not rotated_at_str:
+              print(f"Latest entry missing rotated_at: {latest}")
+              sys.exit(1)
+
+          try:
+              rotated_at = datetime.fromisoformat(rotated_at_str.replace("Z", "+00:00"))
+          except ValueError as exc:
+              print(f"Invalid rotated_at timestamp '{rotated_at_str}': {exc}")
+              sys.exit(1)
+
+          age = datetime.now(timezone.utc) - rotated_at
+          age_hours = age.total_seconds() / 3600
+          if age_hours > ROTATION_WINDOW_HOURS:
+              print(
+                  "Rotation drill stale: "
+                  f"{age_hours:.2f}h old (window {ROTATION_WINDOW_HOURS}h)."
+              )
+              sys.exit(1)
+
+          print(
+              f"Rotation drill fresh: {age_hours:.2f}h old within "
+              f"the {ROTATION_WINDOW_HOURS}h window."
+          )
+          PY
+      - name: Upload Stage B artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stage-b-smoke
+          path: |
+            stage_b_smoke.json
+            logs/stage_b_rotation_drills.jsonl
+          if-no-files-found: warn

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |


### PR DESCRIPTION
## Summary
- add a nightly Stage B operator MCP drill job that runs the smoke script with MCP toggles, validates rotation recency, and uploads drill artifacts
- surface stale rotation failures directly in the workflow through an inline parser that reuses the canonical rotation window
- document the new automation cadence and expectations in the MCP audit and refresh the generated documentation index

## Testing
- `pre-commit run --files .github/workflows/nightly_ci.yml docs/connectors/operator_mcp_audit.md docs/INDEX.md` *(fails: repo-wide pytest coverage target unmet, docs registry timestamps stale, and monitoring/self-healing checks require external services)*
- `pre-commit run verify-onboarding-refs`


------
https://chatgpt.com/codex/tasks/task_e_68cefc32d2f0832ea8c0def4725c10c4