### PR TITLE
Document quarterly Codex review workflow

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,6 +9,12 @@ See [component_maturity.md](component_maturity.md) for per-component maturity me
 
 This document summarizes the current state of the ABZU codebase. It serves as a living roadmap covering repository layout, milestones, open issues, and release targets. Use the consolidated [readiness ledger](readiness_ledger.md) to track sandbox evidence owners, outstanding risks, and the remediation steps required before hardware promotion.【F:docs/readiness_ledger.md†L1-L32】
 
+## Upcoming reviews
+
+- **Next quarterly Codex lessons review:** 2026-03-10 — Owner: @release-ops. Use the
+  [quarterly checklist](knowledge_base/review_checklist.md) to prep and capture
+  outcomes so roadmap and doctrine updates land within three business days.
+
 ## Codex sandbox constraints
 
 Stage owners must review the sandbox limitations before planning new work so the roadmap, readiness packets, and doctrine stay

--- a/docs/knowledge_base/codex_lessons.md
+++ b/docs/knowledge_base/codex_lessons.md
@@ -62,6 +62,37 @@ fully understood.【F:docs/glossary/neo_apsu_terms.md†L1-L55】
    debugging attempts and gives future agents immediate context before modifying
    automation, connectors, or media tooling.
 
+## Quarterly review cadence
+
+The sandbox council meets once per quarter to reconcile Codex lessons with the
+broader doctrine. The session is led by the Release Ops owner and includes the
+Ops lead, Memory lead, Connector steward, QA representative, and the current
+scribe for [`docs/knowledge_base/change_log.md`](change_log.md). Each review is
+booked alongside the readiness sync so status owners can align the sandbox
+findings with hardware follow-up plans.
+
+**Deliverables**
+
+- Updated lesson entries here and in the linked doctrine references so auditors
+  inherit the latest mitigations without rereading archived bundles.
+- Decision log updates capturing accepted trade-offs, deferred items, and the
+  bridge window chosen for hardware validation.
+- Adjusted roadmap checkpoints (see [`docs/roadmap.md`](../roadmap.md)) that
+  reflect any timeline shifts triggered by new lessons or risk discoveries.
+
+**Timeline**
+
+- Pre-work: attendees collect new lessons, open questions, and outstanding
+  skips. Consolidate sandbox stubs and readiness ledger deltas at least one
+  week before the meeting and circulate the agenda so owners can flag missing
+  evidence.
+- Review meeting: walk through the consolidated lessons, capture follow-ups in
+  the decision log, and tag roadmap items that require schedule changes or
+  additional hardware validation.
+- Post-work: publish the refreshed lessons and update doctrine references,
+  ensuring the readiness ledger and roadmap link to any new decision log
+  entries or deferred hardware tasks.
+
 ## How to contribute updates
 
 - Append weekly summaries or decision records to

--- a/docs/knowledge_base/review_checklist.md
+++ b/docs/knowledge_base/review_checklist.md
@@ -1,0 +1,35 @@
+# Quarterly Review Checklist
+
+Use this checklist to run the Codex lessons quarterly review. Duplicate it into
+your calendar or task manager so pre-work and post-work stay visible to all
+owners.
+
+## Pre-work (due one week before the review)
+
+- [ ] Aggregate new sandbox lessons from `docs/knowledge_base/codex_lessons.md`
+      drafts and team notebooks.
+- [ ] Collect decision candidates and unresolved risks from the readiness ledger
+      and prior review minutes.
+- [ ] Confirm roadmap items that may require schedule adjustments based on new
+      lessons or blockers.
+- [ ] Circulate the agenda with assigned sections for Release Ops, Ops, Memory,
+      Connector, and QA representatives.
+
+## During the review
+
+- [ ] Walk through the compiled lessons and confirm which updates belong in the
+      canonical Codex knowledge base.
+- [ ] Record decisions, owners, and hardware follow-up windows in the decision
+      log.
+- [ ] Identify roadmap checkpoints that need timeline changes and tag the
+      responsible leads.
+
+## Post-work (due within three business days)
+
+- [ ] Update `docs/knowledge_base/codex_lessons.md` with approved changes and
+      cross-link supporting evidence.
+- [ ] Add new entries to the decision log and note any deferred items in the
+      readiness ledger.
+- [ ] Adjust roadmap milestones or dependencies to reflect the decisions.
+- [ ] Update doctrine references (The Absolute Protocol, documentation protocol,
+      readiness ledger) so the quarterly outcomes remain discoverable.


### PR DESCRIPTION
## Summary
- document the quarterly Codex lessons review cadence, attendees, and deliverables
- add a reusable quarterly review checklist covering pre-work, meeting actions, and follow-ups
- record the next quarterly review date and owner in the project status overview

## Testing
- pre-commit run --files docs/knowledge_base/codex_lessons.md docs/knowledge_base/review_checklist.md docs/PROJECT_STATUS.md *(fails: `pre-commit` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e054295bbc832e8716d961f4bd0085