### PR TITLE
Document Codex sandbox lessons and cross-link doctrine

### DIFF
--- a/docs/The_Absolute_Protocol.md
+++ b/docs/The_Absolute_Protocol.md
@@ -33,6 +33,11 @@ Codex-hosted rehearsals intentionally operate inside a constrained sandbox that 
 telemetry bridges, and production connector credentials. The guardrails below keep doctrine updates honest about what ran, what
 was deferred, and how migration evidence will be replayed on hardware.
 
+> [!INFO]
+> Review the consolidated lessons in [`docs/knowledge_base/codex_lessons.md`](knowledge_base/codex_lessons.md) before
+> scheduling work. The knowledge base captures failed sandbox attempts, workarounds, and policy rationale so contributors enter
+> reviews with the latest context.
+
 #### Deferred hardware tasks
 
 - **GPU rendering, DAW-integrated rehearsals, and FFmpeg-dependent exports** remain sandbox-only dry runs until the hardware

--- a/docs/knowledge_base/change_log.md
+++ b/docs/knowledge_base/change_log.md
@@ -1,0 +1,20 @@
+# Knowledge Base Change Log
+
+Use this ledger to append weekly summaries, decision records, and notable
+documentation updates. Each entry should:
+
+1. Reference the related pull request, readiness ledger row, or readiness packet
+   minutes so the origin of the change is traceable.
+2. State whether the work occurred inside the Codex sandbox or on hardware.
+3. Mirror the exact `environment-limited: <reason>` phrasing from tests or
+   readiness bundles when documenting deferred validations.
+
+| Date | Summary | Linked evidence |
+| --- | --- | --- |
+| 2025-12-05 | Seeded the knowledge base with Codex sandbox lessons and cross-links
+to roadmap, readiness ledger, and Absolute Protocol guidance. | PR TBD ·
+`logs/stage_c/20251205T193000Z-readiness_packet/` |
+
+> [!TIP]
+> New contributors should add a brief weekly note even when no changes land so
+> future agents can see which sandbox gaps or hardware follow-ups were reviewed.

