### PR TITLE
Document contracts for memory, crown, identity, and transport modules

### DIFF
--- a/docs/contracts/crown.md
+++ b/docs/contracts/crown.md
@@ -1,0 +1,26 @@
+# Crown Module Contract
+
+## Overview
+The crown contract documents orchestration between the decider, servant registry, and prompt orchestrator when bootstrapping a mission. It captures how servant endpoints are registered from configuration, how decision history drives LLM selection, and what telemetry reviewers should expect during sandbox boot.
+
+## Sample Inputs and Outputs
+- **Servant bootstrap.** Initialization reads a YAML configuration (empty in tests) and discovers servant endpoints via environment variables such as `DEEPSEEK_URL`, `MISTRAL_URL`, and `KIMI_K2_URL`, registering each under the servant model manager.【F:tests/crown/test_servant_registration.py†L27-L56】
+- **Dynamic registry override.** Setting `SERVANT_MODELS="alpha=http://a,beta=http://b"` yields a registry containing both aliases after initialization, demonstrating the parsing contract for comma-separated `name=url` pairs.【F:tests/crown/test_servant_registration.py†L59-L85】
+- **Decision scoring.** The decider inspects emotional memory history records and affect scores; when the latest successful entries for model "B" report higher joy/trust, `recommend_llm("instructional", "joy")` returns "B".【F:tests/crown/test_decider.py†L26-L74】
+
+## Expected Logging and Telemetry
+- Malformed servant entries trigger warnings such as "Skipping malformed SERVANT_MODELS entry" and "Duplicate servant model name" while still registering valid endpoints, ensuring operators see hygiene issues without breaking boot.【F:tests/crown/test_servant_registration.py†L88-L120】
+- Sandbox runtime hooks automatically stub heavy dependencies (`crown_decider`, `crown_prompt_orchestrator`, `servant_model_manager`) so tests emit `EnvironmentLimitedWarning` rather than import failures when native crates are missing.【F:scripts/_stage_runtime.py†L27-L63】
+
+## Failure Modes and Recovery
+- **Configuration errors.** A malformed `SERVANT_MODELS` token (missing `=`) causes initialization to log warnings and skip the invalid entry; duplicates collapse to the first occurrence, preserving deterministic routing.【F:tests/crown/test_servant_registration.py†L88-L120】
+- **Registry validation.** If every entry is malformed (for example `SERVANT_MODELS="brokenpair"`), the process exits, prompting operators to fix configuration before running production handoffs.【F:tests/crown/test_servant_registration.py†L123-L148】
+- **Dependency shims.** Audio-analysis libraries (`librosa`, `opensmile`, `soundfile`) and NumPy functions are stubbed for the decider tests, illustrating the minimum interface required for sandbox-compatible emotional scoring.【F:tests/crown/test_decider.py†L12-L73】
+
+## Reusable Fixtures and Stubs
+- Reuse the servant-registration monkeypatches from `tests/crown/test_servant_registration.py` when crafting contract tests that simulate HTTP pings and registry hydration.【F:tests/crown/test_servant_registration.py†L27-L120】
+- The decider history objects created in `tests/crown/test_decider.py` serve as canonical emotional-memory records for verifying scoring heuristics in future suites.【F:tests/crown/test_decider.py†L33-L74】
+- Leverage `_stage_runtime`'s sandbox override registry to preload servant and decider modules before test execution, ensuring parity with the automation harness.【F:scripts/_stage_runtime.py†L27-L108】
+
+## Future Work
+Neo‑APSU adoption requires replaying Stage B rotation windows and Stage C readiness hashes on hardware before graduating the Rust `neoabzu_crown` decision path; the roadmap outlines how Stage D–H bundles carry those parity diffs and approvals.【F:docs/roadmap.md†L187-L193】 Contract dashboards must surface REST↔gRPC transport parity alongside crown telemetry so reviewers can trace sandbox warnings and servant registry status into Stage E beta gates and Stage G hardware replays.【F:docs/roadmap.md†L170-L218】 Continue flagging sandbox overrides with `EnvironmentLimitedWarning` until the hardware bridge enables native audio and emotional pipelines.【F:scripts/_stage_runtime.py†L27-L63】

