### PR TITLE
Align rehearsal audio extras and pipeline provisioning

### DIFF
--- a/INANNA_AI/README.md
+++ b/INANNA_AI/README.md
@@ -82,7 +82,7 @@ Install the optional packages below to enable higher quality emotion detection
 and real-time voice conversion:
 
 ```bash
-pip install opensmile==2.5.1 EmotiVoice==0.2.0 voicefixer==0.1.3
+pip install opensmile==2.6.0 EmotiVoice==0.2.0 voicefixer==0.1.3
 ```
 
 When these libraries are present the listening engine automatically uses

--- a/deployment/pipelines/stage_b_rehearsal.yml
+++ b/deployment/pipelines/stage_b_rehearsal.yml
@@ -3,6 +3,7 @@
 # and credential rotation summaries end-to-end.
 name: stage-b-rehearsal
 steps:
+  - run: bash scripts/setup_audio_env.sh
   - run: python scripts/rehearsal_scheduler.py --artifact-root monitoring/stage_b
   - run: |
       python - <<'PY'

--- a/docs/audio_stack.md
+++ b/docs/audio_stack.md
@@ -30,3 +30,14 @@ its role and the behaviour when it is not available.
 Operators should validate this matrix during rehearsals and capture any
 intentional degradations in the run log alongside the `audio.check_env`
 transcript.
+
+## Automated rehearsal host provisioning
+
+Stage B rehearsal hosts install and verify this bundle automatically.
+The `stage-b-rehearsal` pipeline now invokes `scripts/setup_audio_env.sh`
+before running smoke checks so every run refreshes the pinned Python
+packages, warns about missing FFmpeg binaries, and executes the strict
+environment validation.【F:deployment/pipelines/stage_b_rehearsal.yml†L1-L47】【F:scripts/setup_audio_env.sh†L1-L42】
+Operators preparing a new host should run the same script manually to
+mirror the pipeline behaviour and capture its validation transcript in
+the rehearsal evidence bundle.

--- a/docs/runbooks/sonic_rehearsal_guide.md
+++ b/docs/runbooks/sonic_rehearsal_guide.md
@@ -30,22 +30,21 @@ degradation matrix covering optional packages such as CLAP or RAVE.
 ## Provisioning steps
 
 1. Install the Python packages inside the rehearsal virtual environment using
-   the pinned versions:
+   the pinned versions. The `stage-b-rehearsal` pipeline now runs
+   `scripts/setup_audio_env.sh` ahead of every smoke test cycle,【F:deployment/pipelines/stage_b_rehearsal.yml†L1-L47】 so local
+   rehearsal hosts should invoke the same helper to stay aligned with the
+   automated workflow:
 
    ```bash
-   pip install \
-       pydub==0.25.1 \
-       simpleaudio==1.0.4 \
-       soundfile==0.13.1 \
-       librosa==0.11.0 \
-       opensmile==2.6.0 \
-       EmotiVoice==0.2.0
+   bash scripts/setup_audio_env.sh
    ```
 
    Optional integrations (CLAP, RAVE, Demucs, Spleeter, EmotiVoice) can be
-   added afterwards depending on the rehearsal focus.
+   added afterwards depending on the rehearsal focus. If the script reports a
+   missing FFmpeg binary, install it using the platform package manager before
+   rerunning the helper.
 
-2. Provision FFmpeg with the system package manager (example for Ubuntu):
+2. Provision FFmpeg manually when required (example for Ubuntu):
 
    ```bash
    sudo apt-get update
@@ -65,17 +64,12 @@ degradation matrix covering optional packages such as CLAP or RAVE.
    will log warnings for missing optional analyzers (e.g. CLAP) so operators
    can record temporary degradations in the rehearsal log.
 
-4. Run the Stage B rehearsal setup script to confirm Ardour/Carla tooling:
-
-   ```bash
-   bash scripts/setup_audio_env.sh
-   ```
-
-   The script installs the pinned audio dependencies, runs the strict audio
-   validation helper, and executes the
-   `modulation_arrangement.check_daw_availability` preflight. When Ardour or
-   Carla binaries are missing, it logs a warning and Stage B exports fall back
-   to audio renders without generating the corresponding session files.【F:scripts/setup_audio_env.sh†L1-L42】
+4. Rerun `scripts/setup_audio_env.sh` whenever FFmpeg or DAW tooling is updated
+   to reconfirm Ardour/Carla availability. The helper runs the strict audio
+   validation and the `modulation_arrangement.check_daw_availability`
+   preflight. When Ardour or Carla binaries are missing, it logs a warning and
+   Stage B exports fall back to audio renders without generating the
+   corresponding session files.【F:scripts/setup_audio_env.sh†L1-L42】
 
 5. Export the backend for local shells when invoking rehearsal utilities:
 


### PR DESCRIPTION
## Summary
- align the Stage B audio extras inventory documentation with the pinned versions and record the automated provisioning flow
- run the Stage B rehearsal pipeline through scripts/setup_audio_env.sh so hosts auto-install validated audio dependencies
- update the sonic rehearsal guide and INANNA optional dependency notes to reference the current openSMILE pin and helper script

## Testing
- pre-commit run --files INANNA_AI/README.md deployment/pipelines/stage_b_rehearsal.yml docs/audio_stack.md docs/runbooks/sonic_rehearsal_guide.md *(fails: coverage, doctrine index, and monitoring/self-healing hooks require the full production environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0322c4500832eb34012dac4136365