### PR TITLE
Add Stage readiness walkthroughs and ledger links

### DIFF
--- a/docs/readiness_ledger.md
+++ b/docs/readiness_ledger.md
@@ -39,3 +39,18 @@ with the hardware replay queue.
    doctrine update, matching the documentation protocol requirements.
 3. Once hardware captures land, update the ledger with refreshed hashes and
    owners’ sign-offs before clearing risks from the roadmap or PROJECT_STATUS.
+
+## Walkthrough references
+
+Operators can follow the stage-specific walkthroughs for reproducible API
+invocations, evidence capture, and environment-limited note taking:
+
+- [Stage A Endpoint Walkthrough](walkthroughs/stage_a.md) — boot telemetry,
+  Crown replays, and gate shakeout instructions aligned with the Stage A
+  evidence bundles.
+- [Stage B Endpoint Walkthrough](walkthroughs/stage_b.md) — memory proof,
+  sonic rehearsal, and connector rotation guidance with sandbox stub
+  checkpoints.
+- [Stage C Endpoint Walkthrough](walkthroughs/stage_c.md) — exit checklist,
+  demo storyline, readiness sync, and MCP drill procedures tied to the Stage C
+  readiness packet.

--- a/docs/walkthroughs/stage_a.md
+++ b/docs/walkthroughs/stage_a.md
@@ -1,0 +1,59 @@
+# Stage A Endpoint Walkthrough
+
+## Overview
+
+Stage A validates the Alpha gate sweep through three operator API routes. Each POST endpoint wraps a stage script, stores artifacts under `logs/stage_a/`, and appends summaries to the readiness bundle via `_attach_summary_artifacts` so auditors can locate evidence quickly.【F:operator_api.py†L2768-L2812】 Cross-check every run against the [Readiness Ledger](../readiness_ledger.md) so sandbox deferrals stay aligned with the hardware replay queue.【F:docs/readiness_ledger.md†L1-L41】
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /alpha/stage-a1-boot-telemetry` | Runs `scripts/bootstrap.py` to capture boot telemetry with sandbox overrides and records output paths in the response payload.【F:operator_api.py†L2768-L2776】 |
+| `POST /alpha/stage-a2-crown-replays` | Executes `scripts/crown_capture_replays.py` to replay deterministic scenarios and attach evidence bundles.【F:operator_api.py†L2779-L2785】 |
+| `POST /alpha/stage-a3-gate-shakeout` | Launches `scripts/run_alpha_gate.sh --sandbox`, normalizes warning payloads, and publishes them as `sandbox_warnings` so downstream ledgers inherit the environment limits.【F:operator_api.py†L2788-L2812】 |
+
+## Before you run
+
+1. Start the FastAPI service locally: `uvicorn server:app --reload --port 8000`. The app wires in the operator router and OAuth2 token endpoint so the stage routes are available.【F:server.py†L256-L276】
+2. Request a bearer token by POSTing valid operator console credentials to `/token`; reuse the returned token for all stage calls.【F:server.py†L269-L276】
+3. Export `AUTH_HEADER="Authorization: Bearer <token>"` so every request records a trace entry and metrics sample.
+
+## Triggering the Stage A endpoints
+
+```bash
+# Stage A1 boot telemetry
+curl -X POST "http://localhost:8000/alpha/stage-a1-boot-telemetry" \
+  -H "${AUTH_HEADER}"
+
+# Stage A2 crown replays
+curl -X POST "http://localhost:8000/alpha/stage-a2-crown-replays" \
+  -H "${AUTH_HEADER}"
+
+# Stage A3 gate shakeout
+curl -X POST "http://localhost:8000/alpha/stage-a3-gate-shakeout" \
+  -H "${AUTH_HEADER}"
+```
+
+Successful responses include `status`, `summary`, and absolute artifact paths. Archive the JSON replies alongside `logs/stage_a/<run-id>/` so the readiness ledger can reference the exact bundle hashes.
+
+## Expected evidence
+
+After the sandbox sweep, confirm each summary file exists and logs the sandbox warning set instead of failing outright:
+
+- `logs/stage_a/20251105T170000Z-stage_a1_boot_telemetry/summary.json` — notes missing `python -m build`, Docker, SoX, FFmpeg, aria2c, and `pytest-cov`, while marking the run `environment-limited` rather than aborting.【F:logs/stage_a/latest/stage_a1_boot_telemetry-summary.json†L1-L29】
+- `logs/stage_a/20251105T171000Z-stage_a2_crown_replays/summary.json` — records deterministic replay outputs and lists audio tooling gaps as environment-limited warnings.【F:logs/stage_a/latest/stage_a2_crown_replays-summary.json†L1-L24】
+- `logs/stage_a/20251105T172000Z-stage_a3_gate_shakeout/summary.json` — captures skipped build/health/test phases with structured reasons so Stage C reviewers can mirror the same skip strings.【F:logs/stage_a/latest/stage_a3_gate_shakeout-summary.json†L1-L28】
+
+Attach these summaries to the readiness ledger entry for Stage A evidence and hyperlink the corresponding bundle ID when updating roadmap or status pages.【F:docs/readiness_ledger.md†L14-L41】
+
+## Recording environment-limited notes
+
+Use the exact `environment-limited: <reason>` phrasing from the summaries whenever you document the run. The documentation protocol requires quoting the skip reasons, referencing the readiness packet location, and tagging the supporting minutes so hardware owners inherit the same replay plan.【F:docs/documentation_protocol.md†L39-L68】 Add the note to the ledger item and to any doctrine update that references the Stage A sweep.
+
+## Troubleshooting & graceful degradation
+
+- **Missing tooling (python -m build, Docker, FFmpeg, SoX, aria2c, pytest-cov).** The stage scripts emit `environment-limited` warnings and continue; verify the summary files list each missing binary rather than failing the request.【F:logs/stage_a/latest/stage_a1_boot_telemetry-summary.json†L1-L29】【F:logs/stage_a/latest/stage_a3_gate_shakeout-summary.json†L1-L28】
+- **Multipart uploads disabled.** If `python-multipart` is absent, `_HAS_MULTIPART` is set to `False`, but Stage A endpoints remain available because they do not rely on file uploads.【F:operator_api.py†L39-L77】 Keep the warning in the environment-limited notes and proceed.
+- **Metrics backend offline.** When OpenTelemetry metrics are unavailable, the router falls back to `None` counters and still serves the stage routes, so runs record successfully albeit without latency histograms.【F:operator_api.py†L46-L132】 Document the lack of metrics as an environment-limited observation if you depend on stage latency dashboards.
+
+## Readiness ledger linkage
+
+After each run, append the JSON response and artifact hash to the Stage A section of the readiness ledger so hardware reviewers can reconcile sandbox skips with the pending gate-runner replay.【F:docs/readiness_ledger.md†L14-L41】 Include the run ID and environment-limited reason in the ledger note to maintain parity with the readiness packet.【F:docs/documentation_protocol.md†L39-L68】

--- a/docs/walkthroughs/stage_b.md
+++ b/docs/walkthroughs/stage_b.md
@@ -1,0 +1,57 @@
+# Stage B Endpoint Walkthrough
+
+## Overview
+
+Stage B endpoints exercise memory load, sonic rehearsal, and connector rotation evidence. Each POST route orchestrates a script, extracts metrics, and enforces HTTP 500 responses only when the script fails; sandbox stubs instead surface `environment-limited` warnings so runs degrade gracefully.【F:operator_api.py†L2815-L2879】 Sync every invocation with the [Readiness Ledger](../readiness_ledger.md) to keep the Stage B rotation ledger and rehearsal packets traceable for hardware follow-up.【F:docs/readiness_ledger.md†L14-L32】
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /alpha/stage-b1-memory-proof` | Runs `scripts/memory_load_proof.py` against `data/vector_memory_scaling/corpus.jsonl`, attaching latency metrics and stub reasons if Neo-APSU bundles are offline.【F:operator_api.py†L2815-L2838】 |
+| `POST /alpha/stage-b2-sonic-rehearsal` | Generates `stage_b_rehearsal_packet.json` with connector capability and dropout data for the rehearsal context.【F:operator_api.py†L2841-L2861】 |
+| `POST /alpha/stage-b3-connector-rotation` | Executes `scripts/stage_b_smoke.py --json`, capturing rotation ledger snapshots plus REST↔gRPC parity traces.【F:operator_api.py†L2864-L2882】 |
+
+## Pre-flight checklist
+
+1. Ensure Stage A summaries referenced by the readiness aggregate exist so Stage B runs can link to the most recent Stage A evidence when aggregated later.【F:operator_api.py†L1084-L1176】
+2. Start the FastAPI service and obtain a bearer token as described in the Stage A walkthrough; Stage B routes share the same authentication model.【F:server.py†L256-L276】
+3. Export `AUTH_HEADER` and confirm `data/vector_memory_scaling/corpus.jsonl` is present; otherwise the memory proof will fail before the sandbox stubs can engage.
+
+## Triggering the Stage B endpoints
+
+```bash
+# Memory proof
+curl -X POST "http://localhost:8000/alpha/stage-b1-memory-proof" \
+  -H "${AUTH_HEADER}"
+
+# Sonic rehearsal packet
+curl -X POST "http://localhost:8000/alpha/stage-b2-sonic-rehearsal" \
+  -H "${AUTH_HEADER}"
+
+# Connector rotation drill
+curl -X POST "http://localhost:8000/alpha/stage-b3-connector-rotation" \
+  -H "${AUTH_HEADER}"
+```
+
+Archive each JSON response next to the corresponding `logs/stage_b/<run-id>/` directory so readiness reviews can cross-check metrics, rotation snapshots, and parity traces.
+
+## Expected evidence
+
+- `logs/stage_b/20251205T142355Z-stage_b1_memory_proof/summary.json` — confirms success while flagging the Neo-APSU bundle stub and sandbox overrides, including latency percentiles and fallback reasons.【F:logs/stage_b/20251205T142355Z-stage_b1_memory_proof/summary.json†L1-L63】
+- `logs/stage_b/20251001T214349Z-stage_b2_sonic_rehearsal/summary.json` — points to the generated rehearsal packet and captures connector capability metadata with zero dropouts.【F:logs/stage_b/20251001T214349Z-stage_b2_sonic_rehearsal/summary.json†L1-L45】
+- `logs/stage_b/20251001T080910Z-stage_b3_connector_rotation/summary.json` — records REST and gRPC handshake traces, rotation window metadata, and sandbox stub warnings for missing Neo-APSU services.【F:logs/stage_b/20251001T080910Z-stage_b3_connector_rotation/summary.json†L1-L75】
+
+Link these paths when updating the ledger’s Stage B rotation entry so reviewers can reconcile sandbox warnings with the pending hardware replay schedule.【F:docs/readiness_ledger.md†L14-L32】
+
+## Recording environment-limited notes
+
+Mirror the environment-limited wording from the summaries (e.g., `neoabzu_memory: optional bundle shim activated`, `MCP gateway offline`) in both the readiness ledger and doctrine updates. The documentation protocol mandates quoting the skip strings, citing the readiness packet (`logs/stage_c/20251205T193000Z-readiness_packet/`), and referencing the review minutes that plan the hardware rerun.【F:docs/documentation_protocol.md†L39-L68】【F:logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md†L1-L33】
+
+## Troubleshooting & graceful degradation
+
+- **Neo-APSU bundle unavailable.** The memory proof summary sets `stubbed_bundle` and `runtime_stubbed` to `true` while still returning HTTP 200; surface this as an environment-limited note rather than treating it as a failure.【F:logs/stage_b/20251205T142355Z-stage_b1_memory_proof/summary.json†L20-L63】
+- **Connector rotation without MCP gateway.** When rotation evidence relies on Stage C MCP artifacts, the summary still records normalized traces but references sandbox handshake placeholders; document the missing handshake in the ledger and in readiness notes instead of rerunning in the sandbox.【F:logs/stage_b/20251001T080910Z-stage_b3_connector_rotation/summary.json†L47-L75】【F:logs/stage_c/20251205T193000Z-readiness_packet/mcp_artifacts/handshake.json†L1-L12】
+- **Optional telemetry tooling missing.** If OpenTelemetry metrics are disabled, Stage B routes proceed because counters default to `None`; capture the absence of histograms as an environment-limited observation if latency dashboards are required.【F:operator_api.py†L46-L132】
+
+## Readiness ledger linkage
+
+Update the Stage B rows in the readiness ledger with run IDs, artifact paths, and environment-limited reasons immediately after execution. Include references to the rehearsal packet and rotation drills so the hardware replay window documented in the review minutes can reconcile sandbox stubs with upcoming evidence updates.【F:docs/readiness_ledger.md†L14-L32】【F:logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md†L1-L24】

