### PR TITLE
Add Neo-APSU Stage D sandbox verification workflows

### DIFF
--- a/scripts/_neoapsu_verifier.py
+++ b/scripts/_neoapsu_verifier.py
@@ -1,0 +1,309 @@
+"""Shared helpers for Neo-APSU Stage D verification CLIs."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _stringify_value(value: Any) -> Any:
+    """Return ``value`` coerced into JSON-serialisable primitives."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _stringify_value(val) for key, val in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_stringify_value(item) for item in value]
+    return str(value)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+
+
+def load_migration_entries(
+    matrix_path: Path, match_tokens: Sequence[str]
+) -> tuple[list[Mapping[str, Any]], list[dict[str, Any]], list[str]]:
+    """Return raw and sanitised migration entries plus warnings."""
+
+    warnings: list[str] = []
+    try:
+        data = json.loads(matrix_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        warnings.append(f"migration matrix missing at {matrix_path}")
+        return [], [], warnings
+    except json.JSONDecodeError as exc:
+        warnings.append(f"migration matrix at {matrix_path} not valid JSON: {exc}")
+        return [], [], warnings
+
+    source_entries = data.get("apsu_migration")
+    if not isinstance(source_entries, list):
+        warnings.append("component_index.json missing 'apsu_migration' list")
+        return [], [], warnings
+
+    tokens = tuple(token.lower() for token in match_tokens)
+    raw_entries: list[Mapping[str, Any]] = []
+    sanitised: list[dict[str, Any]] = []
+    for entry in source_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        neo_module = str(entry.get("neo_module", "")).lower()
+        if tokens and not any(token in neo_module for token in tokens):
+            continue
+        raw_entries.append(entry)
+        defects_raw = entry.get("defects")
+        if isinstance(defects_raw, Sequence) and not isinstance(
+            defects_raw, (str, bytes, bytearray)
+        ):
+            defects = [str(item) for item in defects_raw]
+        elif defects_raw is None:
+            defects = []
+        else:
+            defects = [str(defects_raw)]
+        sanitised.append(
+            {
+                "legacy_entry": entry.get("legacy_entry"),
+                "neo_module": entry.get("neo_module"),
+                "status": entry.get("status"),
+                "defects": defects,
+            }
+        )
+
+    if not raw_entries:
+        warnings.append("no matching migration entries located for Neo-APSU service")
+
+    return raw_entries, sanitised, warnings
+
+
+def run_contract_suite(module_name: str, **kwargs: Any) -> dict[str, Any]:
+    """Invoke ``module_name.run_contract_suite`` with ``kwargs`` if available."""
+
+    module = importlib.import_module(module_name)
+    runner = getattr(module, "run_contract_suite", None)
+    if not callable(runner):
+        return {
+            "suite": module_name,
+            "status": "unavailable",
+            "tests": [],
+            "sandbox": bool(getattr(module, "__neoapsu_sandbox__", False)),
+            "notes": ["run_contract_suite missing on module"],
+        }
+
+    try:
+        result = runner(**kwargs)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.exception("Neo-APSU contract suite '%s' failed", module_name)
+        return {
+            "suite": module_name,
+            "status": "error",
+            "tests": [],
+            "sandbox": bool(getattr(module, "__neoapsu_sandbox__", False)),
+            "notes": [f"contract suite raised {exc.__class__.__name__}: {exc}"],
+        }
+
+    if isinstance(result, Mapping):
+        return dict(result)
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+        return {
+            "suite": module_name,
+            "status": "ok",
+            "tests": list(result),
+        }
+    return {
+        "suite": module_name,
+        "status": str(result),
+        "tests": [],
+        "sandbox": bool(getattr(module, "__neoapsu_sandbox__", False)),
+        "notes": ["unexpected contract suite result shape"],
+    }
+
+
+def sanitise_contract_result(
+    result: Mapping[str, Any], *, module_name: str
+) -> dict[str, Any]:
+    """Normalise ``result`` from :func:`run_contract_suite`."""
+
+    suite = str(result.get("suite") or module_name)
+    tests_raw = result.get("tests")
+    tests: list[dict[str, Any]] = []
+    if isinstance(tests_raw, Sequence) and not isinstance(
+        tests_raw, (str, bytes, bytearray)
+    ):
+        for index, item in enumerate(tests_raw, start=1):
+            if isinstance(item, Mapping):
+                test_id = str(item.get("id") or item.get("name") or index)
+                name = str(item.get("name") or item.get("id") or f"test-{index}")
+                status = str(item.get("status") or "unknown")
+                entry: dict[str, Any] = {
+                    "id": test_id,
+                    "name": name,
+                    "status": status,
+                }
+                if item.get("reason") is not None:
+                    entry["reason"] = _stringify_value(item.get("reason"))
+                if item.get("details") is not None:
+                    entry["details"] = _stringify_value(item.get("details"))
+                tests.append(entry)
+            else:
+                tests.append(
+                    {
+                        "id": f"{suite}-{index}",
+                        "name": str(item),
+                        "status": "unknown",
+                    }
+                )
+
+    notes_raw = result.get("notes")
+    if isinstance(notes_raw, Sequence) and not isinstance(
+        notes_raw, (str, bytes, bytearray)
+    ):
+        notes = [str(note) for note in notes_raw]
+    elif notes_raw is None:
+        notes = []
+    else:
+        notes = [str(notes_raw)]
+
+    fixtures_raw = result.get("fixtures")
+    fixtures = None
+    if isinstance(fixtures_raw, Mapping):
+        fixtures = {
+            str(key): _stringify_value(val) for key, val in fixtures_raw.items()
+        }
+
+    sanitised: dict[str, Any] = {
+        "suite": suite,
+        "status": str(result.get("status") or "unknown"),
+        "tests": tests,
+        "notes": notes,
+        "sandboxed": bool(
+            result.get("sandbox")
+            or result.get("sandboxed")
+            or result.get("runtime_stubbed")
+        ),
+    }
+    if fixtures is not None:
+        sanitised["fixtures"] = fixtures
+    return sanitised
+
+
+def summarise_test_counts(tests: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    """Return aggregate counts for ``tests``."""
+
+    counts = {"passed": 0, "failed": 0, "skipped": 0, "total": 0}
+    for test in tests:
+        status = str(test.get("status") or "").lower()
+        counts["total"] += 1
+        if status == "passed":
+            counts["passed"] += 1
+        elif status in {"failed", "error", "failure"}:
+            counts["failed"] += 1
+        elif status in {"skipped", "pending", "stubbed"}:
+            counts["skipped"] += 1
+    return counts
+
+
+def execute_verification(
+    *,
+    service: str,
+    module_name: str,
+    repo_root: Path,
+    log_dir: Path,
+    run_id: str,
+    matrix_path: Path,
+    matrix_tokens: Sequence[str],
+    overrides: Mapping[str, str],
+    sandbox_summary: str,
+    contract_kwargs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Run the Neo-APSU verification workflow and return a summary payload."""
+
+    raw_entries, sanitised_entries, matrix_warnings = load_migration_entries(
+        matrix_path, matrix_tokens
+    )
+
+    kwargs = dict(contract_kwargs or {})
+    kwargs.setdefault("matrix_entries", raw_entries)
+
+    contract_raw = run_contract_suite(module_name, **kwargs)
+    contract = sanitise_contract_result(contract_raw, module_name=module_name)
+    counts = summarise_test_counts(contract.get("tests", []))
+    sandboxed = bool(contract.get("sandboxed")) or module_name in overrides
+
+    warnings = list(matrix_warnings)
+    if counts["failed"]:
+        warnings.append(f"{counts['failed']} contract test(s) failed")
+    if not sanitised_entries:
+        warnings.append("no APSU migration entries matched service tokens")
+    if sandboxed:
+        warnings.append("sandbox stub active for Neo-APSU contracts")
+
+    status = "success"
+    if counts["failed"] or not sanitised_entries:
+        status = "requires_attention"
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    service_root = log_dir.parent
+    service_root.mkdir(parents=True, exist_ok=True)
+
+    contract_results_path = log_dir / "contract_results.json"
+    migration_snapshot_path = log_dir / "migration_snapshot.json"
+    run_summary_path = log_dir / "service_summary.json"
+    latest_summary_path = service_root / "summary.json"
+
+    _write_json(contract_results_path, contract)
+    _write_json(migration_snapshot_path, sanitised_entries)
+
+    summary_contract = {
+        "suite": contract.get("suite", module_name),
+        "status": contract.get("status", "unknown"),
+        "passed": counts["passed"],
+        "failed": counts["failed"],
+        "skipped": counts["skipped"],
+        "total": counts["total"],
+        "sandboxed": sandboxed,
+        "notes": contract.get("notes", []),
+        "tests": contract.get("tests", []),
+    }
+    if "fixtures" in contract:
+        summary_contract["fixtures"] = contract["fixtures"]
+
+    summary = {
+        "status": status,
+        "service": service,
+        "module": module_name,
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "log_dir": str(log_dir),
+        "sandbox_summary": sandbox_summary,
+        "sandbox_overrides": dict(sorted(overrides.items())),
+        "sandboxed": sandboxed,
+        "contract_suite": summary_contract,
+        "migration_entries": sanitised_entries,
+        "warnings": warnings,
+    }
+
+    artifacts = {
+        "service_summary": str(run_summary_path),
+        "latest_summary": str(latest_summary_path),
+        "contract_results": str(contract_results_path),
+        "migration_snapshot": str(migration_snapshot_path),
+    }
+    summary["artifacts"] = artifacts
+
+    _write_json(run_summary_path, summary)
+    _write_json(latest_summary_path, summary)
+
+    return summary

--- a/scripts/verify_neoapsu_crown.py
+++ b/scripts/verify_neoapsu_crown.py
@@ -1,0 +1,118 @@
+"""Stage D sandbox verification for the Neo-APSU crown contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts import _stage_runtime as stage_runtime  # noqa: E402 (bootstrap first)
+from scripts._neoapsu_verifier import execute_verification
+
+LOGGER = logging.getLogger("neoapsu.verify.crown")
+SERVICE = "neoapsu_crown"
+MODULE = "neoapsu_crown"
+MATRIX_TOKENS = ("neoapsu_crown", "neoabzu_crown")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        help="Path to component_index.json (defaults to <repo>/component_index.json)",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Optional scenario fixture forwarded to the contract suite",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Explicit run identifier. Defaults to <timestamp>-neoapsu_crown.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        help=(
+            "Directory for run artifacts. Defaults to "
+            "logs/stage_d/neoapsu_crown/<run_id>"
+        ),
+    )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Force sandbox overrides and emit a summary of active stubs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_run_context(
+    repo_root: Path, run_id_arg: str | None, log_dir_arg: Path | None
+) -> tuple[str, Path]:
+    if log_dir_arg is not None:
+        log_dir = Path(log_dir_arg)
+        run_id = run_id_arg or log_dir.name
+    else:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_id = run_id_arg or f"{timestamp}-{SERVICE}"
+        log_dir = repo_root / "logs" / "stage_d" / SERVICE / run_id
+    return run_id, log_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+    sandbox_logger = logging.getLogger("neoapsu.verify.crown.sandbox")
+    repo_root = stage_runtime.bootstrap(
+        optional_modules=[MODULE],
+        sandbox=True if args.sandbox else None,
+        log_summary=bool(args.sandbox),
+        summary_logger=sandbox_logger,
+    )
+
+    matrix_path = (
+        Path(args.matrix) if args.matrix else repo_root / "component_index.json"
+    )
+    run_id, log_dir = _resolve_run_context(repo_root, args.run_id, args.log_dir)
+
+    contract_kwargs: dict[str, Any] = {}
+    if args.fixture is not None:
+        fixture_path = Path(args.fixture)
+        if fixture_path.exists():
+            contract_kwargs["fixture_path"] = str(fixture_path)
+        else:
+            LOGGER.warning(
+                "fixture path %s not found; continuing without fixture", fixture_path
+            )
+
+    overrides = stage_runtime.get_sandbox_overrides()
+    sandbox_summary = stage_runtime.format_sandbox_summary("Neo-APSU sandbox")
+
+    summary = execute_verification(
+        service=SERVICE,
+        module_name=MODULE,
+        repo_root=repo_root,
+        log_dir=log_dir,
+        run_id=run_id,
+        matrix_path=matrix_path,
+        matrix_tokens=MATRIX_TOKENS,
+        overrides=overrides,
+        sandbox_summary=sandbox_summary,
+        contract_kwargs=contract_kwargs,
+    )
+
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if summary.get("status") == "success" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/verify_neoapsu_identity.py
+++ b/scripts/verify_neoapsu_identity.py
@@ -1,0 +1,122 @@
+"""Stage D sandbox verification for the Neo-APSU identity bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts import _stage_runtime as stage_runtime  # noqa: E402 (bootstrap first)
+from scripts._neoapsu_verifier import execute_verification
+
+LOGGER = logging.getLogger("neoapsu.verify.identity")
+SERVICE = "neoapsu_identity"
+MODULE = "neoapsu_identity"
+MATRIX_TOKENS = (
+    "neoapsu_identity",
+    "neoabzu_identity",
+    "neoabzu_crown::load_identity",
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        help="Path to component_index.json (defaults to <repo>/component_index.json)",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Optional identity fixture forwarded to the contract suite",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Explicit run identifier. Defaults to <timestamp>-neoapsu_identity.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        help=(
+            "Directory for run artifacts. Defaults to "
+            "logs/stage_d/neoapsu_identity/<run_id>"
+        ),
+    )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Force sandbox overrides and emit a summary of active stubs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_run_context(
+    repo_root: Path, run_id_arg: str | None, log_dir_arg: Path | None
+) -> tuple[str, Path]:
+    if log_dir_arg is not None:
+        log_dir = Path(log_dir_arg)
+        run_id = run_id_arg or log_dir.name
+    else:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_id = run_id_arg or f"{timestamp}-{SERVICE}"
+        log_dir = repo_root / "logs" / "stage_d" / SERVICE / run_id
+    return run_id, log_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+    sandbox_logger = logging.getLogger("neoapsu.verify.identity.sandbox")
+    repo_root = stage_runtime.bootstrap(
+        optional_modules=[MODULE],
+        sandbox=True if args.sandbox else None,
+        log_summary=bool(args.sandbox),
+        summary_logger=sandbox_logger,
+    )
+
+    matrix_path = (
+        Path(args.matrix) if args.matrix else repo_root / "component_index.json"
+    )
+    run_id, log_dir = _resolve_run_context(repo_root, args.run_id, args.log_dir)
+
+    contract_kwargs: dict[str, Any] = {}
+    if args.fixture is not None:
+        fixture_path = Path(args.fixture)
+        if fixture_path.exists():
+            contract_kwargs["fixture_path"] = str(fixture_path)
+        else:
+            LOGGER.warning(
+                "fixture path %s not found; continuing without fixture", fixture_path
+            )
+
+    overrides = stage_runtime.get_sandbox_overrides()
+    sandbox_summary = stage_runtime.format_sandbox_summary("Neo-APSU sandbox")
+
+    summary = execute_verification(
+        service=SERVICE,
+        module_name=MODULE,
+        repo_root=repo_root,
+        log_dir=log_dir,
+        run_id=run_id,
+        matrix_path=matrix_path,
+        matrix_tokens=MATRIX_TOKENS,
+        overrides=overrides,
+        sandbox_summary=sandbox_summary,
+        contract_kwargs=contract_kwargs,
+    )
+
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if summary.get("status") == "success" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/verify_neoapsu_memory.py
+++ b/scripts/verify_neoapsu_memory.py
@@ -1,0 +1,125 @@
+"""Stage D sandbox verification for the Neo-APSU memory contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts import _stage_runtime as stage_runtime  # noqa: E402 (bootstrap first)
+from scripts._neoapsu_verifier import execute_verification
+
+LOGGER = logging.getLogger("neoapsu.verify.memory")
+SERVICE = "neoapsu_memory"
+MODULE = "neoapsu_memory"
+MATRIX_TOKENS = ("neoapsu_memory", "neoabzu_memory")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        help="Path to component_index.json (defaults to <repo>/component_index.json)",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Optional query fixture passed to the contract suite",
+    )
+    parser.add_argument(
+        "--run-id",
+        help=(
+            "Explicit run identifier. Defaults to <timestamp>-neoapsu_memory when not "
+            "provided."
+        ),
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        help=(
+            "Directory for run artifacts. Defaults to "
+            "logs/stage_d/neoapsu_memory/<run_id>"
+        ),
+    )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Force sandbox overrides and emit a summary of active stubs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_run_context(
+    repo_root: Path, run_id_arg: str | None, log_dir_arg: Path | None
+) -> tuple[str, Path]:
+    if log_dir_arg is not None:
+        log_dir = Path(log_dir_arg)
+        run_id = run_id_arg or log_dir.name
+    else:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_id = run_id_arg or f"{timestamp}-{SERVICE}"
+        log_dir = repo_root / "logs" / "stage_d" / SERVICE / run_id
+    return run_id, log_dir
+
+
+def _default_fixture(repo_root: Path) -> Path:
+    candidate = repo_root / "data" / "vector_memory_scaling" / "corpus.jsonl"
+    return candidate
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+    sandbox_logger = logging.getLogger("neoapsu.verify.memory.sandbox")
+    repo_root = stage_runtime.bootstrap(
+        optional_modules=[MODULE],
+        sandbox=True if args.sandbox else None,
+        log_summary=bool(args.sandbox),
+        summary_logger=sandbox_logger,
+    )
+
+    matrix_path = (
+        Path(args.matrix) if args.matrix else repo_root / "component_index.json"
+    )
+    run_id, log_dir = _resolve_run_context(repo_root, args.run_id, args.log_dir)
+
+    fixture_path = Path(args.fixture) if args.fixture else _default_fixture(repo_root)
+    contract_kwargs: dict[str, Any] = {}
+    if fixture_path.exists():
+        contract_kwargs["fixture_path"] = str(fixture_path)
+    else:
+        LOGGER.warning(
+            "fixture path %s not found; continuing without fixture", fixture_path
+        )
+
+    overrides = stage_runtime.get_sandbox_overrides()
+    sandbox_summary = stage_runtime.format_sandbox_summary("Neo-APSU sandbox")
+
+    summary = execute_verification(
+        service=SERVICE,
+        module_name=MODULE,
+        repo_root=repo_root,
+        log_dir=log_dir,
+        run_id=run_id,
+        matrix_path=matrix_path,
+        matrix_tokens=MATRIX_TOKENS,
+        overrides=overrides,
+        sandbox_summary=sandbox_summary,
+        contract_kwargs=contract_kwargs,
+    )
+
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if summary.get("status") == "success" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/web_console/game_dashboard/dashboard.js
+++ b/web_console/game_dashboard/dashboard.js
@@ -18,6 +18,7 @@ const stageTitles = {
   'stage-a': 'Stage A – Alpha Automation',
   'stage-b': 'Stage B – Mission Ops',
   'stage-c': 'Stage C – Continuity Planning',
+  'stage-d': 'Stage D – Neo-APSU Bridge',
 };
 
 const stageAFallback = {
@@ -98,6 +99,51 @@ const stageBFallback = {
     error: 'stage_b3_connector_rotation exited with code 1',
     metricsError: 'no JSON payload found in command stdout',
     notes: 'Connector rehearsal blocked: connectors package import failed inside smoke script.',
+  },
+};
+
+const stageDFallback = {
+  'stage-d1-neoapsu-memory': {
+    status: 'error',
+    runId: '20250930T120000Z-stage_d1_neoapsu_memory',
+    logDir: 'logs/stage_d/neoapsu_memory/20250930T120000Z-stage_d1_neoapsu_memory',
+    summaryPath:
+      'logs/stage_d/neoapsu_memory/20250930T120000Z-stage_d1_neoapsu_memory/summary.json',
+    stdoutPath:
+      'logs/stage_d/neoapsu_memory/20250930T120000Z-stage_d1_neoapsu_memory/stage_d1_neoapsu_memory.stdout.log',
+    stderrPath:
+      'logs/stage_d/neoapsu_memory/20250930T120000Z-stage_d1_neoapsu_memory/stage_d1_neoapsu_memory.stderr.log',
+    error: 'stage_d1_neoapsu_memory exited with code 1',
+    notes:
+      'Sandbox stub engaged; install neoapsu_memory bindings to clear stubbed warnings.',
+  },
+  'stage-d2-neoapsu-crown': {
+    status: 'error',
+    runId: '20250930T120000Z-stage_d2_neoapsu_crown',
+    logDir: 'logs/stage_d/neoapsu_crown/20250930T120000Z-stage_d2_neoapsu_crown',
+    summaryPath:
+      'logs/stage_d/neoapsu_crown/20250930T120000Z-stage_d2_neoapsu_crown/summary.json',
+    stdoutPath:
+      'logs/stage_d/neoapsu_crown/20250930T120000Z-stage_d2_neoapsu_crown/stage_d2_neoapsu_crown.stdout.log',
+    stderrPath:
+      'logs/stage_d/neoapsu_crown/20250930T120000Z-stage_d2_neoapsu_crown/stage_d2_neoapsu_crown.stderr.log',
+    error: 'stage_d2_neoapsu_crown exited with code 1',
+    notes:
+      'Neo-APSU crown contracts deferred – sandbox summary archived for readiness bundle.',
+  },
+  'stage-d3-neoapsu-identity': {
+    status: 'error',
+    runId: '20250930T120000Z-stage_d3_neoapsu_identity',
+    logDir: 'logs/stage_d/neoapsu_identity/20250930T120000Z-stage_d3_neoapsu_identity',
+    summaryPath:
+      'logs/stage_d/neoapsu_identity/20250930T120000Z-stage_d3_neoapsu_identity/summary.json',
+    stdoutPath:
+      'logs/stage_d/neoapsu_identity/20250930T120000Z-stage_d3_neoapsu_identity/stage_d3_neoapsu_identity.stdout.log',
+    stderrPath:
+      'logs/stage_d/neoapsu_identity/20250930T120000Z-stage_d3_neoapsu_identity/stage_d3_neoapsu_identity.stderr.log',
+    error: 'stage_d3_neoapsu_identity exited with code 1',
+    notes:
+      'Identity bridge verification stubbed – sync native crate to replace sandbox report.',
   },
 };
 