--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -1,0 +1,26 @@
+# Identity Module Contract
+
+## Overview
+Identity synthesis blends mission, persona, and doctrine excerpts into a persisted summary that Crown broadcasts to downstream services. The contract describes how the loader interacts with the GLM integration, how embeddings are seeded into vector and corpus stores, and what telemetry confirms the identity fingerprint is ready.
+
+## Sample Inputs and Outputs
+- **Mission/persona merge.** `load_identity` concatenates mission and persona documents plus doctrine snippets before prompting the GLM; the resulting summary is written to `identity.json` and reused on subsequent calls without re-prompting.【F:tests/test_identity_loader.py†L24-L95】
+- **Embedding side effects.** After initialization, the identity summary is pushed into both vector memory (`add_vector`) and corpus memory (`add_entry`) with metadata marking `type="identity_summary"` and `stage="crown_boot"`.【F:tests/test_identity_loader.py†L143-L176】
+- **Handshake acknowledgement.** The GLM must respond with `CROWN-IDENTITY-ACK` when the loader sends the acknowledgement prompt; otherwise the loader raises an error and leaves no persisted summary, enforcing the handshake contract.【F:tests/test_identity_loader.py†L96-L121】
+
+## Expected Logging and Telemetry
+- Crown boot emits the `crown_identity_ready` gauge once the stored summary hash matches the generated fingerprint, as recorded in the system blueprint milestones.【F:docs/system_blueprint.md†L29-L37】
+- Sandbox automation keeps `neoapsu_identity` in the forced-module override list so `_stage_runtime` can emit `EnvironmentLimitedWarning` when native bindings are missing instead of failing import, keeping telemetry intact for contract tests.【F:scripts/_stage_runtime.py†L27-L63】
+
+## Failure Modes and Recovery
+- **Ack mismatch.** If the GLM returns any string other than `CROWN-IDENTITY-ACK`, the loader aborts with a `RuntimeError`, prompting operators to troubleshoot mission/persona prompts or GLM connectivity before rerunning boot.【F:tests/test_identity_loader.py†L96-L121】
+- **Missing doctrine artifacts.** Tests stub doctrine paths explicitly; real deployments should reuse the same path list to surface missing files early. Reapply the fixtures shown above when adding assertions about fingerprint deltas.【F:tests/test_identity_loader.py†L24-L95】
+- **Vector ingestion gaps.** Should vector/corpus stores reject the identity entry, downstream retrieval lacks persona context. Use the `SimpleNamespace` stubs from the tests to verify metadata propagation while the sandbox vector memory remains stubbed.【F:tests/test_identity_loader.py†L143-L176】
+
+## Reusable Fixtures and Stubs
+- `DummyGLM` in the tests captures prompt history and emulates acknowledgement flow; reimport it for regression suites that exercise multi-step prompts.【F:tests/test_identity_loader.py†L12-L95】
+- Monkeypatched vector/corpus memory stubs demonstrate the minimal interfaces (`add_vector`, `add_entry`) required for contract validation without the full Neo‑ABZU stack.【F:tests/test_identity_loader.py†L143-L176】
+- `_stage_runtime` ensures `neoapsu_identity` stays patched during sandbox runs; call `bootstrap()` from that module when reproducing CLI behaviour so the same overrides apply.【F:scripts/_stage_runtime.py†L27-L108】
+
+## Future Work
+Identity readiness must promote the Rust loader and handshake pipeline onto gate-runner hardware, replaying Stage C readiness bundles and attaching Stage G parity approvals before removing sandbox overrides. The system blueprint already notes that each boot should publish a `CROWN_IDENTITY_FINGERPRINT`; extend that telemetry into Grafana once native bindings are enabled so reviewers can trace identity drift across hardware promotions.【F:docs/system_blueprint.md†L29-L37】 Document environment-limited skips emitted by `_stage_runtime` until the Neo‑APSU identity crate links successfully in CI and hardware runners, mirroring roadmap and PROJECT_STATUS updates for hardware bridge scheduling.【F:scripts/_stage_runtime.py†L27-L63】

