### PR TITLE
Accept stage C demo seed flag

### DIFF
--- a/scripts/stage_c_scripted_demo.py
+++ b/scripts/stage_c_scripted_demo.py
@@ -562,6 +562,14 @@ def main() -> None:
             "(defaults to <output>/_stage_b_assets)."
         ),
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help=(
+            "Deterministic seed used by higher-level launchers; "
+            "accepted for compatibility even when no randomization is required."
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")


### PR DESCRIPTION
## Summary
- allow the Stage C scripted demo harness to accept an optional --seed argument for compatibility with the stage-c2 API helper

## Testing
- pre-commit run --files scripts/stage_c_scripted_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68d519feecbc832e9fda40f3ccd685e3