### PR TITLE
Improve Stage A sandbox bootstrap resilience

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,9 +13,13 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR.parent) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR.parent))
 
-from scripts import _stage_runtime
+from scripts._stage_runtime import (
+    EnvironmentLimitedWarning,
+    bootstrap,
+    format_sandbox_summary,
+)
 
-ROOT = _stage_runtime.bootstrap(optional_modules=["env_validation"])
+ROOT = bootstrap(optional_modules=["env_validation"])
 
 try:  # pragma: no cover - guarded import for sandboxed envs
     from env_validation import check_required
@@ -24,7 +28,7 @@ except Exception:  # pragma: no cover - fallback to stubbed check
     def check_required(_: tuple[str, ...]) -> None:
         warnings.warn(
             "environment-limited: env_validation unavailable; skipping checks",
-            _stage_runtime.EnvironmentLimitedWarning,
+            EnvironmentLimitedWarning,
             stacklevel=2,
         )
 
@@ -61,7 +65,7 @@ def ensure_optional_deps() -> None:
                         "environment-limited: unable to install optional package "
                         f"'{package}' ({exc})"
                     ),
-                    _stage_runtime.EnvironmentLimitedWarning,
+                    EnvironmentLimitedWarning,
                     stacklevel=2,
                 )
 
@@ -73,7 +77,7 @@ def validate_env() -> None:
     except SystemExit as exc:  # pragma: no cover - sandbox fallback
         warnings.warn(
             f"environment-limited: {exc}; continuing without required credentials",
-            _stage_runtime.EnvironmentLimitedWarning,
+            EnvironmentLimitedWarning,
             stacklevel=2,
         )
 
@@ -131,7 +135,7 @@ def main() -> None:
     validate_env()
     device = detect_device()
     log_hardware_support(device)
-    print(_stage_runtime.format_sandbox_summary("Stage A1 bootstrap completed"))
+    print(format_sandbox_summary("Stage A1 bootstrap completed"))
 
 
 if __name__ == "__main__":

--- a/scripts/export_alpha_gate_metrics.py
+++ b/scripts/export_alpha_gate_metrics.py
@@ -16,16 +16,19 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR.parent) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR.parent))
 
-from scripts import _stage_runtime
+from scripts._stage_runtime import (
+    EnvironmentLimitedWarning,
+    bootstrap,
+)
 
-_stage_runtime.bootstrap(optional_modules=[])
+bootstrap(optional_modules=[])
 
 try:  # pragma: no cover - optional dependency varies per sandbox
     from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
 except Exception as exc:  # pragma: no cover - sandbox fallback
     warnings.warn(
         f"environment-limited: prometheus_client unavailable ({exc})",
-        _stage_runtime.EnvironmentLimitedWarning,
+        EnvironmentLimitedWarning,
         stacklevel=2,
     )
 


### PR DESCRIPTION
## Summary
- extend `scripts/_stage_runtime.py` with stronger optional-module shims, including a Prometheus instrumentator stub and a resilient `neoabzu_memory` sandbox bundle
- update Stage A entrypoints to call the runtime bootstrap helper, degrade gracefully when optional imports fail, and ship deterministic fallback replay scenarios when PyYAML is absent
- rerun the Stage A telemetry, replay capture, and gate shakeout flows to record successful summaries that note sandbox warnings

## Testing
- python scripts/bootstrap.py
- python scripts/crown_capture_replays.py
- python - <<'PY' ... (operator_api stage A endpoints)


------
https://chatgpt.com/codex/tasks/task_e_68d70941168c832e85be7a407f0a0221