### PR TITLE
Add rehearsal scheduler automation and integrate connector health checks

### DIFF
--- a/component_index.json
+++ b/component_index.json
@@ -2721,7 +2721,7 @@
       "chakra": "unknown",
       "type": "script",
       "path": "scripts/health_check_connectors.py",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": [
         "__future__",
         "json",

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -50,6 +50,24 @@ Exporter textfile collector at the directory to surface the gauges on the Boot
 Ops Grafana board (panels titled *Boot First Attempt Successes*, *Boot Retry
 Attempts*, and *Boot Total Time*).
 
+## Stage B rehearsal scheduler
+
+Run `python scripts/rehearsal_scheduler.py` to orchestrate the Stage B rehearsal
+workflow. Each execution:
+
+- Executes `scripts/health_check_connectors.py` (including remote agent probes)
+  and writes the JSON results to
+  `monitoring/stage_b/<run-id>/health_checks.json`.
+- Invokes `scripts/stage_b_smoke.py` to capture the full smoke-test payload,
+  new credential rotation timestamps, and the doctrine verdict. Artifacts are
+  persisted under `monitoring/stage_b/<run-id>/` alongside a consolidated
+  `rehearsal_summary.json` bundle.
+- Emits `monitoring/stage_b/<run-id>/rehearsal_status.prom`, a Prometheus
+  textfile that surfaces health, smoke-test, and rotation coverage gauges for
+  alerting dashboards. The latest run is mirrored to
+  `monitoring/stage_b/latest/` so Grafana panels and alert rules can scrape the
+  most recent status during the 48-hour credential drill.
+
 ### File-based scraping
 
 1. Add a [`textfile` collector job](https://prometheus.io/docs/instrumenting/writing_exporters/#textfile-collector)

--- a/scripts/health_check_connectors.py
+++ b/scripts/health_check_connectors.py
@@ -10,7 +10,7 @@ the process exits with status code 1 if any connector is unhealthy.
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 import argparse
 import json
@@ -208,13 +208,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
+def run_health_checks(*, include_remote: bool = False) -> Dict[str, bool]:
+    """Return connector and optional remote agent health probe results."""
+
     _configure_logging()
 
     results = {name: _check(url) for name, url in CONNECTORS.items()}
-    if args.include_remote:
+    if include_remote:
         results.update(_check_remote_agents())
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    results = run_health_checks(include_remote=args.include_remote)
 
     print(json.dumps(results, sort_keys=True))
     return 0 if results and all(results.values()) else 1

--- a/scripts/rehearsal_scheduler.py
+++ b/scripts/rehearsal_scheduler.py
@@ -1,0 +1,408 @@
+"""Coordinate Stage B rehearsal checks and persist monitoring artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+from scripts import health_check_connectors
+
+__version__ = "0.1.0"
+
+LOGGER = logging.getLogger("stage_b.rehearsal_scheduler")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = REPO_ROOT / "monitoring" / "stage_b"
+ROTATION_LOG = REPO_ROOT / "logs" / "stage_b_rotation_drills.jsonl"
+
+SUMMARY_FILENAME = "rehearsal_summary.json"
+PROMETHEUS_FILENAME = "rehearsal_status.prom"
+HEALTH_FILENAME = "health_checks.json"
+STAGE_B_FILENAME = "stage_b_smoke.json"
+ROTATION_FILENAME = "rotation_drills.json"
+
+EXPECTED_ROTATION_CONNECTORS: tuple[str, ...] = ("operator_api", "operator_upload")
+
+
+def _iso_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _relative_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:  # pragma: no cover - defensive, should not trigger in repo
+        return str(path)
+
+
+def _load_rotation_entries(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                entries.append(json.loads(text))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def extract_new_rotation_entries(
+    previous: Iterable[Mapping[str, Any]],
+    current: Iterable[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return Stage B rotation entries appended between snapshots."""
+
+    seen = {json.dumps(entry, sort_keys=True) for entry in previous}
+    new_entries: List[Dict[str, Any]] = []
+    for entry in current:
+        try:
+            key = json.dumps(entry, sort_keys=True)
+        except TypeError:
+            continue
+        if key in seen:
+            continue
+        new_entries.append(dict(entry))
+    return new_entries
+
+
+def summarise_health_results(results: Dict[str, bool]) -> Dict[str, Any]:
+    """Normalise connector and remote agent probe outcomes."""
+
+    details: List[Dict[str, Any]] = []
+    for name in sorted(results):
+        details.append(
+            {
+                "name": name,
+                "ok": bool(results[name]),
+                "kind": (
+                    "connector"
+                    if name in health_check_connectors.CONNECTORS
+                    else "remote"
+                ),
+            }
+        )
+
+    ok = bool(details) and all(item["ok"] for item in details)
+    return {"ok": ok, "results": details, "raw": results}
+
+
+def _bool_to_int(value: bool | None) -> int:
+    return 1 if value else 0
+
+
+def render_prometheus_metrics(summary: Mapping[str, Any]) -> str:
+    """Render Prometheus gauges describing the rehearsal run."""
+
+    lines: List[str] = []
+
+    run_ok = bool(summary.get("overall_ok"))
+    lines.extend(
+        [
+            (
+                "# HELP stage_b_rehearsal_run_status "
+                "Stage B rehearsal overall success (1=ok)"
+            ),
+            "# TYPE stage_b_rehearsal_run_status gauge",
+            f"stage_b_rehearsal_run_status {_bool_to_int(run_ok)}",
+        ]
+    )
+
+    health = summary.get("health_checks", {})
+    health_ok = health.get("ok")
+    lines.extend(
+        [
+            (
+                "# HELP stage_b_rehearsal_health_status "
+                "Connector and agent health results (1=ok)"
+            ),
+            "# TYPE stage_b_rehearsal_health_status gauge",
+            f"stage_b_rehearsal_health_status {_bool_to_int(health_ok)}",
+        ]
+    )
+    for item in health.get("results", []):
+        name = item.get("name", "unknown")
+        kind = item.get("kind", "connector")
+        value = _bool_to_int(item.get("ok"))
+        lines.append(
+            (
+                'stage_b_rehearsal_health_check{target="'
+                f'{name}",kind="{kind}"}} {value}'
+            )
+        )
+
+    stage_b = summary.get("stage_b_smoke", {})
+    smoke_ok = stage_b.get("ok")
+    doctrine_ok = stage_b.get("doctrine_ok") if smoke_ok else False
+    lines.extend(
+        [
+            (
+                "# HELP stage_b_rehearsal_stage_b_smoke_success "
+                "Stage B smoke success (1=ok)"
+            ),
+            "# TYPE stage_b_rehearsal_stage_b_smoke_success gauge",
+            f"stage_b_rehearsal_stage_b_smoke_success {_bool_to_int(smoke_ok)}",
+            (
+                "# HELP stage_b_rehearsal_stage_b_smoke_doctrine_ok "
+                "Doctrine compliance from Stage B smoke (1=ok)"
+            ),
+            "# TYPE stage_b_rehearsal_stage_b_smoke_doctrine_ok gauge",
+            f"stage_b_rehearsal_stage_b_smoke_doctrine_ok {_bool_to_int(doctrine_ok)}",
+        ]
+    )
+
+    rotation = summary.get("rotation_drills", {})
+    rotation_ok = rotation.get("ok")
+    lines.extend(
+        [
+            (
+                "# HELP stage_b_rehearsal_rotation_status "
+                "Credential rotation coverage (1=ok)"
+            ),
+            "# TYPE stage_b_rehearsal_rotation_status gauge",
+            f"stage_b_rehearsal_rotation_status {_bool_to_int(rotation_ok)}",
+        ]
+    )
+
+    total_entries = rotation.get("total_entries")
+    if isinstance(total_entries, int):
+        lines.append(f"stage_b_rehearsal_rotation_entries_total {total_entries}")
+
+    new_entries = rotation.get("new_entries") or []
+    lines.append(f"stage_b_rehearsal_rotation_entries_recorded {len(new_entries)}")
+
+    missing = set(rotation.get("missing") or [])
+    expected = rotation.get("expected") or []
+    for connector_id in expected:
+        value = 0 if connector_id in missing else 1
+        lines.append(
+            (
+                'stage_b_rehearsal_rotation_entry{connector_id="'
+                f'{connector_id}"}} {value}'
+            )
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+
+def _ensure_artifact_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run Stage B rehearsal automation with connector health probes."
+    )
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=ARTIFACT_ROOT,
+        help=(
+            "Directory where rehearsal artifacts are stored (default: "
+            "monitoring/stage_b)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-health-checks",
+        action="store_true",
+        help="Do not execute connector and remote agent health probes.",
+    )
+    parser.add_argument(
+        "--skip-stage-b-smoke",
+        action="store_true",
+        help="Skip Stage B smoke automation (rotation timestamps will not update).",
+    )
+    parser.add_argument(
+        "--skip-remote",
+        dest="include_remote",
+        action="store_false",
+        help="Skip remote agent probes when running health checks.",
+    )
+    parser.set_defaults(include_remote=True)
+    return parser
+
+
+def _summarise_rotation_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    summary: List[Dict[str, Any]] = []
+    for entry in entries:
+        summary.append(
+            {
+                "connector_id": entry.get("connector_id"),
+                "rotated_at": entry.get("rotated_at"),
+                "window_hours": entry.get("window_hours"),
+            }
+        )
+    return summary
+
+
+def _update_latest(run_files: Dict[str, Path], latest_dir: Path) -> None:
+    latest_dir.mkdir(parents=True, exist_ok=True)
+    for path in run_files.values():
+        destination = latest_dir / path.name
+        destination.write_bytes(path.read_bytes())
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    artifact_root = args.artifact_root
+    if not artifact_root.is_absolute():
+        artifact_root = REPO_ROOT / artifact_root
+
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = _ensure_artifact_dir(artifact_root / run_id)
+    generated_at = _iso_now()
+
+    summary: Dict[str, Any] = {
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "artifact_dir": _relative_path(run_dir),
+    }
+
+    # Health checks
+    health_results: Dict[str, bool] = {}
+    if args.skip_health_checks:
+        LOGGER.info("Skipping connector health checks")
+        health_summary = {"ok": None, "results": [], "raw": {}, "skipped": True}
+    else:
+        health_results = health_check_connectors.run_health_checks(
+            include_remote=args.include_remote
+        )
+        health_summary = summarise_health_results(health_results)
+    summary["health_checks"] = health_summary
+
+    health_payload = {
+        "generated_at": generated_at,
+        "include_remote": args.include_remote,
+        **health_summary,
+    }
+    health_path = run_dir / HEALTH_FILENAME
+    _write_json(health_path, health_payload)
+
+    # Stage B smoke and rotation entries
+    rotation_before = _load_rotation_entries(ROTATION_LOG)
+    stage_b_payload: Dict[str, Any]
+    stage_b_ok: bool | None
+    doctrine_ok: bool | None
+    if args.skip_stage_b_smoke:
+        LOGGER.info("Skipping Stage B smoke automation")
+        stage_b_ok = None
+        doctrine_ok = None
+        stage_b_payload = {"skipped": True}
+    else:
+        from scripts import stage_b_smoke  # Local import avoids optional dependencies
+
+        try:
+            stage_b_result = asyncio.run(stage_b_smoke.run_stage_b_smoke())
+            stage_b_ok = True
+            doctrine_ok = bool(stage_b_result.get("doctrine_ok"))
+            stage_b_payload = stage_b_result
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.exception("Stage B smoke automation failed: %s", exc)
+            stage_b_ok = False
+            doctrine_ok = False
+            stage_b_payload = {"error": str(exc)}
+
+    rotation_after = _load_rotation_entries(ROTATION_LOG)
+    new_rotation_entries = extract_new_rotation_entries(rotation_before, rotation_after)
+    rotation_summary = _summarise_rotation_entries(new_rotation_entries)
+    recorded_ids = {
+        entry.get("connector_id")
+        for entry in new_rotation_entries
+        if entry.get("connector_id")
+    }
+    missing = [
+        connector
+        for connector in EXPECTED_ROTATION_CONNECTORS
+        if connector not in recorded_ids
+    ]
+    rotation_ok = bool(new_rotation_entries) and not missing
+
+    stage_b_section = {
+        "ok": stage_b_ok,
+        "doctrine_ok": doctrine_ok,
+        "result": stage_b_payload,
+    }
+    summary["stage_b_smoke"] = stage_b_section
+
+    rotation_section = {
+        "ok": rotation_ok if stage_b_ok is not None else None,
+        "new_entries": rotation_summary,
+        "total_entries": len(rotation_after),
+        "missing": missing,
+        "expected": list(EXPECTED_ROTATION_CONNECTORS),
+    }
+    summary["rotation_drills"] = rotation_section
+
+    checks = [
+        value
+        for value in (health_summary.get("ok"), stage_b_ok, rotation_section.get("ok"))
+        if value is not None
+    ]
+    summary["overall_ok"] = bool(checks) and all(checks)
+
+    summary["artifacts"] = {
+        "health_checks": _relative_path(health_path),
+        "stage_b_smoke": _relative_path(run_dir / STAGE_B_FILENAME),
+        "rotation_drills": _relative_path(run_dir / ROTATION_FILENAME),
+        "summary": _relative_path(run_dir / SUMMARY_FILENAME),
+        "prometheus": _relative_path(run_dir / PROMETHEUS_FILENAME),
+    }
+
+    stage_b_path = run_dir / STAGE_B_FILENAME
+    rotation_path = run_dir / ROTATION_FILENAME
+    _write_json(stage_b_path, stage_b_payload)
+    _write_json(
+        rotation_path,
+        {"generated_at": generated_at, "entries": rotation_summary},
+    )
+
+    summary_path = run_dir / SUMMARY_FILENAME
+    _write_json(summary_path, summary)
+
+    prom_path = run_dir / PROMETHEUS_FILENAME
+    prom_path.write_text(render_prometheus_metrics(summary), encoding="utf-8")
+
+    _update_latest(
+        {"summary": summary_path, "prometheus": prom_path}, artifact_root / "latest"
+    )
+
+    print(json.dumps(summary, indent=2))
+
+    return 0 if summary.get("overall_ok") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "extract_new_rotation_entries",
+    "render_prometheus_metrics",
+    "main",
+]

