### PR TITLE
Add Stage B rehearsal pipeline definition

### DIFF
--- a/deployment/pipelines/stage_b_rehearsal.yml
+++ b/deployment/pipelines/stage_b_rehearsal.yml
@@ -1,0 +1,36 @@
+# Stage B rehearsal pipeline executed via spiral-os pipeline deploy
+# Mirrors the Stage B readiness rehearsal to run health checks, smoke tests,
+# and credential rotation summaries end-to-end.
+name: stage-b-rehearsal
+steps:
+  - run: python scripts/rehearsal_scheduler.py --artifact-root monitoring/stage_b
+  - run: |
+      python - <<'PY'
+import json
+from pathlib import Path
+
+summary_path = Path("monitoring/stage_b/latest/rehearsal_summary.json")
+if summary_path.exists():
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    print("Stage B rehearsal overview:")
+    print(f"  Run ID: {data.get('run_id')}")
+    print(f"  Generated: {data.get('generated_at')}")
+    health = data.get("health_checks", {})
+    print(f"  Health checks ok: {health.get('ok')}")
+    stage_b = data.get("stage_b_smoke", {})
+    print(
+        "  Stage B smoke ok: {} (doctrine_ok={})".format(
+            stage_b.get("ok"), stage_b.get("doctrine_ok")
+        )
+    )
+    rotation = data.get("rotation_drills", {})
+    print(
+        "  Rotation coverage ok: {} (entries recorded: {})".format(
+            rotation.get("ok"), len(rotation.get("new_entries") or [])
+        )
+    )
+    print(f"  Overall success: {data.get('overall_ok')}")
+else:
+    print("Stage B rehearsal summary missing", flush=True)
+PY
+  - run: tar -czf logs/stage_b_rehearsal_artifacts.tgz monitoring/stage_b

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -53,7 +53,9 @@ Attempts*, and *Boot Total Time*).
 ## Stage B rehearsal scheduler
 
 Run `python scripts/rehearsal_scheduler.py` to orchestrate the Stage B rehearsal
-workflow. Each execution:
+workflow or trigger the automated pipeline defined in
+`deployment/pipelines/stage_b_rehearsal.yml` via
+`spiral-os pipeline deploy stage_b_rehearsal`. Each execution:
 
 - Executes `scripts/health_check_connectors.py` (including remote agent probes)
   and writes the JSON results to
@@ -67,6 +69,10 @@ workflow. Each execution:
   alerting dashboards. The latest run is mirrored to
   `monitoring/stage_b/latest/` so Grafana panels and alert rules can scrape the
   most recent status during the 48-hour credential drill.
+
+The pipeline archives the entire `monitoring/stage_b/` directory as
+`logs/stage_b_rehearsal_artifacts.tgz` after the scheduler completes so ops
+teams can attach the run artifacts to Stage B readiness reviews.
 
 ### File-based scraping
 


### PR DESCRIPTION
## Summary
- add a Stage B rehearsal pipeline that runs the rehearsal scheduler, prints the latest summary, and archives artifacts
- document the new pipeline entry point and artifact bundle in the Stage B monitoring runbook

## Testing
- `pre-commit run --files deployment/pipelines/stage_b_rehearsal.yml monitoring/README.md` *(fails: pre-commit command not available in container)*
- `python scripts/verify_docs_up_to_date.py` *(fails: repository doctrine index timestamps already stale upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe090387c832e840c7e52b18ef48e