--- a/docs/contracts/memory.md
+++ b/docs/contracts/memory.md
@@ -1,0 +1,26 @@
+# Memory Module Contract
+
+## Overview
+The memory contract covers the lightweight SQLite-backed `MemoryStore`, the vector snapshot helper, and the shims that stand in for Chroma/Neo‑ABZU services during sandbox runs. It documents how ingestion, similarity search, and snapshot export behave when optional accelerators are absent.
+
+## Sample Inputs and Outputs
+- **Scalar vector ingestion.** Tests add two vectors with IDs `"a"` and `"b"` and later query for the nearest neighbours with a 2D query vector. The store returns tuples `(id, score, metadata)` where the expected IDs include both inserted records before deletion.【F:tests/memory/test_memory_store_fallback.py†L6-L17】
+- **Snapshot manifest.** The vector memory snapshotter persists files under `<db_path>/snapshots/` and lists each snapshot path inside `manifest.json`. After restoring the latest snapshot, `query_vectors(limit=10)` returns entries whose `text` field matches the stored payload.【F:tests/memory/test_vector_memory.py†L24-L47】
+- **Baseline embeddings.** The `FakeCollection` fixture accepts both single-record and batched `add` calls, tracking inserted embeddings and metadata, while `query` returns ordered matches shaped like the real Chroma responses (`{"ids": [[...]], "metadatas": [[...]]}`).【F:tests/fixtures/chroma_baseline/fake_chroma.py†L15-L156】
+- **Stage readiness metrics.** Memory readiness bundles emit rotation and heartbeat metadata such as `rotation_summary` and `heartbeat_expiry`, which downstream automation consumes to gate releases.【F:tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json†L1-L16】
+
+## Expected Logging and Telemetry
+- Memory readiness exports should surface rotation summaries and heartbeat expirations that match the Stage B fixtures above, signalling when credential windows need renewal.【F:tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json†L1-L16】
+- Sandbox automation emits `EnvironmentLimitedWarning` entries when native extensions are unavailable; the runtime loader keeps a list of forced modules (including `neoapsu_memory`) to patch in stubs before tests execute.【F:scripts/_stage_runtime.py†L27-L63】
+
+## Failure Modes and Recovery
+- **Optional dependency gaps.** When FAISS and NumPy are unavailable, the store falls back to pure-Python similarity scoring while keeping CRUD semantics intact. Tests verify this by monkeypatching both dependencies to `None` and ensuring search/delete still succeed.【F:tests/memory/test_memory_store_fallback.py†L6-L17】
+- **Snapshot drift.** If snapshot manifests are missing, re-running `persist_snapshot()` repopulates the manifest before the next restore attempt. Reuse the snapshot scaffolding from `tests/memory/test_vector_memory.py` when reproducing recovery flows.【F:tests/memory/test_vector_memory.py†L24-L47】
+
+## Reusable Fixtures and Stubs
+- Import `FakeCollection` from `tests/fixtures/chroma_baseline/fake_chroma.py` for deterministic vector-store behaviour in contract tests.【F:tests/fixtures/chroma_baseline/fake_chroma.py†L15-L156】
+- Seed readiness telemetry by copying the Stage B `summary.json` template in `tests/fixtures/stage_readiness/` so log parsers keep consuming identical keys.【F:tests/fixtures/stage_readiness/stage_b/20240102T000000Z-stage_b1_memory_proof/summary.json†L1-L16】
+- Use the sandbox override registry from `_stage_runtime` to stub heavy dependencies (`neoapsu_memory`, `crown_decider`) while keeping interfaces identical across Python and native builds.【F:scripts/_stage_runtime.py†L27-L108】
+
+## Future Work
+Hardware parity requires swapping the SQLite shim with the `neoabzu_memory::MemoryBundle` and replaying Stage B rotations plus Stage C readiness hashes on gate-runner hardware before promoting the Rust bundle.【F:docs/roadmap.md†L191-L192】 Continue publishing checksum and telemetry parity to Grafana once hardware spans are available, mirroring the roadmap checkpoints so reviewers can trace sandbox evidence through Stage G and GA cutovers.【F:docs/roadmap.md†L170-L218】 Until FFmpeg/SoX are restored in the sandbox, keep documenting `EnvironmentLimitedWarning` skips alongside the memory contract results for audit parity.【F:scripts/_stage_runtime.py†L27-L63】

