### PR TITLE
Document Stage F hardware replay execution

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -555,6 +555,9 @@ Use `python scripts/verify_doctrine_refs.py` to validate doctrine references.
 | [voice_aura.md](voice_aura.md) | Voice Aura FX | `audio/voice_aura.py` applies subtle reverb and delay based on the current emotion. Each emotion maps to a simple pre... | - |
 | [voice_cloner.md](voice_cloner.md) | Voice Cloner | The `VoiceCloner` utility records a short sample of a speaker and synthesises new speech in the captured voice. It ex... | - |
 | [voice_setup.md](voice_setup.md) | Voice Model Setup | This guide explains how to install external text-to-speech models so ABZU can produce spoken output. | - |
+| [walkthroughs/stage_a.md](walkthroughs/stage_a.md) | Stage A Endpoint Walkthrough | - | - |
+| [walkthroughs/stage_b.md](walkthroughs/stage_b.md) | Stage B Endpoint Walkthrough | - | - |
+| [walkthroughs/stage_c.md](walkthroughs/stage_c.md) | Stage C Endpoint Walkthrough | - | - |
 | [world_bootstrap.md](world_bootstrap.md) | World Bootstrap | Guidelines for seeding and cloning world configurations. | - |
 | [../floor_client/README.md](../floor_client/README.md) | Floor Client | This folder contains the React interface for Floor channels. | - |
 | [../guides/visual_customization.md](../guides/visual_customization.md) | Avatar Visual Customization | This guide outlines how to turn a 2D concept image into the 3D model used by the video engine. | - |

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -247,7 +247,7 @@ with the [readiness ledger](readiness_ledger.md) and sandbox policy rules in
 
 | Stage | Status summary | Upcoming evidence | Responsible teams |
 | --- | --- | --- | --- |
-| Stage F – Hardware replay soak alignment | Waiting on gate-runner access; readiness ledger rows for Stage B rotation, Stage C readiness bundle, and Stage E transport traces stitched together with sandbox policy references for each deferred skip.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L11-L40】【F:docs/readiness_ledger.md†L9-L27】 | Gate-runner parity diffs, MCP handshake refresh, and Stage E dashboard hash confirmation recorded with sandbox policy citations once hardware replay executes.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L31-L40】 | @ops-team, @neoabzu-core, @qa-alliance |
+| Stage F – Hardware replay soak alignment | Waiting on gate-runner access; readiness ledger rows for Stage B rotation, Stage C readiness bundle, and Stage E transport traces stitched together with sandbox policy references for each deferred skip while the Stage F hardware replay plan governs entry work.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L11-L40】【F:docs/stage_f_hardware_replay_plan.md†L1-L162】【F:docs/readiness_ledger.md†L9-L27】 | Gate-runner parity diffs, MCP handshake refresh, and Stage E dashboard hash confirmation recorded with sandbox policy citations once hardware replay executes per the Stage F hardware replay plan.【F:docs/roadmap.md†L209-L247】【F:docs/stage_f_plus_plan.md†L31-L40】【F:docs/stage_f_hardware_replay_plan.md†L74-L162】 | @ops-team, @neoabzu-core, @qa-alliance |
 | Stage G – Sandbox-to-hardware bridge validation | Bridge scripts prepped; readiness ledger rows linked to rollback drills and parity bundles per sandbox policy guardrails while awaiting hardware slot execution.【F:docs/roadmap.md†L248-L273】【F:docs/stage_f_plus_plan.md†L42-L64】【F:docs/readiness_ledger.md†L9-L27】 | Stage G hardware parity diffs and rollback transcripts signed with readiness ledger IDs and sandbox policy references.【F:docs/roadmap.md†L248-L273】【F:docs/stage_f_plus_plan.md†L55-L64】 | @ops-team, @neoabzu-core, @qa-alliance, @release-ops |
 | Stage H – Production adoption & LTS cutover | GA cutover prep anchored to Stage G approvals; readiness ledger closures drafted with sandbox policy callouts awaiting final hardware telemetry and governance signatures.【F:docs/roadmap.md†L274-L299】【F:docs/stage_f_plus_plan.md†L66-L94】【F:docs/readiness_ledger.md†L9-L27】 | GA hardware cutover bundle, readiness ledger closure notes, and LTS governance checklist citing The Absolute Protocol sandbox policy.【F:docs/roadmap.md†L274-L299】【F:docs/stage_f_plus_plan.md†L74-L94】 | @release-ops, @operations-lead, @qa-alliance, @neoabzu-core |
 
@@ -290,13 +290,16 @@ with the [readiness ledger](readiness_ledger.md) and sandbox policy rules in
 ### Stage F soak entry controls
 
 Stage F entry requires both the sandbox evidence bundle and a confirmed
