### PR TITLE
Add Stage C readiness bundle exposure and MCP credential window

### DIFF
--- a/onboarding_confirm.yml
+++ b/onboarding_confirm.yml
@@ -176,8 +176,8 @@ documents:
       purpose: Comprehensive RAZAR agent guide.
       scope: RAZAR agent workflows and deployment.
   docs/The_Absolute_Protocol.md:
-    commit: worktree
-    sha256: 4b1af28faae3f7d850310099d087e8f2d8a917f23c8ebce33debab11f2f09ef9
+    commit: 0c111f39c4396bbf9dcb30dd800f2e23c6e6c755
+    sha256: 8841888fefbbfe8f803767e32761d812ca08f98b0f8aee9569102f6a0c6f85ca
     summary:
       insight: Central doctrine coordinates versioning, MCP governance, and documentation
         duties for every subsystem.

--- a/scripts/aggregate_stage_readiness.py
+++ b/scripts/aggregate_stage_readiness.py
@@ -23,6 +23,7 @@ STAGE_A_ROOT = Path("logs") / "stage_a"
 STAGE_B_ROOT = Path("logs") / "stage_b"
 BUNDLE_FILENAME = "readiness_bundle.json"
 SUMMARY_FILENAME = "summary.json"
+STAGE_C_STAGE_LABEL = "stage_c3_readiness_sync"
 STAGE_A_EXPECTED_SLUGS = ("A1", "A2", "A3")
 STAGE_B_EXPECTED_SLUGS = ("B1", "B2", "B3")
 
@@ -811,8 +812,11 @@ def aggregate(
     merged = _merge_stage_data(stage_a_snapshot, stage_b_snapshot)
     missing = [*stage_a_missing, *stage_b_missing]
 
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
     bundle = {
-        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "stage": STAGE_C_STAGE_LABEL,
+        "generated_at": generated_at,
         "stage_a": stage_a_snapshot,
         "stage_b": stage_b_snapshot,
         "merged": merged,
@@ -839,7 +843,8 @@ def aggregate(
 
     summary_payload = {
         "status": status,
-        "generated_at": bundle["generated_at"],
+        "stage": STAGE_C_STAGE_LABEL,
+        "generated_at": generated_at,
         "bundle_path": str(bundle_path),
         "stage_a": stage_a_snapshot,
         "stage_b": stage_b_snapshot,


### PR DESCRIPTION
## Summary
- annotate the readiness aggregator output with the Stage C3 slug and capture the generated timestamp in the bundle and summary payloads
- expose the merged readiness snapshot and credential window data from the Stage C API responses
- extend Stage C test fixtures to validate readiness bundling and MCP credential window artifacts

## Testing
- pytest -o addopts="" tests/test_operator_api.py::test_stage_c3_readiness_sync_success tests/test_operator_api.py::test_stage_c4_operator_mcp_drill_success
- SKIP=ensure-blueprint-sync,verify-versions,check-env,pytest-cov,verify-docs-up-to-date,cargo-check pre-commit run --files scripts/aggregate_stage_readiness.py operator_api.py tests/test_operator_api.py onboarding_confirm.yml

------
https://chatgpt.com/codex/tasks/task_e_68dd14f1b268832eb0b39f16a787fe2a