### PR TITLE
Add quarterly review cadence guidance to Codex lessons

### DIFF
--- a/docs/knowledge_base/codex_lessons.md
+++ b/docs/knowledge_base/codex_lessons.md
@@ -62,6 +62,24 @@ fully understood.【F:docs/glossary/neo_apsu_terms.md†L1-L55】
    debugging attempts and gives future agents immediate context before modifying
    automation, connectors, or media tooling.
 
+## Review cadence
+
+Quarterly reviews replace the previous ad-hoc check-ins so the sandbox lessons
+stay synchronized with planning milestones. The rhythm keeps doctrine updates
+predictable and gives facilitators enough runway to collect evidence from the
+readiness ledger.
+
+- **Quarter kickoff (Week 1).** Confirm facilitators, share the review
+  checklist, and flag any sandbox skips that will require hardware follow-up.
+- **Pre-review sync (Week 5).** Reconcile outstanding action items, refresh the
+  readiness ledger, and identify doctrine pages that need updates before the
+  formal review.
+- **Formal review (Week 6).** Host the quarterly session, capture lessons, and
+  schedule hardware replays for any unresolved sandbox gaps.
+- **Quarter close-out (Week 11).** Publish the review summary, link the
+  readiness ledger updates, and queue any doctrine revisions that slipped past
+  the formal meeting.
+
 ## Review summaries
 
 Document each quarterly review using the checklist in


### PR DESCRIPTION
## Summary
- add a quarterly review cadence section so the sandbox lessons stay aligned with planning checkpoints
- restore the review summaries table directly after the cadence guidance and keep existing links intact

## Testing
- pre-commit run --files docs/knowledge_base/codex_lessons.md *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1142de5bc832e8a9c084118cab0e4