--- a/docs/walkthroughs/stage_c.md
+++ b/docs/walkthroughs/stage_c.md
@@ -1,0 +1,59 @@
+# Stage C Endpoint Walkthrough
+
+## Overview
+
+Stage C routes assemble exit checklist evidence, demo telemetry, and MCP parity artifacts ahead of the readiness review. The operator API wraps dedicated scripts, writes outputs under `logs/stage_c/`, and defers to graceful fallbacks when sandbox prerequisites are missing so reviewers still receive structured summaries.【F:operator_api.py†L2948-L3031】【F:operator_api.py†L2902-L2935】 Always reconcile results with the [Readiness Ledger](../readiness_ledger.md), which tracks the Stage C bundle, demo stub, and pending hardware follow-ups.【F:docs/readiness_ledger.md†L14-L29】
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /alpha/stage-c1-exit-checklist` | Runs `validate_absolute_protocol_checklist.py` and returns checklist status, emitting HTTP 400 only when explicit failures are logged.【F:operator_api.py†L2948-L2971】 |
+| `POST /alpha/stage-c2-demo-storyline` | Invokes the scripted demo harness to capture telemetry, storing assets under `stage_c2_demo_storyline/` inside the run directory.【F:operator_api.py†L2974-L2990】 |
+| `POST /alpha/stage-c3-readiness-sync` | Aggregates Stage A/B artifacts into a merged readiness snapshot, writing fallback JSON if aggregation fails so the call still completes.【F:operator_api.py†L2902-L2935】【F:operator_api.py†L2993-L3008】 |
+| `POST /alpha/stage-c4-operator-mcp-drill` | Exercises the MCP adapter, attaches REST↔gRPC parity data on success, and reports environment-limited errors if credentials are absent.【F:operator_api.py†L3011-L3029】 |
+
+## Pre-flight checklist
+
+1. Verify the latest Stage A and Stage B summaries exist before running the readiness sync so aggregation can attach accurate slugs and artifacts.【F:operator_api.py†L1084-L1176】
+2. Launch the FastAPI service and obtain a bearer token per the Stage A walkthrough.【F:server.py†L256-L276】
+3. Ensure `logs/stage_c/20251205T193000Z-readiness_packet/` is mounted or writable so new runs can be compared with the existing readiness bundle and review schedule.【F:logs/stage_c/20251205T193000Z-readiness_packet/readiness_bundle.json†L1-L37】
+
+## Triggering the Stage C endpoints
+
+```bash
+curl -X POST "http://localhost:8000/alpha/stage-c1-exit-checklist" \
+  -H "${AUTH_HEADER}"
+
+curl -X POST "http://localhost:8000/alpha/stage-c2-demo-storyline" \
+  -H "${AUTH_HEADER}"
+
+curl -X POST "http://localhost:8000/alpha/stage-c3-readiness-sync" \
+  -H "${AUTH_HEADER}"
+
+curl -X POST "http://localhost:8000/alpha/stage-c4-operator-mcp-drill" \
+  -H "${AUTH_HEADER}"
+```
+
+Capture each JSON response together with the generated directories so the readiness ledger and review minutes can confirm bundle contents.
+
+## Expected evidence
+
+- `logs/stage_c/20251205T193000Z-readiness_packet/readiness_bundle.json` — documents sandbox-only MCP artifacts, demo telemetry stub, and missing rotation drills marked as environment-limited.【F:logs/stage_c/20251205T193000Z-readiness_packet/readiness_bundle.json†L1-L37】
+- `logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md` — records the 2025-12-08 review decisions and the scheduled 2025-12-12 hardware replay window.【F:logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md†L1-L33】
+- `logs/stage_c/20251205T193000Z-readiness_packet/mcp_artifacts/handshake.json` — shows `status: not-captured` with an `environment_limited` reason, signalling that the sandbox run succeeded without live credentials.【F:logs/stage_c/20251205T193000Z-readiness_packet/mcp_artifacts/handshake.json†L1-L12】
+- `logs/stage_c/20251205T193000Z-readiness_packet/demo_telemetry/summary.json` — tracks the demo telemetry stub awaiting hardware replay.【F:logs/stage_c/20251205T193000Z-readiness_packet/demo_telemetry/summary.json†L1-L4】
+
+Reference these artifacts in the readiness ledger so reviewers can reconcile sandbox stubs with the planned gate-runner replay.【F:docs/readiness_ledger.md†L14-L29】
+
+## Recording environment-limited notes
+
+Follow the documentation protocol by quoting the exact `environment-limited` strings from the readiness bundle and minutes, citing the bundle directory, and tagging the hardware replay schedule in every doctrine update.【F:docs/documentation_protocol.md†L39-L68】【F:logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md†L1-L24】 Note that Stage C runs should inherit Stage A/B skip strings, so include those references when updating roadmap or PROJECT_STATUS entries.
+
+## Troubleshooting & graceful degradation
+
+- **Aggregation failures.** If `_stage_c3_command` encounters an error, the fallback writer creates an error summary that still completes the request. Inspect the generated JSON for `status: error` and document it as environment-limited while scheduling a rerun after the blocking dependency is restored.【F:operator_api.py†L2902-L2935】
+- **Missing MCP credentials.** Stage C4 surfaces a sandbox failure message and marks the handshake JSON as not captured; treat this as environment-limited evidence and coordinate with the hardware replay window instead of retrying in the sandbox.【F:operator_api.py†L3011-L3029】【F:logs/stage_c/20251205T193000Z-readiness_packet/mcp_artifacts/handshake.json†L1-L12】
+- **Telemetry tooling unavailable.** Even without OpenTelemetry metrics, the router sets counters to `None` and the endpoints continue to run. Note the missing histograms in your environment-limited log so dashboards can be reconciled later.【F:operator_api.py†L46-L132】
+
+## Readiness ledger linkage
+
+Update the Stage C entries in the readiness ledger with run IDs, bundle paths, and environment-limited reasons immediately after each call. Include links to the review minutes and scheduled hardware replay date so auditors can cross-reference the sandbox evidence with forthcoming hardware captures.【F:docs/readiness_ledger.md†L14-L29】【F:logs/stage_c/20251205T193000Z-readiness_packet/review_minutes.md†L1-L33】


### PR DESCRIPTION
## Summary
- document Stage A, Stage B, and Stage C operator endpoints with walkthroughs that cover triggering steps, expected evidence, environment-limited notes, and troubleshooting guidance
- link the readiness ledger to the new walkthroughs so operators can cross-check sandbox artifacts from a single index

## Testing
- pre-commit run --files docs/walkthroughs/stage_a.md docs/walkthroughs/stage_b.md docs/walkthroughs/stage_c.md docs/readiness_ledger.md *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e034ba787c832ebf5fc2c333cef5bd