@@ -424,6 +470,9 @@ function GameDashboard() {
     ...stageBFallback,
   }));
   const [stageCResults, setStageCResults] = React.useState({});
+  const [stageDResults, setStageDResults] = React.useState(() => ({
+    ...stageDFallback,
+  }));
 
   const logStreamChunk = React.useCallback(
     (label, chunk) => {
@@ -899,6 +948,224 @@ function GameDashboard() {
     [stageCResults]
   );
 
+  const renderStageDDetails = React.useCallback(
+    (id) => {
+      const entry = stageDResults[id] ?? stageDFallback[id];
+      if (!entry) return null;
+      const elements = [];
+      if (entry.status) {
+        elements.push(
+          React.createElement(
+            'p',
+            {
+              key: 'status',
+              className: `mission-stage__status mission-stage__status--${entry.status}`,
+            },
+            `Status: ${entry.status}`
+          )
+        );
+      }
+      if (entry.responseStatus != null) {
+        elements.push(
+          React.createElement(
+            'p',
+            { key: 'http' },
+            `HTTP status: ${entry.responseStatus}`
+          )
+        );
+      }
+      if (entry.runId) {
+        elements.push(
+          React.createElement('p', { key: 'run' }, `Run ID: ${entry.runId}`)
+        );
+      }
+      if (entry.logDir) {
+        elements.push(
+          React.createElement('p', { key: 'logs' }, `Log dir: ${entry.logDir}`)
+        );
+      }
+      if (entry.summaryPath) {
+        elements.push(
+          React.createElement('p', { key: 'summary' }, `Summary: ${entry.summaryPath}`)
+        );
+      }
+      if (entry.stdoutPath) {
+        elements.push(
+          React.createElement('p', { key: 'stdout' }, `Stdout: ${entry.stdoutPath}`)
+        );
+      }
+      if (entry.stderrPath) {
+        elements.push(
+          React.createElement('p', { key: 'stderr' }, `Stderr: ${entry.stderrPath}`)
+        );
+      }
+      if (entry.startedAt) {
+        elements.push(
+          React.createElement('p', { key: 'started' }, `Started: ${entry.startedAt}`)
+        );
+      }
+      if (entry.completedAt) {
+        elements.push(
+          React.createElement('p', { key: 'completed' }, `Completed: ${entry.completedAt}`)
+        );
+      }
+      if (entry.sandboxSummary) {
+        elements.push(
+          React.createElement('p', { key: 'sandbox' }, entry.sandboxSummary)
+        );
+      }
+      if (entry.sandboxOverrides && Object.keys(entry.sandboxOverrides).length) {
+        elements.push(
+          React.createElement(
+            'div',
+            { key: 'overrides' },
+            [
+              React.createElement('p', { key: 'overrides-label' }, 'Sandbox overrides:'),
+              React.createElement(
+                'ul',
+                { key: 'overrides-list' },
+                Object.entries(entry.sandboxOverrides).map(([key, value]) =>
+                  React.createElement('li', { key }, `${key}: ${value}`)
+                )
+              ),
+            ]
+          )
+        );
+      }
+      if (Array.isArray(entry.warnings) && entry.warnings.length) {
+        elements.push(
+          React.createElement(
+            'div',
+            { key: 'warnings' },
+            [
+              React.createElement('p', { key: 'warnings-label' }, 'Warnings:'),
+              React.createElement(
+                'ul',
+                { key: 'warnings-list' },
+                entry.warnings.map((warning, index) =>
+                  React.createElement('li', { key: `${index}-${warning}` }, warning)
+                )
+              ),
+            ]
+          )
+        );
+      }
+      if (entry.contract) {
+        const contract = entry.contract;
+        elements.push(
+          React.createElement(
+            'div',
+            { key: 'contract' },
+            [
+              React.createElement(
+                'p',
+                { key: 'contract-summary' },
+                `Contract suite: ${contract.suite} (${contract.status})`
+              ),
+              React.createElement(
+                'p',
+                { key: 'contract-counts' },
+                `Tests: ${contract.passed}/${contract.total} passed, ${contract.failed} failed, ${contract.skipped} skipped`
+              ),
+              contract.sandboxed
+                ? React.createElement(
+                    'p',
+                    { key: 'contract-sandboxed', className: 'mission-stage__warning' },
+                    'Sandbox contract stub executed'
+                  )
+                : null,
+              Array.isArray(contract.notes) && contract.notes.length
+                ? React.createElement(
+                    'ul',
+                    { key: 'contract-notes' },
+                    contract.notes.map((note, index) =>
+                      React.createElement('li', { key: `${index}-note` }, note)
+                    )
+                  )
+                : null,
+              Array.isArray(contract.tests) && contract.tests.length
+                ? React.createElement(
+                    'ul',
+                    { key: 'contract-tests', className: 'mission-stage__list' },
+                    contract.tests.map((test, index) => {
+                      const name = test.name || test.id || `test-${index + 1}`;
+                      const reason = test.reason ? ` – ${test.reason}` : '';
+                      return React.createElement(
+                        'li',
+                        { key: test.id || `${name}-${index}` },
+                        `${name}: ${test.status}${reason}`
+                      );
+                    })
+                  )
+                : null,
+              contract.fixtures
+                ? React.createElement(
+                    'pre',
+                    { key: 'contract-fixtures', className: 'mission-stage__metrics' },
+                    JSON.stringify(contract.fixtures, null, 2)
+                  )
+                : null,
+            ].filter(Boolean)
+          )
+        );
+      }
+      if (Array.isArray(entry.migrationEntries) && entry.migrationEntries.length) {
+        elements.push(
+          React.createElement(
+            'div',
+            { key: 'migration' },
+            [
+              React.createElement('p', { key: 'migration-label' }, 'Migration entries:'),
+              React.createElement(
+                'ul',
+                { key: 'migration-list' },
+                entry.migrationEntries.map((item, index) => {
+                  const legacy = item?.legacy_entry ?? 'unknown';
+                  const neo = item?.neo_module ?? 'unknown';
+                  const status = item?.status ? ` (${item.status})` : '';
+                  return React.createElement(
+                    'li',
+                    { key: `${index}-${legacy}` },
+                    `${legacy} → ${neo}${status}`
+                  );
+                })
+              ),
+            ]
+          )
+        );
+      }
+      if (entry.artifacts && Object.keys(entry.artifacts).length) {
+        elements.push(
+          React.createElement(
+            'div',
+            { key: 'artifacts' },
+            [
+              React.createElement('p', { key: 'artifacts-label' }, 'Artifacts:'),
+              React.createElement(
+                'ul',
+                { key: 'artifacts-list' },
+                Object.entries(entry.artifacts).map(([key, value]) =>
+                  React.createElement('li', { key }, `${key}: ${value}`)
+                )
+              ),
+            ]
+          )
+        );
+      }
+      if (entry.notes) {
+        elements.push(
+          React.createElement('p', { key: 'notes' }, `Notes: ${entry.notes}`)
+        );
+      }
+      return React.createElement(
+        'div',
+        { className: 'mission-stage__details', key: `${id}-details` },
+        elements
+      );
+    },
+    [stageDResults]
+  );
+
   const createStageCAction = React.useCallback(
     ({ id, label, endpoint }) => {
       const execute = async () => {
@@ -1025,6 +1292,189 @@ function GameDashboard() {
       };
     },
     [appendLog, createLoggedAction, formatStageABlock, renderStageCDetails, stageCResults]
+  );
+
+  const createStageDAction = React.useCallback(
+    ({ id, label, endpoint }) => {
+      const execute = async () => {
+        const startedAt = new Date().toISOString();
+        setStageDResults((prev) => ({
+          ...prev,
+          [id]: {
+            ...(prev[id] ?? stageDFallback[id] ?? {}),
+            status: 'running',
+            startedAt,
+            completedAt: null,
+            responseStatus: null,
+            error: null,
+            sandboxSummary: null,
+            sandboxOverrides: null,
+            warnings: null,
+            contract: null,
+            migrationEntries: null,
+            artifacts: null,
+          },
+        }));
+        const { response, data, raw, parseError } = await streamJsonPost(
+          endpoint,
+          label
+        );
+        if (parseError) {
+          const message = `Failed to parse response JSON: ${parseError.message}`;
+          const completedAt = new Date().toISOString();
+          setStageDResults((prev) => ({
+            ...prev,
+            [id]: {
+              ...(prev[id] ?? stageDFallback[id] ?? {}),
+              status: 'error',
+              startedAt,
+              completedAt,
+              error: message,
+              responseStatus: response?.status ?? null,
+              warnings: null,
+              artifacts:
+                (prev[id] ?? stageDFallback[id] ?? {}).artifacts ?? null,
+            },
+          }));
+          appendLog(
+            formatStageABlock(label, {
+              status: 'error',
+              error: message,
+              raw,
+            })
+          );
+          throw new Error(message);
+        }
+        const payload = {
+          status: response.ok ? 'success' : 'error',
+          status_code: response.status,
+          ...(data ?? {}),
+        };
+        appendLog(formatStageABlock(label, payload));
+        const completedAt = new Date().toISOString();
+        const fallback = stageDFallback[id] ?? {};
+        const summary =
+          payload.summary && typeof payload.summary === 'object'
+            ? payload.summary
+            : {};
+        const contractSuite =
+          summary.contract_suite && typeof summary.contract_suite === 'object'
+            ? summary.contract_suite
+            : null;
+        const contract = contractSuite
+          ? {
+              suite: contractSuite.suite ?? label,
+              status: contractSuite.status ?? 'unknown',
+              passed: contractSuite.passed ?? 0,
+              failed: contractSuite.failed ?? 0,
+              skipped: contractSuite.skipped ?? 0,
+              total:
+                contractSuite.total ??
+                (Array.isArray(contractSuite.tests)
+                  ? contractSuite.tests.length
+                  : 0),
+              sandboxed: Boolean(contractSuite.sandboxed),
+              notes: Array.isArray(contractSuite.notes)
+                ? contractSuite.notes
+                : contractSuite.notes
+                ? [contractSuite.notes]
+                : [],
+              tests: Array.isArray(contractSuite.tests)
+                ? contractSuite.tests
+                : [],
+              fixtures:
+                typeof contractSuite.fixtures === 'object'
+                  ? contractSuite.fixtures
+                  : null,
+            }
+          : null;
+        const warnings = Array.isArray(summary.warnings)
+          ? summary.warnings
+          : [];
+        const sandboxOverrides =
+          summary.sandbox_overrides &&
+          typeof summary.sandbox_overrides === 'object'
+            ? summary.sandbox_overrides
+            : null;
+        const baseUpdate = {
+          status: payload.status,
+          startedAt,
+          completedAt,
+          responseStatus: response.status,
+          runId: payload.run_id ?? summary.run_id ?? fallback.runId ?? null,
+          logDir: payload.log_dir ?? summary.log_dir ?? fallback.logDir ?? null,
+          summaryPath:
+            payload.summary_path ?? summary.summary_path ?? fallback.summaryPath ?? null,
+          stdoutPath:
+            payload.stdout_path ?? summary.stdout_path ?? fallback.stdoutPath ?? null,
+          stderrPath:
+            payload.stderr_path ?? summary.stderr_path ?? fallback.stderrPath ?? null,
+          sandboxSummary: summary.sandbox_summary ?? null,
+          sandboxOverrides,
+          warnings,
+          contract,
+          migrationEntries: Array.isArray(summary.migration_entries)
+            ? summary.migration_entries
+            : null,
+          artifacts:
+            payload.artifacts ?? summary.artifacts ?? fallback.artifacts ?? null,
+          error: null,
+          notes: fallback.notes ?? null,
+        };
+        if (payload.status !== 'success') {
+          baseUpdate.error =
+            payload.error ||
+            payload.detail ||
+            (warnings && warnings.length ? warnings.join('; ') : null) ||
+            `HTTP ${response.status}`;
+          setStageDResults((prev) => ({ ...prev, [id]: baseUpdate }));
+          const error = new Error(baseUpdate.error ?? `${label} failed`);
+          error.stageResult = payload;
+          throw error;
+        }
+        setStageDResults((prev) => ({ ...prev, [id]: baseUpdate }));
+        return payload;
+      };
+
+      const action = createLoggedAction(id, label, execute, {
+        onError: (error) => {
+          if (error?.stageResult) {
+            return;
+          }
+          setStageDResults((prev) => ({
+            ...prev,
+            [id]: {
+              ...(prev[id] ?? stageDFallback[id] ?? {}),
+              status: 'error',
+              completedAt: new Date().toISOString(),
+              error: error?.message ?? String(error),
+              artifacts:
+                (prev[id] ?? stageDFallback[id] ?? {}).artifacts ?? null,
+            },
+          }));
+          appendLog(
+            formatStageABlock(label, {
+              status: 'error',
+              error: error?.message ?? String(error),
+            })
+          );
+        },
+      });
+
+      return {
+        ...action,
+        status: stageDResults[id]?.status ?? stageDFallback[id]?.status ?? null,
+        renderDetails: () => renderStageDDetails(id),
+      };
+    },
+    [
+      appendLog,
+      createLoggedAction,
+      formatStageABlock,
+      renderStageDDetails,
+      stageDResults,
+      streamJsonPost,
+    ]
   );
 
   const logSuccess = React.useCallback(
@@ -1176,12 +1626,40 @@ function GameDashboard() {
           },
         ],
       },
+      {
+        id: 'stage-d',
+        title: stageTitles['stage-d'],
+        groups: [
+          {
+            id: 'stage-d-verification',
+            title: 'Neo-APSU Sandbox',
+            actions: [
+              createStageDAction({
+                id: 'stage-d1-neoapsu-memory',
+                label: 'Stage D1 – Neo-APSU Memory',
+                endpoint: '/alpha/stage-d1-neoapsu-memory',
+              }),
+              createStageDAction({
+                id: 'stage-d2-neoapsu-crown',
+                label: 'Stage D2 – Neo-APSU Crown',
+                endpoint: '/alpha/stage-d2-neoapsu-crown',
+              }),
+              createStageDAction({
+                id: 'stage-d3-neoapsu-identity',
+                label: 'Stage D3 – Neo-APSU Identity',
+                endpoint: '/alpha/stage-d3-neoapsu-identity',
+              }),
+            ],
+          },
+        ],
+      },
     ],
     [
       createLoggedAction,
       createStageAAction,
       createStageBAction,
       createStageCAction,
+      createStageDAction,
       logSuccess,
     ]
   );


### PR DESCRIPTION
## Summary
- add sandbox overrides for the Neo-APSU crates and emit a summary when fallbacks are activated
- provide shared verification helpers plus CLIs to execute Neo-APSU contract suites and archive artifacts
- expose Stage D automation endpoints and mission map controls to trigger the new verifications

## Testing
- pre-commit run --files scripts/_stage_runtime.py scripts/_neoapsu_verifier.py scripts/verify_neoapsu_memory.py scripts/verify_neoapsu_crown.py scripts/verify_neoapsu_identity.py operator_api.py web_console/game_dashboard/dashboard.js *(fails: ensure-blueprint-sync, verify-versions, check-env, pytest-cov, verify-docs-up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2a8b8194832ebc89ca4c852ca029