--- a/docs/knowledge_base/codex_lessons.md
+++ b/docs/knowledge_base/codex_lessons.md
@@ -1,0 +1,71 @@
+# Codex Lessons
+
+The Codex sandbox forces contributors to operate with constrained tooling and
+hardware. This knowledge base entry captures the recurring limitations,
+experiments that failed inside the sandbox, the workarounds we rely on, and the
+policies that evolved from those lessons. Review this page alongside
+[`docs/documentation_protocol.md`](../documentation_protocol.md) and
+[`docs/The_Absolute_Protocol.md`](../The_Absolute_Protocol.md#codex-sandbox-constraints)
+before planning any new effort so the sandbox context is fully understood.
+
+## Sandbox limitations
+
+- **Hardware access gaps.** GPU acceleration, DAW plug-ins, FFmpeg, SoX, and the
+  extended Neo-APSU harness are unavailable. Tests that require these assets must
+  log the `environment-limited: <reason>` skip string and be scheduled for
+  hardware replay via the readiness ledger.
+- **Credentialed connectors.** Secrets needed for `/alpha/stage-b3-connector-rotation`
+  and MCP parity drills are blocked in Codex. Sandbox runs can only verify mocks
+  or dry-run scripts; production credentials stay quarantined until a gate-runner
+  slot opens.
+- **Packaging and coverage exports.** `python -m build`, `pytest-cov`, and
+  release packaging utilities are missing. The roadmap, readiness packet, and PR
+  summaries must note when automation phases are deferred for hardware replay.
+
+## Failed attempts logged in the sandbox
+
+| Attempt | Date | Outcome | Follow-up |
+| --- | --- | --- | --- |
+| Stage A automation replay | 2025-11-05 | `environment-limited: python -m build unavailable` halted the
+  packaging phase and prevented coverage exports. | Re-run on hardware during the
+  Stage D/E bridge slot with the tooling installed; attach updated bundles to the
+  readiness packet. |
+| Connector rotation rehearsal | 2025-12-05 | MCP gateway offline prevented credential refresh and
+  heartbeat capture. | Schedule the `/alpha/stage-b3-connector-rotation` command
+  on gate-runner-02 and archive refreshed handshake payloads. |
+| Demo telemetry capture | 2025-12-05 | Media export deferred because FFmpeg/SoX are blocked. | Log the
+  stub summary and replay the demo on hardware, capturing signed telemetry
+  bundles for doctrine. |
+
+## Workarounds and mitigations
+
+- **Documented stubs.** Every deferred bundle must include a stub summary inside
+  `logs/stage_c/` so auditors know which evidence is pending.
+- **Readiness ledger tracking.** Each sandbox skip is mirrored in
+  [`docs/readiness_ledger.md`](../readiness_ledger.md) with owner assignments and
+  replay targets so no deferral gets lost between reviews.
+- **Cross-team callouts.** Minutes in `logs/stage_c/20251205T193000Z-readiness_packet/`
+  list the gate-runner slots reserved for clearing sandbox gaps. Link these
+  minutes in change logs and doctrine updates to maintain visibility.
+
+## Policy rationale
+
+1. **Consistency for auditors.** Mirroring the `environment-limited` phrases in
+   documentation, readiness packets, and PRs ensures audits trace sandbox-only
+   runs without reinterpreting terminology.
+2. **Hardware replay lineage.** The Absolute Protocol requires every sandbox
+   deferral to point at an explicit hardware slot. Referencing the readiness
+   ledger keeps that lineage visible to stage owners.
+3. **Shared institutional memory.** Capturing lessons here reduces duplicate
+   debugging attempts and gives future agents immediate context before modifying
+   automation, connectors, or media tooling.
+
+## How to contribute updates
+
+- Append weekly summaries or decision records to
+  [`change_log.md`](change_log.md) with links to the related pull requests or
+  readiness ledger entries.
+- Reference this page whenever sandbox constraints influence planning,
+  documentation, or testing strategy.
+- When hardware replays resolve a limitation, update both this document and the
+  readiness ledger to retire outdated guidance.

--- a/docs/readiness_ledger.md
+++ b/docs/readiness_ledger.md
@@ -6,6 +6,11 @@ on 2025-12-05, and the accompanying demo telemetry stub. Use it alongside the
 Stage C review minutes when updating doctrine so sandbox deferrals stay aligned
 with the hardware replay queue.
 
+> [!INFO]
+> Before recording new ledger entries, review the sandbox history in
+> [`docs/knowledge_base/codex_lessons.md`](knowledge_base/codex_lessons.md). The knowledge base highlights known gaps,
+> failed attempts, and agreed workarounds so ledger updates inherit the full context.
+
 ## Artifact overview
 
 | Artifact | Path | Owner(s) | Sandbox caveat | Hardware follow-up |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,6 +23,11 @@ Bi-weekly working sessions align the charter backlog with the roadmap. Squad lea
 Roadmap updates must delineate what happened inside the Codex sandbox versus what still needs hardware so
 weekly reviews avoid chasing impossible tests:
 
+> [!INFO]
+> Consult the sandbox lessons captured in [`docs/knowledge_base/codex_lessons.md`](knowledge_base/codex_lessons.md) before
+> editing roadmap entries. The knowledge base records prior failures, deferred evidence, and approved workarounds so planning
+> notes stay aligned with Codex limitations.
+
 - **Sandbox-only tasks.** GPU renders, DAW-assisted rehearsals, FFmpeg exports, and Neo-APSU parity drills
   remain dry runs until the Stage D/E bridge backlog or the Stage G hardware window replays them on
   gate-runner hosts. Flag these items directly in the stage tables so owners inherit the constraint.


### PR DESCRIPTION
## Summary
- add a Codex sandbox lessons page under docs/knowledge_base with failures, workarounds, and policy rationale
- introduce a knowledge base change log encouraging decision records tied to pull requests or readiness entries
- cross-link the knowledge base from the Absolute Protocol, roadmap, and readiness ledger so reviewers pick up context first

## Testing
- `pre-commit run --files docs/knowledge_base/codex_lessons.md docs/knowledge_base/change_log.md docs/The_Absolute_Protocol.md docs/roadmap.md docs/readiness_ledger.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfce7476e0832eb1d6375a13dde1fd