### PR TITLE
Add documentation for corpus ingestion workflow

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -347,6 +347,7 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [contribution_guide.md](contribution_guide.md) | Contribution Guide | Thank you for considering a contribution! | - |
 | [contributor_checklist.md](contributor_checklist.md) | Contributor Checklist | This checklist distills mandatory practices for ABZU contributors. | - |
 | [core_usage.md](core_usage.md) | Core Usage | Install the compiled wheels: | - |
+| [corpus_ingestion.md](corpus_ingestion.md) | Corpus Ingestion Workflow | The corpus ingestion routine rebuilds the ethics memory collection so the Crown can retrieve up-to-date doctrine pass... | - |
 | [crown_invocation_guide.md](crown_invocation_guide.md) | Crown Invocation Guide | This guide documents the precise sequence Spiral OS follows when the Crown layer boots. Use it to rehearse the handsh... | `../init_crown_agent.py` |
 | [crown_manifest.md](crown_manifest.md) | CROWN Manifest | The **CROWN** agent runs the GLM-4.1V-9B model and acts as the root layer of Spiral OS. It holds the highest permissi... | - |
 | [crown_servant_models.md](crown_servant_models.md) | Crown Servant Models | Guidance for deploying auxiliary servant models used by Crown. | `../memory/query_memory.py` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Milestone VIII expands on the sovereign voice work with memory-aided routing and
 
 - [ALBEDO_LAYER.md](ALBEDO_LAYER.md)
 - [CORPUS_MEMORY.md](CORPUS_MEMORY.md)
+- [corpus_ingestion.md](corpus_ingestion.md)
 - [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md)
 - [DASHBOARD.md](DASHBOARD.md)
 - [ETHICS_VALIDATION.md](ETHICS_VALIDATION.md)

--- a/docs/corpus_ingestion.md
+++ b/docs/corpus_ingestion.md
@@ -1,0 +1,48 @@
+# Corpus Ingestion Workflow
+
+The corpus ingestion routine rebuilds the ethics memory collection so the Crown can retrieve up-to-date doctrine passages. This guide walks through the full process—from invoking the CLI helper to persisting a snapshot for disaster recovery.
+
+## Prerequisites
+
+- The `sentence-transformers` and `chromadb` packages must be installed so embeddings can be generated and stored.
+- Markdown source files (for example the ethics canon) should live under a directory such as `sacred_inputs/`.
+- Ensure you have credentials or filesystem access required by the Chroma persistent client at `data/chroma/`.
+
+## Step-by-step flow
+
+1. **Invoke the helper script.** Run `python scripts/ingest_ethics.py <directory>` to start a reindex. The script validates the path and logs the directory it will process.
+2. **Scan Markdown sources.** `INANNA_AI.corpus_memory.scan_memory` walks the provided directory (or the default memory set) and reads each Markdown file into memory.
+3. **Embed new documents.** `SentenceTransformer` creates embeddings for each document, packaging file metadata including the last modification timestamp.
+4. **Rebuild the Chroma collection.** `corpus_memory.reindex_corpus` deletes the existing `corpus` collection, creates a fresh collection, and uploads the embeddings.
+5. **Persist a snapshot.** Run `python scripts/snapshot_state.py` after the reindex completes. This calls `vector_memory.persist_snapshot()` to write the updated embeddings to `vector_memory`'s snapshot directory and records the snapshot path inside a JSON manifest.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant CLI as ingest_ethics.py
+    participant Memory as corpus_memory.reindex_corpus
+    participant Chroma as Chroma collection
+    participant Snapshot as vector_memory.persist_snapshot
+    participant Archive as snapshot_state.create_snapshot
+
+    Operator->>CLI: python scripts/ingest_ethics.py <directory>
+    CLI->>Memory: reindex_corpus([directory])
+    Memory->>Memory: scan_memory() + build embeddings
+    Memory->>Chroma: delete_collection("corpus")
+    Chroma-->>Memory: create_collection("corpus")
+    Memory->>Chroma: add_embeddings(paths, metadata)
+    Operator->>Archive: python scripts/snapshot_state.py
+    Archive->>Snapshot: persist_snapshot()
+    Snapshot-->>Archive: snapshot path recorded
+    Archive-->>Operator: snapshot_<timestamp>.json written
+```
+
+## Validation checklist
+
+- Confirm the CLI exited with status code `0` and printed `Ethics corpus reindexed` in the logs.
+- Inspect `data/chroma/` to verify the Chroma store timestamp updates.
+- Review the JSON written to `storage/snapshots/` to confirm the snapshot path captures the new embeddings.
+
+Keeping this workflow in sync ensures the ethics corpus stays searchable while snapshots provide an audit trail for recovery drills.


### PR DESCRIPTION
## Summary
- add `docs/corpus_ingestion.md` describing the ethics corpus ingestion steps and include a Mermaid sequence diagram
- link the new guide from `docs/README.md` and regenerate `docs/INDEX.md` so the workflow is discoverable

## Testing
- `pre-commit run --files docs/corpus_ingestion.md docs/README.md docs/INDEX.md` *(fails: pytest-cov requires 90% coverage across the full suite; verify-docs-up-to-date flags pre-existing doctrine index drift; monitoring checks cannot reach local exporters; self-healing check reports no recent cycles)*

------
https://chatgpt.com/codex/tasks/task_e_68cf18ff899c832eb7b9c9ef1633e1aa