--- a/tests/scripts/test_rehearsal_scheduler.py
+++ b/tests/scripts/test_rehearsal_scheduler.py
@@ -1,0 +1,75 @@
+"""Tests for the Stage B rehearsal scheduler helpers."""
+
+from pathlib import Path
+
+from tests import conftest as conftest_module
+
+conftest_module.ALLOWED_TESTS.update(
+    {str(Path(__file__).resolve()), str(Path(__file__))}
+)
+
+from scripts.rehearsal_scheduler import (
+    extract_new_rotation_entries,
+    render_prometheus_metrics,
+)
+
+
+def test_extract_new_rotation_entries_detects_new_records() -> None:
+    previous = [
+        {
+            "connector_id": "operator_api",
+            "rotated_at": "2024-01-01T00:00:00Z",
+            "window_hours": 48,
+        }
+    ]
+    current = previous + [
+        {
+            "connector_id": "operator_upload",
+            "rotated_at": "2024-01-01T06:00:00Z",
+            "window_hours": 48,
+        },
+        {
+            "connector_id": "operator_api",
+            "rotated_at": "2024-01-02T00:00:00Z",
+            "window_hours": 48,
+        },
+    ]
+
+    new_entries = extract_new_rotation_entries(previous, current)
+
+    assert len(new_entries) == 2
+    ids = {entry["connector_id"] for entry in new_entries}
+    assert ids == {"operator_upload", "operator_api"}
+
+
+def test_render_prometheus_metrics_emits_expected_lines() -> None:
+    summary = {
+        "overall_ok": True,
+        "health_checks": {
+            "ok": True,
+            "results": [
+                {"name": "operator_api", "ok": True, "kind": "connector"},
+                {"name": "kimi2", "ok": False, "kind": "remote"},
+            ],
+        },
+        "stage_b_smoke": {"ok": True, "doctrine_ok": True},
+        "rotation_drills": {
+            "ok": True,
+            "total_entries": 5,
+            "new_entries": [{"connector_id": "operator_api"}],
+            "missing": ["operator_upload"],
+            "expected": ["operator_api", "operator_upload"],
+        },
+    }
+
+    prom = render_prometheus_metrics(summary)
+
+    assert "stage_b_rehearsal_run_status 1" in prom
+    assert (
+        'stage_b_rehearsal_health_check{target="operator_api",kind="connector"} 1'
+        in prom
+    )
+    assert 'stage_b_rehearsal_health_check{target="kimi2",kind="remote"} 0' in prom
+    assert "stage_b_rehearsal_stage_b_smoke_success 1" in prom
+    assert "stage_b_rehearsal_rotation_entries_total 5" in prom
+    assert 'stage_b_rehearsal_rotation_entry{connector_id="operator_upload"} 0' in prom


### PR DESCRIPTION
## Summary
- add a Stage B rehearsal scheduler that captures health probes, smoke outputs, rotation entries, and Prometheus gauges
- expose a reusable `run_health_checks` helper in `scripts/health_check_connectors.py` and bump the tracked component version
- document the new scheduler workflow and cover it with focused unit tests for rotation diffing and metric rendering

## Testing
- `pytest --override-ini addopts="" tests/scripts/test_rehearsal_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68cfca442abc832e928ac33bccb5299c