### PR TITLE
Document Stage A planning checklist across planning docs

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -62,6 +62,7 @@ The replay regression writes `monitoring/crown_replay_summary.json` so contribut
 - [Pydantic v2 migration](https://github.com/DINGIRABZU/ABZU/issues/211) — owner: @DINGIRABZU.
 - [FastAPI lifespan migration](https://github.com/DINGIRABZU/ABZU/issues/212) — owner: web team.
 - [Optional dependency stubs](https://github.com/DINGIRABZU/ABZU/issues/213) — owner: infra team.
+- **Sprint planning checklist:** Flag Stage A pipeline changes during sprint planning so operations can reserve the gate hardware or queue an alternative backlog slice. The Stage A1/A2/A3 failures in the [Stage A evidence register](#stagea-evidence-register)—missing `env_validation`, unavailable `crown_decider`, and aborted automation shakeouts—show how unplanned access stalls the sprint when this step is skipped.
 
 ## Planned Releases
 - v0.1 – minimal Spiral OS boot sequence and CLI tools (target: Q3 2025). **Status:** Charter baseline approved in [alpha_v0_1_charter.md](alpha_v0_1_charter.md); subsystem execution tracked through the [Alpha v0.1 execution plan](roadmap.md#alpha-v01-execution-plan). Stage snapshots: **Stage A** focuses on Alpha gate automation readiness, **Stage B** locks subsystem hardening for sonic core, memory, and connectors, and **Stage C** synchronizes exit checklist, demo assets, and readiness signals. See the [Milestone Stages overview](roadmap.md#milestone-stages) for task-level detail. Reference the [Python Alpha Squad dossier](onboarding/python_alpha_squad.md) for RAZAR boot ownership and daily reliability rituals feeding that plan.

--- a/docs/releases/alpha_v0_1_workflow.md
+++ b/docs/releases/alpha_v0_1_workflow.md
@@ -17,6 +17,7 @@ loop documented in [alpha_v0_1_charter.md](../alpha_v0_1_charter.md) and the
 - Review the Stage A runner requirements in
   [hardware_support.md](../hardware_support.md) to confirm firmware and
   exporter configuration before starting the gate.
+- During sprint planning, flag Stage A pipeline changes so operations can reserve the gate hardware or arrange alternate backlog. The Stage A1/A2/A3 failures cited in the [Stage A evidence register](../PROJECT_STATUS.md#stagea-evidence-register) (missing `env_validation`, unavailable `crown_decider`, aborted automation shakeouts) illustrate how unscheduled access blocks the workflow.
 
 ## Build Packaging
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,9 @@ alongside [`docs/PROJECT_STATUS.md`](PROJECT_STATUS.md), the
 | **A2. Crown replay verification** | @crown-core | Guarantee decider routing and session logs replay deterministically for gate reviews. | Sync the refreshed session logger API with Spiral OS boot stability milestones as documented in the charter interlocks. | Execute five cross-agent replay drills and deliver the resulting traces into the Alpha gate review packet. |
 | **A3. Gate automation shakeout** | @release-ops | Harden `scripts/run_alpha_gate.sh` and the acceptance coverage described in the workflow guide before promoting builds. | Stage the build tooling, secrets, and health-check prerequisites from the workflow doc on the automation host. | Record a full dry-run Alpha gate run with packaging, health, and acceptance logs handed to Stage B owners. |
 
+> [!NOTE]
+> **Sprint planning checklist:** Flag Stage A pipeline changes during sprint planning so operations can schedule the gate hardware or supply alternate backlog. The Stage A1/A2/A3 failures logged in the [Stage A evidence register](PROJECT_STATUS.md#stagea-evidence-register)—missing `env_validation`, unavailable `crown_decider`, and aborted automation shakeouts—show how unplanned access halts progress when this step is skipped.
+
 Operator consoles now expose Stage A automation directly through the `operator_api` endpoints:
 `POST /alpha/stage-a1-boot-telemetry`, `POST /alpha/stage-a2-crown-replays`, and
 `POST /alpha/stage-a3-gate-shakeout`. Each call archives stdout/stderr under


### PR DESCRIPTION
## Summary
- highlight the Stage A sprint planning checklist in `PROJECT_STATUS.md`, referencing the Stage A1/A2/A3 failures that occur when hardware access is unplanned
- mirror the Stage A planning reminder in the alpha v0.1 workflow prerequisites so teams flag hardware needs while grooming sprints
- add a Stage A planning callout to the roadmap to keep expectations aligned across portfolio views

## Testing
- `python -m pre_commit run --files docs/PROJECT_STATUS.md docs/releases/alpha_v0_1_workflow.md docs/roadmap.md` *(fails: repository baseline requires updated doctrine index, unavailable local metrics exporters, and missing self-heal telemetry)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c6e1e9fc832eb31ccf84b80e42a6