### PR TITLE
Refactor Stage B rehearsal stubs

### DIFF
--- a/scripts/_dependency_stubs/__init__.py
+++ b/scripts/_dependency_stubs/__init__.py
@@ -1,0 +1,9 @@
+"""Fallback dependency shims for Stage B rehearsal tooling."""
+
+from __future__ import annotations
+
+__all__ = [
+    "STUB_DEPENDENCIES",
+]
+
+STUB_DEPENDENCIES = ("torch", "simpleaudio", "clap", "rave")

--- a/scripts/_dependency_stubs/clap/__init__.py
+++ b/scripts/_dependency_stubs/clap/__init__.py
@@ -1,0 +1,51 @@
+"""Fallback implementation of the :mod:`clap` package."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "ClapModel",
+    "ClapProcessor",
+    "get_version",
+    "__version__",
+    "__ABZU_FALLBACK__",
+]
+
+__version__ = "0.0.0-stub"
+__ABZU_FALLBACK__ = True
+
+
+class _Unavailable:
+    """Base class raising informative errors for stubbed access."""
+
+    name: str = "clap"
+
+    @classmethod
+    def from_pretrained(cls, *_args: Any, **_kwargs: Any) -> "_Unavailable":
+        raise RuntimeError(
+            f"{cls.name} unavailable: clap fallback stub active during rehearsal"
+        )
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError(
+            f"{self.name} unavailable: clap fallback stub active during rehearsal"
+        )
+
+
+class ClapModel(_Unavailable):
+    """Placeholder that matches the transformer CLAP API surface."""
+
+    name = "ClapModel"
+
+
+class ClapProcessor(_Unavailable):
+    """Placeholder processor mirroring :class:`transformers.ClapProcessor`."""
+
+    name = "ClapProcessor"
+
+
+def get_version() -> str:
+    """Return the stub description used in diagnostics."""
+
+    return "clap-fallback-stub"

--- a/scripts/_dependency_stubs/rave/__init__.py
+++ b/scripts/_dependency_stubs/rave/__init__.py
@@ -1,0 +1,55 @@
+"""Simplified :mod:`rave` interface used during rehearsals when the real
+implementation is unavailable."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as _np
+import torch
+
+__all__ = ["RAVE", "__version__", "__ABZU_FALLBACK__"]
+
+__version__ = "0.0.0-stub"
+__ABZU_FALLBACK__ = True
+
+
+@dataclass
+class RAVE:
+    """Minimal codec preserving the encode/decode API of the real package."""
+
+    checkpoint: Path | str
+    device: str = "cpu"
+
+    def __post_init__(self) -> None:
+        self.checkpoint = Path(self.checkpoint)
+        self.device = str(self.device)
+
+    def _tensor(self, value: Any) -> torch.Tensor:
+        tensor = value if isinstance(value, torch.Tensor) else torch.as_tensor(value)
+        return tensor.to(self.device, dtype=torch.float32)
+
+    def encode(self, audio: Any) -> torch.Tensor:
+        tensor = self._tensor(audio)
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        return tensor.clone()
+
+    def decode(self, latents: Any) -> torch.Tensor:
+        tensor = self._tensor(latents)
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        return tensor.clone()
+
+
+def _ensure_imports() -> None:  # pragma: no cover - defensive guard
+    """Ensure NumPy arrays convert cleanly through the tensor shim."""
+
+    if not hasattr(torch, "as_tensor"):
+        raise RuntimeError("torch fallback missing as_tensor helper")
+    _ = torch.as_tensor(_np.zeros(1, dtype=_np.float32))
+
+
+_ensure_imports()

