### PR TITLE
Add stage readiness fixtures and override support

### DIFF
--- a/tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240101T000000Z-stage_a1_boot_telemetry

--- a/tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/summary.json
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/summary.json
@@ -1,0 +1,7 @@
+{
+  "run_id": "a1-run",
+  "status": "success",
+  "completed_at": "2024-01-01T00:10:00Z",
+  "stage": "stage_a1_boot_telemetry",
+  "log_dir": "stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry"
+}

--- a/tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240101T000500Z-stage_a2_crown_replays

--- a/tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/summary.json
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/summary.json
@@ -1,0 +1,7 @@
+{
+  "run_id": "a2-run",
+  "status": "success",
+  "completed_at": "2024-01-01T00:15:00Z",
+  "stage": "stage_a2_crown_replays",
+  "log_dir": "stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays"
+}

--- a/tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240101T001000Z-stage_a3_gate_shakeout

--- a/tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/summary.json
+++ b/tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/summary.json
@@ -1,0 +1,7 @@
+{
+  "run_id": "a3-run",
+  "status": "success",
+  "completed_at": "2024-01-01T00:20:00Z",
+  "stage": "stage_a3_gate_shakeout",
+  "log_dir": "stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout"
+}

--- a/tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240102T000000Z-stage_b1_memory_proof

--- a/tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "b1-run",
+  "status": "success",
+  "completed_at": "2024-01-02T00:10:00Z",
+  "stage": "stage_b1_memory_proof",
+  "log_dir": "stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof",
+  "metrics": {
+    "rotation_window": {
+      "window_id": "win-1",
+      "started_at": "2024-01-01T00:00:00Z",
+      "expires_at": "2024-01-03T00:00:00Z"
+    },
+    "rotation_summary": "Rotated operator_api/operator_upload (doctrine ok); window win-1; rotation expires 2024-01-03T00:00:00Z; credentials expire 2024-01-03T00:00:00Z",
+    "heartbeat_expiry": "2024-01-03T00:00:00Z"
+  }
+}

--- a/tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240102T000500Z-stage_b2_sonic_rehearsal

--- a/tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/summary.json
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/summary.json
@@ -1,0 +1,7 @@
+{
+  "run_id": "b2-run",
+  "status": "success",
+  "completed_at": "2024-01-02T00:15:00Z",
+  "stage": "stage_b2_sonic_rehearsal",
+  "log_dir": "stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal"
+}

--- a/tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/artifact.log
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/artifact.log
@@ -1,0 +1,1 @@
+artifact for 20240102T001000Z-stage_b3_connector_rotation

--- a/tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/summary.json
+++ b/tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/summary.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "b3-run",
+  "status": "success",
+  "completed_at": "2024-01-02T00:20:00Z",
+  "stage": "stage_b3_connector_rotation",
+  "log_dir": "stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation",
+  "metrics": {
+    "rotation_window": {
+      "window_id": "win-1",
+      "started_at": "2024-01-01T00:00:00Z",
+      "expires_at": "2024-01-03T00:00:00Z"
+    },
+    "rotation_summary": "Rotated operator_api/operator_upload (doctrine ok); window win-1; rotation expires 2024-01-03T00:00:00Z; credentials expire 2024-01-03T00:00:00Z",
+    "heartbeat_expiry": "2024-01-03T00:00:00Z"
+  }
+}


### PR DESCRIPTION
## Summary
- add a stage readiness fixture tree covering the expected Stage A and Stage B slugs with minimal summaries and artifact placeholders
- allow `aggregate_stage_readiness` to resolve Stage A/B roots from CLI arguments or environment overrides while keeping the existing defaults
- switch the operator API readiness tests to load the new fixtures in a tmp workspace and keep the merged run/rotation assertions intact

## Testing
- pre-commit run --files scripts/aggregate_stage_readiness.py tests/test_operator_api.py tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/summary.json tests/fixtures/stage_readiness/stage_a/20240101T000000Z-stage_a1_boot_telemetry/artifact.log tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/summary.json tests/fixtures/stage_readiness/stage_a/20240101T000500Z-stage_a2_crown_replays/artifact.log tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/summary.json tests/fixtures/stage_readiness/stage_a/20240101T001000Z-stage_a3_gate_shakeout/artifact.log tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/artifact.log tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/summary.json tests/fixtures/stage_readiness/stage_b/20240102T000500Z-stage_b2_sonic_rehearsal/artifact.log tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/summary.json tests/fixtures/stage_readiness/stage_b/20240102T001000Z-stage_b3_connector_rotation/artifact.log
- pytest tests/test_operator_api.py::test_stage_c3_readiness_sync_success tests/test_operator_api.py::test_stage_c3_readiness_sync_missing tests/test_operator_api.py::test_stage_c3_readiness_sync_requires_attention_when_stage_a_slug_fails tests/test_operator_api.py::test_stage_c3_readiness_sync_requires_attention_for_upstream_risk_notes


------
https://chatgpt.com/codex/tasks/task_e_68da87ddc6bc832e90573d495def99cf