### PR TITLE
Sync Stage B rotation ledger with Stage C promotion

### DIFF
--- a/tests/scripts/test_stage_b_smoke.py
+++ b/tests/scripts/test_stage_b_smoke.py
@@ -78,6 +78,11 @@ def test_run_stage_b_smoke_invokes_rotation(monkeypatch):
         "_collect_crown_metadata",
         lambda: {"version": "0.0", "module": "stub"},
     )
+    monkeypatch.setattr(
+        stage_b_smoke,
+        "load_latest_stage_c_handshake",
+        lambda: (None, {}),
+    )
 
     results = asyncio.run(stage_b_smoke.run_stage_b_smoke())
     assert (


### PR DESCRIPTION
## Summary
- load the latest Stage C MCP drill handshake and promote the stage-c-prep context during Stage B smoke runs
- persist promotion metadata in the rotation ledger entry written by the smoke script
- add regression coverage so Stage B readiness aggregation reports the accepted Stage C prep context

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/scripts/test_stage_b_smoke.py tests/test_aggregate_stage_readiness.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f7a187f0832ea496791d3a24ed58