### PR TITLE
Add quarterly Codex lessons review workflow

### DIFF
--- a/docs/knowledge_base/codex_lessons.md
+++ b/docs/knowledge_base/codex_lessons.md
@@ -62,6 +62,17 @@ fully understood.【F:docs/glossary/neo_apsu_terms.md†L1-L55】
    debugging attempts and gives future agents immediate context before modifying
    automation, connectors, or media tooling.
 
+## Review summaries
+
+Document each quarterly review using the checklist in
+[`review_checklist.md`](review_checklist.md). Capture the date, facilitators,
+key takeaways, and any roadmap or doctrine updates triggered by new insights so
+future planning sessions inherit the latest context.
+
+| Date | Facilitator(s) | Key takeaways | Roadmap/doctrine updates |
+| --- | --- | --- | --- |
+| _TBD_ | _TBD_ | _Populate after the first quarterly review._ | _List follow-up updates and owners._ |
+
 ## How to contribute updates
 
 - Append weekly summaries or decision records to

--- a/docs/knowledge_base/review_checklist.md
+++ b/docs/knowledge_base/review_checklist.md
@@ -1,0 +1,20 @@
+# Quarterly Lessons Review Checklist
+
+The Codex knowledge base review happens once per quarter to capture the latest sandbox lessons and align roadmap decisions with new evidence.
+
+## Pre-review preparation
+- **Collect new lessons:** Gather additions for [`codex_lessons.md`](codex_lessons.md) from readiness minutes, roadmap updates, and sandbox run logs.
+- **Update source material:** Ensure `change_log.md` entries reference the relevant pull requests or readiness ledger updates that triggered new lessons.
+- **Draft evidence bundle:** Compile links to supporting artifacts (logs, dashboards, doctrine updates) so reviewers can verify each proposed lesson.
+
+## Meeting flow
+1. **Confirm objectives:** Restate the review goal—updating Codex lessons, identifying roadmap impacts, and tracking doctrine changes.
+2. **Walk recent lessons:** Present each new lesson with its source evidence and proposed knowledge base edits.
+3. **Assess roadmap impact:** Note any execution ladder, roadmap, or charter checkpoints that must change based on the lessons.
+4. **Doctrine alignment:** Identify doctrine, protocol, or readiness ledger updates required to reflect the latest insights.
+5. **Action capture:** Assign owners and due dates for every follow-up, ensuring environment-limited items include hardware replay plans.
+
+## Post-review updates
+- **Publish summary:** Append key takeaways to [`codex_lessons.md`](codex_lessons.md) under the review summaries section, including roadmap or doctrine updates and their owners.
+- **Refresh doctrine:** Update roadmap entries, readiness ledgers, and doctrine pages noted during the meeting.
+- **Log actions:** Record assigned follow-ups in the readiness ledger and change log, linking to the evidence bundle for traceability.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,11 @@ This roadmap tracks five core milestones on the path to a stable release. Each s
 
 Bi-weekly working sessions align the charter backlog with the roadmap. Squad leads surface their next three Execution Ladder tasks, confirm interlocks, and record any required sign-offs so dependency owners can prepare before the following sprint checkpoint.【F:docs/alpha_v0_1_charter.md†L74-L88】 The resulting notes should update this roadmap and the companion status trackers so milestone reviews inherit the latest ownership and dependency signals.
 
+> [!TIP]
+> Add a standing agenda item to confirm the quarterly Codex lessons review is on track.
+> Reference [`docs/knowledge_base/review_checklist.md`](knowledge_base/review_checklist.md)
+> when reconciling roadmap or charter updates that emerge from the lessons cadence.
+
 ## Milestone Stages
 
 | Stage | Expected Outcome | Status |


### PR DESCRIPTION
## Summary
- add a quarterly lessons review checklist covering preparation, meeting flow, and post-review follow-through
- extend the Codex lessons knowledge base with a review summaries table tied to the new checklist
- note the standing agenda item in the roadmap charter cadence to confirm the lessons review remains on track

## Testing
- `pre-commit run --files docs/knowledge_base/review_checklist.md docs/knowledge_base/codex_lessons.md docs/roadmap.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d62473cc832eb62c17beda5515f6