### PR TITLE
Add Stage C readiness aggregation workflow

### DIFF
--- a/scripts/aggregate_stage_readiness.py
+++ b/scripts/aggregate_stage_readiness.py
@@ -1,0 +1,166 @@
+"""Aggregate Stage A/B readiness evidence into a Stage C bundle.
+
+This helper consolidates the latest readiness summaries from Stage A and
+Stage B together with supporting telemetry references. The resulting bundle
+is written to the Stage C run directory supplied on the command line so the
+Stage C readiness sync endpoint can surface a complete snapshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+STAGE_A_ROOT = Path("logs") / "stage_a"
+STAGE_B_ROOT = Path("logs") / "stage_b"
+BUNDLE_FILENAME = "readiness_bundle.json"
+
+
+def _latest_summary(stage_root: Path) -> tuple[Path | None, dict[str, Any] | None]:
+    if not stage_root.exists():
+        return None, None
+    summary_files = sorted(stage_root.glob("*/summary.json"))
+    if not summary_files:
+        return None, None
+    latest = max(summary_files)
+    data = json.loads(latest.read_text(encoding="utf-8"))
+    return latest, data
+
+
+def _collect_supporting_artifacts(summary: dict[str, Any] | None) -> list[str]:
+    if not summary:
+        return []
+
+    log_dir_value = summary.get("log_dir")
+    if not log_dir_value:
+        return []
+
+    log_dir = Path(log_dir_value)
+    if not log_dir.exists():
+        return []
+
+    artifacts: list[str] = []
+    for candidate in sorted(log_dir.iterdir()):
+        if candidate.name == "summary.json" or candidate.is_dir():
+            continue
+        artifacts.append(str(candidate))
+    return artifacts
+
+
+def _extract_risk_notes(summary: dict[str, Any] | None) -> list[str]:
+    if not summary:
+        return ["readiness summary missing"]
+
+    notes: list[str] = []
+    status = summary.get("status")
+    if status and status != "success":
+        error = summary.get("error")
+        if error:
+            notes.append(str(error))
+
+        stderr_tail = summary.get("stderr_tail")
+        if isinstance(stderr_tail, Iterable) and not isinstance(stderr_tail, (str, bytes)):
+            notes.extend(str(line) for line in stderr_tail if str(line).strip())
+        elif isinstance(stderr_tail, (str, bytes)) and stderr_tail:
+            notes.append(str(stderr_tail))
+
+    warnings = summary.get("warnings") if summary else None
+    if isinstance(warnings, Iterable) and not isinstance(warnings, (str, bytes)):
+        notes.extend(str(item) for item in warnings if str(item).strip())
+    elif isinstance(warnings, (str, bytes)) and warnings:
+        notes.append(str(warnings))
+
+    return notes
+
+
+def _build_stage_snapshot(
+    stage_label: str,
+    summary_path: Path | None,
+    summary: dict[str, Any] | None,
+) -> dict[str, Any]:
+    artifacts = _collect_supporting_artifacts(summary)
+    snapshot: dict[str, Any] = {
+        "label": stage_label,
+        "summary_path": str(summary_path) if summary_path else None,
+        "summary": summary,
+        "artifacts": artifacts,
+        "risk_notes": _extract_risk_notes(summary),
+    }
+    return snapshot
+
+
+def _merge_stage_data(stage_a: dict[str, Any], stage_b: dict[str, Any]) -> dict[str, Any]:
+    def _latest(attr: str, data: dict[str, Any]) -> Any:
+        summary = data.get("summary") or {}
+        return summary.get(attr)
+
+    merged = {
+        "run_ids": {
+            "stage_a": _latest("run_id", stage_a),
+            "stage_b": _latest("run_id", stage_b),
+        },
+        "completed_at": {
+            "stage_a": _latest("completed_at", stage_a),
+            "stage_b": _latest("completed_at", stage_b),
+        },
+        "status_flags": {
+            "stage_a": _latest("status", stage_a) or "missing",
+            "stage_b": _latest("status", stage_b) or "missing",
+        },
+        "risk_notes": {
+            "stage_a": stage_a.get("risk_notes", []),
+            "stage_b": stage_b.get("risk_notes", []),
+        },
+    }
+
+    stages = merged["status_flags"].values()
+    if all(status == "success" for status in stages):
+        merged["overall_status"] = "ready"
+    else:
+        merged["overall_status"] = "requires_attention"
+    return merged
+
+
+def aggregate(stage_c_log_dir: Path) -> Path:
+    stage_c_log_dir.mkdir(parents=True, exist_ok=True)
+
+    stage_a_path, stage_a_summary = _latest_summary(STAGE_A_ROOT)
+    stage_b_path, stage_b_summary = _latest_summary(STAGE_B_ROOT)
+
+    stage_a_snapshot = _build_stage_snapshot("stage_a", stage_a_path, stage_a_summary)
+    stage_b_snapshot = _build_stage_snapshot("stage_b", stage_b_path, stage_b_summary)
+
+    bundle = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "stage_a": stage_a_snapshot,
+        "stage_b": stage_b_snapshot,
+        "merged": _merge_stage_data(stage_a_snapshot, stage_b_snapshot),
+    }
+
+    bundle_path = stage_c_log_dir / BUNDLE_FILENAME
+    bundle_path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+    return bundle_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "stage_c_log_dir",
+        help="Path to the Stage C run directory where the bundle should be written.",
+    )
+    args = parser.parse_args()
+
+    stage_c_log_dir = Path(args.stage_c_log_dir)
+    bundle_path = aggregate(stage_c_log_dir)
+    print(json.dumps({"bundle_path": str(bundle_path)}, indent=2))
+
+    stage_a_ready = bool(bundle_path.exists() and bundle_path.stat().st_size)
+    return 0 if stage_a_ready else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a helper script that collects the latest Stage A/B readiness summaries and telemetry into a consolidated bundle for Stage C
- update the Stage C readiness sync command to invoke the new helper and persist the bundle in the run directory
- enrich Stage C metrics to surface the readiness bundle, merged payload, and artifact references in the API response

## Testing
- python scripts/aggregate_stage_readiness.py logs/stage_c/test_run
- pre-commit run --files scripts/aggregate_stage_readiness.py operator_api.py *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e1073628832e9985eabb176f65a5