--- a/scripts/_dependency_stubs/simpleaudio/__init__.py
+++ b/scripts/_dependency_stubs/simpleaudio/__init__.py
@@ -1,0 +1,36 @@
+"""Runtime stub for :mod:`simpleaudio` used during Stage B rehearsals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = ["play_buffer", "__version__", "__ABZU_FALLBACK__"]
+
+__version__ = "0.0.0-stub"
+__ABZU_FALLBACK__ = True
+
+
+@dataclass
+class _Playback:
+    channels: int
+    bytes_per_sample: int
+    sample_rate: int
+
+    def wait_done(self) -> None:  # pragma: no cover - trivial noop
+        return None
+
+
+def play_buffer(
+    _audio: Any,
+    channels: int,
+    bytes_per_sample: int,
+    sample_rate: int,
+) -> _Playback:
+    """Return a dummy playback object that no-ops when waited upon."""
+
+    return _Playback(
+        channels=channels,
+        bytes_per_sample=bytes_per_sample,
+        sample_rate=sample_rate,
+    )

--- a/scripts/_dependency_stubs/torch/__init__.py
+++ b/scripts/_dependency_stubs/torch/__init__.py
@@ -1,0 +1,101 @@
+"""Minimal :mod:`torch` fallback to satisfy Stage B rehearsal imports."""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+import numpy as _np
+
+__all__ = [
+    "Tensor",
+    "as_tensor",
+    "from_numpy",
+    "no_grad",
+    "tensor",
+    "float32",
+    "__version__",
+    "__ABZU_FALLBACK__",
+]
+
+__version__ = "0.0.0-stub"
+__ABZU_FALLBACK__ = True
+
+float32 = _np.float32
+
+
+@dataclass
+class Tensor:
+    """Lightweight tensor wrapper used by the rehearsal fallbacks."""
+
+    _array: _np.ndarray
+
+    def __init__(self, data: Any, *, dtype: Any | None = None) -> None:
+        array = _np.array(data, dtype=dtype or _np.float32, copy=False)
+        if array.dtype.kind not in {"f", "i", "u"}:
+            array = array.astype(_np.float32)
+        object.__setattr__(self, "_array", array)
+
+    # ------------------------------------------------------------------
+    # Torch-like helpers
+    # ------------------------------------------------------------------
+    def detach(self) -> "Tensor":
+        return Tensor(self._array.copy())
+
+    def clone(self) -> "Tensor":
+        return Tensor(self._array.copy())
+
+    def unsqueeze(self, dim: int) -> "Tensor":
+        return Tensor(_np.expand_dims(self._array, axis=dim))
+
+    def squeeze(self, axis: int | None = None) -> "Tensor":
+        return Tensor(_np.squeeze(self._array, axis=axis))
+
+    def to(self, *_args: Any, dtype: Any | None = None, **_kwargs: Any) -> "Tensor":
+        if dtype is not None:
+            return Tensor(self._array.astype(dtype))
+        return self
+
+    def cpu(self) -> "Tensor":
+        return self
+
+    def numpy(self) -> _np.ndarray:
+        return _np.array(self._array, copy=True)
+
+    def dim(self) -> int:
+        return int(self._array.ndim)
+
+    # ------------------------------------------------------------------
+    # NumPy compatibility
+    # ------------------------------------------------------------------
+    def __array__(self, dtype: Any | None = None) -> _np.ndarray:
+        if dtype is None:
+            return _np.array(self._array, copy=True)
+        return _np.array(self._array, copy=True).astype(dtype)
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._array)
+
+    def __len__(self) -> int:
+        return int(self._array.shape[0]) if self._array.ndim else 1
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"Tensor(shape={self._array.shape}, dtype={self._array.dtype})"
+
+
+def as_tensor(data: Any, *, dtype: Any | None = None) -> Tensor:
+    return Tensor(data, dtype=dtype)
+
+
+def from_numpy(array: _np.ndarray) -> Tensor:
+    return Tensor(_np.array(array, copy=False))
+
+
+def tensor(data: Any, dtype: Any | None = None) -> Tensor:
+    return Tensor(data, dtype=dtype)
+
+
+@contextlib.contextmanager
+def no_grad() -> Iterator[None]:  # pragma: no cover - trivial helper
+    yield


### PR DESCRIPTION
## Summary
- add dedicated fallback modules for torch, simpleaudio, clap, and rave under scripts/_dependency_stubs so they no longer ship from src
- update scripts/generate_stage_b_rehearsal_packet.py to prefer real dependencies, inject stubs only for the rehearsal run, and record dependency fallback notes in the generated packet

## Testing
- pytest -c /dev/null tests/test_operator_api.py::test_stage_b2_sonic_rehearsal_success

------
https://chatgpt.com/codex/tasks/task_e_68dad076eaa0832eaf2c39b387c6bb45