### PR TITLE
Align stage B rehearsal packet timestamps with 20250924 run

### DIFF
--- a/logs/stage_b_rehearsal_packet.json
+++ b/logs/stage_b_rehearsal_packet.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-09-21T09:43:11Z",
+  "generated_at": "2025-09-24T18:23:00.412Z",
   "stage": "B",
   "context": "stage-b-rehearsal",
   "connectors": {
@@ -28,7 +28,7 @@
           }
         ],
         "rotation": {
-          "last_rotated": "2025-09-21T09:43:11Z",
+          "last_rotated": "2025-09-24T18:23:00.412Z",
           "rotation_window": "PT48H",
           "supports_hot_swap": true,
           "token_hint": "operator"
@@ -50,7 +50,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-12-01T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "heartbeat_payload": {
         "status": "aligned",
@@ -58,7 +58,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-12-01T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "doctrine_ok": true,
       "doctrine_failures": [],
@@ -98,7 +98,7 @@
           }
         ],
         "rotation": {
-          "last_rotated": "2025-09-21T09:43:11Z",
+          "last_rotated": "2025-09-24T18:23:00.412Z",
           "rotation_window": "PT48H",
           "supports_hot_swap": true,
           "token_hint": "operator-upload"
@@ -120,7 +120,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-12-01T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "heartbeat_payload": {
         "status": "aligned",
@@ -128,7 +128,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-12-01T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "doctrine_ok": true,
       "doctrine_failures": [],
@@ -168,7 +168,7 @@
           }
         ],
         "rotation": {
-          "last_rotated": "2025-09-21T09:43:11Z",
+          "last_rotated": "2025-09-24T18:23:00.412Z",
           "rotation_window": "PT48H",
           "supports_hot_swap": true,
           "token_hint": "crown"
@@ -190,7 +190,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-11-15T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "heartbeat_payload": {
         "status": "mission-brief-ready",
@@ -198,7 +198,7 @@
         "cycle_count": 0,
         "context": "stage-b-rehearsal",
         "credential_expiry": "2025-11-15T00:00:00Z",
-        "emitted_at": "2025-09-21T09:43:11Z"
+        "emitted_at": "2025-09-24T18:23:00.412Z"
       },
       "doctrine_ok": true,
       "doctrine_failures": [],


### PR DESCRIPTION
## Summary
- update the stage B rehearsal packet header to the 2025-09-24T18:23:00.412Z generation time
- refresh all connector rotation and heartbeat timestamps to the latest rehearsal execution

## Testing
- `pre-commit run --files logs/stage_b_rehearsal_packet.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cfec1abe8c832e9491762f2402d90b