--- a/docs/contracts/transport.md
+++ b/docs/contracts/transport.md
@@ -1,0 +1,27 @@
+# Transport Module Contract
+
+## Overview
+The transport contract covers parity between REST and gRPC operator surfaces plus the recorded Stage C/Stage E artifacts that prove checksum stability. It outlines how command payloads travel through the REST router, how the gRPC service mirrors results (with REST fallback), and what evidence bundles must accompany beta and hardware reviews.
+
+## Sample Inputs and Outputs
+- **Command parity.** Posting `{"operator": "crown", "agent": "razar", "command": "status"}` to `/operator/command` returns `{ "result": {"ack": "status"}, "command_id": ... }`, and the gRPC `_dispatch_command` yields the same structure for the same payload.【F:tests/test_operator_transport_contract.py†L150-L175】
+- **Fallback metadata.** When the first gRPC dispatch raises `RuntimeError("grpc failure")`, enabling `enable_rest_fallback` causes the second attempt to call REST and set trailing metadata `("abzu-fallback", "rest")`, proving the fallback hook works.【F:tests/test_operator_transport_contract.py†L178-L206】
+- **Stage C bundle format.** Trial entries expose `rest_path`, `grpc_path`, and `diff_path` fields whose JSON payloads must produce identical normalized handshakes and checksums, with diff artifacts asserting `parity=True` and empty `differences` arrays.【F:tests/test_operator_transport_contract.py†L209-L239】
+- **Stage E readiness snapshot.** The latest readiness summary enumerates connectors (`operator_api`, `operator_upload`, `crown_handshake`), parity booleans, checksum hashes, telemetry hashes, and artifact paths that must exist on disk for each connector.【F:tests/test_operator_transport_contract.py†L241-L273】 Sample payloads live under `tests/fixtures/transport_parity/`, capturing both legacy and Neo revisions plus telemetry spans.【F:tests/fixtures/transport_parity/operator_api_stage_e.json†L1-L148】
+
+## Expected Logging and Telemetry
+- Stage E summaries should list `heartbeat_missing`, `rest_latency_missing`, and `grpc_latency_missing` gap tags whenever sandbox runs lack hardware metrics, alongside a dashboard URL for reviewers to track remediation.【F:tests/test_operator_transport_contract.py†L275-L303】
+- Automation should emit `EnvironmentLimitedWarning` from `_stage_runtime` when FFmpeg/SoX or native Neo‑APSU modules are absent; keep these warnings in the transport evidence bundle so reviewers know why heartbeat metrics remain stubbed.【F:scripts/_stage_runtime.py†L27-L63】
+
+## Failure Modes and Recovery
+- **Missing artifacts.** If any Stage C handshake file is absent or unreadable, `_load_stage_c_trial_entries` drops the entry, causing the contract test to fail with `"expected Stage C transport parity artifacts"`. Mirror this check when validating new exports.【F:tests/test_operator_transport_contract.py†L29-L71】【F:tests/test_operator_transport_contract.py†L209-L213】
+- **Checksum drift.** Mismatched checksums or diff payloads will trip the assertions that parity is `True` and the checksum fields align; recompute bundles with `compute_handshake_checksum` before publishing readiness packets.【F:tests/test_operator_transport_contract.py†L229-L239】
+- **Heartbeat telemetry gaps.** Stage E summaries deliberately mark missing heartbeat and latency metrics. Until hardware spans are captured, leave the gaps visible and document them as environment-limited skips in roadmap and PROJECT_STATUS updates.【F:tests/test_operator_transport_contract.py†L275-L303】
+
+## Reusable Fixtures and Stubs
+- Recorded Stage E connector exchanges (`operator_api_stage_e.json`, `operator_upload_stage_e.json`, `crown_handshake_stage_e.json`) provide canonical payloads and telemetry hashes for transport contract tests.【F:tests/fixtures/transport_parity/operator_api_stage_e.json†L1-L148】
+- The `_DummyContext` class in the contract tests is the minimal gRPC context stub; reuse it when exercising metadata flows or fallback behaviour in new tests.【F:tests/test_operator_transport_contract.py†L112-L148】
+- Call `_stage_runtime.bootstrap()` before running integration scripts so the same sandbox overrides (including `INANNA_AI.glm_integration` and Crown modules) are active when transport exercises cross-module calls.【F:scripts/_stage_runtime.py†L27-L108】
+
+## Future Work
+Stage E roadmap checkpoints require attaching REST↔gRPC contract results, Grafana dashboard hashes, and Stage C bundle references to beta reviews, then replaying the same artifacts on gate-runner hardware during Stage G parity drills.【F:docs/roadmap.md†L170-L218】 Continue exporting heartbeat telemetry once hardware spans land, updating readiness packets and dashboards so the transport contract tracks the closure of sandbox gaps ahead of GA sign-off.【F:docs/roadmap.md†L209-L218】 Document every environment-limited warning from `_stage_runtime` alongside transport evidence until FFmpeg/SoX and Neo‑APSU binaries can be exercised outside the sandbox.【F:scripts/_stage_runtime.py†L27-L63】


### PR DESCRIPTION
## Summary
- add memory module contract covering sample vector flows, readiness telemetry, and sandbox fallbacks
- document crown registration and decision-making contract with warnings, fixtures, and future hardware steps
- outline identity and transport contracts referencing current fixtures, sandbox overrides, and roadmap follow-through

## Testing
- `pre-commit run --files docs/contracts/memory.md docs/contracts/crown.md docs/contracts/identity.md docs/contracts/transport.md` *(fails: `pre-commit` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df88c376b8832e8e3b9f02261d509d