### PR TITLE
Surface memory optional stubs in Stage B artifacts

### DIFF
--- a/deployment/pipelines/stage_b_rehearsal.yml
+++ b/deployment/pipelines/stage_b_rehearsal.yml
@@ -23,6 +23,16 @@ if summary_path.exists():
             stage_b.get("ok"), stage_b.get("doctrine_ok")
         )
     )
+    memory = data.get("memory_checks", {})
+    memory_note = memory.get("notes")
+    if memory_note:
+        print(
+            "  Memory layers ok: {} (notes: {})".format(
+                memory.get("ok"), memory_note
+            )
+        )
+    else:
+        print(f"  Memory layers ok: {memory.get('ok')}")
     rotation = data.get("rotation_drills", {})
     print(
         "  Rotation coverage ok: {} (entries recorded: {})".format(

--- a/memory/bundle.py
+++ b/memory/bundle.py
@@ -51,14 +51,28 @@ class MemoryBundle:
                 optional_fallbacks.append((layer, entry))
         self.statuses = statuses
         self.diagnostics = diagnostics
-        for layer, entry in optional_fallbacks:
+        if optional_fallbacks:
+            summary_pairs = []
+            for layer, entry in optional_fallbacks:
+                module = entry.get("loaded_module")
+                summary_pairs.append(f"{layer}:{module}")
+                logger.warning(
+                    "Optional memory stub activated",
+                    extra={
+                        "memory_layer": layer,
+                        "fallback_module": module,
+                        "fallback_reason": entry.get("fallback_reason"),
+                        "layer_status": entry.get("status"),
+                    },
+                )
             logger.warning(
-                "Optional memory stub activated",
+                "Optional memory modules loaded during initialization",
                 extra={
-                    "memory_layer": layer,
-                    "fallback_module": entry.get("loaded_module"),
-                    "fallback_reason": entry.get("fallback_reason"),
-                    "layer_status": entry.get("status"),
+                    "optional_layers": [layer for layer, _ in optional_fallbacks],
+                    "optional_modules": [
+                        entry.get("loaded_module") for _, entry in optional_fallbacks
+                    ],
+                    "optional_summary": ", ".join(summary_pairs),
                 },
             )
         return statuses


### PR DESCRIPTION
## Summary
- expand the Rust bundle proxy logging to emit an aggregate warning whenever optional memory modules load during initialization
- extend the Stage B rehearsal scheduler to run the memory layer checker, surface stub activations in the summary, and persist a dedicated artifact
- show the new memory check outcome when printing the Stage B rehearsal overview so reviewers immediately see optional module usage

## Testing
- `pre-commit run --files memory/bundle.py scripts/rehearsal_scheduler.py deployment/pipelines/stage_b_rehearsal.yml` *(fails: ensure-blueprint-sync requires updating multiple blueprint documents; pytest-cov fails due to repository-wide coverage threshold; verify-docs-up-to-date flags pre-existing documentation drift)*

------
https://chatgpt.com/codex/tasks/task_e_68d011d750fc832e943a5cc7f046296a