### PR TITLE
Expose rotation metadata in stage readiness artifacts

### DIFF
--- a/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation/summary.json
+++ b/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation/summary.json
@@ -1,0 +1,78 @@
+{
+  "status": "success",
+  "stage": "stage_b3_connector_rotation",
+  "run_id": "20250927T234018Z-stage_b3_connector_rotation",
+  "command": [
+    "/root/.pyenv/versions/3.12.10/bin/python",
+    "/workspace/ABZU/scripts/stage_b_smoke.py",
+    "--json"
+  ],
+  "returncode": 0,
+  "started_at": "2025-09-27T23:40:18+00:00",
+  "completed_at": "2025-09-27T23:40:29+00:00",
+  "duration_seconds": 11.0,
+  "log_dir": "/workspace/ABZU/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation",
+  "stdout_path": "/workspace/ABZU/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation/stage_b3_connector_rotation.stdout.log",
+  "stderr_path": "/workspace/ABZU/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation/stage_b3_connector_rotation.stderr.log",
+  "stdout_lines": 118,
+  "stderr_lines": 18,
+  "stderr_tail": [
+    "/workspace/ABZU/scripts/_stage_runtime.py:183: EnvironmentLimitedWarning: environment-limited: neoabzu optional bundle unavailable; using minimal sandbox MemoryBundle",
+    "  _apply_override(name, force=_should_force_override(name))",
+    "/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'neoabzu_memory' (neoabzu_memory: optional bundle shim activated)",
+    "  _prepare_overrides()",
+    "/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'servant_model_manager' (servant_model_manager: local registry only)",
+    "  _prepare_overrides()",
+    "/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'state_transition_engine' (state_transition_engine: deterministic rotation)",
+    "  _prepare_overrides()",
+    "/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'prometheus_fastapi_instrumentator' (prometheus instrumentation disabled in sandbox)",
+    "  _prepare_overrides()",
+    "/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'INANNA_AI.glm_integration' (glm_integration: remote health check bypassed)",
+    "  _prepare_overrides()"
+  ],
+  "summary": "Rotated operator_api/operator_upload/crown_handshake (doctrine ok); window 20250928T001910Z-PT48H; rotation expires 2025-09-30T00:19:10Z; credentials expire 2025-09-30T00:19:10Z",
+  "stderr": "/workspace/ABZU/scripts/_stage_runtime.py:183: EnvironmentLimitedWarning: environment-limited: neoabzu optional bundle unavailable; using minimal sandbox MemoryBundle\n  _apply_override(name, force=_should_force_override(name))\n/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'neoabzu_memory' (neoabzu_memory: optional bundle shim activated)\n  _prepare_overrides()\n/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'servant_model_manager' (servant_model_manager: local registry only)\n  _prepare_overrides()\n/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'state_transition_engine' (state_transition_engine: deterministic rotation)\n  _prepare_overrides()\n/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'prometheus_fastapi_instrumentator' (prometheus instrumentation disabled in sandbox)\n  _prepare_overrides()\n/workspace/ABZU/scripts/_stage_runtime.py:226: EnvironmentLimitedWarning: environment-limited: activated sandbox stub for 'INANNA_AI.glm_integration' (glm_integration: remote health check bypassed)\n  _prepare_overrides()",
+  "artifacts": {
+    "rotation_log": "/workspace/ABZU/logs/stage_b/20250927T234018Z-stage_b3_connector_rotation/stage_b_rotation_drills.jsonl"
+  },
+  "metrics": {
+    "stage": "B",
+    "targets": [
+      "operator_api",
+      "operator_upload",
+      "crown_handshake"
+    ],
+    "doctrine_ok": true,
+    "doctrine_failures": [],
+    "accepted_contexts": [
+      {
+        "name": "stage-b-rehearsal",
+        "status": "accepted"
+      },
+      {
+        "name": "stage-c-prep",
+        "status": "accepted"
+      }
+    ],
+    "session": {
+      "id": "stage-b-session",
+      "credential_expiry": "2025-09-30T00:19:10Z"
+    },
+    "heartbeat_payload": {
+      "event": "stage-b-smoke",
+      "session": {
+        "id": "stage-b-session",
+        "credential_expiry": "2025-09-30T00:19:10Z"
+      },
+      "credential_expiry": "2025-09-30T00:19:10Z"
+    },
+    "heartbeat_expiry": "2025-09-30T00:19:10Z",
+    "rotation_window": {
+      "window_id": "20250928T001910Z-PT48H",
+      "started_at": "2025-09-28T00:19:10Z",
+      "expires_at": "2025-09-30T00:19:10Z",
+      "duration": "PT48H"
+    },
+    "rotation_summary": "Rotated operator_api/operator_upload/crown_handshake (doctrine ok); window 20250928T001910Z-PT48H; rotation expires 2025-09-30T00:19:10Z; credentials expire 2025-09-30T00:19:10Z"
+  }
+}


### PR DESCRIPTION
## Summary
- fall back to the Stage B rotation ledger so connector rotation metrics always emit a populated `rotation_window` and `rotation_summary`
- thread the new rotation metadata through the Stage C readiness merge so `merged.rotation` records the window and credential expiry
- refresh the Stage B3 connector rotation summary artifact to capture the expanded rotation fields required by downstream checks

## Testing
- `ABZU_USE_MCP=1 ABZU_STAGE_B_SMOKE_STUB=1 PYTHONPATH=. python scripts/stage_b_smoke.py --json > /tmp/stage_b_smoke.json`
- `PYTHONPATH=. python scripts/aggregate_stage_readiness.py logs/stage_c/20250927T234026Z-stage_c3_readiness_sync > /tmp/stage_c3_summary.json`
- `pre-commit run --files operator_api.py scripts/aggregate_stage_readiness.py` *(fails: ensure-blueprint-sync, missing prometheus_client/websockets, pytest coverage args unsupported, verify-crate-refs, verify-docs-up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_68d87dc3d798832ea5eab777c9ed708a