### PR TITLE
Document Stage F-H readiness alignment

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -238,6 +238,19 @@ sandbox skips while still persisting the summary bundle.【F:logs/stage_a/202511
 
 Matrix status: the [APSU Migration Matrix](apsu_migration_matrix.md) now surfaces fixture links and Stage runtime shims, showing `crown_router` and `identity_loader.py` as ready (`ported`), the servant/decider/orchestrator/state/emotion stack as in-progress (`pending_rewrite` with sandbox stubs), and `memory_store.py` plus `connectors/operator_mcp_adapter.py` as hardware-validation rows (`wrapped`).【F:docs/apsu_migration_matrix.md†L7-L46】【F:component_index.json†L4-L98】 Stage D owners should refresh the matrix alongside readiness packets so Stage E/G reviewers inherit synchronized parity evidence and prototype pointers.
 
+### Stage F+ status rollup
+
+Weekly reviews track Stage F through Stage H using the consolidated
+[Stage F+ execution plan](stage_f_plus_plan.md) so hardware adoption stays aligned
+with the [readiness ledger](readiness_ledger.md) and sandbox policy rules in
+[The Absolute Protocol](The_Absolute_Protocol.md#codex-sandbox-constraints).
+
+| Stage | Status summary | Upcoming evidence | Responsible teams |
+| --- | --- | --- | --- |
+| Stage F – Hardware replay soak alignment | Waiting on gate-runner access; readiness ledger rows for Stage B rotation, Stage C readiness bundle, and Stage E transport traces stitched together with sandbox policy references for each deferred skip.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L11-L40】【F:docs/readiness_ledger.md†L9-L27】 | Gate-runner parity diffs, MCP handshake refresh, and Stage E dashboard hash confirmation recorded with sandbox policy citations once hardware replay executes.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L31-L40】 | @ops-team, @neoabzu-core, @qa-alliance |
+| Stage G – Sandbox-to-hardware bridge validation | Bridge scripts prepped; readiness ledger rows linked to rollback drills and parity bundles per sandbox policy guardrails while awaiting hardware slot execution.【F:docs/roadmap.md†L248-L273】【F:docs/stage_f_plus_plan.md†L42-L64】【F:docs/readiness_ledger.md†L9-L27】 | Stage G hardware parity diffs and rollback transcripts signed with readiness ledger IDs and sandbox policy references.【F:docs/roadmap.md†L248-L273】【F:docs/stage_f_plus_plan.md†L55-L64】 | @ops-team, @neoabzu-core, @qa-alliance, @release-ops |
+| Stage H – Production adoption & LTS cutover | GA cutover prep anchored to Stage G approvals; readiness ledger closures drafted with sandbox policy callouts awaiting final hardware telemetry and governance signatures.【F:docs/roadmap.md†L274-L299】【F:docs/stage_f_plus_plan.md†L66-L94】【F:docs/readiness_ledger.md†L9-L27】 | GA hardware cutover bundle, readiness ledger closure notes, and LTS governance checklist citing The Absolute Protocol sandbox policy.【F:docs/roadmap.md†L274-L299】【F:docs/stage_f_plus_plan.md†L74-L94】 | @release-ops, @operations-lead, @qa-alliance, @neoabzu-core |
+
 #### Hardware replay prerequisites queue
 
 - **Toolchains ready for gate-runner execution.** Stage F requires the Rust toolchain, Python bridge headers, and build prerequisites called out in the Neo-APSU onboarding and blueprint host prerequisites so hardware binaries match sandbox builds; queue installation tasks now so the window can start immediately when access resumes.【F:docs/stage_f_hardware_replay_plan.md†L42-L47】【F:docs/system_blueprint.md†L625-L627】【F:NEOABZU/docs/onboarding.md†L1-L36】

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,10 +193,26 @@ Stage E extends the Stage C transport pilot: contract tests and dashboards n
 | `memory_store.py` | `neoabzu_memory::MemoryBundle` | Stage D bridge aligns Stage B rotations with Stage C readiness latency metrics before switching hardware writes to the Rust bundle.【F:logs/stage_b_rotation_drills.jsonl†L1-L40】【F:logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json†L1-L185】 | Telemetry updates publish memory checksum parity results through Grafana so roadmap/PROJECT_STATUS audiences monitor ingestion gaps during beta prep.【F:tests/test_operator_transport_contract.py†L231-L320】【F:monitoring/operator_transport_pilot.md†L1-L84】【F:docs/PROJECT_STATUS.md†L162-L181】 | Soak cycles document sandbox latency evidence alongside dashboard hashes until hardware metrics converge.【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L20-L87】 | Stage G hardware bundle records memory checksum parity and sandbox replay transcripts under Neo-APSU approvals.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json†L1-L13】 | GA cutover retains the memory parity hash from Stage G to prove production readiness.【F:logs/stage_h/20251115T090000Z-ga_hardware_cutover/summary.json†L15-L28】 |
 | `emotional_state.py` | `neoabzu_crown` expression pipeline | Stage D hardware checks replay Stage B rotation history with Stage C sandbox diffs to validate aura persistence under the Neo-APSU expression path.【F:logs/stage_b_rotation_drills.jsonl†L1-L40】【F:logs/stage_c/20251031T000000Z-test/summary.json†L1-L120】 | Beta-facing updates surface expression heartbeat telemetry inside contract dashboards so deferrals stay visible while sandbox evidence feeds hardware replays.【F:tests/test_operator_transport_contract.py†L1-L210】【F:monitoring/operator_transport_pilot.md†L1-L66】【F:docs/PROJECT_STATUS.md†L162-L181】 | Soak tracking references sandbox aura transcripts plus dashboard hashes until Neo-APSU hardware emits continuous heartbeats.【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L49-L87】 | Stage G parity approvals append aura diffs that cite sandbox evidence and rollback rehearsals.【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/summary.json†L1-L13】 | GA summary confirms aura telemetry hash continuity from Stage G hardware bundles.【F:logs/stage_h/20251115T090000Z-ga_hardware_cutover/summary.json†L1-L28】 |
 
-### Stage F – Hardware replay soak entry criteria
+### Stage F – Hardware replay soak alignment
 
 Stage F promotions remain blocked until sandbox evidence and hardware access
-align. Use this checklist before attempting a Stage F soak handoff:
+align. Consult the [Stage F+ execution plan](stage_f_plus_plan.md#stagef--hardware-replay-soak-alignment)
+for the full set of goals, exit criteria, and evidence bundles that weekly
+reviews should rehearse. Each checkpoint below cites the consolidated
+[readiness ledger](readiness_ledger.md) and sandbox policy guardrails in
+[The Absolute Protocol](The_Absolute_Protocol.md#codex-sandbox-constraints) so
+contributors know which ledger rows and policy clauses to update when hardware
+access opens up.
+
+| Focus | Details |
+| --- | --- |
+| Goal | Coordinate a soak window that replays the Stage C readiness packet, Stage E transport traces, and Stage B rotation ledger on hardware without losing traceability to sandbox-only skips. |
+| Entry criteria | Readiness ledger rows for the Stage B rotation ledger, Stage C readiness packet, and Stage E parity traces are stitched together with owners and remediation notes; the gate-runner slot is booked in readiness minutes; automation hooks log sandbox policy references for every `environment-limited` skip. |
+| Exit criteria | Hardware replays export checksum-matched bundles tagged with their readiness ledger row IDs and explicitly cite The Absolute Protocol sandbox policy section for each retired skip. |
+| Required evidence | Gate-runner parity diffs, MCP handshake/heartbeat captures, Stage E dashboard hash confirmation, and signed readiness minutes linking back to ledger rows and sandbox policy citations. |
+| Responsible teams | @ops-team orchestrates hardware access, @neoabzu-core manages service parity, and @qa-alliance stitches the evidence across roadmap, PROJECT_STATUS, and the readiness ledger. |
+
+Use this checklist before attempting a Stage F soak handoff:
 
 | Entry requirement | Owner | Evidence bundle | Notes |
 | --- | --- | --- | --- |
@@ -208,7 +224,13 @@ Document Stage F readiness using the dedicated hardware replay plan so roadmap
 and PROJECT_STATUS stay synchronized on the sandbox inputs, scheduled hardware
 windows, and required Neo-APSU validations before the soak window opens.【F:docs/stage_f_hardware_replay_plan.md†L1-L73】
 
-### Stage G – Sandbox-to-hardware bridge validation
+### Stage G – Sandbox-to-hardware bridge validation
+
+Stage G extends the soak outputs recorded in the [Stage F+ execution plan](stage_f_plus_plan.md#stageg--sandbox-to-hardware-bridge-validation)
+and the readiness ledger by replaying sandbox parity bundles on hardware under
+the sandbox policy guardrails defined in [The Absolute Protocol](The_Absolute_Protocol.md#stage-gate-alignment).
+Reference the readiness ledger rows when updating rollback scripts or parity
+hashes so reviewers can map each hardware approval to the sandbox evidence trail.
 
 | Task | Owner | Hardware Validation Owner | Rollback Drill | Evidence Bundling |
 | --- | --- | --- | --- | --- |
@@ -216,7 +238,22 @@ windows, and required Neo-APSU validations before the soak window opens.【F:doc
 | **G2. Neo-APSU services parity** | @neoabzu-core | @neoabzu-core | `logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/rollback_drill.md` walks the control-plane/workspace rollback using `scripts/stage_b_smoke.py` against the Stage B rotation ledger before re-enabling hardware. | `logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/parity_diff.json` and `transport_contract.json` capture checksum matches, fallback events, and heartbeat recovery with signatures in `approvals.yaml`. |
 | **G3. Evidence bundle stitching** | @qa-alliance | @ops-team | Rollback confirmation references the operator console export and sandbox replay noted in the Stage A/C readiness bundles to ensure gate-runner and Neo-APSU drills fall back to sandbox telemetry without data loss. | `logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json` and `logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/summary.json` enumerate bundle hashes aligned with [The Absolute Protocol](The_Absolute_Protocol.md#stage-gate-alignment). |
 
-Stage G maps the sandbox-to-hardware bridge directives from The Absolute Protocol directly into the roadmap. Hardware rehearsals must cite the Stage C readiness minutes and bundle hashes, attach rollback transcripts, and archive approvals from the operator lead, hardware owner, and QA reviewer before promoting later bridges.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json†L1-L13】【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/approvals.yaml†L1-L12】【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/summary.json†L1-L13】【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/approvals.yaml†L1-L12】【F:docs/The_Absolute_Protocol.md†L54-L114】 Weekly reviews should confirm the `parity_diff.json` artifacts stay in sync with `logs/stage_c/20251001T010101Z-readiness_packet/` references and that rollback drills remain current before opening the production bridge window.
+Stage G maps the sandbox-to-hardware bridge directives from The Absolute Protocol directly into the roadmap. Hardware rehearsals must cite the Stage C readiness minutes and bundle hashes, attach rollback transcripts, reference the relevant readiness ledger rows, and archive approvals from the operator lead, hardware owner, and QA reviewer before promoting later bridges.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json†L1-L13】【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/approvals.yaml†L1-L12】【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/summary.json†L1-L13】【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/approvals.yaml†L1-L12】【F:docs/The_Absolute_Protocol.md†L54-L114】【F:docs/readiness_ledger.md†L9-L27】 Weekly reviews should confirm the `parity_diff.json` artifacts stay in sync with `logs/stage_c/20251001T010101Z-readiness_packet/` references and that rollback drills remain current before opening the production bridge window.
+
+### Stage H – Production adoption and LTS cutover
+
+Stage H closes out the Stage F+ plan with the GA bridge described in the
+[Stage F+ execution plan](stage_f_plus_plan.md#stageh--production-adoption-and-lts-cutover).
+Production adoption must maintain lineage to the readiness ledger and sandbox
+policy directives so future hardware reviews can replay the same evidence trail.
+
+| Focus | Details |
+| --- | --- |
+| Goal | Promote the GA cutover with verifiable lineage from Stage G approvals, readiness ledger closures, and sandbox policy compliance. |
+| Entry criteria | Stage G bridge report archived in the readiness ledger with sandbox deferrals resolved or migrated; incident response, rollback, and telemetry playbooks refreshed to cite The Absolute Protocol sandbox policy and bridge clauses. |
+| Exit criteria | GA readiness packet logs final hardware telemetry hashes alongside readiness ledger closure notes and sandbox policy references; LTS cadence documentation confirms future audits can replay retired sandbox skips. |
+| Required evidence | GA hardware cutover bundle, readiness ledger closure entries, LTS governance checklist with sandbox policy citations, and signed approvals from production, operations, and QA leads. |
+| Responsible teams | @release-ops leads GA governance, @operations-lead manages production telemetry, @qa-alliance maintains doctrine integrity, and @neoabzu-core stewards Neo-APSU services. |
 
 ## Maintenance
 

--- a/docs/stage_f_plus_plan.md
+++ b/docs/stage_f_plus_plan.md
@@ -1,0 +1,74 @@
+# Stage F+ Execution Plan
+
+_Updated: 2025-12-18_
+
+This plan expands the roadmap view for Stage F through Stage H so weekly reviews
+have a single reference for hardware adoption goals, exit criteria, and evidence
+handoffs. Every stage ties back to the [readiness ledger](readiness_ledger.md)
+and the sandbox policy in [The Absolute Protocol](The_Absolute_Protocol.md#codex-sandbox-constraints)
+to keep Codex-only skips visible until hardware replay closes the gaps.
+
+## Stage F – Hardware replay soak alignment
+
+- **Goals.** Deliver a coordinated soak window that replays the Stage C readiness
+  packet, Stage E transport traces, and Stage B rotation ledger on hardware while
+  documenting every sandbox-only deferral.
+- **Entry criteria.**
+  - Sandbox artifacts stitched together and cataloged in the readiness ledger
+    with owners and remediation notes.
+  - Gate-runner hardware slot booked and mirrored in the readiness minutes.
+  - Automation hooks upgraded to log sandbox policy references for each
+    `environment-limited` skip in accordance with The Absolute Protocol.
+- **Exit criteria.**
+  - Gate-runner replay exports checksum-matched bundles for the Stage C packet,
+    Stage B rotation ledger, and Stage E transport traces, each tagged with the
+    readiness ledger item that tracked the risk.
+  - All soak evidence references The Absolute Protocol sandbox policy section
+    plus the exact skip string being retired.
+- **Required evidence.** Gate-runner parity diffs, MCP handshake/heartbeat
+  captures, Stage E dashboard hash confirmation, and signed readiness minutes
+  linking back to the ledger rows.
+- **Responsible teams.** @ops-team (hardware orchestration), @neoabzu-core
+  (service parity), @qa-alliance (evidence stitching).
+
+## Stage G – Sandbox-to-hardware bridge validation
+
+- **Goals.** Validate that sandbox replay hashes, rollback drills, and parity
+  telemetry survive the hardware bridge while remaining traceable to the
+  readiness ledger and sandbox policy directives.
+- **Entry criteria.**
+  - Stage F soak summary logged in the readiness ledger with updated residual
+    risks and sandbox policy citations.
+  - Hardware bridge playbooks aligned with The Absolute Protocol
+    stage-alignment guidance and signed off in roadmap/PROJECT_STATUS updates.
+- **Exit criteria.**
+  - Gate-runner parity bundle and Neo-APSU parity bundle both capture approvals
+    tying hardware evidence to the ledger rows and sandbox policy references.
+  - Rollback drills execute without divergence and document how sandbox traces
+    are restored per The Absolute Protocol guidance.
+- **Required evidence.** Hardware parity diffs, rollback transcripts, updated
+  readiness ledger entries, and synchronized roadmap/status excerpts pointing to
+  sandbox policy clauses.
+- **Responsible teams.** @ops-team, @neoabzu-core, @qa-alliance, with @release-ops
+  confirming that readiness ledger hashes match the sandbox policy callouts.
+
+## Stage H – Production adoption and LTS cutover
+
+- **Goals.** Promote the GA cutover with verifiable lineage from Stage G
+  approvals, readiness ledger closures, and sandbox policy compliance.
+- **Entry criteria.**
+  - Stage G bridge report archived in the readiness ledger with all sandbox
+    deferrals marked resolved or migrated to GA tracking.
+  - Incident response, rollback, and telemetry playbooks refreshed to cite
+    The Absolute Protocol sandbox policy and bridge clauses.
+- **Exit criteria.**
+  - GA readiness packet logs final hardware telemetry hashes alongside the
+    readiness ledger closure notes and sandbox policy references.
+  - LTS cadence documentation confirms future hardware audits can replay the
+    retired sandbox skips using the readiness ledger history.
+- **Required evidence.** GA hardware cutover bundle, updated readiness ledger
+  closure entries, LTS governance checklist with sandbox policy citations, and
+  signed approvals from production, operations, and QA leads.
+- **Responsible teams.** @release-ops (GA governance), @operations-lead
+  (production telemetry), @qa-alliance (doctrine integrity), @neoabzu-core
+  (Neo-APSU stewardship).


### PR DESCRIPTION
## Summary
- add a dedicated Stage F+ execution plan that captures goals, entry/exit criteria, required evidence, and accountable teams for the hardware bridge
- expand the roadmap Stage F–H sections to reference the readiness ledger and sandbox policy while summarizing goals, evidence, and ownership
- add a Stage F+ status rollup to PROJECT_STATUS so weekly reviews stay aligned with the long-term hardware adoption plan

## Testing
- python -m pre_commit run --files docs/roadmap.md docs/PROJECT_STATUS.md docs/stage_f_plus_plan.md *(fails: No module named pre_commit)*
- python -m pre_commit run verify-onboarding-refs *(fails: No module named pre_commit)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc1e3c84c832e9aa410b177b57e52