-hardware schedule to prevent promotions without live replay coverage:
+hardware schedule to prevent promotions without live replay coverage.
+Follow the [Stage F hardware replay plan](stage_f_hardware_replay_plan.md)
+before approving the soak handoff so operators, QA, and Neo-APSU owners
+execute the same checklist and evidence capture cadence.【F:docs/stage_f_hardware_replay_plan.md†L74-L162】
 
 | Control | Owner | Evidence | Status |
 | --- | --- | --- | --- |
 | Sandbox bundle attached to Stage F ticket | @qa-alliance | `logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json`, `logs/stage_b_rotation_drills.jsonl`, `logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json` | ⚠️ Environment-limited – bundle assembled but awaiting hardware execution.【F:logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json†L1-L210】【F:logs/stage_b_rotation_drills.jsonl†L12-L115】【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L1-L142】 |
 | Gate-runner window confirmed in readiness minutes | @ops-team | `logs/stage_c/20250930T210000Z-stage_c1_exit_checklist/summary.json`, `logs/stage_c/20251001T010101Z-readiness_packet/review_minutes.md` | ✅ Scheduled – window reserved for Stage F hardware replay per Absolute Protocol bridge rules.【F:logs/stage_c/20250930T210000Z-stage_c1_exit_checklist/summary.json†L1-L33】【F:logs/stage_c/20251001T010101Z-readiness_packet/review_minutes.md†L14-L44】【F:docs/The_Absolute_Protocol.md†L54-L114】 |
-| Automation hook aligned with hardware plan | @neoabzu-core | `scripts/run_stage_f_replay.py`, `docs/stage_f_hardware_replay_plan.md` | ⚠️ Environment-limited – script currently emits placeholder notice pending hardware access.【F:scripts/run_stage_f_replay.py†L1-L36】【F:docs/stage_f_hardware_replay_plan.md†L1-L73】 |
+| Automation hook aligned with hardware plan | @neoabzu-core | `scripts/run_stage_f_replay.py`, `docs/stage_f_hardware_replay_plan.md` | ⚠️ Environment-limited – script currently emits placeholder notice pending hardware access.【F:scripts/run_stage_f_replay.py†L1-L36】【F:docs/stage_f_hardware_replay_plan.md†L1-L162】 |
 
 ### Stage G
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -201,7 +201,8 @@ Stage E extends the Stage C transport pilot: contract tests and dashboards n
 ### Stage F – Hardware replay soak alignment
 
 Stage F promotions remain blocked until sandbox evidence and hardware access
