### PR TITLE
Document Stage B MCP rehearsal evidence

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,6 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [../.github/ISSUE_TEMPLATE/plugin_proposal.md](../.github/ISSUE_TEMPLATE/plugin_proposal.md) | plugin_proposal.md | - | - |
 | [../.github/ISSUE_TEMPLATE/ritual_proposal.md](../.github/ISSUE_TEMPLATE/ritual_proposal.md) | ritual_proposal.md | - | - |
 | [../.github/pull_request_template.md](../.github/pull_request_template.md) | pull_request_template.md | - | `../scripts/register_task.py` |
-| [../.pytest_cache/README.md](../.pytest_cache/README.md) | pytest cache directory # | This directory contains data from the pytest's cache plugin, which provides the `--lf` and `--ff` options, as well as... | - |
 | [../AGENTS.md](../AGENTS.md) | AGENTS | - Always read [docs/documentation_protocol.md](docs/documentation_protocol.md) before editing documentation. - Comple... | - |
 | [../CHANGELOG.md](../CHANGELOG.md) | Changelog | All notable changes to this project will be documented in this file. | - |
 | [../CHANGELOG_insight_matrix.md](../CHANGELOG_insight_matrix.md) | Changelog for `insight_matrix` | All notable changes to this component will be documented in this file. | - |

--- a/docs/connectors/CONNECTOR_INDEX.md
+++ b/docs/connectors/CONNECTOR_INDEX.md
@@ -27,6 +27,22 @@ refer to the [MCP Migration Guide](mcp_migration.md).
 | `operator_upload_stage_b` | Stage B MCP handshake and heartbeat for operator uploads | 0.1.0 | Bearer | `POST /handshake`, `POST /heartbeat` | RAZAR | experimental | [connectors/operator_upload_stage_b.py](../../connectors/operator_upload_stage_b.py) | [operator_mcp_runbook.md](operator_mcp_runbook.md), [credential_rotation_playbook.md](credential_rotation_playbook.md) | [mcp_heartbeat_payload.schema.json](../../schemas/mcp_heartbeat_payload.schema.json) |
 | `crown_handshake_stage_b` | Stage B MCP handshake mirroring Crown mission briefs | 0.1.0 | Bearer | `POST /handshake`, `POST /heartbeat` | Crown | experimental | [connectors/crown_handshake_stage_b.py](../../connectors/crown_handshake_stage_b.py) | [operator_mcp_runbook.md](operator_mcp_runbook.md), [credential_rotation_playbook.md](credential_rotation_playbook.md) | [mcp_heartbeat_payload.schema.json](../../schemas/mcp_heartbeat_payload.schema.json) |
 
+### Stage B MCP rehearsal evidence
+
+Stage B rehearsals refreshed the MCP connector catalog with validated handshakes,
+accepted contexts, and credential rotation telemetry. The artifacts below capture
+the negotiated capabilities and rotation windows exercised during the latest run.
+
+| Connector | Module | Contexts, channels, capabilities | Credential rotation | Evidence |
+| --- | --- | --- | --- | --- |
+| `operator_api_stage_b` | `connectors.operator_api_stage_b` | Context `stage-b-rehearsal` accepted with channels `handshake`, `heartbeat`, `command` and capabilities `register`, `telemetry`, `command`. | `last_rotated` `2025-09-21T09:43:11Z`, window `PT48H`, hot swap supported, token hint `operator`; session expires `2025-12-01T00:00:00Z`. | [Stage B rehearsal packet](../../logs/stage_b_rehearsal_packet.json) · [Rotation drills](../../logs/stage_b/latest/stage_b_rotation_drills.jsonl) |
+| `operator_upload_stage_b` | `connectors.operator_upload_stage_b` | Context `stage-b-rehearsal` accepted with channels `handshake`, `heartbeat`, `upload` and capabilities `register`, `telemetry`, `upload`. | `last_rotated` `2025-09-21T09:43:11Z`, window `PT48H`, hot swap supported, token hint `operator-upload`; session expires `2025-12-01T00:00:00Z`. | [Stage B rehearsal packet](../../logs/stage_b_rehearsal_packet.json) · [Rotation drills](../../logs/stage_b/latest/stage_b_rotation_drills.jsonl) |
+| `crown_handshake_stage_b` | `connectors.crown_handshake_stage_b` | Context `stage-b-rehearsal` accepted with channels `handshake`, `heartbeat`, `mission-brief` and capabilities `register`, `telemetry`, `mission-brief`. | `last_rotated` `2025-09-21T09:43:11Z`, window `PT48H`, hot swap supported, token hint `crown`; session expires `2025-11-15T00:00:00Z`. | [Stage B rehearsal packet](../../logs/stage_b_rehearsal_packet.json) |
+
+Rotation drills captured alongside the rehearsal confirm the operator connectors
+rotated credentials on `2025-01-01T00:00:00Z`, maintaining the declared 48-hour
+window for Stage B readiness ([stage_b_rotation_drills.jsonl](../../logs/stage_b/latest/stage_b_rotation_drills.jsonl)).
+
 ## MCP Migration Status
 
 | connector | protocol | migration_notes |


### PR DESCRIPTION
## Summary
- document the Stage B rehearsal handshakes, accepted contexts, and credential rotation metadata in the MCP connector index
- link Stage B catalog entries to the archived rehearsal packet and rotation drill logs for easy evidence tracing
- regenerate the documentation index via doc-indexer to drop stale entries

## Testing
- pre-commit run --files docs/connectors/CONNECTOR_INDEX.md *(fails: pytest-cov hook expects coverage args not supported in this environment; verify-docs-up-to-date reports pre-existing doctrine index drift; monitoring/self-heal hooks cannot reach local exporters)*
- python scripts/verify_docs_up_to_date.py *(fails: doctrine index timestamps predating upstream updates)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcfb4d998832ea5069df67e2b1548