### PR TITLE
Improve optional memory stub visibility before load tests

### DIFF
--- a/scripts/check_memory_layers.py
+++ b/scripts/check_memory_layers.py
@@ -4,16 +4,25 @@
 Runs minimal queries against each layer. Raises ``RuntimeError``
 if any layer is empty or unavailable, mirroring the ``ready``
 state emitted by the Rust bundle. Used to guard Albedo
-initialisation before persona modules load.
+initialisation before persona modules load. Reports optional
+fallback usage so Stage B rehearsals can halt when stubs are
+active.
 """
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
 from pathlib import Path
 import sys
 import os
+from typing import Dict, List
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
 
 DATA_DIR = ROOT / "data"
 os.environ.setdefault("CORTEX_PATH", str(DATA_DIR / "cortex.jsonl"))
@@ -23,6 +32,8 @@ os.environ.setdefault("SPIRITUAL_DB_PATH", str(DATA_DIR / "ontology.db"))
 os.environ.setdefault("NARRATIVE_LOG_PATH", str(DATA_DIR / "story.log"))
 
 __version__ = "0.1.2"
+
+logger = logging.getLogger("memory.layer_check")
 
 from memory.cortex import query_spirals
 from memory.emotional import fetch_emotion_history, get_connection as emotion_conn
@@ -37,10 +48,45 @@ except Exception:  # mental layer optional
     _MENTAL_FALLBACK = True
 from memory.spiritual import lookup_symbol_history, get_connection as spirit_conn
 from memory.narrative_engine import stream_stories
+from memory.bundle import MemoryBundle
 
 
-def verify_memory_layers() -> None:
-    """Ensure each memory layer returns data."""
+@dataclass(frozen=True)
+class OptionalStubActivation:
+    """Structured record describing an optional stub activation."""
+
+    layer: str
+    module: str
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class MemoryLayerCheckReport:
+    """Summary of memory layer readiness and optional fallback usage."""
+
+    statuses: Dict[str, str]
+    optional_stubs: List[OptionalStubActivation]
+
+
+def _gather_optional_stubs(bundle: MemoryBundle) -> List[OptionalStubActivation]:
+    optional: List[OptionalStubActivation] = []
+    for layer, diag in bundle.diagnostics.items():
+        loaded_module = diag.get("loaded_module")
+        if isinstance(loaded_module, str) and loaded_module.startswith(
+            "memory.optional."
+        ):
+            reason = diag.get("fallback_reason")
+            activation = OptionalStubActivation(
+                layer=layer,
+                module=loaded_module,
+                reason=str(reason) if reason is not None else None,
+            )
+            optional.append(activation)
+    return optional
+
+
+def verify_memory_layers() -> MemoryLayerCheckReport:
+    """Ensure each memory layer returns data and report fallback usage."""
     if not query_spirals(tags=["example"]):
         raise RuntimeError("cortex layer empty")
 
@@ -56,7 +102,31 @@ def verify_memory_layers() -> None:
     if not list(stream_stories()):
         raise RuntimeError("narrative layer empty")
 
+    bundle = MemoryBundle()
+    statuses = bundle.initialize()
+    optional = _gather_optional_stubs(bundle)
+
+    for activation in optional:
+        logger.warning(
+            "Optional memory stub active: layer=%s module=%s reason=%s",
+            activation.layer,
+            activation.module,
+            activation.reason or "unspecified",
+        )
+
+    return MemoryLayerCheckReport(statuses=statuses, optional_stubs=optional)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual check
-    verify_memory_layers()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+    report = verify_memory_layers()
+    if report.optional_stubs:
+        print(
+            "optional stubs detected:",
+            ", ".join(f"{item.layer}→{item.module}" for item in report.optional_stubs),
+        )
+        sys.exit(1)
     print("memory checks passed")


### PR DESCRIPTION
## Summary
- add structured logging in `MemoryBundle.initialize` that flags optional fallbacks so gate logs reveal the loaded stub modules
- extend `scripts/check_memory_layers.py` to surface optional stub usage via warnings and its return value, failing the CLI when stubs answer queries
- run the memory layer checker as a preflight inside `scripts/memory_load_proof.py`, aborting the load proof and writing a pretest report when fallbacks are detected

## Testing
- pytest tests/test_memory_bundle.py *(fails: ModuleNotFoundError: neoabzu_memory shared library is unavailable in the container)*
- pre-commit run --files memory/bundle.py scripts/check_memory_layers.py scripts/memory_load_proof.py *(fails: blueprint/doc index gates, missing `websockets`, coverage target for unrelated suites, and stale doctrine timestamps)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1af89edc832ea4a62fdb5a5035ce