-align. Consult the [Stage F+ execution plan](stage_f_plus_plan.md#stagef--hardware-replay-soak-alignment)
+align. Use the [Stage F hardware replay plan](stage_f_hardware_replay_plan.md)
+as the authoritative entry playbook, and consult the [Stage F+ execution plan](stage_f_plus_plan.md#stagef--hardware-replay-soak-alignment)
 for the full set of goals, exit criteria, and evidence bundles that weekly
 reviews should rehearse. Each checkpoint below cites the consolidated
 [readiness ledger](readiness_ledger.md) and sandbox policy guardrails in
@@ -227,7 +228,7 @@ Use this checklist before attempting a Stage F soak handoff:
 
 Document Stage F readiness using the dedicated hardware replay plan so roadmap
 and PROJECT_STATUS stay synchronized on the sandbox inputs, scheduled hardware
-windows, and required Neo-APSU validations before the soak window opens.【F:docs/stage_f_hardware_replay_plan.md†L1-L73】
+windows, and required Neo-APSU validations before the soak window opens.【F:docs/stage_f_hardware_replay_plan.md†L1-L162】
 
 ### Stage G – Sandbox-to-hardware bridge validation
 

--- a/docs/stage_f_hardware_replay_plan.md
+++ b/docs/stage_f_hardware_replay_plan.md
@@ -37,31 +37,95 @@ capture matching hashes, rollback transcripts, and approvals:
   documented during Stage C readiness with live sensor metrics captured during
   the replay window.【F:docs/roadmap.md†L170-L182】【F:logs/stage_c/20251031T000000Z-test/summary.json†L1-L50】
 
-## Prerequisites
+## Tooling prerequisites
 
-- **Toolchains.** Gate-runner hosts must expose the Rust toolchain, Python
-  bridge utilities, and build prerequisites enumerated in the Neo-APSU
-  onboarding guide so hardware parity binaries match the sandbox builds.【F:NEOABZU/docs/onboarding.md†L1-L36】
+- **Compiler and bridge parity.** Gate-runner hosts must expose the Rust
+  toolchain, Python bridge utilities, and build prerequisites enumerated in the
+  Neo-APSU onboarding guide so hardware parity binaries match the sandbox
+  builds.【F:NEOABZU/docs/onboarding.md†L1-L36】
+- **Blueprint host services.** Provision telemetry exporters, MCP heartbeat
+  relays, and the Grafana snapshot pipeline described in the system blueprint so
+  hardware captures mirror sandbox instrumentation when the replay executes.【F:docs/system_blueprint.md†L612-L667】
+- **Audio/connector dependencies.** Install FFmpeg, SoX, aria2c, DAW plug-ins,
+  and pytest coverage tooling flagged as environment-limited during sandbox
+  rehearsals so the hardware run clears every deferred warning before
+  sign-off.【F:docs/documentation_protocol.md†L31-L52】【F:logs/stage_a/20251105T172000Z-stage_a3_gate_shakeout/summary.json†L1-L53】【F:logs/stage_b/20251205T142355Z-stage_b1_memory_proof/summary.json†L1-L63】
+
+## Dataset and evidence requirements
+
 - **Sandbox evidence bundles.** Stage F runs start from the merged Stage C
   readiness bundle, Stage B rotation ledger, and Stage E transport readiness
   snapshot so every hardware replay references canonical sandbox artifacts and
   credential windows.【F:logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json†L1-L210】【F:logs/stage_b_rotation_drills.jsonl†L12-L115】【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L1-L142】
-- **Scheduled hardware windows.** Reserve gate-runner execution slots aligned
-  to the Stage C exit checklist and readiness minutes so the sandbox-to-hardware
-  bridge meets The Absolute Protocol handoff requirements.【F:logs/stage_c/20250930T210000Z-stage_c1_exit_checklist/summary.json†L1-L33】【F:docs/The_Absolute_Protocol.md†L54-L114】
+- **MCP handshake lineage.** Attach the handshake payloads and readiness
+  minutes from the Stage C packet so hardware reviewers can trace queue
+  ownership and confirm the replay window matches the recorded approvals.【F:logs/stage_c/20251001T010101Z-readiness_packet/mcp_drill/index.json†L1-L11】【F:logs/stage_c/20251001T010101Z-readiness_packet/review_minutes.md†L14-L44】
+- **Neo-APSU module baselines.** Archive the most recent Neo-APSU servant
+  telemetry exports and route inevitability transcripts referenced by the Stage F
+  module list so comparisons on hardware are hash-aligned.【F:logs/stage_c/20251031T000000Z-test/summary.json†L1-L50】【F:logs/stage_c/20251001T010101Z-readiness_packet/checklist_logs/README.md†L1-L16】
 
-## Sandbox-to-hardware transition
+## Scheduled hardware window
 
-1. **Assemble sandbox evidence.** Package the latest Stage C readiness bundle,
-   Stage B rotation ledger, and Stage E transport summaries into the Stage F
-   submission so reviewers can confirm parity inputs before hardware replay.【F:logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json†L1-L210】【F:logs/stage_b_rotation_drills.jsonl†L12-L115】【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L1-L142】
-2. **Execute hardware replay.** Run the Stage F automation hook on the
-   scheduled gate-runner window to stream parity traces, rollback drills, and
-   telemetry snapshots into the Stage F evidence bundle while tagging sandbox
-   limitations as `environment-limited` where dependencies remain deferred.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json†L1-L13】【F:docs/documentation_protocol.md†L21-L49】
-3. **Record approvals.** File sign-offs from the operator lead, hardware owner,
+Reserve gate-runner execution slots aligned to the Stage C exit checklist and
+readiness minutes so the sandbox-to-hardware bridge meets The Absolute
+Protocol handoff requirements.【F:logs/stage_c/20250930T210000Z-stage_c1_exit_checklist/summary.json†L1-L33】【F:docs/The_Absolute_Protocol.md†L54-L114】 Document the reservation ID and
+ops contact in the Stage F ticket before staging artifacts on hardware.
+
+## Sandbox-to-hardware replay sequence
+
+1. **Stage sandbox artifacts.** Package the Stage C readiness bundle, Stage B
+   rotation ledger, Stage E transport summaries, and the MCP handshake payloads
+   into the Stage F submission so reviewers can confirm parity inputs before
+   hardware replay.【F:logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json†L1-L210】【F:logs/stage_b_rotation_drills.jsonl†L12-L115】【F:logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json†L1-L142】【F:logs/stage_c/20251001T010101Z-readiness_packet/mcp_drill/index.json†L1-L11】
+2. **Validate tooling parity.** Confirm required toolchains, connectors, and
+   telemetry exporters on the gate-runner host using the blueprint checklist
+   before invoking the replay hook; log any deltas as
+   `environment-limited: <reason>` in the Stage F packet and roadmap callouts.【F:docs/system_blueprint.md†L612-L667】【F:docs/documentation_protocol.md†L45-L70】
+3. **Execute automation hook.** Run the Stage F automation on the reserved
+   hardware window to stream parity traces, rollback drills, and telemetry
+   snapshots into the Stage F evidence bundle while mirroring sandbox tagging
+   for any deferred dependencies.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/summary.json†L1-L13】【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/approvals.yaml†L1-L12】
+4. **Capture evidence snapshots.** Export Grafana dashboards, MCP heartbeat
+   diffs, and Neo-APSU servant telemetry from the hardware run and attach them
+   alongside the sandbox bundle to keep the lineage verifiable.【F:docs/system_blueprint.md†L612-L667】【F:logs/stage_c/20251001T010101Z-readiness_packet/checklist_logs/README.md†L1-L16】
+5. **Record approvals.** File sign-offs from the operator lead, hardware owner,
    and QA reviewer using the same checklist cadence established during the
    Stage G bridge so parity lineage remains traceable through GA.【F:logs/stage_g/20251102T090000Z-stage_g_gate_runner_hardware/approvals.yaml†L1-L12】【F:logs/stage_g/20251102T094500Z-stage_g_neo_apsu_parity/approvals.yaml†L1-L12】
+
+## Role sign-off checklists
+
+Each role completes the checklist below, attaches the required snapshots to the
+Stage F evidence bundle, and signs the acknowledgement line.
+
+### Operator lead checklist
+
+| Item | Required evidence snapshot | Status |
+| --- | --- | --- |
+| ✅ Sandbox bundle staged with Stage B/Stage C/Stage E artifacts | `logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json`, `logs/stage_b_rotation_drills.jsonl`, `logs/stage_e/20250930T121727Z-stage_e_transport_readiness/summary.json` | [ ] Complete |
+| ✅ Gate-runner automation hook dry-run executed | Stage F evidence bundle `operator_hook.md` with console capture, linked to Stage C readiness checklist summary | [ ] Complete |
+| ✅ Grafana dashboard export queued for hardware replay | Stage F evidence bundle `grafana_snapshot.png` covering panels defined in Stage C readiness checklist | [ ] Complete |
+
+- **Operator lead signature:** ____________________ **Date:** __________
+
+### QA reviewer checklist
+
+| Item | Required evidence snapshot | Status |
+| --- | --- | --- |
+| ✅ Hash comparison between sandbox and hardware bundles archived | Stage F evidence bundle `hash_report.json`, sandbox baseline manifests | [ ] Complete |
+| ✅ MCP heartbeat replay verified | `logs/stage_c/20251001T010101Z-readiness_packet/mcp_drill/index.json` baselines + hardware capture `mcp_heartbeat.json` | [ ] Complete |
+| ✅ Environment-limited skips mirrored in roadmap and ticket notes | Roadmap Stage F callout diff, `docs/documentation_protocol.md` citation excerpt | [ ] Complete |
+
+- **QA reviewer signature:** ____________________ **Date:** __________
+
+### Neo-APSU owner checklist
+
+| Item | Required evidence snapshot | Status |
+| --- | --- | --- |
+| ✅ Neo-APSU servant telemetry replayed with matching hashes | Stage F telemetry export `neoapsu_servant_hardware.csv`, sandbox baseline `logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json` sections | [ ] Complete |
+| ✅ Route inevitability traces aligned with sandbox transcripts | Hardware `route_inevitability.log`, sandbox `logs/stage_c/20251001T010101Z-readiness_packet/readiness_bundle/readiness_bundle.json` sections | [ ] Complete |
+| ✅ Approvals bundle signed and archived | Stage F approvals packet `approvals.yaml`, Stage G bridge approvals reference | [ ] Complete |
+
+- **Neo-APSU owner signature:** ____________________ **Date:** __________
 
 Stage F promotion is blocked until the hardware replay reproduces the sandbox
 hashes for every Neo-APSU module above and captures the signed approvals bundle


### PR DESCRIPTION
## Summary
- expand the Stage F hardware replay plan with tooling prerequisites, required evidence bundles, the replay sequence, and role-specific sign-off checklists
- update roadmap and project status Stage F entries to point to the hardware replay plan as the authoritative entry guide and to align soak controls
- regenerate the documentation index after updating Stage F doctrine references

## Testing
- pre-commit run --files docs/stage_f_hardware_replay_plan.md docs/roadmap.md docs/PROJECT_STATUS.md *(fails: missing prometheus_client/websockets, pytest-cov argument mismatch, doctrine verification prerequisites in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e037080e7c832eb3b28966ca0f0d31